### PR TITLE
add min_max_aspect_ratios_order attr in prior box op （x2paddle）

### DIFF
--- a/lite/backends/arm/math/prior_box.cc
+++ b/lite/backends/arm/math/prior_box.cc
@@ -63,7 +63,8 @@ void density_prior_box(const lite::Tensor* input,
                        int prior_num_,
                        bool is_flip_,
                        bool is_clip_,
-                       const std::vector<std::string>& order_) {
+                       const std::vector<std::string>& order_,
+                       bool min_max_aspect_ratios_order) {
   // compute output shape
   int win1 = input->dims()[3];
   int hin1 = input->dims()[2];
@@ -284,12 +285,21 @@ void density_prior_box(const lite::Tensor* input,
             //! ymax
             com_buf[com_idx++] = (center_y + box_height / 2.f) / img_height;
           }
-          memcpy(_cpu_data + idx, min_buf, sizeof(float) * min_idx);
-          idx += min_idx;
-          memcpy(_cpu_data + idx, com_buf, sizeof(float) * com_idx);
-          idx += com_idx;
-          memcpy(_cpu_data + idx, max_buf, sizeof(float) * max_idx);
-          idx += max_idx;
+          if (min_max_aspect_ratios_order) {
+            memcpy(_cpu_data + idx, min_buf, sizeof(float) * min_idx);
+            idx += min_idx;
+            memcpy(_cpu_data + idx, max_buf, sizeof(float) * max_idx);
+            idx += max_idx;
+            memcpy(_cpu_data + idx, com_buf, sizeof(float) * com_idx);
+            idx += com_idx;
+          } else {
+            memcpy(_cpu_data + idx, min_buf, sizeof(float) * min_idx);
+            idx += min_idx;
+            memcpy(_cpu_data + idx, com_buf, sizeof(float) * com_idx);
+            idx += com_idx;
+            memcpy(_cpu_data + idx, max_buf, sizeof(float) * max_idx);
+            idx += max_idx;
+          }
         }
         fast_free(min_buf);
         fast_free(max_buf);
@@ -333,7 +343,8 @@ void prior_box(const lite::Tensor* input,
                int prior_num,
                bool is_flip,
                bool is_clip,
-               const std::vector<std::string>& order) {
+               const std::vector<std::string>& order,
+               bool min_max_aspect_ratios_order) {
   density_prior_box(input,
                     image,
                     boxes,
@@ -353,7 +364,8 @@ void prior_box(const lite::Tensor* input,
                     prior_num,
                     is_flip,
                     is_clip,
-                    order);
+                    order,
+                    min_max_aspect_ratios_order);
 }
 
 }  // namespace math

--- a/lite/backends/arm/math/prior_box.h
+++ b/lite/backends/arm/math/prior_box.h
@@ -42,7 +42,8 @@ void density_prior_box(const lite::Tensor* input,
                        int prior_num_,
                        bool is_flip_,
                        bool is_clip_,
-                       const std::vector<std::string>& order_);
+                       const std::vector<std::string>& order_,
+                       bool min_max_aspect_ratios_order);
 
 void prior_box(const lite::Tensor* input,
                const lite::Tensor* image,
@@ -60,7 +61,8 @@ void prior_box(const lite::Tensor* input,
                int prior_num,
                bool is_flip,
                bool is_clip,
-               const std::vector<std::string>& order);
+               const std::vector<std::string>& order,
+               bool min_max_aspect_ratios_order);
 
 }  // namespace math
 }  // namespace arm

--- a/lite/kernels/arm/density_prior_box_compute.cc
+++ b/lite/kernels/arm/density_prior_box_compute.cc
@@ -100,7 +100,8 @@ void DensityPriorBoxCompute::Run() {
                                      prior_num,
                                      is_flip,
                                      is_clip,
-                                     order);
+                                     order,
+                                     false);
 }
 
 }  // namespace arm

--- a/lite/kernels/arm/prior_box_compute.cc
+++ b/lite/kernels/arm/prior_box_compute.cc
@@ -65,6 +65,7 @@ void PriorBoxCompute::Run() {
   size_t prior_num = aspect_ratios_vec.size() * min_size.size();
   prior_num += max_size.size();
   std::vector<std::string> order = param.order;
+  bool min_max_aspect_ratios_order = param.min_max_aspect_ratios_order;
 
   lite::arm::math::prior_box(param.input,
                              param.image,
@@ -82,7 +83,8 @@ void PriorBoxCompute::Run() {
                              prior_num,
                              is_flip,
                              is_clip,
-                             order);
+                             order,
+                             min_max_aspect_ratios_order);
 }
 
 }  // namespace arm

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -540,6 +540,7 @@ struct PriorBoxParam {
   int prior_num{0};
   // priortype: prior_min, prior_max, prior_com
   std::vector<std::string> order;
+  bool min_max_aspect_ratios_order{false};
 };
 
 struct DensityPriorBoxParam : public PriorBoxParam {

--- a/lite/operators/prior_box_op.cc
+++ b/lite/operators/prior_box_op.cc
@@ -67,6 +67,10 @@ bool PriorBoxOpLite::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   if (opdesc.HasAttr("order")) {
     param_.order = opdesc.GetAttr<std::vector<std::string>>("order");
   }
+  if (opdesc.HasAttr("min_max_aspect_ratios_order")) {
+    param_.min_max_aspect_ratios_order =
+        opdesc.GetAttr<bool>("min_max_aspect_ratios_order");
+  }
   return true;
 }
 


### PR DESCRIPTION
为跑通x2paddle新转换的caffe_ssd模型，prior_box op需要支持min_max_aspect_ratios_orders属性。