### PR TITLE
fix ci_build.sh : prepare_thirdparty

### DIFF
--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -18,9 +18,9 @@ function prepare_thirdparty {
         rm -rf $workspace/third-party
 
         if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+            wget -P $workspace $THIRDPARTY_TAR
         fi
-        tar xzf third-party-05b862.tar.gz
+        tar xzf $workspace/third-party-05b862.tar.gz -C $workspace
     else
         git submodule update --init --recursive
     fi


### PR DESCRIPTION
* ci_build.sh: prepare_thirdparty
        modify function code to make sure that third_party tar is downloaded and parsed into workroot 