### PR TITLE
fix the issue that arm_linux and android can not compile properly 

### DIFF
--- a/lite/core/mir/subgraph/subgraph_detector.cc
+++ b/lite/core/mir/subgraph/subgraph_detector.cc
@@ -94,7 +94,7 @@ std::string SubgraphVisualizer::operator()() {
   }
 
   auto res = dot.Build();
-  VLOG(3) << "subgraphs: " << subgraphs_.size() << "\n" << res << std::endl;
+  VLOG(3) << "subgraphs: " << subgraphs_.size() << "\n" << res;
   return res;
 }
 


### PR DESCRIPTION
问题描述： develop分支的armlinux和android 编译失败
找到原因：新融入代码中`lite/core/mir/subgraph/subgraph_detector.cc`代码中有问题
解决方法：
将第97行`  VLOG(3) << "subgraphs: " << subgraphs_.size() << "\n" << res << std::endl;`
改为：`  VLOG(3) << "subgraphs: " << subgraphs_.size() << "\n" << res;`

下一步需要解决的问题：为什么这样的问题通过了CI 检测，CI检测是否全面