### PR TITLE
[WIP][Profile] More friendly info for human read

### DIFF
--- a/lite/core/profile/basic_profiler.cc
+++ b/lite/core/profile/basic_profiler.cc
@@ -103,8 +103,7 @@ std::string BasicTimer::basic_repr_header() {
   auto time_unit = GetTimeUnit();
   STL::stringstream ss;
   // clang-format off
-  ss << "op"         << "\t"
-     << "kernel"     << "\t"
+  ss << "kernel"     << "\t"
      << "k_average(" << time_unit << ")\t"
      << "k_min("     << time_unit << ")\t"
      << "k_max("     << time_unit << ")\t"
@@ -126,8 +125,7 @@ std::string BasicTimer::basic_repr() const {
   }
   STL::stringstream ss;
   // clang-format off
-  ss << GetCustomInfo("op_type")                    << "\t"
-     << key()                                       << "\t"
+  ss << key()                                       << "\t"
      << kernel_timer_info.ave() / time_unit_factor  << "\t"
      << kernel_timer_info.min() / time_unit_factor  << "\t"
      << kernel_timer_info.max() / time_unit_factor  << "\t"

--- a/lite/core/program.h
+++ b/lite/core/program.h
@@ -90,7 +90,7 @@ struct Instruction {
       : op_(op), kernel_(std::move(kernel)) {
 #ifdef LITE_WITH_PROFILE
     profile_id_ = profile::BasicProfiler<profile::BasicTimer>::Global()
-                      .NewRcd(kernel_->SerializedKernelType())
+                      .NewRcd(kernel_->summary())
                       .id();
     kernel_->SetProfileID(profile_id_);
     // Set profile custom info


### PR DESCRIPTION
# 状态：等待review、CI

## 优化Profile显示

### 优化点1：将之前的kernel相关的Layout、target等信息由之前的数字转为实际含义

先前的SerializedKernelType会调用如下函数：

```cpp
std::string KernelBase::SerializeKernelType(const std::string &op_type,
                                            const std::string &alias,
                                            const Place &place) {
  STL::stringstream ss;
  ss << op_type << "/";
  ss << alias << "/";
  // We serialize the place value not the string representation here for
  // easier deserialization.
  ss << static_cast<int>(place.target) << "/";
  ss << static_cast<int>(place.precision) << "/";
  ss << static_cast<int>(place.layout);
  return ss.str();
}
```
显示的内容会转为int，不适合大伙儿阅读，而summary转为对应的str，方便易于阅读：

```cpp
std::string KernelBase::summary() const {
  STL::stringstream ss;
  ss << op_type() << ":" << TargetToStr(target()) << "/"
     << PrecisionToStr(precision()) << "/" << DataLayoutToStr(layout()) << "("
     << alias() << ")";
  return ss.str();
}
```

### 优化点2：KernelBase::summary()会显示op_type，前一列显示op_type多余，移除前一列


## 之前的信息显示


![image](https://user-images.githubusercontent.com/6871053/65745914-d84abd00-e12f-11e9-8281-cb6617af8760.png)

## 优化后的信息显示



![image](https://user-images.githubusercontent.com/7320657/66623537-b61c6900-ec1e-11e9-8bd2-cee754f8c95c.png)
