### PR TITLE
Enable the model tests precision checks

### DIFF
--- a/lite/api/test_googlenet_lite.cc
+++ b/lite/api/test_googlenet_lite.cc
@@ -59,8 +59,7 @@ TEST(CXXApi, test_lite_googlenet) {
             << ", warmup: " << FLAGS_warmup << ", repeats: " << FLAGS_repeats
             << ", spend " << (GetCurrentUS() - start) / FLAGS_repeats / 1000.0
             << " ms in average.";
-  // TODO(FrostML): open this check.
-  /*auto out = predictor->GetOutput(0);
+  auto out = predictor->GetOutput(0);
   std::vector<float> results(
       {0.00034298553, 0.0008200012, 0.0005046297, 0.000839279,
        0.00052616704, 0.0003447803, 0.0010877076, 0.00081762316,
@@ -72,7 +71,7 @@ TEST(CXXApi, test_lite_googlenet) {
   }
   ASSERT_EQ(out->shape().size(), 2);
   ASSERT_EQ(out->shape()[0], 1);
-  ASSERT_EQ(out->shape()[1], 1000);*/
+  ASSERT_EQ(out->shape()[1], 1000);
 }
 #endif
 }  // namespace lite

--- a/lite/api/test_inceptionv4_lite_x86.cc
+++ b/lite/api/test_inceptionv4_lite_x86.cc
@@ -59,8 +59,7 @@ TEST(InceptionV4, test_inceptionv4_lite_x86) {
             << ", repeats: " << FLAGS_repeats << ", spend "
             << (GetCurrentUS() - start) / FLAGS_repeats / 1000.0
             << " ms in average.";
-  // TODO(FrostML): open this check.
-  /*std::vector<std::vector<float>> results;
+  std::vector<std::vector<float>> results;
   // i = 1
   results.emplace_back(std::vector<float>(
       {0.0011684548,  0.0010390386,  0.0011301535,  0.0010133048,
@@ -81,7 +80,7 @@ TEST(InceptionV4, test_inceptionv4_lite_x86) {
                   results[i][j],
                   1e-6);
     }
-  }*/
+  }
 }
 
 }  // namespace lite

--- a/lite/api/test_mobilenetv1_lite_x86.cc
+++ b/lite/api/test_mobilenetv1_lite_x86.cc
@@ -59,8 +59,7 @@ TEST(Mobilenet_v1, test_mobilenetv1_lite_x86) {
             << ", repeats: " << FLAGS_repeats << ", spend "
             << (GetCurrentUS() - start) / FLAGS_repeats / 1000.0
             << " ms in average.";
-  // TODO(FrostML): open this check.
-  /*std::vector<std::vector<float>> results;
+  std::vector<std::vector<float>> results;
   // i = 1
   results.emplace_back(std::vector<float>(
       {0.00019130898, 9.467885e-05,  0.00015971427, 0.0003650665,
@@ -80,7 +79,7 @@ TEST(Mobilenet_v1, test_mobilenetv1_lite_x86) {
                   results[i][j],
                   1e-6);
     }
-  }*/
+  }
 }
 
 }  // namespace lite

--- a/lite/api/test_mobilenetv2_lite_x86.cc
+++ b/lite/api/test_mobilenetv2_lite_x86.cc
@@ -60,8 +60,7 @@ TEST(Mobilenet_v2, test_mobilenetv2_lite_x86) {
             << ", repeats: " << FLAGS_repeats << ", spend "
             << (GetCurrentUS() - start) / FLAGS_repeats / 1000.0
             << " ms in average.";
-  // TODO(FrostML): open this check.
-  /*std::vector<std::vector<float>> results;
+  std::vector<std::vector<float>> results;
   // i = 1
   results.emplace_back(std::vector<float>(
       {0.00017082224, 5.699624e-05,  0.000260885,   0.00016412718,
@@ -81,7 +80,7 @@ TEST(Mobilenet_v2, test_mobilenetv2_lite_x86) {
                   results[i][j],
                   1e-6);
     }
-  }*/
+  }
 }
 
 }  // namespace lite

--- a/lite/api/test_resnet50_lite_x86.cc
+++ b/lite/api/test_resnet50_lite_x86.cc
@@ -60,8 +60,7 @@ TEST(Resnet50, test_resnet50_lite_x86) {
             << ", spend " << (GetCurrentUS() - start) / FLAGS_repeats / 1000.0
             << " ms in average.";
 
-  // TODO(FrostML): open this check.
-  /*std::vector<std::vector<float>> results;
+  std::vector<std::vector<float>> results;
   // i = 1
   results.emplace_back(std::vector<float>(
       {0.00024139918, 0.00020566184, 0.00022418296, 0.00041731037,
@@ -81,7 +80,7 @@ TEST(Resnet50, test_resnet50_lite_x86) {
                   results[i][j],
                   1e-6);
     }
-  }*/
+  }
 }
 
 }  // namespace lite


### PR DESCRIPTION
Enable the model tests precision checks.
Model list:
resnet50, inceptionv4, googlenet, mobilenetv1, mobilenetv2