### PR TITLE
strip cxx_dynamic so in tiny_publish test=develop

### DIFF
--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -173,6 +173,8 @@ if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
                     )
                 add_dependencies(tiny_publish_cxx_lib paddle_light_api_shared)
                 add_dependencies(publish_inference tiny_publish_cxx_lib)
+                add_custom_command(TARGET tiny_publish_cxx_lib POST_BUILD
+                            COMMAND ${CMAKE_STRIP} "-s" ${INFER_LITE_PUBLISH_ROOT}/cxx/lib/libpaddle_light_api_shared.so)
             endif()
         endif()
     endif()


### PR DESCRIPTION
(解决tiny_publish编译时，cxx的so文件大约时java so文件3倍大小的问题)
Strip cxx_dynamic so in `tiny_publish` to make its size the same as that of  jni so.
The resulted performance is shown below :
![image](https://user-images.githubusercontent.com/45189361/69209328-c74b8480-0b91-11ea-895a-6014aeb7a4f8.png)
