### PR TITLE
[Java API] add getVersion() interface to get c++ lib's version

### DIFF
--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -58,7 +58,7 @@ if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
     endif(LITE_WITH_NPU)
     if (LITE_WITH_FPGA)
         set(INFER_LITE_PUBLISH_ROOT "${INFER_LITE_PUBLISH_ROOT}.fpga")
-    endif(LITE_WITH_NPU)
+    endif(LITE_WITH_FPGA)
     message(STATUS "publish inference lib to ${INFER_LITE_PUBLISH_ROOT}")
 
     # The final target for publish lite lib

--- a/lite/api/android/jni/native/convert_util_jni.h
+++ b/lite/api/android/jni/native/convert_util_jni.h
@@ -49,6 +49,27 @@ inline std::string jstring_to_cpp_string(JNIEnv *env, jstring jstr) {
   return ret;
 }
 
+inline jstring cpp_string_to_jstring(JNIEnv *env, std::string str) {
+  auto *data = str.c_str();
+  jclass strClass = env->FindClass("java/lang/String");
+  jmethodID strClassInitMethodID =
+      env->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
+
+  jbyteArray bytes = env->NewByteArray(strlen(data));
+  env->SetByteArrayRegion(
+      bytes, 0, strlen(data), reinterpret_cast<const jbyte *>(data));
+
+  jstring encoding = env->NewStringUTF("UTF-8");
+  jstring res = (jstring)(
+      env->NewObject(strClass, strClassInitMethodID, bytes, encoding));
+
+  env->DeleteLocalRef(strClass);
+  env->DeleteLocalRef(encoding);
+  env->DeleteLocalRef(bytes);
+
+  return res;
+}
+
 inline jfloatArray cpp_array_to_jfloatarray(JNIEnv *env,
                                             const float *buf,
                                             int64_t len) {

--- a/lite/api/android/jni/native/paddle_lite_jni.cc
+++ b/lite/api/android/jni/native/paddle_lite_jni.cc
@@ -50,6 +50,16 @@ JNIEXPORT jboolean JNICALL Java_com_baidu_paddle_lite_PaddlePredictor_run(
   return JNI_TRUE;
 }
 
+JNIEXPORT jstring JNICALL Java_com_baidu_paddle_lite_PaddlePredictor_getVersion(
+    JNIEnv *env, jobject jpaddle_predictor) {
+  std::shared_ptr<PaddlePredictor> *predictor =
+      getPaddlePredictorPointer(env, jpaddle_predictor);
+  if (predictor == nullptr || (*predictor == nullptr)) {
+    return cpp_string_to_jstring(env, "");
+  }
+  return cpp_string_to_jstring(env, (*predictor)->GetVersion());
+}
+
 JNIEXPORT jboolean JNICALL
 Java_com_baidu_paddle_lite_PaddlePredictor_saveOptimizedModel(
     JNIEnv *env, jobject jpaddle_predictor, jstring model_dir) {

--- a/lite/api/android/jni/native/paddle_lite_jni.h
+++ b/lite/api/android/jni/native/paddle_lite_jni.h
@@ -39,6 +39,14 @@ Java_com_baidu_paddle_lite_PaddlePredictor_run(JNIEnv *, jobject);
 
 /*
  * Class:     com_baidu_paddle_lite_PaddlePredictor
+ * Method:    getVersion
+ * Signature: ()Z
+ */
+JNIEXPORT jstring JNICALL
+Java_com_baidu_paddle_lite_PaddlePredictor_getVersion(JNIEnv *, jobject);
+
+/*
+ * Class:     com_baidu_paddle_lite_PaddlePredictor
  * Method:    saveOptimizedModel
  * Signature: (Ljava/lang/String;)Z
  */

--- a/lite/api/android/jni/src/com/baidu/paddle/lite/PaddlePredictor.java
+++ b/lite/api/android/jni/src/com/baidu/paddle/lite/PaddlePredictor.java
@@ -83,6 +83,13 @@ public class PaddlePredictor {
     public native boolean run();
 
     /**
+     * Get c++ lib's version information.
+     *
+     * @return C++ lib's version information.
+     */
+    public native String getVersion();
+
+    /**
      * Saves the optimized model. It is available only for {@link CxxConfig}
      *
      * @param modelDir the path to save the optimized model

--- a/lite/demo/java/android/PaddlePredictor/app/src/main/java/com/baidu/paddle/lite/MainActivity.java
+++ b/lite/demo/java/android/PaddlePredictor/app/src/main/java/com/baidu/paddle/lite/MainActivity.java
@@ -20,9 +20,13 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         String textOutput = "";
+
+        String version = getVersionInfo("lite_naive_model_opt.nb", this);
+        textOutput += "Version: " + version + "\n";
+
         Tensor output;
         output = setInputAndRunNaiveModel("lite_naive_model_opt.nb", this);
-        textOutput += "lite_naive_model output: " + output.getFloatData()[0] + ", "
+        textOutput += "\nlite_naive_model output: " + output.getFloatData()[0] + ", "
                 + output.getFloatData()[1] + "\n";
         textOutput += "expected: 50.2132, -28.8729\n";
 
@@ -52,6 +56,14 @@ public class MainActivity extends AppCompatActivity {
 
         TextView textView = findViewById(R.id.text_view);
         textView.setText(textOutput);
+    }
+
+    public static String getVersionInfo(String modelName, Context context) {
+        String modelPath = copyFromAssetsToCache(modelName, context);
+        MobileConfig config = new MobileConfig();
+        config.setModelDir(modelPath);
+        PaddlePredictor predictor = PaddlePredictor.createPaddlePredictor(config);
+        return predictor.getVersion();
     }
 
     public static String copyFromAssetsToCache(String modelPath, Context context) {

--- a/lite/tools/cmake_tools/parse_kernel_registry.py
+++ b/lite/tools/cmake_tools/parse_kernel_registry.py
@@ -30,7 +30,6 @@ with open(ops_list_path) as f:
     paths = set([path for path in f])
     for path in paths:
         with open(path.strip()) as g:
-            print 'path: ', path
             c = g.read()
             kernel_parser = RegisterLiteKernelParser(c)
             kernel_parser.parse()


### PR DESCRIPTION
Java api加入getVersion接口：
函数声明：String getVersion()
使用方法：predictor.getVersion()(可参考lite/demo/java/android/PaddlePredictor/app/src/main/java/com/baidu/paddle/lite/MainActivity.java)
返回说明：
a) 若根据当前commitid查找到对应tag，则返回相应tag，如"2.0.0-beta"
b) 若找不到当前commitid对应的tag，则返回当前分支与commitid，如"develop(a2a5c8)"