### PR TITLE
make armliunx compile on raspberry pi and rk3399 test=develop

### DIFF
--- a/lite/core/arena/framework.h
+++ b/lite/core/arena/framework.h
@@ -17,6 +17,7 @@
 #include <time.h>
 #include <algorithm>
 #include <chrono>  // NOLINT
+#include <cmath>
 #include <iomanip>
 #include <memory>
 #include <string>

--- a/lite/core/mir/fusion/conv_bn_fuser.h
+++ b/lite/core/mir/fusion/conv_bn_fuser.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <memory>
 #include <string>
 #include "lite/core/mir/pattern_matcher_high_api.h"

--- a/lite/kernels/arm/batch_norm_compute_test.cc
+++ b/lite/kernels/arm/batch_norm_compute_test.cc
@@ -14,6 +14,7 @@
 
 #include "lite/kernels/arm/batch_norm_compute.h"
 #include <gtest/gtest.h>
+#include <cmath>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/lite/kernels/arm/decode_bboxes_compute_test.cc
+++ b/lite/kernels/arm/decode_bboxes_compute_test.cc
@@ -14,6 +14,7 @@
 
 #include "lite/kernels/arm/decode_bboxes_compute.h"
 #include <gtest/gtest.h>
+#include <cmath>
 #include <string>
 #include <vector>
 #include "lite/core/op_registry.h"

--- a/lite/kernels/arm/lrn_compute_test.cc
+++ b/lite/kernels/arm/lrn_compute_test.cc
@@ -14,6 +14,7 @@
 
 #include "lite/kernels/arm/lrn_compute.h"
 #include <gtest/gtest.h>
+#include <cmath>
 #include <string>
 #include <vector>
 #include "lite/core/op_registry.h"

--- a/lite/kernels/arm/softmax_compute_test.cc
+++ b/lite/kernels/arm/softmax_compute_test.cc
@@ -14,6 +14,7 @@
 
 #include "lite/kernels/arm/softmax_compute.h"
 #include <gtest/gtest.h>
+#include <cmath>
 #include <limits>
 #include <vector>
 #include "lite/core/op_registry.h"


### PR DESCRIPTION
在以下文件中添加cmath的头文件，使得armlinux gcc可以在树莓派和rk3399上编译 test=develop

lite/core/arena/framework.h
lite/core/mir/fusion/conv_bn_fuser.h
lite/kernels/arm/batch_norm_compute_test.cc
lite/kernels/arm/decode_bboxes_compute_test.cc
lite/kernels/arm/lrn_compute_test.cc
lite/kernels/arm/softmax_compute_test.cc