### PR TITLE
[Cxx API] add build-in version info

### DIFF
--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "lite/api/cxx_api.h"
+#include <string>
 #include "lite/api/paddle_api.h"
+#include "lite/core/version.h"
 
 namespace paddle {
 namespace lite {
@@ -30,6 +32,8 @@ class CxxPaddleApiImpl : public lite_api::PaddlePredictor {
   std::unique_ptr<const lite_api::Tensor> GetOutput(int i) const override;
 
   void Run() override;
+
+  std::string GetVersion() const override;
 
   std::unique_ptr<const lite_api::Tensor> GetTensor(
       const std::string &name) const override;
@@ -62,6 +66,8 @@ std::unique_ptr<const lite_api::Tensor> CxxPaddleApiImpl::GetOutput(
 }
 
 void CxxPaddleApiImpl::Run() { raw_predictor_.Run(); }
+
+std::string CxxPaddleApiImpl::GetVersion() const { return version(); }
 
 std::unique_ptr<const lite_api::Tensor> CxxPaddleApiImpl::GetTensor(
     const std::string &name) const {

--- a/lite/api/light_api_impl.cc
+++ b/lite/api/light_api_impl.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "lite/api/light_api.h"
+#include <string>
 #include "lite/api/paddle_api.h"
+#include "lite/core/version.h"
 #include "lite/model_parser/model_parser.h"
 
 namespace paddle {
@@ -28,6 +30,8 @@ class LightPredictorImpl : public PaddlePredictor {
   std::unique_ptr<const Tensor> GetOutput(int i) const override;
 
   void Run() override;
+
+  std::string GetVersion() const override;
 
   std::unique_ptr<const Tensor> GetTensor(
       const std::string& name) const override;
@@ -60,6 +64,8 @@ std::unique_ptr<const Tensor> LightPredictorImpl::GetOutput(int i) const {
 }
 
 void LightPredictorImpl::Run() { raw_predictor_->Run(); }
+
+std::string LightPredictorImpl::GetVersion() const { return lite::version(); }
 
 std::unique_ptr<const Tensor> LightPredictorImpl::GetTensor(
     const std::string& name) const {

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -72,6 +72,8 @@ class LITE_API PaddlePredictor {
 
   virtual void Run() = 0;
 
+  virtual std::string GetVersion() const = 0;
+
   /// Get a readonly tensor, return null if no one called `name` exists.
   virtual std::unique_ptr<const Tensor> GetTensor(
       const std::string& name) const = 0;

--- a/lite/api/paddle_api_test.cc
+++ b/lite/api/paddle_api_test.cc
@@ -36,6 +36,8 @@ TEST(CxxApi, run) {
 
   auto predictor = lite_api::CreatePaddlePredictor(config);
 
+  LOG(INFO) << "Version: " << predictor->GetVersion();
+
   auto input_tensor = predictor->GetInput(0);
   input_tensor->Resize(std::vector<int64_t>({100, 100}));
   auto* data = input_tensor->mutable_data<float>();
@@ -65,6 +67,8 @@ TEST(LightApi, run) {
   config.set_model_dir(FLAGS_model_dir + ".opt2.naive");
 
   auto predictor = lite_api::CreatePaddlePredictor(config);
+
+  LOG(INFO) << "Version: " << predictor->GetVersion();
 
   auto input_tensor = predictor->GetInput(0);
   input_tensor->Resize(std::vector<int64_t>({100, 100}));

--- a/lite/core/CMakeLists.txt
+++ b/lite/core/CMakeLists.txt
@@ -38,6 +38,33 @@ else()
 lite_cc_library(context SRCS context.cc DEPS tensor any device_info eigen3 CL_DEPS cl_context gflags)
 endif()
 
+#-------------------------------------------- GET CODE META INFO ------------------------------------------
+execute_process(
+  COMMAND git describe --tags --exact-match
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE PADDLE_LITE_TAG
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+  COMMAND git rev-parse --abbrev-ref HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE PADDLE_LITE_BRANCH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+  COMMAND git log -1 --format=%h
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE PADDLE_LITE_COMMIT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+message(STATUS "tag: ${PADDLE_LITE_TAG}")
+message(STATUS "branch: ${PADDLE_LITE_BRANCH}")
+message(STATUS "commit: ${PADDLE_LITE_COMMIT}")
+
+configure_file(version.h.in version.h)
 #----------------------------------------------- NOT CHANGE -----------------------------------------------
 # A trick to generate the paddle_use_kernels.h
 add_custom_command(

--- a/lite/core/version.h.in
+++ b/lite/core/version.h.in
@@ -1,0 +1,49 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include "lite/utils/replace_stl/stream.h"
+
+namespace paddle {
+namespace lite {
+
+static std::string paddlelite_commit() {
+  return "@PADDLE_LITE_COMMIT@";
+}
+
+static std::string paddlelite_branch() {
+  return "@PADDLE_LITE_BRANCH@";
+}
+
+static std::string paddlelite_tag() {
+  return "@PADDLE_LITE_TAG@";
+}
+
+static std::string version() {
+  STL::stringstream ss;
+
+  std::string tag = paddlelite_tag();
+  if (tag.empty()) {
+    ss << paddlelite_branch() << "(" << paddlelite_commit() << ")";
+  } else {
+    ss << tag;
+  }
+
+  return ss.str();
+}
+
+}  // namespace lite
+}  // namespace paddle


### PR DESCRIPTION
c++ api加入GetVersion接口：
函数声明：std::string GetVersion()(lite/api/paddle_api.h)
使用方法：predictor->GetVersion()(可参考lite/api/paddle_api_test.cc)
返回说明：
a) 若根据当前commitid查找到对应tag，则返回相应tag，如"2.0.0-beta"
                  b) 若找不到当前commitid对应的tag，则返回当前分支与commitid，如"develop(a2a5c8)"