### PR TITLE
Adding linux to available target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,4 @@ elseif(V7)
     add_definitions(-DMDL_V7="true")
 elseif(V8)
     add_definitions(-DMDL_V8="true")
-endif(V8)
-
-
-
+endif(IS_MAC)

--- a/build.sh
+++ b/build.sh
@@ -153,7 +153,7 @@ error_fn () {
 
 if [ $# = 0 ]; then
     echo "error: target missing!"
-    echo "available targets: mac|ios|android"
+    echo "available targets: mac|linux|ios|android"
     echo "sample usage: ./build.sh mac"
 else
     if [ $1 = "mac" ]; then

--- a/tools/caffe2mdl.cpp
+++ b/tools/caffe2mdl.cpp
@@ -21,6 +21,7 @@ SOFTWARE.
 
 #include <stdio.h>
 #include <limits.h>
+#include <limits>
 #include <fstream>
 #include <set>
 #include <iostream>


### PR DESCRIPTION
1. include <limits> header for linux.
2. Fix error ‘numeric_limits’ is not a member of ‘std’.
3. CMake: fix mis-matching arguments  warning.