### PR TITLE
[profile] open profile on arm ci test=develop

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -210,6 +210,9 @@ void Predictor::Build(const lite_api::CxxConfig &config,
   const bool model_from_memory = config.model_from_memory();
   LOG(INFO) << "load from memory " << model_from_memory;
 
+  // Set predictor's name
+  name_ = config.name();
+
   Build(model_path,
         model_file,
         param_file,
@@ -273,6 +276,7 @@ void Predictor::Build(const cpp::ProgramDesc &desc,
 
 void Predictor::GenRuntimeProgram() {
   program_ = optimizer_.GenRuntimeProgram();
+  program_->set_name(name_);
   CHECK_EQ(exec_scope_, program_->exec_scope());
   program_generated_ = true;
 }

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -110,7 +110,12 @@ class LITE_API Predictor {
   void FeedVars(const std::vector<framework::Tensor>& tensors);
 #endif
 
+  void SetName(const std::string& name) { name_ = name; }
+
+  std::string name() { return name_; }
+
  private:
+  std::string name_;
   Optimizer optimizer_;
   cpp::ProgramDesc program_desc_;
   std::shared_ptr<Scope> scope_;

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -142,6 +142,7 @@ void LightPredictor::BuildRuntimeProgram(const cpp::ProgramDesc& prog) {
 
   CHECK(program.exec_scope());
   program_->set_exec_scope(program.exec_scope());
+  program_->set_name(name_);
 }
 
 }  // namespace lite

--- a/lite/api/light_api.h
+++ b/lite/api/light_api.h
@@ -40,6 +40,19 @@ namespace lite {
 class LITE_API LightPredictor {
  public:
   LightPredictor(
+      const lite_api::MobileConfig& config,
+      lite_api::LiteModelType model_type = lite_api::LiteModelType::kProtobuf) {
+    // Set predictor's name
+    name_ = config.name();
+
+    Build(config.model_dir(),
+          config.model_buffer(),
+          config.param_buffer(),
+          model_type,
+          config.model_from_memory());
+  }
+
+  LightPredictor(
       const std::string& model_dir,
       const std::string& model_buffer = "",
       const std::string& param_buffer = "",
@@ -78,7 +91,11 @@ class LITE_API LightPredictor {
 
   void BuildRuntimeProgram(const cpp::ProgramDesc& prog);
 
+  void SetName(const std::string& name) { name_ = name; }
+  std::string name() { return name_; }
+
  private:
+  std::string name_;
   std::shared_ptr<Scope> scope_;
   std::unique_ptr<RuntimeProgram> program_;
   cpp::ProgramDesc cpp_program_desc_;

--- a/lite/api/light_api_impl.cc
+++ b/lite/api/light_api_impl.cc
@@ -24,11 +24,7 @@ namespace lite {
 void LightPredictorImpl::Init(const lite_api::MobileConfig& config) {
   // LightPredictor Only support NaiveBuffer backend in publish lib
   raw_predictor_.reset(
-      new LightPredictor(config.model_dir(),
-                         config.model_buffer(),
-                         config.param_buffer(),
-                         config.model_from_memory(),
-                         lite_api::LiteModelType::kNaiveBuffer));
+      new LightPredictor(config, lite_api::LiteModelType::kNaiveBuffer));
 
   mode_ = config.power_mode();
   threads_ = config.threads();

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -164,7 +164,8 @@ std::shared_ptr<PaddlePredictor> CreatePaddlePredictor(const ConfigT &) {
   return std::shared_ptr<PaddlePredictor>();
 }
 
-ConfigBase::ConfigBase(PowerMode mode, int threads) {
+ConfigBase::ConfigBase(PowerMode mode, int threads, const std::string &name) {
+  name_ = name;
 #ifdef LITE_WITH_ARM
   lite::DeviceInfo::Init();
   lite::DeviceInfo::Global().SetRunMode(mode, threads);
@@ -188,6 +189,8 @@ void ConfigBase::set_threads(int threads) {
   threads_ = lite::DeviceInfo::Global().threads();
 #endif
 }
+
+void ConfigBase::set_name(const std::string &name) { name_ = name; }
 
 }  // namespace lite_api
 }  // namespace paddle

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -110,12 +110,15 @@ class LITE_API PaddlePredictor {
 
 /// Base class for all the configs.
 class LITE_API ConfigBase {
+  std::string name_{"predictor"};
   std::string model_dir_;
   int threads_{1};
   PowerMode mode_{LITE_POWER_NO_BIND};
 
  public:
-  explicit ConfigBase(PowerMode mode = LITE_POWER_NO_BIND, int threads = 1);
+  explicit ConfigBase(PowerMode mode = LITE_POWER_NO_BIND,
+                      int threads = 1,
+                      const std::string& name = "");
   // set Model_dir
   void set_model_dir(const std::string& x) { model_dir_ = x; }
   const std::string& model_dir() const { return model_dir_; }
@@ -125,6 +128,9 @@ class LITE_API ConfigBase {
   // set Thread
   void set_threads(int threads);
   int threads() const { return threads_; }
+  // set predictor name
+  void set_name(const std::string& name);
+  std::string name() const { return name_; }
 };
 
 /// CxxConfig is the config for the Full feature predictor.

--- a/lite/api/test_googlenet_lite.cc
+++ b/lite/api/test_googlenet_lite.cc
@@ -31,6 +31,7 @@ TEST(CXXApi, test_lite_googlenet) {
   config.set_model_dir(FLAGS_model_dir);
   config.set_valid_places({lite_api::Place{TARGET(kX86), PRECISION(kFloat)},
                            lite_api::Place{TARGET(kHost), PRECISION(kFloat)}});
+  config.set_name("GoogLeNet");
   auto predictor = lite_api::CreatePaddlePredictor(config);
 
   auto input_tensor = predictor->GetInput(0);

--- a/lite/core/profile/basic_profiler.cc
+++ b/lite/core/profile/basic_profiler.cc
@@ -16,13 +16,9 @@
 #include <map>
 #include <string>
 
-DEFINE_string(time_profile_file,
-              "time_profile.txt",
-              "Lite time profile information dump file");
-
-DEFINE_string(time_profile_summary_file,
-              "time_profile_summary.txt",
-              "Lite time profile summary information dump file");
+DEFINE_bool(dump_profile_to_file,
+            false,
+            "Dump profile infomation to file or not");
 
 DEFINE_string(time_profile_unit,
               "ms",
@@ -210,27 +206,29 @@ std::string BasicProfiler<TimerT>::summary_repr() const {
 
 template <typename TimerT>
 BasicProfiler<TimerT>::~BasicProfiler() {
-  LOG(INFO) << "Basic Profile dumps:";
+  LOG(INFO) << "[" << name_ << "] Basic Profile dumps:";
   auto b_repr = TimerT::basic_repr_header() + "\n" + basic_repr();
   LOG(INFO) << "\n" + b_repr;
 
-  // Dump to file
-  std::ofstream basic_ostream(FLAGS_time_profile_file);
-  CHECK(basic_ostream.is_open()) << "Open " << FLAGS_time_profile_file
-                                 << " failed";
-  basic_ostream.write(b_repr.c_str(), b_repr.size());
-  basic_ostream.close();
-
-  LOG(INFO) << "Summary Profile dumps:";
+  LOG(INFO) << "[" << name_ << "] Summary Profile dumps:";
   auto s_repr = summary_repr_header() + "\n" + summary_repr();
   LOG(INFO) << "\n" + s_repr;
 
-  // Dump to file
-  std::ofstream summary_ostream(FLAGS_time_profile_summary_file);
-  CHECK(summary_ostream.is_open()) << "Open " << FLAGS_time_profile_summary_file
-                                   << " failed";
-  summary_ostream.write(s_repr.c_str(), s_repr.size());
-  summary_ostream.close();
+  if (FLAGS_dump_profile_to_file) {
+    // Dump detail profile information to file
+    std::string detail_file = name_ + '_' + detail_file_;
+    std::ofstream basic_ostream(detail_file);
+    CHECK(basic_ostream.is_open()) << "Open " << detail_file << " failed";
+    basic_ostream.write(b_repr.c_str(), b_repr.size());
+    basic_ostream.close();
+
+    // Dump summary profile information to file
+    std::string summary_file = name_ + '_' + summary_file_;
+    std::ofstream summary_ostream(summary_file);
+    CHECK(summary_ostream.is_open()) << "Open " << summary_file << " failed";
+    summary_ostream.write(s_repr.c_str(), s_repr.size());
+    summary_ostream.close();
+  }
 }
 
 }  // namespace profile

--- a/lite/core/profile/basic_profiler_test.cc
+++ b/lite/core/profile/basic_profiler_test.cc
@@ -28,19 +28,19 @@ TEST(basic_record, init) {
 }
 
 TEST(basic_profile, real_latency) {
-  auto profile_id = profile::BasicProfiler<profile::BasicTimer>::Global()
-                        .NewRcd("test0")
-                        .id();
-  auto& profiler =
-      *BasicProfiler<profile::BasicTimer>::Global().mutable_record(profile_id);
+  std::shared_ptr<BasicProfiler<BasicTimer>> basic_profiler(
+      new BasicProfiler<BasicTimer>("default"));
+  ASSERT_EQ(basic_profiler->name(), "default");
+  auto profile_id = basic_profiler->NewRcd("test0").id();
+  auto& profiler = *basic_profiler->mutable_record(profile_id);
   // Set op info
   profiler.SetCustomInfo("op_type", "fc");
   profiler.SetCustomInfo("op_info", "size:5x6");
 
-  profile::ProfileBlock x(profile_id, "instruction");
+  profile::ProfileBlock x(profile_id, "instruction", basic_profiler);
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
-  profile::ProfileBlock y(profile_id, "kernel");
+  profile::ProfileBlock y(profile_id, "kernel", basic_profiler);
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -184,10 +184,9 @@ void Instruction::Run() {
   CHECK(op_) << "op null";
   CHECK(kernel_) << "kernel null";
 #ifdef LITE_WITH_PROFILE
-  if (profile_id_ >= 0) {
-    profile::ProfileBlock x(profile_id_, "instruction");
-  }
-#endif  // LITE_WITH_PROFILE
+  std::unique_ptr<profile::ProfileBlock> block(
+      profile_block_creater_("instruction"));
+#endif
   if (first_epoch_) {
     first_epoch_ = false;
     CHECK(op_->CheckShape());

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -542,6 +542,7 @@ function cmake_arm {
         -DLITE_WITH_CUDA=OFF \
         -DLITE_WITH_X86=OFF \
         -DLITE_WITH_ARM=ON \
+        -DLITE_WITH_PROFILE=ON \
         -DWITH_ARM_DOTPROD=ON   \
         -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=ON \
         -DWITH_TESTING=ON \


### PR DESCRIPTION
1、加入FLAGS_dump_profile_to_file控制是否将profile数据写入文件，默认为false.
2、由全局profiler切换成每个predictor持有一个profiler
3、加入set_name接口用于设置predictor名字，可以config中调用set_name设置，默认为”predictor“
4、predictor持有的profiler输出文件为<predictor name>_time_profile.txt与<predictor name>_time_profile_summary.txt.