### PR TITLE
fix lookup_table and test bugs

### DIFF
--- a/lite/api/ocr_attention_test.cc
+++ b/lite/api/ocr_attention_test.cc
@@ -45,7 +45,7 @@ void TestModel(const std::vector<Place>& valid_places,
   auto* init_scores = predictor.GetInput(2);
   init_scores->Resize(DDim(std::vector<DDim::value_type>({1, 1})));
   auto* data_scores = init_scores->mutable_data<float>();
-  auto scores_size = input_tensor->dims().production();
+  auto scores_size = init_scores->dims().production();
   for (int i = 0; i < scores_size; i++) {
     data_scores[i] = 0;
   }

--- a/lite/kernels/arm/lookup_table_compute.cc
+++ b/lite/kernels/arm/lookup_table_compute.cc
@@ -53,7 +53,7 @@ void LookupTableCompute::Run() {
       CHECK_GE(ids_data[i], 0) << "lookuptable ids[i] >= 0 check failed";
 
       memcpy(dout + i * row_width,
-             table_data + ids_int * row_width,
+             table_data + ids_data[i] * row_width,
              row_width * sizeof(float));
     }
   }


### PR DESCRIPTION
lookup_table  word id is wrong.
<img width="333" alt="图片" src="https://user-images.githubusercontent.com/39645414/64400888-c631ad80-d0a0-11e9-96e7-e260c711ee89.png">
<img width="424" alt="图片" src="https://user-images.githubusercontent.com/39645414/64400883-bca84580-d0a0-11e9-81ea-29cc865a7b71.png">

ocr test code score size is wrong.
<img width="554" alt="图片" src="https://user-images.githubusercontent.com/39645414/64400911-e1042200-d0a0-11e9-9a35-d8f5c3220ffb.png">
