### PR TITLE
X86 fix cherrypick

### DIFF
--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -86,6 +86,16 @@ if (LITE_WITH_PYTHON)
     add_dependencies(publish_inference publish_inference_python_light_demo)
 endif()
 
+if (LITE_WITH_X86)
+    add_dependencies(publish_inference eigen3)
+    add_dependencies(publish_inference fluid_data_type)
+    add_dependencies(publish_inference bundle_full_api)
+    add_dependencies(publish_inference bundle_light_api)
+    add_dependencies(publish_inference test_model_bin)
+    add_dependencies(publish_inference paddle_full_api_shared)
+    add_dependencies(publish_inference paddle_light_api_shared)
+endif()
+
 if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
     if (NOT LITE_ON_TINY_PUBLISH)
         # add cxx lib

--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -15,7 +15,6 @@ if ((NOT LITE_ON_TINY_PUBLISH) AND (LITE_WITH_X86 OR ARM_TARGET_OS STREQUAL "and
     target_sources(paddle_full_api_shared PUBLIC ${__lite_cc_files} paddle_api.cc light_api.cc cxx_api.cc cxx_api_impl.cc light_api_impl.cc)
     add_dependencies(paddle_full_api_shared op_list_h kernel_list_h framework_proto)
     target_link_libraries(paddle_full_api_shared framework_proto)
-    add_dependencies(lite_compile_deps paddle_full_api_shared)
     if(LITE_WITH_X86)
        add_dependencies(paddle_full_api_shared xxhash)
        target_link_libraries(paddle_full_api_shared xxhash)

--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -237,6 +237,35 @@ function make_cuda {
   cd -
 }
 
+function make_x86 {
+  prepare_thirdparty
+
+  root_dir=$(pwd)
+  build_directory=$BUILD_DIR/build_x86
+
+  if [ -d $build_directory ]
+  then
+    rm -rf $build_directory
+  fi
+  mkdir -p $build_directory
+  cd $build_directory
+
+  prepare_workspace $root_dir $build_directory
+
+  cmake ..  -DWITH_MKL=ON       \
+            -DWITH_MKLDNN=OFF    \
+            -DLITE_WITH_X86=ON  \
+            -DLITE_WITH_PROFILE=OFF \
+            -DWITH_LITE=ON \
+            -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=OFF \
+            -DLITE_WITH_ARM=OFF \
+            -DWITH_GPU=OFF \
+            -DLITE_BUILD_EXTRA=ON
+
+  make publish_inference -j4
+  cd -
+}
+
 function print_usage {
     set +x
     echo -e "\nUSAGE:"
@@ -355,6 +384,10 @@ function main {
                 make_cuda 
                 shift
                 ;;
+            x86)
+               make_x86
+               shift
+               ;;
             *)
                 # unknown option
                 print_usage


### PR DESCRIPTION
x86 compiling method is modified here:
(1) `./lite/tool/ci_build.sh build_test_server` method will not build `libpaddle_full_api_shared.so`
(2) we can build x86 static and dynamic library by the method of `./lite/tool/build.sh x86`