### PR TITLE
make armliunx compile on raspberry pi and rk3399

### DIFF
--- a/lite/core/arena/framework.h
+++ b/lite/core/arena/framework.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <cmath>
 #include "lite/core/op_registry.h"
 #include "lite/core/program.h"
 #include "lite/core/scope.h"

--- a/lite/core/mir/fusion/conv_bn_fuser.h
+++ b/lite/core/mir/fusion/conv_bn_fuser.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <cmath>
 #include "lite/core/mir/pattern_matcher_high_api.h"
 #include "lite/utils/paddle_enforce.h"
 

--- a/lite/kernels/arm/batch_norm_compute_test.cc
+++ b/lite/kernels/arm/batch_norm_compute_test.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <cmath>
 #include "lite/core/op_registry.h"
 
 namespace paddle {

--- a/lite/kernels/arm/decode_bboxes_compute.cc
+++ b/lite/kernels/arm/decode_bboxes_compute.cc
@@ -14,6 +14,7 @@
 
 #include "lite/kernels/arm/decode_bboxes_compute.h"
 #include <string>
+#include <cmath>
 #include "lite/backends/arm/math/funcs.h"
 
 namespace paddle {

--- a/lite/kernels/arm/decode_bboxes_compute_test.cc
+++ b/lite/kernels/arm/decode_bboxes_compute_test.cc
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include <string>
 #include <vector>
+#include <cmath>
 #include "lite/core/op_registry.h"
 
 namespace paddle {

--- a/lite/kernels/arm/lrn_compute_test.cc
+++ b/lite/kernels/arm/lrn_compute_test.cc
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include <string>
 #include <vector>
+#include <cmath>
 #include "lite/core/op_registry.h"
 
 namespace paddle {

--- a/lite/kernels/arm/softmax_compute_test.cc
+++ b/lite/kernels/arm/softmax_compute_test.cc
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include <limits>
 #include <vector>
+#include <cmath>
 #include "lite/core/op_registry.h"
 
 namespace paddle {


### PR DESCRIPTION
在以下文件中添加cmath的头文件，使得armlinux gcc可以在树莓派和rk3399上编译    test=develop

lite/core/arena/framework.h          
lite/core/mir/fusion/conv_bn_fuser.h                                
lite/kernels/arm/batch_norm_compute_test.cc                
lite/kernels/arm/decode_bboxes_compute.cc                 
lite/kernels/arm/decode_bboxes_compute_test.cc           
lite/kernels/arm/lrn_compute_test.cc                                 
lite/kernels/arm/softmax_compute_test.cc          