### PR TITLE
fix mask rcnn error when run several times, test=develop

### DIFF
--- a/lite/core/memory.h
+++ b/lite/core/memory.h
@@ -120,6 +120,7 @@ class Buffer {
     if (space_ > 0) {
       TargetFree(target_, data_);
     }
+    data_ = nullptr;
     target_ = TargetType::kHost;
     space_ = 0;
   }

--- a/lite/core/tensor.h
+++ b/lite/core/tensor.h
@@ -176,6 +176,10 @@ class TensorLite {
         (static_cast<char *>(buffer_->data()) + offset_));
   }
 
+  void clear() {
+    buffer_->Free();
+    offset_ = 0;
+  }
   size_t data_size() const { return this->dims().production(); }
 
   size_t memory_size() const { return memory_size_; }

--- a/lite/kernels/arm/conditional_block_compute.cc
+++ b/lite/kernels/arm/conditional_block_compute.cc
@@ -34,6 +34,9 @@ void ConditionalBlockCompute::PrepareForRun() {
 }
 void ConditionalBlockCompute::Run() {
   auto& param = Param<operators::ConditionalBlockParam>();
+  for (auto& out : param.outs) {
+    out->clear();
+  }
   bool need_run = true;
   if (param.is_scalar_condition) {
     auto* cond = param.cond;

--- a/lite/kernels/arm/split_lod_tensor_compute.cc
+++ b/lite/kernels/arm/split_lod_tensor_compute.cc
@@ -82,6 +82,10 @@ void SplitLodTensorCompute::Run() {
         ranges.begin(), ranges.end(), 0UL, [](size_t a, const CopyRange &b) {
           return a + b.end - b.begin;
         });
+    if (height == 0) {
+      out->clear();
+      continue;
+    }
     auto x_dim = x->dims();
     x_dim[0] = static_cast<int64_t>(height);
     out->Resize(x_dim);


### PR DESCRIPTION
fix mask rcnn error when run several times, test=develop

condintional_block是根据输入来判断是否进行计算，而merge_lod_tensor是按照输入来设置输出shape并计算输出。所以多次计算的时候，condintional_block如果没有计算，它的输出会依旧保持为上一次计算的值，此时merge_lod_tensor就会报错。所以必须在condintional_block计算前清空上次的输出。