### PR TITLE
【Fix Issue in X86 Compiling】add  headfile into beam_search.cc 

### DIFF
--- a/lite/backends/x86/math/beam_search.cc
+++ b/lite/backends/x86/math/beam_search.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "lite/backends/x86/math/beam_search.h"
 #include <algorithm>
+#include <cmath>
 #include <map>
 #include "lite/fluid/lod.h"
 


### PR DESCRIPTION
add `#include <cmath>` into `beam_search.cc`  to fix the problem that x86 compiling can't succeed in ubuntu 18.04