### PR TITLE
modify layer_norm_compute_test.cc

### DIFF
--- a/lite/kernels/arm/layer_norm_compute_test.cc
+++ b/lite/kernels/arm/layer_norm_compute_test.cc
@@ -14,6 +14,7 @@
 
 #include "lite/kernels/arm/layer_norm_compute.h"
 #include <gtest/gtest.h>
+#include <cmath>
 #include <limits>
 #include <vector>
 #include "lite/core/op_registry.h"


### PR DESCRIPTION
在RK3399本地编译test中，layer_norm_compute_test.cc中使用sqrt但未加#include<cmath>导致编译出错

test=develop