### PR TITLE
remove unused ci_tasks

### DIFF
--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -1042,23 +1042,6 @@ function main {
                 build_test_arm_subtask_armlinux
                 shift
                 ;;
-            build_test_arm_model_mobilenetv1)
-                build_test_arm_subtask_model test_mobilenetv1 mobilenet_v1
-                build_test_arm_subtask_model test_mobilenetv1_int8 MobileNetV1_quant
-                shift
-                ;;
-            build_test_arm_model_mobilenetv2)
-                build_test_arm_subtask_model test_mobilenetv2 mobilenet_v2_relu
-                shift
-                ;;
-            build_test_arm_model_resnet50)
-                build_test_arm_subtask_model test_resnet50 resnet50
-                shift
-                ;;
-            build_test_arm_model_inceptionv4)
-                build_test_arm_subtask_model test_inceptionv4 inception_v4_simple
-                shift
-                ;;
             check_style)
                 check_style
                 shift


### PR DESCRIPTION
remove test_models functions in ci_build.sh , because these project hass been removed in online ci_tasks:
```
build_test_arm_model_mobilenetv1
build_test_arm_model_mobilenetv2
build_test_arm_model_resnet50
build_test_arm_model_inceptionv4
```
注：[PR #2639](https://github.com/PaddlePaddle/Paddle-Lite/pull/2639)中已经将以上四个model_test的CI合入`build_test_arm_subtask_android`，以上四个function不会再用到，本PR将以上四个删除。