### PR TITLE
add yolo_box to mem_optimize_pass's unuse op set

### DIFF
--- a/lite/core/mir/memory_optimize_pass.cc
+++ b/lite/core/mir/memory_optimize_pass.cc
@@ -49,6 +49,7 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
                                         "equal",
                                         "lod_reset",
                                         "concat",
+                                        "yolo_box",
                                         "graph_op",
                                         "feed",
                                         "fetch"};


### PR DESCRIPTION
memory_optimize_pass failed when encounter yolo_box op, so temporarily remove reuse yolo_box op.