### PR TITLE
CHERRY_PICK: from #2070 Fix BUG: The split op's bug will cause memory optimize pass failed.

### DIFF
--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -69,6 +69,7 @@ bool SplitOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   auto input = opdesc.Input("X").front();
   auto outs = opdesc.Output("Out");
   param_.x = scope->FindVar(input)->GetMutable<lite::Tensor>();
+  param_.output.clear();
   for (auto var : outs) {
     param_.output.push_back(scope->FindVar(var)->GetMutable<lite::Tensor>());
   }


### PR DESCRIPTION
There is bug in the AttachImpl func of the split op :
```
bool SplitOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
  param_.axis = opdesc.GetAttr<int>("axis");
  param_.num = opdesc.GetAttr<int>("num");
  param_.sections = opdesc.GetAttr<std::vector<int>>("sections");
  auto input = opdesc.Input("X").front();
  auto outs = opdesc.Output("Out");
  param_.x = scope->FindVar(input)->GetMutable<lite::Tensor>();
  for (auto var : outs) {
    param_.output.push_back(scope->FindVar(var)->GetMutable<lite::Tensor>());
  }
  return true;
}
```

the `param_.output` should be cleared before the `push_back` operation.


