### PR TITLE
exclude x86_target of fc_fusion_pass test=develop

### DIFF
--- a/lite/core/mir/fusion/fc_fuse_pass.cc
+++ b/lite/core/mir/fusion/fc_fuse_pass.cc
@@ -33,4 +33,5 @@ void FcFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 
 REGISTER_MIR_PASS(lite_fc_fuse_pass, paddle::lite::mir::FcFusePass)
     .BindTargets({TARGET(kAny)})
+    .ExcludeTargets({TARGET(kX86)})
     .BindKernel("fc");


### PR DESCRIPTION
解决问题：x86编译的预测库因为缺少FC kernel无法运行Fc_fuse_pass，导致很多基础模型无法使用x86预测库
本PR解决方法：将`Target(kX86)`移出Fc_fuse_pass的作用域，x86预测库不使用fc_fuse_pass，但是可以正常运行基础model