### PR TITLE
Fix target bug: kHost and kARM not equal. test=develop

### DIFF
--- a/lite/core/mir/type_target_cast_pass.cc
+++ b/lite/core/mir/type_target_cast_pass.cc
@@ -12,20 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 #include "lite/core/mir/type_target_cast_pass.h"
 #include <list>
 #include <memory>

--- a/lite/core/mir/type_target_cast_pass.cc
+++ b/lite/core/mir/type_target_cast_pass.cc
@@ -12,6 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "lite/core/mir/type_target_cast_pass.h"
 #include <list>
 #include <memory>
@@ -125,7 +139,8 @@ void TypeTargetTransformPass::AddIoCopyInst(
     VLOG(4) << "------ kernel info -------";
     VLOG(4) << "*in_arg_ty(io_copy kernel input):" << *in_arg_ty;
     VLOG(4) << "from(last kernel output):" << from;
-    VLOG(4) << "to:" << to;
+    VLOG(4) << "out_arg_ty(io_copy kernel output):" << *out_arg_ty;
+    VLOG(4) << "to:" << to << "\n";
 
 // kernel choose branch for opencl backend
 //   judge inst's target whether is kOpenCL
@@ -143,7 +158,7 @@ void TypeTargetTransformPass::AddIoCopyInst(
     if (TargetCompatibleTo(*in_arg_ty, from) &&
         PrecisionCompatibleTo(*in_arg_ty, from) &&
         DeviceCompatibleTo(*in_arg_ty, from) &&
-        out_arg_ty->target() == to.target()) {
+        TargetCompatibleTo(*out_arg_ty, to)) {
       VLOG(4) << "do nothing. opencl found";
 #else
     if (TypeCompatible(*in_arg_ty, from) &&


### PR DESCRIPTION
# 状态
1. [x] review
2. [x] CI
3. [x] merge到develop
4. [x] cherry-pick到release/v2.0.0: https://github.com/PaddlePaddle/Paddle-Lite/pull/2289

## 修复target pass的bug

- 单测模型：mobilenetv1
- OpenCL

跑paddle-lite会在这里挂掉，原因是挂在：当已确定要加io_copy的kernel时，在一堆io_copy的kernel中选择，这时会判断io_copy的前一个kernel的输出（out_arg_ty）与当前io_copy的输入，二者target是否一致。

![image](https://user-images.githubusercontent.com/7320657/67746104-bca14200-fa60-11e9-8578-ffa1f96627af.png)

![image](https://user-images.githubusercontent.com/7320657/67747773-6e8e3d80-fa64-11e9-8e53-aab9afc3ea84.png)


当前的实现有问题：因为在OpenCL这端，处在模型需要download数据到CPU的过程中，io_copy的输出是kHost，softmax的输入是kARM导致不匹配，直接判断`==`没有重载得到的结果是`false`，因而需要改为`TargetCompatibleTo`。


其它：因没有实现NHWC的mul，所以整个mobilenetv1仍旧是以buffer形式跑的。