### PR TITLE
modify ci_build.sh to support test with mobilephone test=develop

### DIFF
--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -142,7 +142,7 @@ if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
                 add_dependencies(publish_inference_cxx_lib bundle_full_api)
                 add_dependencies(publish_inference_cxx_lib bundle_light_api)
                 add_dependencies(publish_inference_cxx_lib test_model_bin)
-                if (ARM_TARGET_OS STREQUAL "android" OR ARM_TARGET_OS STREQUAL "armlinux")
+                if (ARM_TARGET_OS STREQUAL "android" OR ARM_TARGET_OS STREQUAL "armlinux" AND NOT WITH_TESTING)
                     add_dependencies(publish_inference_cxx_lib paddle_full_api_shared)
                     add_dependencies(publish_inference paddle_light_api_shared)
                     add_custom_command(TARGET publish_inference_cxx_lib

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -142,7 +142,7 @@ if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
                 add_dependencies(publish_inference_cxx_lib bundle_full_api)
                 add_dependencies(publish_inference_cxx_lib bundle_light_api)
                 add_dependencies(publish_inference_cxx_lib test_model_bin)
-                if (ARM_TARGET_OS STREQUAL "android" OR ARM_TARGET_OS STREQUAL "armlinux" AND NOT WITH_TESTING)
+                if (ARM_TARGET_OS STREQUAL "android" OR ARM_TARGET_OS STREQUAL "armlinux")
                     add_dependencies(publish_inference_cxx_lib paddle_full_api_shared)
                     add_dependencies(publish_inference paddle_light_api_shared)
                     add_custom_command(TARGET publish_inference_cxx_lib

--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -26,6 +26,12 @@ readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/t
 
 readonly workspace=$PWD
 
+# if operating in mac env, we should expand the maximum file num
+os_nmae=`uname -s`
+if [ ${os_nmae} == "Darwin" ]; then
+   ulimit -n 1024
+fi
+
 # for code gen, a source file is generated after a test, but is dependended by some targets in cmake.
 # here we fake an empty file to make cmake works.
 function prepare_workspace {

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -695,12 +695,12 @@ function build_test_arm_subtask_android {
     port_armv8=5554
     port_armv7=5556
 
-    if [ $USE_ADB_EMULATOR=="ON" ]; then
+    if [ $USE_ADB_EMULATOR == "ON" ]; then
        prepare_emulator $port_armv8 $port_armv7
        local portname_armv8=emulator-$port_armv8
        local portname_armv7=emulator-$port_armv7
    else
-       adb_devices=${adb devices |grep -v devices | grep device | awk -F " " 'print $1'}
+       adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " 'print $1')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
       $port_armv7
@@ -737,11 +737,11 @@ function build_test_arm_subtask_android {
 # sub-task2
 function build_test_arm_subtask_armlinux {
 
-    if [ $USE_ADB_EMULATOR =="ON" ]; then
+    if [ $USE_ADB_EMULATOR == "ON" ]; then
        prepare_emulator $port_armv8 $port_armv7
        local portname_armv8=emulator-$port_armv8
     else
-       adb_devices=${adb devices |grep -v devices | grep device | awk -F " " 'print $1'}
+       adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " 'print $1')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
     fi
@@ -783,11 +783,11 @@ function build_test_arm_subtask_model {
     cd $build_dir
     cmake_arm $os $abi $lang
     make $test_name -j$NUM_CORES_FOR_COMPILE
-    if [ $USE_ADB_EMULATOR =="ON" ]; then
+    if [ $USE_ADB_EMULATOR == "ON" ]; then
        prepare_emulator $port_armv8 $port_armv7
        local portname_armv8=emulator-$port_armv8
     else
-       adb_devices=${adb devices |grep -v devices | grep device | awk -F " " 'print $1'}
+       adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " 'print $1')
        local portname_armv8=${adb_devices[0]}
     fi
     # just test the model on armv8
@@ -843,11 +843,11 @@ function build_test_npu {
     # just test the model on armv8
     # prepare_emulator $port_armv8
 
-    if [ $USE_ADB_EMULATOR =="ON" ]; then
+    if [ $USE_ADB_EMULATOR == "ON" ]; then
        prepare_emulator $port_armv8 $port_armv7
        local portname_armv8=emulator-$port_armv8
     else
-       adb_devices=${adb devices |grep -v devices | grep device | awk -F " " 'print $1'}
+       adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " 'print $1')
        local portname_armv8=${adb_devices[0]}
     fi
 

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -709,8 +709,8 @@ function build_test_arm_subtask_android {
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-       abd shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
-       abd shell -s $portname_armv7 'rm -rf /data/local/tmp/*'
+       adb shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb shell -s $portname_armv7 'rm -rf /data/local/tmp/*'
     fi
 
     # job 1
@@ -751,8 +751,8 @@ function build_test_arm_subtask_armlinux {
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-       abd shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
-       abd shell -s $portname_armv7 'rm -rf /data/local/tmp/*'
+       adb shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb shell -s $portname_armv7 'rm -rf /data/local/tmp/*'
     fi
 
     cur=$PWD
@@ -798,7 +798,7 @@ function build_test_arm_subtask_model {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
-       abd shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
     fi
     # just test the model on armv8
     test_arm_model $test_name $portname_armv8 "./third_party/install/$model_name"
@@ -859,7 +859,7 @@ function build_test_npu {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
-       abd shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
     fi
 
 

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -708,6 +708,9 @@ function build_test_arm_subtask_android {
    else
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        echo  %system.agent.name%
+       index=${adbindex}
+       echo index
+       echo ${adb_devices[${index}]}
        agentname=%system.agent.name%
        agentNames="%system.agent.name%"
        if [ ${agentname} == "mobile_mac2" ]; then

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -587,7 +587,7 @@ function build_arm {
     build $TESTS_FILE
 
     # test publish inference lib
-    make publish_inference -j$NUM_CORES_FOR_COMPILE
+    # make publish_inference -j$NUM_CORES_FOR_COMPILE
 }
 
 # $1: ARM_TARGET_OS in "android"

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -18,6 +18,12 @@ NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}
 #whether to use emulator as adb devices,when USE_ADB_EMULATOR=ON we use emulator, else we will use connected mobile phone as adb devices.
 USE_ADB_EMULATOR=ON
 
+# if operating in mac env, we should expand the maximum file num
+os_nmae=`uname -s`
+if [ ${os_nmae} == "Darwin" ]; then
+   ulimit -n 1024
+fi
+
 function prepare_thirdparty {
     if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
         rm -rf $workspace/third-party

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -707,8 +707,13 @@ function build_test_arm_subtask_android {
        local portname_armv7=emulator-$port_armv7
    else
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
-       local portname_armv8=${adb_devices[0]}
-       local portname_armv7=${adb_devices[0]}
+       if [ %system.agent.name% == "mobile_mac2"]
+           local portname_armv8=${adb_devices[1]}
+           local portname_armv7=${adb_devices[1]}
+       else
+           local portname_armv8=${adb_devices[0]}
+           local portname_armv7=${adb_devices[0]}
+       fi
     fi
 
     # job 1

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -707,7 +707,7 @@ function build_test_arm_subtask_android {
        local portname_armv7=emulator-$port_armv7
    else
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
-       if [ %system.agent.name% == "mobile_mac2"]
+       if [ %system.agent.name% == "mobile_mac2"]; then
            local portname_armv8=${adb_devices[1]}
            local portname_armv7=${adb_devices[1]}
        else

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -201,7 +201,7 @@ function build_single {
 }
 
 function build {
-    make lite_compile_deps -j$NUM_CORES_FOR_COMPILE
+    make lite_compile_deps -j4
 
     # test publish inference lib
     # make publish_inference
@@ -706,7 +706,7 @@ function build_test_arm_subtask_android {
        local portname_armv8=emulator-$port_armv8
        local portname_armv7=emulator-$port_armv7
    else
-       adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
+       adb_devices=($(adb devices |grep -v devices |grep device | awk -F " " '{print $1}'))
        # adbindex is the env variable registered in ci agent to tell which mobile is to used as adb
        echo ${adb_devices[${adbindex}]}
        local portname_armv8=${adb_devices[${adbindex}]}

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -707,7 +707,16 @@ function build_test_arm_subtask_android {
        local portname_armv7=emulator-$port_armv7
    else
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
-       if [ %system.agent.name% == "mobile_mac2"]; then
+       echo  %system.agent.name%
+       agentname=%system.agent.name%
+       agentNames="%system.agent.name%"
+       if [ ${agentname} == "mobile_mac2" ]; then
+           echo ${agentname}
+       fi
+       if [ ${agentNames} == "mobile_mac2" ]; then
+           echo ${agentNames}
+       fi
+       if [ %system.agent.name% == "mobile_mac2" ]; then
            local portname_armv8=${adb_devices[1]}
            local portname_armv7=${adb_devices[1]}
        else

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -14,6 +14,10 @@ readonly workspace=$PWD
 
 NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}
 
+# global variables
+#whether to use emulator as adb devices,when USE_ADB_EMULATOR=ON we use emulator, else we will use connected mobile phone as adb devices.
+USE_ADB_EMULATOR=ON
+
 function prepare_thirdparty {
     if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
         rm -rf $workspace/third-party
@@ -87,20 +91,20 @@ function run_gen_code_test {
 
     # 2. run test_cxx_api_lite in emulator to get opt model 
     local test_cxx_api_lite_path=$(find ./lite -name test_cxx_api)
-    adb -s emulator-${port} push "./third_party/install/lite_naive_model" ${adb_work_dir}
-    adb -s emulator-${port} push ${test_cxx_api_lite_path} ${adb_work_dir}
-    adb -s emulator-${port} shell "${adb_work_dir}/test_cxx_api --model_dir=${adb_work_dir}/lite_naive_model --optimized_model=${adb_work_dir}/lite_naive_model_opt"
+    adb -s ${port} push "./third_party/install/lite_naive_model" ${adb_work_dir}
+    adb -s ${port} push ${test_cxx_api_lite_path} ${adb_work_dir}
+    adb -s ${port} shell "${adb_work_dir}/test_cxx_api --model_dir=${adb_work_dir}/lite_naive_model --optimized_model=${adb_work_dir}/lite_naive_model_opt"
 
     # 3. build test_gen_code
     make test_gen_code -j$NUM_CORES_FOR_COMPILE
 
     # 4. run test_gen_code_lite in emulator to get __generated_code__.cc
     local test_gen_code_lite_path=$(find ./lite -name test_gen_code)
-    adb -s emulator-${port} push ${test_gen_code_lite_path} ${adb_work_dir}
-    adb -s emulator-${port} shell "${adb_work_dir}/test_gen_code --optimized_model=${adb_work_dir}/lite_naive_model_opt --generated_code_file=${adb_work_dir}/${gen_code_file_name}"
+    adb -s ${port} push ${test_gen_code_lite_path} ${adb_work_dir}
+    adb -s ${port} shell "${adb_work_dir}/test_gen_code --optimized_model=${adb_work_dir}/lite_naive_model_opt --generated_code_file=${adb_work_dir}/${gen_code_file_name}"
 
     # 5. pull __generated_code__.cc down and mv to build real path
-    adb -s emulator-${port} pull "${adb_work_dir}/${gen_code_file_name}" .
+    adb -s ${port} pull "${adb_work_dir}/${gen_code_file_name}" .
     mv ${gen_code_file_name} ${gen_code_file_path}
 
     # 6. build test_generated_code
@@ -344,9 +348,9 @@ function test_arm_android {
 
     local testpath=$(find ./lite -name ${test_name})
 
-    adb -s emulator-${port} push ${testpath} ${adb_work_dir}
-    adb -s emulator-${port} shell "cd ${adb_work_dir} && ./${test_name}"
-    adb -s emulator-${port} shell "rm ${adb_work_dir}/${test_name}"
+    adb -s ${port} push ${testpath} ${adb_work_dir}
+    adb -s ${port} shell "cd ${adb_work_dir} && ./${test_name}"
+    adb -s ${port} shell "rm ${adb_work_dir}/${test_name}"
 }
 
 # test_npu <some_test_name> <adb_port_number>
@@ -373,20 +377,20 @@ function test_npu {
     local testpath=$(find ./lite -name ${test_name})
 
     # note the ai_ddk_lib is under paddle-lite root directory
-    adb -s emulator-${port} push ../ai_ddk_lib/lib64/* ${adb_work_dir}
-    adb -s emulator-${port} push ${testpath} ${adb_work_dir}
+    adb -s ${port} push ../ai_ddk_lib/lib64/* ${adb_work_dir}
+    adb -s ${port} push ${testpath} ${adb_work_dir}
 
     if [[ ${test_name} == "test_npu_pass" ]]; then
         local model_name=mobilenet_v1
-        adb -s emulator-${port} push "./third_party/install/${model_name}" ${adb_work_dir}
-        adb -s emulator-${port} shell "rm -rf ${adb_work_dir}/${model_name}_opt "
-        adb -s emulator-${port} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; export GLOG_v=0; ./${test_name} --model_dir=./${model_name} --optimized_model=./${model_name}_opt"
+        adb -s ${port} push "./third_party/install/${model_name}" ${adb_work_dir}
+        adb -s ${port} shell "rm -rf ${adb_work_dir}/${model_name}_opt "
+        adb -s ${port} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; export GLOG_v=0; ./${test_name} --model_dir=./${model_name} --optimized_model=./${model_name}_opt"
     elif [[ ${test_name} == "test_subgraph_pass" ]]; then
         local model_name=mobilenet_v1
-        adb -s emulator-${port} push "./third_party/install/${model_name}" ${adb_work_dir}
-        adb -s emulator-${port} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; export GLOG_v=0; ./${test_name} --model_dir=./${model_name}"
+        adb -s ${port} push "./third_party/install/${model_name}" ${adb_work_dir}
+        adb -s ${port} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; export GLOG_v=0; ./${test_name} --model_dir=./${model_name}"
     else
-        adb -s emulator-${port} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; ./${test_name}"
+        adb -s ${port} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; ./${test_name}"
     fi
 }
 
@@ -412,12 +416,12 @@ function test_npu_model {
     adb_work_dir="/data/local/tmp"
 
     testpath=$(find ./lite -name ${test_name})
-    adb -s emulator-${port} push ../ai_ddk_lib/lib64/* ${adb_work_dir}
-    adb -s emulator-${port} push ${model_dir} ${adb_work_dir}
-    adb -s emulator-${port} push ${testpath} ${adb_work_dir}
-    adb -s emulator-${port} shell chmod +x "${adb_work_dir}/${test_name}"
+    adb -s ${port} push ../ai_ddk_lib/lib64/* ${adb_work_dir}
+    adb -s ${port} push ${model_dir} ${adb_work_dir}
+    adb -s ${port} push ${testpath} ${adb_work_dir}
+    adb -s ${port} shell chmod +x "${adb_work_dir}/${test_name}"
     local adb_model_path="${adb_work_dir}/`basename ${model_dir}`"
-    adb -s emulator-${port} shell "export LD_LIBRARY_PATH=${adb_work_dir}; ${adb_work_dir}/${test_name} --model_dir=$adb_model_path"
+    adb -s ${port} shell "export LD_LIBRARY_PATH=${adb_work_dir}; ${adb_work_dir}/${test_name} --model_dir=$adb_model_path"
 }
 
 # test the inference high level api
@@ -432,10 +436,10 @@ function test_arm_api {
     local testpath=$(find ./lite -name ${test_name})
 
     arm_push_necessary_file $port $model_path $remote_model
-    adb -s emulator-${port} shell mkdir -p $remote_model
-    adb -s emulator-${port} push ${testpath} ${adb_work_dir}
-    adb -s emulator-${port} shell chmod +x "${adb_work_dir}/${test_name}"
-    adb -s emulator-${port} shell "${adb_work_dir}/${test_name} --model_dir $remote_model"
+    adb -s ${port} shell mkdir -p $remote_model
+    adb -s ${port} push ${testpath} ${adb_work_dir}
+    adb -s ${port} shell chmod +x "${adb_work_dir}/${test_name}"
+    adb -s ${port} shell "${adb_work_dir}/${test_name} --model_dir $remote_model"
 }
 
 function test_arm_model {
@@ -460,11 +464,11 @@ function test_arm_model {
     adb_work_dir="/data/local/tmp"
 
     testpath=$(find ./lite -name ${test_name})
-    adb -s emulator-${port} push ${model_dir} ${adb_work_dir}
-    adb -s emulator-${port} push ${testpath} ${adb_work_dir}
-    adb -s emulator-${port} shell chmod +x "${adb_work_dir}/${test_name}"
+    adb -s ${port} push ${model_dir} ${adb_work_dir}
+    adb -s ${port} push ${testpath} ${adb_work_dir}
+    adb -s ${port} shell chmod +x "${adb_work_dir}/${test_name}"
     local adb_model_path="${adb_work_dir}/`basename ${model_dir}`"
-    adb -s emulator-${port} shell "${adb_work_dir}/${test_name} --model_dir=$adb_model_path"
+    adb -s ${port} shell "${adb_work_dir}/${test_name} --model_dir=$adb_model_path"
 }
 
 # function _test_model_optimize_tool {
@@ -495,7 +499,7 @@ function _test_paddle_code_generator {
     local test_name=paddle_code_generator
     local remote_test=$ADB_WORK_DIR/$test_name
     local remote_model=$ADB_WORK_DIR/lite_naive_model.opt
-    local adb="adb -s emulator-${port}"
+    local adb="adb -s ${port}"
 
     make paddle_code_generator -j$NUM_CORES_FOR_COMPILE
     local test_path=$(find . -name $test_name | head -n1)
@@ -628,7 +632,7 @@ function test_arm {
     fi
 
     # prepare for CXXApi test
-    local adb="adb -s emulator-${port}"
+    local adb="adb -s ${port}"
     $adb shell mkdir -p /data/local/tmp/lite_naive_model_opt
 
     echo "test file: ${TESTS_FILE}"
@@ -665,7 +669,7 @@ function arm_push_necessary_file {
     local testpath=$2
     local adb_work_dir=$3
 
-    adb -s emulator-${port} push ${testpath} ${adb_work_dir}
+    adb -s ${port} push ${testpath} ${adb_work_dir}
 }
 
 function build_test_arm_opencl {
@@ -691,12 +695,21 @@ function build_test_arm_subtask_android {
     port_armv8=5554
     port_armv7=5556
 
-    prepare_emulator $port_armv8 $port_armv7
+    if [ $USE_ADB_EMULATOR=="ON" ]; then
+       prepare_emulator $port_armv8 $port_armv7
+       local portname_armv8=emulator-$port_armv8
+       local portname_armv7=emulator-$port_armv7
+   else
+       adb_devices=${adb devices |grep -v devices | grep device | awk -F " " 'print $1'}
+       local portname_armv8=${adb_devices[0]}
+       local portname_armv7=${adb_devices[0]}
+      $port_armv7
+    fi
 
     # job 1
     build_arm "android" "armv8" "gcc"
-    run_gen_code_test ${port_armv8}
-    test_arm "android" "armv8" "gcc" ${port_armv8}
+    run_gen_code_test ${portname_armv8}
+    test_arm "android" "armv8" "gcc" ${portname_armv8}
     cd -
 
     # job 2
@@ -707,8 +720,8 @@ function build_test_arm_subtask_android {
 
     # job 3
     build_arm "android" "armv7" "gcc"
-    run_gen_code_test ${port_armv7}
-    test_arm "android" "armv7" "gcc" ${port_armv7}
+    run_gen_code_test ${portname_armv7}
+    test_arm "android" "armv7" "gcc" ${portname_armv7}
     cd -
 
     # job 4
@@ -723,20 +736,30 @@ function build_test_arm_subtask_android {
 
 # sub-task2
 function build_test_arm_subtask_armlinux {
+
+    if [ $USE_ADB_EMULATOR =="ON" ]; then
+       prepare_emulator $port_armv8 $port_armv7
+       local portname_armv8=emulator-$port_armv8
+    else
+       adb_devices=${adb devices |grep -v devices | grep device | awk -F " " 'print $1'}
+       local portname_armv8=${adb_devices[0]}
+       local portname_armv7=${adb_devices[0]}
+    fi
+
     cur=$PWD
     # job 5
     build_arm "armlinux" "armv8" "gcc"
-    test_arm "armlinux" "armv8" "gcc" $port_armv8
+    test_arm "armlinux" "armv8" "gcc" $portname_armv8
     cd $cur
 
     # job 6
     build_arm "armlinux" "armv7" "gcc"
-    test_arm "armlinux" "armv7" "gcc" $port_armv8
+    test_arm "armlinux" "armv7" "gcc" $portname_armv8
     cd $cur
 
     # job 7
     build_arm "armlinux" "armv7hf" "gcc"
-    test_arm "armlinux" "armv7hf" "gcc" $port_armv8
+    test_arm "armlinux" "armv7hf" "gcc" $portname_armv8
     cd $cur
 
     echo "Done"
@@ -760,11 +783,15 @@ function build_test_arm_subtask_model {
     cd $build_dir
     cmake_arm $os $abi $lang
     make $test_name -j$NUM_CORES_FOR_COMPILE
-
-    prepare_emulator $port_armv8 $port_armv7
-
+    if [ $USE_ADB_EMULATOR =="ON" ]; then
+       prepare_emulator $port_armv8 $port_armv7
+       local portname_armv8=emulator-$port_armv8
+    else
+       adb_devices=${adb devices |grep -v devices | grep device | awk -F " " 'print $1'}
+       local portname_armv8=${adb_devices[0]}
+    fi
     # just test the model on armv8
-    test_arm_model $test_name $port_armv8 "./third_party/install/$model_name"
+    test_arm_model $test_name $portname_armv8 "./third_party/install/$model_name"
 
     adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done
     echo "Done"
@@ -780,11 +807,11 @@ function test_arm_predict_apis {
     local naive_model_path=$3
     local api_test_path=$(find . -name "test_apis")
     # the model is pushed to ./lite_naive_model
-    adb -s emulator-${port} push ${naive_model_path} ${workspace}
-    adb -s emulator-${port} push $api_test_path ${workspace}
+    adb -s ${port} push ${naive_model_path} ${workspace}
+    adb -s ${port} push $api_test_path ${workspace}
 
     # test cxx_api first to store the optimized model.
-    adb -s emulator-${port} shell ./test_apis --model_dir ./lite_naive_model --optimized_model ./lite_naive_model_opt
+    adb -s ${port} shell ./test_apis --model_dir ./lite_naive_model --optimized_model ./lite_naive_model_opt
 }
 
 
@@ -816,16 +843,25 @@ function build_test_npu {
     # just test the model on armv8
     # prepare_emulator $port_armv8
 
+    if [ $USE_ADB_EMULATOR =="ON" ]; then
+       prepare_emulator $port_armv8 $port_armv7
+       local portname_armv8=emulator-$port_armv8
+    else
+       adb_devices=${adb devices |grep -v devices | grep device | awk -F " " 'print $1'}
+       local portname_armv8=${adb_devices[0]}
+    fi
+
+
     if [[ "${test_name}x" != "x" ]]; then
-        test_npu ${test_name} ${port_armv8}
+        test_npu ${test_name} $portname_armv8}
     else
         # run_gen_code_test ${port_armv8}
         for _test in $(cat $TESTS_FILE | grep npu); do
-            test_npu $_test $port_armv8
+            test_npu $_test $portname_armv8
         done
     fi
 
-    test_npu_model $test_model_name $port_armv8 "./third_party/install/$model_name"
+    test_npu_model $test_model_name $portname_armv8 "./third_party/install/$model_name"
     cd -
     # just test the model on armv8
     # adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done
@@ -908,6 +944,10 @@ function main {
                 ;;
             --arm_port=*)
                 ARM_PORT="${i#*=}"
+                shift
+                ;;
+            --use_adb_emulator=*)
+                USE_ADB_EMULATOR="${i#*=}"
                 shift
                 ;;
             build)

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -40,6 +40,8 @@ function prepare_thirdparty {
 # prepare adb devices
 # if USE_ADB_EMULATOR=ON , we create adb emulator port_armv8 and port_armv7 for usage, else we will use actual mobilephone according to adbindex.
 function prepare_adb_devices {
+    port_armv8=5554
+    port_armv7=5556
     if [ $USE_ADB_EMULATOR == "ON" ]; then
        prepare_emulator $port_armv8 $port_armv7
        device_armv8=emulator-$port_armv8
@@ -106,7 +108,7 @@ function cmake_opencl {
 }
 
 function run_gen_code_test {
-    local port=$1
+    local device=$1
     local gen_code_file_name="__generated_code__.cc"
     local gen_code_file_path="./lite/gen_code/${gen_code_file_path}"
     local adb_work_dir="/data/local/tmp"
@@ -116,20 +118,20 @@ function run_gen_code_test {
 
     # 2. run test_cxx_api_lite in emulator to get opt model 
     local test_cxx_api_lite_path=$(find ./lite -name test_cxx_api)
-    adb -s ${port} push "./third_party/install/lite_naive_model" ${adb_work_dir}
-    adb -s ${port} push ${test_cxx_api_lite_path} ${adb_work_dir}
-    adb -s ${port} shell "${adb_work_dir}/test_cxx_api --model_dir=${adb_work_dir}/lite_naive_model --optimized_model=${adb_work_dir}/lite_naive_model_opt"
+    adb -s ${device} push "./third_party/install/lite_naive_model" ${adb_work_dir}
+    adb -s ${device} push ${test_cxx_api_lite_path} ${adb_work_dir}
+    adb -s ${device} shell "${adb_work_dir}/test_cxx_api --model_dir=${adb_work_dir}/lite_naive_model --optimized_model=${adb_work_dir}/lite_naive_model_opt"
 
     # 3. build test_gen_code
     make test_gen_code -j$NUM_CORES_FOR_COMPILE
 
     # 4. run test_gen_code_lite in emulator to get __generated_code__.cc
     local test_gen_code_lite_path=$(find ./lite -name test_gen_code)
-    adb -s ${port} push ${test_gen_code_lite_path} ${adb_work_dir}
-    adb -s ${port} shell "${adb_work_dir}/test_gen_code --optimized_model=${adb_work_dir}/lite_naive_model_opt --generated_code_file=${adb_work_dir}/${gen_code_file_name}"
+    adb -s ${device} push ${test_gen_code_lite_path} ${adb_work_dir}
+    adb -s ${device} shell "${adb_work_dir}/test_gen_code --optimized_model=${adb_work_dir}/lite_naive_model_opt --generated_code_file=${adb_work_dir}/${gen_code_file_name}"
 
     # 5. pull __generated_code__.cc down and mv to build real path
-    adb -s ${port} pull "${adb_work_dir}/${gen_code_file_name}" .
+    adb -s ${device} pull "${adb_work_dir}/${gen_code_file_name}" .
     mv ${gen_code_file_name} ${gen_code_file_path}
 
     # 6. build test_generated_code
@@ -353,12 +355,12 @@ function build_test_xpu {
 # test_arm_android <some_test_name> <adb_port_number>
 function test_arm_android {
     local test_name=$1
-    local port=$2
+    local device=$2
     if [[ "${test_name}x" == "x" ]]; then
         echo "test_name can not be empty"
         exit 1
     fi
-    if [[ "${port}x" == "x" ]]; then
+    if [[ "${device}x" == "x" ]]; then
         echo "Port can not be empty"
         exit 1
     fi
@@ -373,20 +375,20 @@ function test_arm_android {
 
     local testpath=$(find ./lite -name ${test_name})
 
-    adb -s ${port} push ${testpath} ${adb_work_dir}
-    adb -s ${port} shell "cd ${adb_work_dir} && ./${test_name}"
-    adb -s ${port} shell "rm ${adb_work_dir}/${test_name}"
+    adb -s ${device} push ${testpath} ${adb_work_dir}
+    adb -s ${device} shell "cd ${adb_work_dir} && ./${test_name}"
+    adb -s ${device} shell "rm ${adb_work_dir}/${test_name}"
 }
 
 # test_npu <some_test_name> <adb_port_number>
 function test_npu {
     local test_name=$1
-    local port=$2
+    local device=$2
     if [[ "${test_name}x" == "x" ]]; then
         echo "test_name can not be empty"
         exit 1
     fi
-    if [[ "${port}x" == "x" ]]; then
+    if [[ "${device}x" == "x" ]]; then
         echo "Port can not be empty"
         exit 1
     fi
@@ -402,33 +404,33 @@ function test_npu {
     local testpath=$(find ./lite -name ${test_name})
 
     # note the ai_ddk_lib is under paddle-lite root directory
-    adb -s ${port} push ../ai_ddk_lib/lib64/* ${adb_work_dir}
-    adb -s ${port} push ${testpath} ${adb_work_dir}
+    adb -s ${device} push ../ai_ddk_lib/lib64/* ${adb_work_dir}
+    adb -s ${device} push ${testpath} ${adb_work_dir}
 
     if [[ ${test_name} == "test_npu_pass" ]]; then
         local model_name=mobilenet_v1
-        adb -s ${port} push "./third_party/install/${model_name}" ${adb_work_dir}
-        adb -s ${port} shell "rm -rf ${adb_work_dir}/${model_name}_opt "
-        adb -s ${port} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; export GLOG_v=0; ./${test_name} --model_dir=./${model_name} --optimized_model=./${model_name}_opt"
+        adb -s ${device} push "./third_party/install/${model_name}" ${adb_work_dir}
+        adb -s ${device} shell "rm -rf ${adb_work_dir}/${model_name}_opt "
+        adb -s ${device} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; export GLOG_v=0; ./${test_name} --model_dir=./${model_name} --optimized_model=./${model_name}_opt"
     elif [[ ${test_name} == "test_subgraph_pass" ]]; then
         local model_name=mobilenet_v1
-        adb -s ${port} push "./third_party/install/${model_name}" ${adb_work_dir}
-        adb -s ${port} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; export GLOG_v=0; ./${test_name} --model_dir=./${model_name}"
+        adb -s ${device} push "./third_party/install/${model_name}" ${adb_work_dir}
+        adb -s ${device} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; export GLOG_v=0; ./${test_name} --model_dir=./${model_name}"
     else
-        adb -s ${port} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; ./${test_name}"
+        adb -s ${device} shell "cd ${adb_work_dir}; export LD_LIBRARY_PATH=./ ; ./${test_name}"
     fi
 }
 
 function test_npu_model {
     local test_name=$1
-    local port=$2
+    local device=$2
     local model_dir=$3
 
     if [[ "${test_name}x" == "x" ]]; then
         echo "test_name can not be empty"
         exit 1
     fi
-    if [[ "${port}x" == "x" ]]; then
+    if [[ "${device}x" == "x" ]]; then
         echo "Port can not be empty"
         exit 1
     fi
@@ -441,17 +443,17 @@ function test_npu_model {
     adb_work_dir="/data/local/tmp"
 
     testpath=$(find ./lite -name ${test_name})
-    adb -s ${port} push ../ai_ddk_lib/lib64/* ${adb_work_dir}
-    adb -s ${port} push ${model_dir} ${adb_work_dir}
-    adb -s ${port} push ${testpath} ${adb_work_dir}
-    adb -s ${port} shell chmod +x "${adb_work_dir}/${test_name}"
+    adb -s ${device} push ../ai_ddk_lib/lib64/* ${adb_work_dir}
+    adb -s ${device} push ${model_dir} ${adb_work_dir}
+    adb -s ${device} push ${testpath} ${adb_work_dir}
+    adb -s ${device} shell chmod +x "${adb_work_dir}/${test_name}"
     local adb_model_path="${adb_work_dir}/`basename ${model_dir}`"
-    adb -s ${port} shell "export LD_LIBRARY_PATH=${adb_work_dir}; ${adb_work_dir}/${test_name} --model_dir=$adb_model_path"
+    adb -s ${device} shell "export LD_LIBRARY_PATH=${adb_work_dir}; ${adb_work_dir}/${test_name} --model_dir=$adb_model_path"
 }
 
 # test the inference high level api
 function test_arm_api {
-    local port=$1
+    local device=$1
     local test_name="test_paddle_api"
 
     make $test_name -j$NUM_CORES_FOR_COMPILE
@@ -460,23 +462,23 @@ function test_arm_api {
     local remote_model=${adb_work_dir}/paddle_api
     local testpath=$(find ./lite -name ${test_name})
 
-    arm_push_necessary_file $port $model_path $remote_model
-    adb -s ${port} shell mkdir -p $remote_model
-    adb -s ${port} push ${testpath} ${adb_work_dir}
-    adb -s ${port} shell chmod +x "${adb_work_dir}/${test_name}"
-    adb -s ${port} shell "${adb_work_dir}/${test_name} --model_dir $remote_model"
+    arm_push_necessary_file $device $model_path $remote_model
+    adb -s ${device} shell mkdir -p $remote_model
+    adb -s ${device} push ${testpath} ${adb_work_dir}
+    adb -s ${device} shell chmod +x "${adb_work_dir}/${test_name}"
+    adb -s ${device} shell "${adb_work_dir}/${test_name} --model_dir $remote_model"
 }
 
 function test_arm_model {
     local test_name=$1
-    local port=$2
+    local device=$2
     local model_dir=$3
 
     if [[ "${test_name}x" == "x" ]]; then
         echo "test_name can not be empty"
         exit 1
     fi
-    if [[ "${port}x" == "x" ]]; then
+    if [[ "${device}x" == "x" ]]; then
         echo "Port can not be empty"
         exit 1
     fi
@@ -489,11 +491,11 @@ function test_arm_model {
     adb_work_dir="/data/local/tmp"
 
     testpath=$(find ./lite -name ${test_name})
-    adb -s ${port} push ${model_dir} ${adb_work_dir}
-    adb -s ${port} push ${testpath} ${adb_work_dir}
-    adb -s ${port} shell chmod +x "${adb_work_dir}/${test_name}"
+    adb -s ${device} push ${model_dir} ${adb_work_dir}
+    adb -s ${device} push ${testpath} ${adb_work_dir}
+    adb -s ${device} shell chmod +x "${adb_work_dir}/${test_name}"
     local adb_model_path="${adb_work_dir}/`basename ${model_dir}`"
-    adb -s ${port} shell "${adb_work_dir}/${test_name} --model_dir=$adb_model_path"
+    adb -s ${device} shell "${adb_work_dir}/${test_name} --model_dir=$adb_model_path"
 }
 
 # function _test_model_optimize_tool {
@@ -520,11 +522,11 @@ function test_model_optimize_tool_compile {
 }
 
 function _test_paddle_code_generator {
-    local port=$1
+    local device=$1
     local test_name=paddle_code_generator
     local remote_test=$ADB_WORK_DIR/$test_name
     local remote_model=$ADB_WORK_DIR/lite_naive_model.opt
-    local adb="adb -s ${port}"
+    local adb="adb -s ${device}"
 
     make paddle_code_generator -j$NUM_CORES_FOR_COMPILE
     local test_path=$(find . -name $test_name | head -n1)
@@ -641,7 +643,7 @@ function test_arm {
     os=$1
     abi=$2
     lang=$3
-    port=$4
+    device=$4
 
     if [[ ${os} == "armlinux" ]]; then
         # TODO(hongming): enable test armlinux on armv8, armv7 and armv7hf
@@ -655,16 +657,16 @@ function test_arm {
     fi
 
     # prepare for CXXApi test
-    local adb="adb -s ${port}"
+    local adb="adb -s ${device}"
     $adb shell mkdir -p /data/local/tmp/lite_naive_model_opt
 
     echo "test file: ${TESTS_FILE}"
     for _test in $(cat $TESTS_FILE); do
-        test_arm_android $_test $port
+        test_arm_android $_test $device
     done
 
     # test finally
-    test_arm_api $port
+    test_arm_api $device
 
     # _test_model_optimize_tool $port
     # _test_paddle_code_generator $port
@@ -688,11 +690,11 @@ function prepare_emulator {
 }
 
 function arm_push_necessary_file {
-    local port=$1
+    local device=$1
     local testpath=$2
     local adb_work_dir=$3
 
-    adb -s ${port} push ${testpath} ${adb_work_dir}
+    adb -s ${device} push ${testpath} ${adb_work_dir}
 }
 
 function build_test_arm_opencl {
@@ -715,9 +717,6 @@ function build_test_arm_opencl {
 function build_test_arm_subtask_android {
     ########################################################################
     # job 1-4 must be in one runner
-    port_armv8=5554
-    port_armv7=5556
-
     prepare_adb_devices
 
     # job 1
@@ -775,8 +774,6 @@ function build_test_arm_subtask_armlinux {
 
 # sub-task-model
 function build_test_arm_subtask_model {
-    local port_armv8=5554
-    local port_armv7=5556
     # We just test following single one environment to limit the CI time.
     local os=android
     local abi=armv8
@@ -810,16 +807,16 @@ function build_test_arm_subtask_model {
 
 # this test load a model, optimize it and check the prediction result of both cxx and light APIS.
 function test_arm_predict_apis {
-    local port=$1
+    local device=$1
     local workspace=$2
     local naive_model_path=$3
     local api_test_path=$(find . -name "test_apis")
     # the model is pushed to ./lite_naive_model
-    adb -s ${port} push ${naive_model_path} ${workspace}
-    adb -s ${port} push $api_test_path ${workspace}
+    adb -s ${device} push ${naive_model_path} ${workspace}
+    adb -s ${device} push $api_test_path ${workspace}
 
     # test cxx_api first to store the optimized model.
-    adb -s ${port} shell ./test_apis --model_dir ./lite_naive_model --optimized_model ./lite_naive_model_opt
+    adb -s ${device} shell ./test_apis --model_dir ./lite_naive_model --optimized_model ./lite_naive_model_opt
 }
 
 
@@ -827,9 +824,6 @@ function test_arm_predict_apis {
 function build_test_arm {
     ########################################################################
     # job 1-4 must be in one runner
-    port_armv8=5554
-    port_armv7=5556
-
     build_test_arm_subtask_android
     build_test_arm_subtask_armlinux
 }

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -709,8 +709,13 @@ function build_test_arm_subtask_android {
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        echo  %system.agent.name%
        index=${adbindex}
-       echo index
+       echo $index
        echo ${adb_devices[${index}]}
+       echo ${adb_devices[$index]}
+       echo ${adb_devices[${adbindex}]}
+       echo ${adb_devices[$adbindex]}
+       echo "test"
+       echo ${adb_devices[0]}
        agentname=%system.agent.name%
        agentNames="%system.agent.name%"
        if [ ${agentname} == "mobile_mac2" ]; then

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -738,6 +738,7 @@ function build_test_arm_subtask_android {
     #run_gen_code_test ${port_armv7}
     #test_arm "android" "armv7" "clang" ${port_armv7}
     #cd -
+
     if [ $USE_ADB_EMULATOR == "ON" ]; then
         adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done
     fi

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -709,8 +709,8 @@ function build_test_arm_subtask_android {
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-       adb -s shell $portname_armv8 'rm -rf /data/local/tmp/*'
-       adb -s shell $portname_armv7 'rm -rf /data/local/tmp/*'
+       adb -s $portname_armv8 shell 'rm -rf /data/local/tmp/*'
+       adb -s $portname_armv7 shell 'rm -rf /data/local/tmp/*'
     fi
 
     # job 1
@@ -751,8 +751,8 @@ function build_test_arm_subtask_armlinux {
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-       adb -s shell $portname_armv8 'rm -rf /data/local/tmp/*'
-       adb -s shell $portname_armv7 'rm -rf /data/local/tmp/*'
+       adb -s $portname_armv8 shell 'rm -rf /data/local/tmp/*'
+       adb -s $portname_armv7 shell 'rm -rf /data/local/tmp/*'
     fi
 
     cur=$PWD
@@ -798,7 +798,7 @@ function build_test_arm_subtask_model {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
-       adb -s shell $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb -s $portname_armv8 shell 'rm -rf /data/local/tmp/*'
     fi
     # just test the model on armv8
     test_arm_model $test_name $portname_armv8 "./third_party/install/$model_name"
@@ -859,7 +859,7 @@ function build_test_npu {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
-       adb -s shell $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb -s $portname_armv8 shell 'rm -rf /data/local/tmp/*'
     fi
 
 

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -700,7 +700,7 @@ function build_test_arm_subtask_android {
        local portname_armv8=emulator-$port_armv8
        local portname_armv7=emulator-$port_armv7
    else
-       adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " 'print $1')
+       adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
       $port_armv7
@@ -741,7 +741,7 @@ function build_test_arm_subtask_armlinux {
        prepare_emulator $port_armv8 $port_armv7
        local portname_armv8=emulator-$port_armv8
     else
-       adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " 'print $1')
+       adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
     fi
@@ -787,7 +787,7 @@ function build_test_arm_subtask_model {
        prepare_emulator $port_armv8 $port_armv7
        local portname_armv8=emulator-$port_armv8
     else
-       adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " 'print $1')
+       adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
     fi
     # just test the model on armv8
@@ -847,7 +847,7 @@ function build_test_npu {
        prepare_emulator $port_armv8 $port_armv7
        local portname_armv8=emulator-$port_armv8
     else
-       adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " 'print $1')
+       adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
     fi
 

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -709,6 +709,8 @@ function build_test_arm_subtask_android {
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
+       abd shell -s portname_armv8 'rm -rf /data/local/tmp/*'
+       abd shell -s portname_armv7 'rm -rf /data/local/tmp/*'
     fi
 
     # job 1
@@ -749,6 +751,8 @@ function build_test_arm_subtask_armlinux {
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
+       abd shell -s portname_armv8 'rm -rf /data/local/tmp/*'
+       abd shell -s portname_armv7 'rm -rf /data/local/tmp/*'
     fi
 
     cur=$PWD
@@ -794,6 +798,7 @@ function build_test_arm_subtask_model {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
+       abd shell -s portname_armv8 'rm -rf /data/local/tmp/*'
     fi
     # just test the model on armv8
     test_arm_model $test_name $portname_armv8 "./third_party/install/$model_name"
@@ -854,6 +859,7 @@ function build_test_npu {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
+       abd shell -s portname_armv8 'rm -rf /data/local/tmp/*'
     fi
 
 

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -709,8 +709,8 @@ function build_test_arm_subtask_android {
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-       abd shell -s portname_armv8 'rm -rf /data/local/tmp/*'
-       abd shell -s portname_armv7 'rm -rf /data/local/tmp/*'
+       abd shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
+       abd shell -s $portname_armv7 'rm -rf /data/local/tmp/*'
     fi
 
     # job 1
@@ -751,8 +751,8 @@ function build_test_arm_subtask_armlinux {
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-       abd shell -s portname_armv8 'rm -rf /data/local/tmp/*'
-       abd shell -s portname_armv7 'rm -rf /data/local/tmp/*'
+       abd shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
+       abd shell -s $portname_armv7 'rm -rf /data/local/tmp/*'
     fi
 
     cur=$PWD
@@ -798,7 +798,7 @@ function build_test_arm_subtask_model {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
-       abd shell -s portname_armv8 'rm -rf /data/local/tmp/*'
+       abd shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
     fi
     # just test the model on armv8
     test_arm_model $test_name $portname_armv8 "./third_party/install/$model_name"
@@ -859,12 +859,12 @@ function build_test_npu {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
-       abd shell -s portname_armv8 'rm -rf /data/local/tmp/*'
+       abd shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
     fi
 
 
     if [[ "${test_name}x" != "x" ]]; then
-        test_npu ${test_name} $portname_armv8}
+        test_npu ${test_name} ${portname_armv8}
     else
         # run_gen_code_test ${port_armv8}
         for _test in $(cat $TESTS_FILE | grep npu); do

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -703,7 +703,6 @@ function build_test_arm_subtask_android {
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-      $port_armv7
     fi
 
     # job 1

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -587,7 +587,7 @@ function build_arm {
     build $TESTS_FILE
 
     # test publish inference lib
-    make publish_inference
+    make publish_inference -j$NUM_CORES_FOR_COMPILE
 }
 
 # $1: ARM_TARGET_OS in "android"

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -709,8 +709,8 @@ function build_test_arm_subtask_android {
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-       adb shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
-       adb shell -s $portname_armv7 'rm -rf /data/local/tmp/*'
+       adb -s shell $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb -s shell $portname_armv7 'rm -rf /data/local/tmp/*'
     fi
 
     # job 1
@@ -751,8 +751,8 @@ function build_test_arm_subtask_armlinux {
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-       adb shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
-       adb shell -s $portname_armv7 'rm -rf /data/local/tmp/*'
+       adb -s shell $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb -s shell $portname_armv7 'rm -rf /data/local/tmp/*'
     fi
 
     cur=$PWD
@@ -798,7 +798,7 @@ function build_test_arm_subtask_model {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
-       adb shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb -s shell $portname_armv8 'rm -rf /data/local/tmp/*'
     fi
     # just test the model on armv8
     test_arm_model $test_name $portname_armv8 "./third_party/install/$model_name"
@@ -859,7 +859,7 @@ function build_test_npu {
     else
        adb_devices=$(adb devices |grep -v devices | grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
-       adb shell -s $portname_armv8 'rm -rf /data/local/tmp/*'
+       adb -s shell $portname_armv8 'rm -rf /data/local/tmp/*'
     fi
 
 

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -707,30 +707,10 @@ function build_test_arm_subtask_android {
        local portname_armv7=emulator-$port_armv7
    else
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
-       echo  %system.agent.name%
-       index=${adbindex}
-       echo $index
-       echo ${adb_devices[${index}]}
-       echo ${adb_devices[$index]}
+       # adbindex is the env variable registered in ci agent to tell which mobile is to used as adb
        echo ${adb_devices[${adbindex}]}
-       echo ${adb_devices[$adbindex]}
-       echo "test"
-       echo ${adb_devices[0]}
-       agentname=%system.agent.name%
-       agentNames="%system.agent.name%"
-       if [ ${agentname} == "mobile_mac2" ]; then
-           echo ${agentname}
-       fi
-       if [ ${agentNames} == "mobile_mac2" ]; then
-           echo ${agentNames}
-       fi
-       if [ %system.agent.name% == "mobile_mac2" ]; then
-           local portname_armv8=${adb_devices[1]}
-           local portname_armv7=${adb_devices[1]}
-       else
-           local portname_armv8=${adb_devices[0]}
-           local portname_armv7=${adb_devices[0]}
-       fi
+       local portname_armv8=${adb_devices[${adbindex}]}
+       local portname_armv7=${adb_devices[${adbindex}]}
     fi
 
     # job 1

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -709,13 +709,11 @@ function build_test_arm_subtask_android {
        adb_devices=$(adb devices |grep -v devices |grep device | awk -F " " '{print $1}')
        local portname_armv8=${adb_devices[0]}
        local portname_armv7=${adb_devices[0]}
-       adb -s $portname_armv8 shell 'rm -rf /data/local/tmp/*'
-       adb -s $portname_armv7 shell 'rm -rf /data/local/tmp/*'
     fi
 
     # job 1
     build_arm "android" "armv8" "gcc"
-    adb shell 'rm -rf /data/local/tmp/*'
+    adb -s $portname_armv8 shell 'rm -rf /data/local/tmp/*'
     run_gen_code_test ${portname_armv8}
     test_arm "android" "armv8" "gcc" ${portname_armv8}
     cd -
@@ -728,7 +726,7 @@ function build_test_arm_subtask_android {
 
     # job 3
     build_arm "android" "armv7" "gcc"
-    adb shell 'rm -rf /data/local/tmp/*'
+    adb -s $portname_armv7 shell 'rm -rf /data/local/tmp/*'
     run_gen_code_test ${portname_armv7}
     test_arm "android" "armv7" "gcc" ${portname_armv7}
     cd -

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -715,6 +715,7 @@ function build_test_arm_subtask_android {
 
     # job 1
     build_arm "android" "armv8" "gcc"
+    adb shell 'rm -rf /data/local/tmp/*'
     run_gen_code_test ${portname_armv8}
     test_arm "android" "armv8" "gcc" ${portname_armv8}
     cd -
@@ -727,6 +728,7 @@ function build_test_arm_subtask_android {
 
     # job 3
     build_arm "android" "armv7" "gcc"
+    adb shell 'rm -rf /data/local/tmp/*'
     run_gen_code_test ${portname_armv7}
     test_arm "android" "armv7" "gcc" ${portname_armv7}
     cd -
@@ -736,8 +738,9 @@ function build_test_arm_subtask_android {
     #run_gen_code_test ${port_armv7}
     #test_arm "android" "armv7" "clang" ${port_armv7}
     #cd -
-
-    adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done
+    if [ $USE_ADB_EMULATOR == "ON" ]; then
+        adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done
+    fi
     echo "Done"
 }
 


### PR DESCRIPTION
modify ci_build.sh to support test with mobilephone
在 ci_build.sh ，可以加上选项  ’--choose_adb_emulator=False‘    来选择使用与主机连接的物理机当作abd 设备