### PR TITLE
[Android] make log info display in android test=develop

### DIFF
--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -1039,7 +1039,7 @@ int DeviceInfo::Setup() {
               << ", max freq: " << max_freqs_[i]
               << ", min freq: " << min_freqs_[i]
               << ", cluster ID: " << cluster_ids_[core_ids_[i]]
-              << ", CPU ARCH: A" << archs_[i];
+              << ", CPU ARCH: A" << static_cast<int>(archs_[i]);
   }
   LOG(INFO) << "L1 DataCache size is: ";
   for (int i = 0; i < core_num_; ++i) {
@@ -1093,7 +1093,7 @@ void DeviceInfo::SetRunMode(lite_api::PowerMode mode, int thread_num) {
       RequestPowerRandLowMode(shift_num, thread_num);
       break;
     default:
-      LOG(FATAL) << "Unsupported power mode: " << mode;
+      LOG(FATAL) << "Unsupported power mode: " << static_cast<int>(mode);
       break;
   }
   if (active_ids_.empty()) {

--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -20,6 +20,7 @@ BUILD_DIR=$(pwd)
 OPTMODEL_DIR=""
 BUILD_TAILOR=OFF
 BUILD_CV=OFF
+SHUTDOWN_LOG=ON
 
 readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
 
@@ -93,7 +94,7 @@ function make_tiny_publish_so {
       -DWITH_TESTING=OFF \
       -DLITE_WITH_JAVA=$BUILD_JAVA \
       -DLITE_WITH_PYTHON=$BUILD_PYTHON \
-      -DLITE_SHUTDOWN_LOG=ON \
+      -DLITE_SHUTDOWN_LOG=$SHUTDOWN_LOG \
       -DLITE_ON_TINY_PUBLISH=ON \
       -DANDROID_STL_TYPE=$android_stl \
       -DLITE_BUILD_EXTRA=$BUILD_EXTRA \
@@ -136,7 +137,7 @@ function make_full_publish_so {
       -DWITH_TESTING=OFF \
       -DLITE_WITH_JAVA=$BUILD_JAVA \
       -DLITE_WITH_PYTHON=$BUILD_PYTHON \
-      -DLITE_SHUTDOWN_LOG=ON \
+      -DLITE_SHUTDOWN_LOG=$SHUTDOWN_LOG \
       -DANDROID_STL_TYPE=$android_stl \
       -DLITE_BUILD_EXTRA=$BUILD_EXTRA \
       -DLITE_WITH_CV=$BUILD_CV \
@@ -290,6 +291,7 @@ function print_usage {
     echo -e "   ./build.sh --arm_os=<os> --arm_abi=<abi> --arm_lang=<lang> test"
     echo
     echo -e "optional argument:"
+    echo -e "--shutdown_log: (OFF|ON); controls whether to shutdown log, default is ON"
     echo -e "--build_extra: (OFF|ON); controls whether to publish extra operators and kernels for (sequence-related model such as OCR or NLP)"
     echo -e "--build_python: (OFF|ON); controls whether to publish python api lib (ANDROID and IOS is not supported)"
     echo -e "--build_java: (OFF|ON); controls whether to publish java api lib (Only ANDROID is supported)"
@@ -364,6 +366,10 @@ function main {
                 ;;
             --build_tailor=*)
                 BUILD_TAILOR="${i#*=}"
+                shift
+                ;;
+            --shutdown_log=*)
+                SHUTDOWN_LOG="${i#*=}"
                 shift
                 ;;
             tiny_publish)

--- a/lite/utils/logging.cc
+++ b/lite/utils/logging.cc
@@ -43,10 +43,10 @@ void gen_log(STL::ostream& log_stream_,
   gettimeofday(&tv, NULL);
 
   // print date / time
-  log_stream_ << '[' << level << ' ' << std::setw(2) << 1 + tm_time.tm_mon
-              << '/' << std::setw(2) << tm_time.tm_mday << ' ' << std::setw(2)
-              << tm_time.tm_hour << ':' << std::setw(2) << tm_time.tm_min << ':'
-              << std::setw(2) << tm_time.tm_sec << '.' << std::setw(3)
+  log_stream_ << '[' << level << ' ' << STL::setw(2) << 1 + tm_time.tm_mon
+              << '/' << STL::setw(2) << tm_time.tm_mday << ' ' << STL::setw(2)
+              << tm_time.tm_hour << ':' << STL::setw(2) << tm_time.tm_min << ':'
+              << STL::setw(2) << tm_time.tm_sec << '.' << STL::setw(3)
               << tv.tv_usec / 1000 << " ";
 
   if (len > kMaxLen) {

--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -30,6 +30,18 @@
 #include <string>
 #include "lite/utils/replace_stl/stream.h"
 
+#ifdef LITE_WITH_ANDROID
+#include <android/log.h>
+// Android log macors
+#define ANDROID_LOG_TAG "Paddle-Lite"
+#define ANDROID_LOG_I(msg) \
+  __android_log_print(ANDROID_LOG_INFO, ANDROID_LOG_TAG, msg)
+#define ANDROID_LOG_W(msg) \
+  __android_log_print(ANDROID_LOG_WARN, ANDROID_LOG_TAG, msg)
+#define ANDROID_LOG_F(msg) \
+  __android_log_print(ANDROID_LOG_FATAL, ANDROID_LOG_TAG, msg)
+#endif
+
 // NOLINTFILE()
 
 // LOG()
@@ -93,11 +105,22 @@ class LogMessage {
              const char* func,
              int lineno,
              const char* level = "I") {
+    level_ = level;
     paddle::lite::gen_log(log_stream_, file, func, lineno, level);
   }
 
   ~LogMessage() {
     log_stream_ << '\n';
+#ifdef LITE_WITH_ANDROID
+    if (level_ == "I") {
+      ANDROID_LOG_I(log_stream_.str().c_str());
+    } else if (level_ == "W") {
+      ANDROID_LOG_W(log_stream_.str().c_str());
+    } else {
+      fprintf(stderr, "Unsupported log level: %s", level_.c_str());
+      assert(false);
+    }
+#endif
     fprintf(stderr, "%s", log_stream_.str().c_str());
   }
 
@@ -105,6 +128,7 @@ class LogMessage {
 
  protected:
   STL::stringstream log_stream_;
+  std::string level_;
 
   LogMessage(const LogMessage&) = delete;
   void operator=(const LogMessage&) = delete;
@@ -121,7 +145,11 @@ class LogMessageFatal : public LogMessage {
 
   ~LogMessageFatal() {
     log_stream_ << '\n';
+#ifdef LITE_WITH_ANDROID
+    ANDROID_LOG_F(log_stream_.str().c_str());
+#endif
     fprintf(stderr, "%s", log_stream_.str().c_str());
+
 #ifndef LITE_ON_TINY_PUBLISH
     abort();
 #else
@@ -152,6 +180,9 @@ class VLogMessage {
       return;
     }
     log_stream_ << '\n';
+#ifdef LITE_WITH_ANDROID
+    ANDROID_LOG_I(log_stream_.str().c_str());
+#endif
     fprintf(stderr, "%s", log_stream_.str().c_str());
   }
 

--- a/lite/utils/replace_stl/stream.cc
+++ b/lite/utils/replace_stl/stream.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "lite/utils/replace_stl/stream.h"
+#include <stdio.h>
 
 #ifdef LITE_ON_TINY_PUBLISH
 
@@ -20,93 +21,119 @@ namespace paddle {
 namespace lite {
 namespace replace_stl {
 
+void ostream::pad(const std::string& text) {
+  if (display_width_ > 0) {
+    if (display_width_ < text.size()) {
+      fprintf(stderr, "Replace STL IO display length less than text\n");
+      assert(false);
+    } else {
+      for (int i = 0; i < display_width_ - text.size(); ++i) {
+        data_.push_back(' ');
+      }
+      display_width_ = -1;
+    }
+  }
+}
+
 #ifdef LITE_SHUTDOWN_LOG
 #define ADD_DATA_AS_STRING(data_, obj_)
 #else
-#define ADD_DATA_AS_STRING(data_, obj_) data_ = data_ + std::to_string(obj_)
+#define ADD_DATA_AS_STRING(data_, obj_)    \
+  std::string text = std::to_string(obj_); \
+  pad(text);                               \
+  data_ = data_ + text;
+
 #endif
 
 template <>
 ostream& ostream::operator<<(const char* obj) {
-  _data = _data + std::string(obj);
+  data_ = data_ + std::string(obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const char& obj) {
-  _data = _data + obj;
+  data_ = data_ + obj;
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const std::string& obj) {
-  _data = _data + obj;
+  data_ = data_ + obj;
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const int16_t& obj) {
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const int& obj) {
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const bool& obj) {
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const long& obj) {  // NOLINT
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const long long& obj) {  // NOLINT
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const unsigned& obj) {
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const unsigned long& obj) {  // NOLINT
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const unsigned long long& obj) {  // NOLINT
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const float& obj) {
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const double& obj) {
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
   return *this;
 }
 
 template <>
 ostream& ostream::operator<<(const long double& obj) {
-  ADD_DATA_AS_STRING(_data, obj);
+  ADD_DATA_AS_STRING(data_, obj);
+  return *this;
+}
+
+template <>
+ostream& ostream::operator<<(const LiteIoWidth& obj) {
+  int width = obj.width;
+  assert(width > 0);
+  display_width_ = width;
   return *this;
 }
 

--- a/lite/utils/replace_stl/stream.h
+++ b/lite/utils/replace_stl/stream.h
@@ -29,18 +29,25 @@ namespace lite {
 
 namespace replace_stl {
 
+struct LiteIoWidth {
+  explicit LiteIoWidth(int value) : width(value) {}
+  int width;
+};
+
+static LiteIoWidth setw(int width) { return LiteIoWidth(width); }
+
 class ostream {
  public:
   ostream() {}
-  explicit ostream(const std::string& x) : _data(x) {}
+  explicit ostream(const std::string& x) : data_(x) {}
   ~ostream() {}
 
-  const char* c_str() { return _data.c_str(); }
+  const char* c_str() { return data_.c_str(); }
 
-  const std::string& str() { return _data; }
+  const std::string& str() { return data_; }
   const std::string& str(const std::string& x) {
-    _data = x;
-    return _data;
+    data_ = x;
+    return data_;
   }
 
   template <typename T>
@@ -50,7 +57,9 @@ class ostream {
   ostream& operator<<(const T* obj);
 
  private:
-  std::string _data;
+  void pad(const std::string& text);
+  std::string data_;
+  int display_width_{-1};  // -1 refers to no setting
 };
 
 class stringstream : public ostream {


### PR DESCRIPTION
1. 在打开`LITE_ON_TINY_PUBLISH`开关情况下，现在可以使用`LITE_SHUTDOWN_LOG=OFF`选项输出log，并且当编译目标平台为android时，相应的log会同步输出到android控制台
2. build.sh新增`--shutdown_log=(ON/OFF)`选项，用于控制发布lib是否启用log，可以使用类似`./lite/tools/build.sh --arm_os=android --arm_abi=armv8 --arm_lang=gcc --android_stl=c++_static --shutdown_log=OFF tiny_publish`的命令来发布带有log信息的lib
3、Android Studio中使用Logcat选项卡，level选择Verbose，过滤条件填入`Paddle-Lite`即可看到相应log输出，示例如下：
<img width="1352" alt="图片" src="https://user-images.githubusercontent.com/6871053/69120126-a91f4f00-0ad3-11ea-80e1-be5c70ffc0ee.png">
     命令行可以使用 adb logcat *:V | grep Paddle-Lite ，示例如下：
<img width="1427" alt="图片" src="https://user-images.githubusercontent.com/6871053/69120134-b6d4d480-0ad3-11ea-80c9-9010f2ee420a.png">

**注意：**
1、使用打开log以后会导致发布lib体积变大，当前develop版本1.5M->1.7M
2、打开log会拖慢执行速度
3、鉴于以上两点原因，`--shutdown_log=OFF`只建议在debug时使用，默认发布及线上服务应使用默认值`--shutdown_log=ON`