### PR TITLE
modify ci_build.sh to ensure the num of adb devices on mac ci

### DIFF
--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -47,10 +47,10 @@ function prepare_adb_devices {
        device_armv8=emulator-$port_armv8
        device_armv7=emulator-$port_armv7
     else
-       adb_devices_num=($(adb devices |grep -v devices |grep device | awk -F " " '{print $1}'))
+       adb_devices=($(adb devices |grep -v devices |grep device | awk -F " " '{print $1}'))
        # adbindex is the env variable registered in ci agent to tell which mobile is to used as adb
        adbindex_pos=`expr ${adbindex} + 1`
-       if [ ${adbindex_pos} -gt ${adb_devices_num} ]; then
+       if [ ${adbindex_pos} -gt ${#adb_devices[@]} ]; then
            echo -e "Error: the adb devices on ci agent are not enough, at least ${adbindex_pos} adb devices are needed."
            exit 1
        fi


### PR DESCRIPTION
ci_build.sh修改：
当从Mac CI设备运行CI时，读取当前设备的adb设备总数，判断adb设备数量是否满足要求