### PR TITLE
Fix typo in set_cpu_math_library_num_threads

### DIFF
--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -153,7 +153,7 @@ class LITE_API CxxConfig : public ConfigBase {
   std::string param_file() const { return param_file_; }
   bool model_from_memory() const { return model_from_memory_; }
 
-  void set_cpu_math_library_math_threads(int threads) {
+  void set_cpu_math_library_num_threads(int threads) {
     cpu_math_library_math_threads_ = threads;
   }
   int cpu_math_library_num_threads() const {

--- a/lite/api/test_step_rnn_lite_x86.cc
+++ b/lite/api/test_step_rnn_lite_x86.cc
@@ -30,7 +30,7 @@ TEST(Step_rnn, test_step_rnn_lite_x86) {
   std::string model_dir = FLAGS_model_dir;
   lite_api::CxxConfig config;
   config.set_model_dir(model_dir);
-  config.set_cpu_math_library_math_threads(10);
+  config.set_cpu_math_library_num_threads(1);
   config.set_valid_places({lite_api::Place{TARGET(kX86), PRECISION(kInt64)},
                            lite_api::Place{TARGET(kX86), PRECISION(kFloat)},
                            lite_api::Place{TARGET(kHost), PRECISION(kFloat)}});


### PR DESCRIPTION
Fix typo in set_cpu_math_library_num_threads which is written as set_cpu_math_library_math_threads by mistake. 
Related to #2592 