### PR TITLE
Add x86 inference and fix_armv7_C++demo         cherry pick

### DIFF
--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -87,13 +87,31 @@ if (LITE_WITH_PYTHON)
 endif()
 
 if (LITE_WITH_X86)
-    add_dependencies(publish_inference eigen3)
-    add_dependencies(publish_inference fluid_data_type)
-    add_dependencies(publish_inference bundle_full_api)
-    add_dependencies(publish_inference bundle_light_api)
-    add_dependencies(publish_inference test_model_bin)
-    add_dependencies(publish_inference paddle_full_api_shared)
-    add_dependencies(publish_inference paddle_light_api_shared)
+    add_custom_target(publish_inference_x86_cxx_lib ${TARGET}
+            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/bin"
+            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
+            COMMAND cp "${CMAKE_SOURCE_DIR}/lite/api/paddle_*.h" "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
+            COMMAND cp "${CMAKE_BINARY_DIR}/libpaddle_api_full_bundled.a" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+            COMMAND cp "${CMAKE_BINARY_DIR}/libpaddle_api_light_bundled.a" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/*.so" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/test_model_bin" "${INFER_LITE_PUBLISH_ROOT}/bin"
+            )
+    add_dependencies(publish_inference_x86_cxx_lib bundle_full_api)
+    add_dependencies(publish_inference_x86_cxx_lib bundle_light_api)
+    add_dependencies(publish_inference_x86_cxx_lib test_model_bin)
+    add_dependencies(publish_inference_x86_cxx_lib paddle_full_api_shared)
+    add_dependencies(publish_inference_x86_cxx_lib paddle_light_api_shared)
+    add_dependencies(publish_inference publish_inference_x86_cxx_lib)
+
+    add_custom_target(publish_inference_x86_cxx_demos ${TARGET}
+           COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/third_party"
+           COMMAND cp -r "${CMAKE_BINARY_DIR}/third_party/install/*" "${INFER_LITE_PUBLISH_ROOT}/third_party"
+           COMMAND cp -r "${CMAKE_BINARY_DIR}/third_party/eigen3" "${INFER_LITE_PUBLISH_ROOT}/third_party"
+           COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/demo/cxx"
+           )
+    add_dependencies(publish_inference_x86_cxx_demos gflags eigen3 mklml  xbyak  xxhash glog)
+    add_dependencies(publish_inference_x86_cxx_lib publish_inference_x86_cxx_demos)
 endif()
 
 if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)

--- a/lite/api/python/pybind/pybind.cc
+++ b/lite/api/python/pybind/pybind.cc
@@ -254,12 +254,7 @@ void BindLiteLightPredictor(py::module *m) {
       .def("get_input", &LightPredictorImpl::GetInput)
       .def("get_output", &LightPredictorImpl::GetOutput)
       .def("run", &LightPredictorImpl::Run)
-      .def("get_version", &LightPredictorImpl::GetVersion)
-      .def("save_optimized_model",
-           [](LightPredictorImpl &self, const std::string &output_dir) {
-             self.SaveOptimizedModel(output_dir,
-                                     lite_api::LiteModelType::kNaiveBuffer);
-           });
+      .def("get_version", &LightPredictorImpl::GetVersion);
 }
 
 }  // namespace pybind

--- a/lite/demo/cxx/Makefile.def
+++ b/lite/demo/cxx/Makefile.def
@@ -26,7 +26,7 @@ else
     CXX_FLAGS = -march=armv7-a -mthumb -mfpu=neon -mfloat-abi=softfp -funwind-tables -no-canonical-prefixes \
 		-D__ANDROID_API__=22 -fexceptions -frtti  -std=c++11 -fopenmp -O3 -DNDEBUG -fPIE  
     CXXFLAGS_LINK = $(CXX_FLAGS) -pie -Wl,--fix-cortex-a8 -Wl,--gc-sections -Wl,-z,nocopyreloc
-    SYSROOT_LINK = --sysroot=/opt/android-ndk-r17c/platforms/android-22/arch-arm
+    SYSROOT_LINK = --sysroot=/opt/android-ndk-r17c/platforms/android-23/arch-arm
     SYSTEM_LIBS = /opt/android-ndk-r17c/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_static.a \
                   /opt/android-ndk-r17c/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++abi.a \
                   /opt/android-ndk-r17c/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libandroid_support.a \

--- a/lite/demo/cxx/Makefile.def
+++ b/lite/demo/cxx/Makefile.def
@@ -15,7 +15,7 @@ THIRD_PARTY_INCLUDES = -I../../../third_party/gflags/include
 
 ifeq ($(ARM_ABI), arm8)
     CC = /opt/android-ndk-r17c/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-g++ 
-    CXX_FLAGS = -funwind-tables -no-canonical-prefixes -D__ANDROID_API__=22 -fexceptions -frtti  -std=c++11 -fopenmp -O3 -DNDEBUG -fPIE
+    CXX_FLAGS = -funwind-tables -no-canonical-prefixes -D__ANDROID_API__=23 -fexceptions -frtti  -std=c++11 -fopenmp -O3 -DNDEBUG -fPIE
     CXXFLAGS_LINK = $(CXX_FLAGS) -pie -Wl,--gc-sections 
     SYSROOT_LINK = --sysroot=/opt/android-ndk-r17c/platforms/android-24/arch-arm64
     SYSTEM_LIBS = /opt/android-ndk-r17c/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_static.a \
@@ -24,7 +24,7 @@ ifeq ($(ARM_ABI), arm8)
 else
     CC = /opt/android-ndk-r17c/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-g++
     CXX_FLAGS = -march=armv7-a -mthumb -mfpu=neon -mfloat-abi=softfp -funwind-tables -no-canonical-prefixes \
-		-D__ANDROID_API__=22 -fexceptions -frtti  -std=c++11 -fopenmp -O3 -DNDEBUG -fPIE  
+		-D__ANDROID_API__=23 -fexceptions -frtti  -std=c++11 -fopenmp -O3 -DNDEBUG -fPIE
     CXXFLAGS_LINK = $(CXX_FLAGS) -pie -Wl,--fix-cortex-a8 -Wl,--gc-sections -Wl,-z,nocopyreloc
     SYSROOT_LINK = --sysroot=/opt/android-ndk-r17c/platforms/android-23/arch-arm
     SYSTEM_LIBS = /opt/android-ndk-r17c/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_static.a \

--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -241,7 +241,7 @@ function make_x86 {
   prepare_thirdparty
 
   root_dir=$(pwd)
-  build_directory=$BUILD_DIR/build_x86
+  build_directory=$BUILD_DIR/build.lite.x86
 
   if [ -d $build_directory ]
   then


### PR DESCRIPTION
(1)Add inference folder into build.lite.x86, build.lite.x86/inference folder contains head files、library files and demo of x86 compiling  (#2301)
(2)link armv7 demo to android-23 to make sure the demo can compile properly
cxx demo can not compile properly because demo' android version is different from that of library file, we fix this bug by linking armv7 demo to android-23  (#2308)