### PR TITLE
[LITE][BENCHMARK] enhance android arm cpu benchmark

### DIFF
--- a/lite/tools/benchmark.sh
+++ b/lite/tools/benchmark.sh
@@ -41,7 +41,7 @@ for threads in ${NUM_THREADS_LIST[@]}; do
     for model_name in ${MODELS_LIST[@]}; do
       echo "Model=$model_name Threads=$threads"
       adb shell "$ANDROID_DIR/benchmark_bin \
-                   --model_dir=$ANDROID_DIR/${MODELS_DIR##*/}/$model_name \
+                   --model_dir=$ANDROID_DIR/${MODELS_DIR}/$model_name \
                    --warmup=$WARMUP \
                    --repeats=$REPEATS \
                    --threads=$threads \

--- a/lite/tools/benchmark.sh
+++ b/lite/tools/benchmark.sh
@@ -1,42 +1,57 @@
 #!/bin/bash
 set -e
 
+# Check input
 if [ $# -lt  3 ];
 then
     echo "Input error"
-    echo "USAGE:"
-    echo "  sh benchmark.sh benchmark_bin_path benchmark_models_path result_filename"
-    echo "  sh benchmark.sh benchmark_bin_path benchmark_models_path result_filename is_run_model_optimize"
+    echo "Usage:"
+    echo "  sh benchmark.sh <benchmark_bin_path> <benchmark_models_path> <result_filename>"
+    echo "  sh benchmark.sh <benchmark_bin_path> <benchmark_models_path> <result_filename> <is_run_model_optimize: [true|false]>"
     exit
 fi
 
+# Set benchmark params
 ANDROID_DIR=/data/local/tmp
-WARMUP=10
-REPEATS=30
 BENCHMARK_BIN=$1
 MODELS_DIR=$2
 RESULT_FILENAME=$3
+
+WARMUP=10
+REPEATS=30
 IS_RUN_MODEL_OPTIMIZE=false
+NUM_THREADS_LIST=(1 2 4)
+MODELS_LIST=$(ls $MODELS_DIR)
+
+# Check input
 if [ $# -gt  3 ];
 then
     IS_RUN_MODEL_OPTIMIZE=$4
 fi
 
+# Adb push benchmark_bin, models
 adb push $BENCHMARK_BIN $ANDROID_DIR/benchmark_bin
-adb shell chmod 777 $ANDROID_DIR/benchmark_bin
+adb shell chmod +x $ANDROID_DIR/benchmark_bin
 adb push $MODELS_DIR $ANDROID_DIR
 
-adb shell "echo  PaddleLite Benchmark > $ANDROID_DIR/$RESULT_FILENAME"
-for threads in 1 2 4
-do
-adb shell "echo Threads=$threads Warmup=$WARMUP Repeats=$REPEATS  >>  $ANDROID_DIR/$RESULT_FILENAME"
-for model_name in `ls $MODELS_DIR`
-do
-  echo "Model=$model_name Threads=$threads"
-  adb shell "$ANDROID_DIR/benchmark_bin --model_dir=$ANDROID_DIR/${MODELS_DIR##*/}/$model_name --warmup=$WARMUP --repeats=$REPEATS --threads=$threads --result_filename=$ANDROID_DIR/$RESULT_FILENAME --run_model_optimize=$IS_RUN_MODEL_OPTIMIZE"
+# Run benchmark
+adb shell "echo 'PaddleLite Benchmark' > $ANDROID_DIR/$RESULT_FILENAME"
+for threads in ${NUM_THREADS_LIST[@]}; do
+    adb shell "echo Threads=$threads Warmup=$WARMUP Repeats=$REPEATS >> $ANDROID_DIR/$RESULT_FILENAME"
+    for model_name in ${MODELS_LIST[@]}; do
+      echo "Model=$model_name Threads=$threads"
+      adb shell "$ANDROID_DIR/benchmark_bin \
+                   --model_dir=$ANDROID_DIR/${MODELS_DIR##*/}/$model_name \
+                   --warmup=$WARMUP \
+                   --repeats=$REPEATS \
+                   --threads=$threads \
+                   --result_filename=$ANDROID_DIR/$RESULT_FILENAME \
+                   --run_model_optimize=$IS_RUN_MODEL_OPTIMIZE"
+    done
+    adb shell "echo >> $ANDROID_DIR/$RESULT_FILENAME"
 done
-adb shell "echo  >>  $ANDROID_DIR/$RESULT_FILENAME"
-done
+
+# Adb pull benchmark result, show result
 adb pull $ANDROID_DIR/$RESULT_FILENAME .
 echo "\n--------------------------------------"
 cat $RESULT_FILENAME

--- a/lite/tools/prepare_benchmark.sh
+++ b/lite/tools/prepare_benchmark.sh
@@ -20,7 +20,7 @@ function download_files_with_url_prefix {
 }
 
 
-# 1.Download tar package: models, benchmark_bin
+# 1.Download tar packages: models, benchmark_bin
 readonly DOWNLOAD_TAR_PREFIX="https://paddle-inference-dist.bj.bcebos.com/PaddleLite/"
 readonly DOWNLOAD_TAR_LIST=("benchmark_bin_android_armv8_cpu.tar.gz" \
                             "benchmark_bin_android_armv7_cpu.tar.gz" \

--- a/lite/tools/prepare_benchmark.sh
+++ b/lite/tools/prepare_benchmark.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+function download_files_with_url_prefix {
+    local url_prefix=$1
+    local download_file_list=$2
+    local tar_file_pattern="tar.gz"
+
+    for file_name in ${download_file_list[*]}; do
+        echo "[INFO] Downloading ${file_name} ..."
+        wget -c ${url_prefix}/${file_name}
+        chmod +x ./${file_name}
+        # check  tar.gz file
+        if [[ ${file_name} =~ ${tar_file_pattern} ]]
+        then
+            echo "[INFO] Extracting ${file_name} ..."
+            tar -zxvf ${file_name}
+        fi
+    done
+}
+
+
+# 1.Download tar package: models, benchmark_bin
+readonly DOWNLOAD_TAR_PREFIX="https://paddle-inference-dist.bj.bcebos.com/PaddleLite/"
+readonly DOWNLOAD_TAR_LIST=("benchmark_bin_android_armv8_cpu.tar.gz" \
+                            "benchmark_bin_android_armv7_cpu.tar.gz" \
+                            "benchmark_models.tar.gz")
+download_files_with_url_prefix ${DOWNLOAD_TAR_PREFIX} "${DOWNLOAD_TAR_LIST[*]}"
+
+# 2.Download script: benchmark
+readonly DOWNLOAD_SCRIPT_PREFIX="https://raw.githubusercontent.com/PaddlePaddle/Paddle-Lite/develop/lite/tools/"
+readonly DOWNLOAD_SCRIPT_LIST=("benchmark.sh")
+download_files_with_url_prefix ${DOWNLOAD_SCRIPT_PREFIX} "${DOWNLOAD_SCRIPT_LIST[*]}"
+
+# 3.Run benchmark
+echo "[INFO] Run benchmark for android armv7 cpu"
+bash benchmark.sh \
+  ./benchmark_bin_android_armv7_cpu \
+  ./benchmark_models \
+  result_android_armv7_cpu.txt
+
+echo "[INFO] Run benchmark for android armv8 cpu"
+bash benchmark.sh \
+  ./benchmark_bin_android_armv8_cpu \
+  ./benchmark_models \
+  result_android_armv8_cpu.txt


### PR DESCRIPTION
增强benchmark脚本易用性和可读性

1. benchmark需要两个脚本：
    - `run_benchmark.sh`：先前放在内网bucket里，无法做版本管理，目前放到github上好做版本管理，再就是优化该代码格式排版，改名为`prepare_benchmark.sh`。该脚本作用：下载预编译好的各版本benchmark_bin、模型压缩包、调用benchmark.sh脚本完成benchmark；
    - `benchmark.sh`：优化代码格式，方便用户阅读使用。
2. 压缩打包预编译benchmark_bin为tar文件：并由先前的`benchmark_bin_v7`和`benchmark_bin_v8`，重命名为具体的`benchmark_bin_android_armv7_cpu`、`benchmark_bin_android_armv8_cpu`并打tar包，减少体积到之前的1/5，优化下载体验，并优化格式增强可读性。

**注：本脚本改动，不影响目前文档中`benchmark_tool`部分。**