### PR TITLE
update profiler, test=develop

### DIFF
--- a/lite/api/model_test.cc
+++ b/lite/api/model_test.cc
@@ -72,10 +72,6 @@ void Run(const std::vector<std::vector<int64_t>>& input_shapes,
          const int thread_num,
          const int repeat,
          const int warmup_times = 0) {
-#ifdef LITE_WITH_PROFILE
-  lite::profile::BasicProfiler<lite::profile::BasicTimer>::Global().SetWarmup(
-      warmup_times);
-#endif
   lite_api::MobileConfig config;
   config.set_model_dir(model_dir);
   config.set_power_mode(power_mode);

--- a/lite/core/profile/profiler.cc
+++ b/lite/core/profile/profiler.cc
@@ -21,6 +21,13 @@ namespace paddle {
 namespace lite {
 namespace profile {
 
+namespace {
+  auto op_comp = [](const OpCharacter& c1, const OpCharacter& c2) {
+    return (c1.target < c2.target) || (c1.op_type < c2.op_type) ||
+           (c1.kernel_name < c2.kernel_name) || (c1.remark < c2.remark);
+  };
+}
+
 int Profiler::NewTimer(const OpCharacter& ch) {
   StatisUnit unit;
   unit.character = ch;
@@ -51,24 +58,28 @@ float Profiler::StopTiming(const int index, KernelContext* ctx) {
 }
 
 std::string Profiler::Summary(bool concise) {
+  using std::setw;
+  using std::left;
+  using std::fixed;
   STL::stringstream ss;
-  auto cout_title = [&ss](const std::string& title, const std::string& name) {
-    // clang-format off
-    ss << "===== " << title << ": " << name << " =====" << std::endl;
-    ss << std::setw(25) << std::left << "Operator Type" \
-       << std::setw(40) << std::left << "Kernel Name"   \
-       << std::setw(10) << std::left << "Remark"        \
-       << std::setw(10) << std::left << "Avg (ms)"      \
-       << std::setw(10) << std::left << "Min (ms)"      \
-       << std::setw(10) << std::left << "Max (ms)"      \
-       << std::endl;
-    // clang-format on
-  };
+  std::string title;
+  // Title.
   if (concise) {
-    auto op_comp = [](const OpCharacter& c1, const OpCharacter& c2) {
-      return (c1.target < c2.target) || (c1.op_type < c2.op_type) ||
-             (c1.kernel_name < c2.kernel_name) || (c1.remark < c2.remark);
-    };
+    ss << "Timing cycle = " << units_.front().timer->LapTimes().Size() << std::endl;
+    ss << "===== Concise Profiler Summary: " << name_ << " =====" << std::endl;
+  } else {
+    ss << "===== Detailed Profiler Summary: " << name_ << " =====" << std::endl;
+  }
+  ss << setw(25) << left << "Operator Type" \
+     << " " << setw(40) << left << "Kernel Name"   \
+     << " " << setw(12) << left << "Remark"        \
+     << " " << setw(12) << left << "Avg (ms)"      \
+     << " " << setw(12) << left << "Min (ms)"      \
+     << " " << setw(12) << left << "Max (ms)"      \
+     << " " << setw(12) << left << "Last (ms)"     \
+     << std::endl;
+  // Profile information.
+  if (concise) {
     std::map<OpCharacter, TimeInfo, decltype(op_comp)> summary(op_comp);
     for (auto& unit : units_) {
       auto ch = summary.find(unit.character);
@@ -83,28 +94,27 @@ std::string Profiler::Summary(bool concise) {
         summary.insert({unit.character, info});
       }
     }
-    cout_title("Concise Profiler Summary", name_);
     for (const auto& item : summary) {
       // clang-format off
-      ss << std::setw(25) << std::left << item.first.op_type      \
-         << std::setw(40) << std::left << item.first.kernel_name  \
-         << std::setw(10) << std::left << item.first.remark       \
-         << std::setw(10) << std::left << item.second.avg         \
-         << std::setw(10) << std::left << item.second.min         \
-         << std::setw(10) << std::left << item.second.max         \
-         << std::endl;
+      ss << setw(25) << left << fixed << item.first.op_type             \
+         << " " << setw(40) << left << fixed << item.first.kernel_name  \
+         << " " << setw(12) << left << fixed << item.first.remark       \
+         << " " << setw(12) << left << fixed << item.second.avg         \
+         << " " << setw(12) << left << fixed << item.second.min         \
+         << " " << setw(12) << left << fixed << item.second.max         \
+         << " " << std::endl;
       // clang-format on
     }
   } else {
-    cout_title("Detailed Profiler Summary", name_);
     for (auto& unit : units_) {
       // clang-format off
-      ss << std::setw(25) << std::left << unit.character.op_type        \
-         << std::setw(40) << std::left << unit.character.kernel_name    \
-         << std::setw(10) << std::left << unit.character.remark         \
-         << std::setw(10) << std::left << unit.timer->LapTimes().Avg()  \
-         << std::setw(10) << std::left << unit.timer->LapTimes().Min()  \
-         << std::setw(10) << std::left << unit.timer->LapTimes().Max()  \
+      ss << setw(25) << left << fixed << unit.character.op_type              \
+         << " " << setw(40) << left << fixed << unit.character.kernel_name    \
+         << " " << setw(12) << left << fixed << unit.character.remark         \
+         << " " << setw(12) << left << fixed << unit.timer->LapTimes().Avg()  \
+         << " " << setw(12) << left << fixed << unit.timer->LapTimes().Min()  \
+         << " " << setw(12) << left << fixed << unit.timer->LapTimes().Max()  \
+         << " " << setw(12) << left << fixed << unit.timer->LapTimes().Last() \
          << std::endl;
       // clang-format on
     }

--- a/lite/core/profile/profiler.h
+++ b/lite/core/profile/profiler.h
@@ -47,7 +47,7 @@ class Profiler final {
   int NewTimer(const OpCharacter& ch);
   void StartTiming(const int index, KernelContext* ctx);
   float StopTiming(const int index, KernelContext* ctx);
-  std::string Summary(bool concise = true);
+  std::string Summary(bool concise = true, size_t warm_up = 10);
 
  private:
   std::string name_{std::string("N/A")};

--- a/lite/core/profile/timer.h
+++ b/lite/core/profile/timer.h
@@ -30,6 +30,7 @@ class TimeList {
  public:
   void Clear() { laps_t_.clear(); }
   void Add(T t) { laps_t_.push_back(t); }
+  T Last() const { return laps_t_.back(); }
   T Max() const { return *std::max_element(laps_t_.begin(), laps_t_.end()); }
   T Min() const { return *std::min_element(laps_t_.begin(), laps_t_.end()); }
   T Sum() const { return std::accumulate(laps_t_.begin(), laps_t_.end(), 0.0); }

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -124,7 +124,7 @@ void RuntimeProgram::Run() {
 #endif  // LITE_WITH_PROFILE
   }
 #ifdef LITE_WITH_PROFILE
-  LOG(INFO) << "\n" << profiler_.Summary();
+    LOG(INFO) << "\n" << profiler_.Summary(false);
 #endif  // LITE_WITH_PROFILE
 }
 

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -124,7 +124,7 @@ void RuntimeProgram::Run() {
 #endif  // LITE_WITH_PROFILE
   }
 #ifdef LITE_WITH_PROFILE
-    LOG(INFO) << "\n" << profiler_.Summary(false);
+  LOG(INFO) << "\n" << profiler_.Summary(false, 0);
 #endif  // LITE_WITH_PROFILE
 }
 

--- a/lite/core/program.h
+++ b/lite/core/program.h
@@ -141,6 +141,11 @@ class LITE_API RuntimeProgram {
     set_profiler();
 #endif
   }
+  ~RuntimeProgram() {
+#ifdef LITE_WITH_PROFILE
+    LOG(INFO) << "\n" << profiler_.Summary();
+#endif  // LITE_WITH_PROFILE
+  }
 
   void Run();
 


### PR DESCRIPTION
1、去掉 model_test.cpp 冗余调用；
2、默认在每次迭代后逐算子输出计时信息，无预热；
3、在程序结束时输出整个模型的热点统计，默认预热次数为 10；
4、修复统计信息有效数字过多的问题。
<img width="917" alt="截屏2019-12-1610 18 46" src="https://user-images.githubusercontent.com/39303645/70874477-42ffec00-1fed-11ea-9b8b-5742cf2d1c12.png">