### PR TITLE
fix type_target_cast pass. Support only once copy for multiple-use args

### DIFF
--- a/lite/core/mir/type_target_cast_pass.h
+++ b/lite/core/mir/type_target_cast_pass.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "lite/core/mir/pass.h"
 #include "lite/core/op_registry.h"
@@ -44,13 +45,17 @@ class TypeTargetTransformPass : public ProgramPass {
  public:
   void Apply(const std::unique_ptr<SSAGraph>& graph) override;
 
-  void ComplementInputs(SSAGraph* graph, Node* inst_node, Node* in);
+  void ComplementInputs(SSAGraph* graph,
+                        Node* inst_node,
+                        Node* in,
+                        std::unordered_map<std::string, Node*>* copied_nodes);
 
   void AddIoCopyInst(const Type& from,
                      const Type& to,
                      Node* in,
                      SSAGraph* graph,
                      Node* inst_node,
+                     std::unordered_map<std::string, Node*>* copied_nodes,
                      const std::vector<Place>& valid_places);
 
   void SetValidPlaces(const std::vector<Place>& valid_places);
@@ -58,6 +63,11 @@ class TypeTargetTransformPass : public ProgramPass {
   const std::vector<Place>& valid_places() const { return valid_places_; }
 
  private:
+  void UpdateInstNode(Node* in,
+                      SSAGraph* graph,
+                      Node* inst_node,
+                      std::string io_copy_output_name);
+
   std::vector<Place> valid_places_;
 };
 


### PR DESCRIPTION
- For multiple-use parameters, only copy once.

- Previous strategy
![image](https://user-images.githubusercontent.com/26377421/70307687-b1ea8180-1844-11ea-8d78-debba2b9b614.png)
- fix
![image](https://user-images.githubusercontent.com/26377421/70307727-c62e7e80-1844-11ea-8b8b-cafd144c2916.png)
