### PR TITLE
Add kernel version table and update framework.proto, test=develop

### DIFF
--- a/lite/backends/cuda/CMakeLists.txt
+++ b/lite/backends/cuda/CMakeLists.txt
@@ -1,8 +1,10 @@
 if(NOT LITE_WITH_CUDA)
     return()
 endif()
+set(cuda_static_deps cudnn_static cublas_static curand_static
+    culibos_static cudart_static)
 
-nv_library(target_wrapper_cuda SRCS target_wrapper.cc)
-nv_library(cuda_blas SRCS blas.cc)
+nv_library(target_wrapper_cuda SRCS target_wrapper.cc DEPS ${cuda_static_deps})
+nv_library(cuda_blas SRCS blas.cc DEPS ${cuda_static_deps})
  
 add_subdirectory(math)

--- a/lite/core/framework.proto
+++ b/lite/core/framework.proto
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 syntax = "proto2";
-// option optimize_for = LITE_RUNTIME;
+option optimize_for = LITE_RUNTIME;
 package paddle.framework.proto;
 
 // Any incompatible changes to ProgramDesc and its dependencies should
@@ -166,6 +166,9 @@ message VarDesc {
   required string name = 1;
   required VarType type = 2;
   optional bool persistable = 3 [ default = false ];
+  // True if the variable is an input data and
+  // have to check the feed data shape and dtype
+  optional bool need_check_feed = 4 [ default = false ];
 }
 
 message BlockDesc {
@@ -176,13 +179,39 @@ message BlockDesc {
   optional int32 forward_block_idx = 5 [ default = -1 ];
 }
 
+// CompatibleInfo is used to determine if a feature is compatible and
+// provides the information.
+message CompatibleInfo {
+  enum Type {
+    COMPATIBLE = 0;
+    DEFINITELY_NOT = 1;
+    POSSIBLE = 2;
+    BUG_FIX = 3;
+    PRECISION_CHANGE = 4;
+  }
+  required string version = 1;
+  required Type type = 2;
+}
+
+// In some cases, Paddle Fluid may perform operator definition iterations,
+// and the operator uses OpCompatibleMap for compatibility testing.
+message OpCompatibleMap {
+  message OpCompatiblePair {
+    required string op_name = 1;
+    required CompatibleInfo compatible_info = 2;
+  }
+  repeated OpCompatiblePair pair = 1;
+  optional string default_required_version = 2;
+}
+
 // Please refer to
 // https://github.com/PaddlePaddle/Paddle/blob/develop/doc/design/program.md
 // for more details.
 // TODO(panyx0718): A model can have multiple programs. Need a
 // way to distinguish them. Maybe ID or name?
 message ProgramDesc {
+  reserved 2; // For backward compatibility.
   repeated BlockDesc blocks = 1;
-
-  optional Version version = 2;
+  optional Version version = 4;
+  optional OpCompatibleMap op_compatible_map = 3;
 }

--- a/lite/core/type_system.h
+++ b/lite/core/type_system.h
@@ -27,6 +27,7 @@
 #include <unordered_set>
 #include <vector>
 #include "lite/core/tensor.h"
+#include "lite/core/version.h"
 #include "lite/utils/all.h"
 
 namespace paddle {
@@ -280,7 +281,7 @@ struct ParamTypeRecorder {
  */
 class ParamTypeRegistry {
  public:
-  enum class IO : int { kInput = 0, kOutput };
+  enum class IO : int { kInvalid = 0, kInput, kOutput };
 
   template <TargetType target,
             PrecisionType precision,
@@ -310,6 +311,12 @@ class ParamTypeRegistry {
           kernel_type_, Place{target, precision, layout}, arg_name, ptype);
       return *this;
     }
+    NewInstance& SetVersion(const std::string& version) {
+      ParamTypeRegistry::Global().SetVersion(int_version(version),
+                                             Split(kernel_type_, "/").front(),
+                                             Place{target, precision, layout});
+      return *this;
+    }
 
     bool Finalize() { return true; }
 
@@ -325,6 +332,22 @@ class ParamTypeRegistry {
     KernelIdTy key{kernel_type, place, io, arg_name};
     types_[key] = data_type;
     CHECK(types_.count(key));
+  }
+
+  void SetVersion(const int64_t version,
+                  const std::string& kernel_type,
+                  const Place& place) {
+    KernelIdTy key{kernel_type, place, IO(), std::string()};
+    versions_[key] = version;
+    CHECK(versions_.count(key));
+  }
+
+  int64_t GetVersion(const std::string& kernel_type, const Place& place) {
+    KernelIdTy key{kernel_type, place, IO(), std::string()};
+    if (versions_.count(key)) {
+      return versions_[key];
+    }
+    return -1;
   }
 
   const ParamType* RetrieveInArgument(const Place& place,
@@ -384,6 +407,7 @@ class ParamTypeRegistry {
 
  private:
   std::map<key_t, ParamType, ParamTypeRegistry::KeyCmp> types_;
+  std::map<key_t, int64_t, ParamTypeRegistry::KeyCmp> versions_;
 };
 
 }  // namespace lite

--- a/lite/core/version.h.in
+++ b/lite/core/version.h.in
@@ -15,10 +15,16 @@
 #pragma once
 
 #include <string>
+#include <assert.h>
 #include "lite/utils/replace_stl/stream.h"
+#include "lite/utils/string.h"
 
 namespace paddle {
 namespace lite {
+
+static constexpr int MAJOR_COEFF = 1000000;
+static constexpr int MINOR_COEFF = 1000;
+static constexpr int PATCH_COEFF = 1;
 
 static std::string paddlelite_commit() {
   return "@PADDLE_LITE_COMMIT@";
@@ -43,6 +49,16 @@ static std::string version() {
   }
 
   return ss.str();
+}
+
+static int64_t int_version(const std::string& version) {
+  const std::vector<std::string> vec = Split(version, ".");
+  if (vec.size() == 3) {
+    return std::stoi(vec[0]) * MAJOR_COEFF +
+           std::stoi(vec[1]) * MINOR_COEFF +
+           std::stoi(vec[2]) * PATCH_COEFF;
+  }
+  return -1;
 }
 
 }  // namespace lite

--- a/lite/core/version.h.in
+++ b/lite/core/version.h.in
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <string>
-#include <assert.h>
 #include "lite/utils/replace_stl/stream.h"
 #include "lite/utils/string.h"
 

--- a/lite/kernels/cuda/CMakeLists.txt
+++ b/lite/kernels/cuda/CMakeLists.txt
@@ -33,7 +33,6 @@ nv_test(transpose_compute_cuda_test SRCS transpose_compute_test.cc DEPS transpos
 nv_test(concat_compute_cuda_test SRCS concat_compute_test.cc DEPS concat_compute_cuda)
 nv_test(elementwise_add_compute_cuda_test SRCS elementwise_add_compute_test.cc DEPS elementwise_add_compute_cuda)
 nv_test(softmax_compute_cuda_test SRCS softmax_compute_test.cc DEPS softmax_compute_cuda)
-nv_test(pool_compute_cuda_test SRCS pool_compute_test.cc DEPS pool_compute_cuda)
 #nv_test(layout_cuda_test SRCS layout_compute_test.cc DEPS layout_compute_cuda)
 nv_test(mul_compute_cuda_test SRCS mul_compute_test.cc DEPS mul_compute_cuda)
 nv_test(dropout_compute_cuda_test SRCS dropout_compute_test.cc DEPS dropout_compute_cuda )

--- a/lite/kernels/cuda/leaky_relu_compute.cu
+++ b/lite/kernels/cuda/leaky_relu_compute.cu
@@ -66,4 +66,5 @@ REGISTER_LITE_KERNEL(leaky_relu,
                      def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kCUDA))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kCUDA))})
+    .SetVersion("1.5.0")
     .Finalize();

--- a/lite/model_parser/CMakeLists.txt
+++ b/lite/model_parser/CMakeLists.txt
@@ -29,5 +29,15 @@ lite_cc_library(model_parser SRCS model_parser.cc DEPS
     compatible_pb
     memory
     CUDA_DEPS target_wrapper_cuda)
-
 lite_cc_test(test_compatible_pb SRCS compatible_pb_test.cc DEPS compatible_pb)
+
+if (LITE_WITH_CUDA AND NOT LITE_ON_TINY_PUBLISH)
+    lite_cc_library(compatibility SRCS compatibility.cc DEPS
+        kernel
+        variable
+        compatible_pb
+        type_system
+        ${cpp_wrapper}
+        ${naive_wrapper})
+    lite_cc_test(test_compatibility SRCS compatibility_test.cc DEPS compatibility leaky_relu_compute_cuda)
+endif()

--- a/lite/model_parser/compatibility.cc
+++ b/lite/model_parser/compatibility.cc
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/model_parser/compatibility.h"
+
+#include "lite/core/type_system.h"
+#include "lite/model_parser/naive_buffer/block_desc.h"
+#include "lite/model_parser/naive_buffer/op_desc.h"
+#include "lite/model_parser/naive_buffer/program_desc.h"
+#include "lite/model_parser/naive_buffer/var_desc.h"
+#ifndef LITE_ON_TINY_PUBLISH
+#include "lite/model_parser/cpp/block_desc.h"
+#include "lite/model_parser/cpp/op_desc.h"
+#include "lite/model_parser/cpp/program_desc.h"
+#include "lite/model_parser/cpp/var_desc.h"
+#endif
+
+namespace paddle {
+namespace lite {
+
+template <typename T>
+bool CompatibleChecker<T>::CheckKernelVersion(const std::string& type,
+                                              const lite_api::Place& place) {
+  int64_t impl_version = ParamTypeRegistry::Global().GetVersion(type, place);
+  const int64_t prog_version = program_.Version();
+  VLOG(3) << "Kernel implement version: " << type << ", " << impl_version;
+  VLOG(3) << "Kernel program version: " << type << ", " << prog_version;
+  if (impl_version == -1) {
+    impl_version = mini_version_;
+  }
+  return prog_version <= impl_version;
+}
+
+template <typename T>
+std::unordered_set<std::string> CompatibleChecker<T>::OpsType(T* program) {
+  LOG(WARNING) << "OpsType() is not yet implemented.";
+  return std::unordered_set<std::string>();
+}
+
+#ifndef LITE_ON_TINY_PUBLISH
+template <>
+std::unordered_set<std::string> CompatibleChecker<cpp::ProgramDesc>::OpsType(
+    cpp::ProgramDesc* program) {
+  std::unordered_set<std::string> ops_type;
+  for (size_t i = 0; i < program->BlocksSize(); ++i) {
+    auto* block = program->GetBlock<cpp::BlockDesc>(i);
+    for (size_t j = 0; j < block->OpsSize(); ++j) {
+      auto* op = block->GetOp<cpp::OpDesc>(j);
+      ops_type.insert(op->Type());
+    }
+  }
+  return ops_type;
+}
+
+template class CompatibleChecker<cpp::ProgramDesc>;
+#endif  // LITE_ON_TINY_PUBLISH
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/model_parser/compatibility.h
+++ b/lite/model_parser/compatibility.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include "lite/api/paddle_place.h"
+#include "lite/model_parser/desc_apis.h"
+
+namespace paddle {
+namespace lite {
+
+template <typename T>
+class CompatibleChecker {
+ public:
+  explicit CompatibleChecker(const T& program,
+                             const int64_t mini_version = 1005000)
+      : program_(program), mini_version_(mini_version) {}
+
+  bool operator()(const lite_api::Place& place) {
+    bool status = true;
+    const std::unordered_set<std::string>& ops_type = OpsType(&program_);
+    if (ops_type.empty()) {
+      VLOG(3) << "You are checking the compatibility of an empty program.";
+    }
+    for (const auto& type : ops_type) {
+      bool ret = CheckKernelVersion(type, place);
+      VLOG(3) << "Kernel version is supported: " << type << ", " << ret;
+      status = status && ret;
+    }
+    return status;
+  }
+
+ private:
+  std::unordered_set<std::string> OpsType(T* program);
+  bool CheckKernelVersion(const std::string& type,
+                          const lite_api::Place& place);
+  T program_;
+  int64_t mini_version_;
+};
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/model_parser/compatibility_test.cc
+++ b/lite/model_parser/compatibility_test.cc
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/model_parser/compatibility.h"
+#include <gtest/gtest.h>
+#include "lite/api/paddle_lite_factory_helper.h"
+
+#include "lite/model_parser/compatible_pb.h"
+#include "lite/model_parser/cpp/block_desc.h"
+#include "lite/model_parser/cpp/op_desc.h"
+#include "lite/model_parser/cpp/program_desc.h"
+#include "lite/model_parser/cpp/var_desc.h"
+
+USE_LITE_KERNEL(leaky_relu, kCUDA, kFloat, kNCHW, def);
+
+namespace paddle {
+namespace lite {
+
+static constexpr int64_t version = 1005000;
+
+TEST(CompatibleChecker, CppProgramDesc) {
+  cpp::ProgramDesc program;
+  program.SetVersion(version);
+  auto* block = program.AddBlock<cpp::BlockDesc>();
+  auto* op = block->AddOp<cpp::OpDesc>();
+  op->SetType("leaky_relu");
+
+  CompatibleChecker<cpp::ProgramDesc> checker(program);
+  lite_api::Place place{TARGET(kCUDA), PRECISION(kFloat), DATALAYOUT(kNCHW)};
+  CHECK(checker(place));
+}
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/model_parser/pb/op_desc.h
+++ b/lite/model_parser/pb/op_desc.h
@@ -143,8 +143,6 @@ class OpDesc : public OpDescAPI {
   template <typename T>
   T GetAttr(const std::string &name) const;
 
-  std::string DebugString() const { return desc_->DebugString(); }
-
  private:
   std::vector<std::string> GetArguments(
       const google::protobuf::RepeatedPtrField<framework::proto::OpDesc_Var>

--- a/lite/tools/cmake_tools/ast.py
+++ b/lite/tools/cmake_tools/ast.py
@@ -292,7 +292,7 @@ class RegisterLiteKernelParser(SyntaxParser):
             self.eat_point()
             self.eat_spaces()
             self.eat_word()
-            assert self.token in ('BindInput', 'BindOutput', 'Finalize')
+            assert self.token in ('BindInput', 'BindOutput', 'SetVersion', 'Finalize')
             io = IO()
 
             if self.token == 'BindInput':
@@ -301,6 +301,12 @@ class RegisterLiteKernelParser(SyntaxParser):
             elif self.token == 'BindOutput':
                 eat_io(False, io)
                 k.outputs.append(io)
+            elif self.token == 'SetVersion':
+                self.eat_left_parentheses()
+                self.eat_str()
+                self.version = self.token
+                self.eat_right_parentheses()
+                self.eat_spaces()
             else:
                 self.eat_left_parentheses()
                 self.eat_right_parentheses()

--- a/lite/utils/all.h
+++ b/lite/utils/all.h
@@ -21,6 +21,7 @@
 #include "lite/utils/hash.h"
 #include "lite/utils/io.h"
 #include "lite/utils/macros.h"
+#include "lite/utils/string.h"
 #include "lite/utils/varient.h"
 
 #ifdef LITE_ON_TINY_PUBLISH


### PR DESCRIPTION
1、对齐 Lite 与 Fluid 的 framework.proto；
2、添加设定算子版本的接口，算子版本号与 Fluid 主框架版本号格式一致（三位小数组成的字符串，如 "1.5.0"），在注册时进行设定。示例：
```
REGISTER_LITE_KERNEL(leaky_relu,
                     kCUDA,
                     kFloat,
                     kNCHW,
                     paddle::lite::kernels::cuda::LeakyReluCompute,
                     def)
    .BindInput("X", {LiteType::GetTensorTy(TARGET(kCUDA))})
    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kCUDA))})
    .SetVersion("1.5.0")
    .Finalize(); 
```
注意：上述接口注册的算子版本是 Kernel 级别的，也就是说，同一名称的 Operator（如 leaky_relu）在不同的 Place（如 kARM 和 kCUDA）下，版本号是分开注册、可以不同的。