### PR TITLE
[BugFix] Fix conv bn bug, check bias in pass

### DIFF
--- a/lite/core/mir/fusion/conv_bn_fuser.cc
+++ b/lite/core/mir/fusion/conv_bn_fuser.cc
@@ -66,7 +66,6 @@ void ConvBNFuser::BuildPattern() {
   if (conv_has_bias_) {
     auto* conv_bias = VarNode("conv_bias")
                           ->assert_is_op_input(conv_type_, "Bias")
-                          ->AsInput()
                           ->AsIntermediate();
     conv->LinksFrom({conv_input, conv_weight, conv_bias}).LinksTo({conv_out});
   } else {
@@ -172,7 +171,8 @@ void ConvBNFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
   }
 
   // compute new conv_bias
-  if (conv_has_bias_) {
+  if (conv_has_bias_ && conv_op_desc->HasInput("Bias") &&
+      conv_op_desc->Input("Bias").size() > 0) {
     auto conv_bias_t = scope->FindVar(matched.at("conv_bias")->arg()->name)
                            ->GetMutable<lite::Tensor>();
     auto conv_bias_d = conv_bias_t->data<float>();

--- a/lite/core/mir/pattern_matcher.cc
+++ b/lite/core/mir/pattern_matcher.cc
@@ -415,7 +415,8 @@ bool IsNthOutput(const Node *var,
   CHECK(var->IsArg());
   CHECK(op->IsStmt());
   auto op_info = op->stmt()->op_info();
-  if (op_info->Output(argument).size() <= nth) return false;
+  if (!op_info->HasOutput(argument) || op_info->Output(argument).size() <= nth)
+    return false;
   return var->arg()->name == op_info->Output(argument)[nth];
 }
 
@@ -426,7 +427,8 @@ bool IsNthInput(const Node *var,
   CHECK(var->IsArg());
   CHECK(op->IsStmt());
   auto op_info = op->stmt()->op_info();
-  if (op_info->Input(argument).size() <= nth) return false;
+  if (!op_info->HasInput(argument) || op_info->Input(argument).size() <= nth)
+    return false;
   return var->arg()->name == op_info->Input(argument)[nth];
 }
 


### PR DESCRIPTION
## 状态

- [x] review
- [x] CI
- [x] cherry-pick: https://github.com/PaddlePaddle/Paddle-Lite/pull/2318

## 出现找不到Bias的bug的原因

![image](https://user-images.githubusercontent.com/7320657/67938589-c23a8b80-fc0a-11e9-8e3d-ab5724c059b2.png)

具体log：

![image](https://user-images.githubusercontent.com/7320657/67939441-83a5d080-fc0c-11e9-8ac0-2ed0cb867730.png)


这个问题是因为，走到不符合的pattern时，对应的arg node找不到，不能没有判断就取（`Input(argument)`或`Output(argument)`），应先判断是否有这个arg node名字（`HasInput(XXX)`或`HasOutput(XXX)`），然后再取。

## conv_bn pass的潜在bug

1. pattern对于`conv_bias`最终应去除（AsIntermediate），与AsInput冲突。由`bn_bias`作为新的`conv_bias`
2. 取conv_bias前，应先判断是否存在`Bias`，加入了判断（`conv_op_desc->HasInput("Bias")`）。
