### PR TITLE
【x86 third-party compiling accelerating】change url type from https: to http: to support curl of low edition

### DIFF
--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -17,8 +17,8 @@ if(WITH_AMD_GPU)
     ExternalProject_Add(
         extern_eigen3
         ${EXTERNAL_PROJECT_LOG_ARGS}
-        GIT_TAG         7cb2b6e5a4b4a1efe658abb215cd866c6fb2275e
-        URL             https://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2Fhipeigen-upstream-702834151eaebcf955fd09ed0ad83c06.zip
+        GIT_TAG
+        URL             http://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2Fhipeigen-upstream-702834151eaebcf955fd09ed0ad83c06.zip
         DOWNLOAD_DIR          ${EIGEN_SOURCECODE_DIR}
         DOWNLOAD_NO_PROGRESS  1
         PREFIX          ${EIGEN_SOURCE_DIR}
@@ -35,8 +35,8 @@ else()
         ${EXTERNAL_PROJECT_LOG_ARGS}
         # eigen on cuda9.1 missing header of math_funtions.hpp
         # https://stackoverflow.com/questions/43113508/math-functions-hpp-not-found-when-using-cuda-with-eigen
-        GIT_TAG         917060c364181f33a735dc023818d5a54f60e54c
-        URL             https://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2Feigen-git-mirror-master-9ab917e9db99f5907d086aa73d5f9103.zip
+        GIT_TAG
+        URL             http://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2Feigen-git-mirror-master-9ab917e9db99f5907d086aa73d5f9103.zip
         DOWNLOAD_DIR          ${EIGEN_SOURCECODE_DIR}
         DOWNLOAD_NO_PROGRESS  1
         PREFIX          ${EIGEN_SOURCE_DIR}

--- a/cmake/external/xbyak.cmake
+++ b/cmake/external/xbyak.cmake
@@ -40,7 +40,7 @@ ExternalProject_Add(
     ${EXTERNAL_PROJECT_LOG_ARGS}
     DEPENDS             ""
     GIT_TAG             "v5.661"  # Jul 26th
-    URL                 https://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2Fxbyak-5.66.zip
+    URL                 http://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2Fxbyak-5.66.zip
     DOWNLOAD_DIR        ${XBYAK_SOURCECODE_DIR}
     DOWNLOAD_NAME   "xbyak-5.66.zip"
     DOWNLOAD_NO_PROGRESS 1

--- a/cmake/external/xxhash.cmake
+++ b/cmake/external/xxhash.cmake
@@ -20,7 +20,7 @@ if(WIN32)
           extern_xxhash
           ${EXTERNAL_PROJECT_LOG_ARGS}
           GIT_TAG         "v0.6.5"
-          URL             https://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2FxxHash-0.6.5.zip 
+          URL             http://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2FxxHash-0.6.5.zip
           DOWNLOAD_DIR          ${XXHASH_SOURCECODE_DIR}
           DOWNLOAD_NAME   "xxHash-0.6.5.zip"
           DOWNLOAD_NO_PROGRESS  1
@@ -45,7 +45,7 @@ else()
       extern_xxhash
       ${EXTERNAL_PROJECT_LOG_ARGS}
       GIT_TAG         "v0.6.5"
-      URL             https://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2FxxHash-0.6.5.zip 
+      URL             http://paddle-inference-dist.bj.bcebos.com/PaddleLite_ThirdParty%2FxxHash-0.6.5.zip
       DOWNLOAD_DIR          ${XXHASH_SOURCECODE_DIR}
       DOWNLOAD_NO_PROGRESS  1
       PREFIX          ${XXHASH_SOURCE_DIR}


### PR DESCRIPTION
【x86 third-party compiling accelerating】

1.【x86编译加速(#2470)】中将x86编译相关第三方库改为直接从百度云下载源码，加速编译过程。但提供的网址为https格式，低版本的curl不支持https格式
2. 本PR中将下载网址改为http格式，使编译过程可以兼容低版本curl