### PR TITLE
Optimize the execution of RuntimeProgram by saving the bool whether the instruction is feed/fetch op

### DIFF
--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -137,8 +137,7 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
 
 void RuntimeProgram::Run() {
   for (auto& inst : instructions_) {
-    std::string op_type = inst.op()->op_info()->Type();
-    if (op_type == "feed" || op_type == "fetch") continue;
+    if (inst.is_feed_fetch_op()) continue;
     inst.Run();
 #ifdef LITE_WITH_PROFILE
 #ifdef LITE_WITH_PRECISION_PROFILE

--- a/lite/core/program.h
+++ b/lite/core/program.h
@@ -90,7 +90,12 @@ struct Program {
 struct Instruction {
   Instruction(const std::shared_ptr<OpLite>& op,
               std::unique_ptr<KernelBase>&& kernel)
-      : op_(op), kernel_(std::move(kernel)) {}
+      : op_(op), kernel_(std::move(kernel)) {
+    std::string op_type = op->Type();
+    if (op_type == "feed" || op_type == "fetch") {
+      is_feed_fetch_op_ = true;
+    }
+  }
 
   // Run the instruction.
   void Run();
@@ -100,6 +105,8 @@ struct Instruction {
   const OpLite* op() const { return op_.get(); }
   const KernelBase* kernel() const { return kernel_.get(); }
   KernelBase* mutable_kernel() { return kernel_.get(); }
+
+  bool is_feed_fetch_op() const { return is_feed_fetch_op_; }
 
 #ifdef LITE_WITH_PROFILE
   void set_profiler(profile::Profiler* profiler) {
@@ -118,6 +125,7 @@ struct Instruction {
  private:
   std::shared_ptr<OpLite> op_;
   std::unique_ptr<KernelBase> kernel_;
+  bool is_feed_fetch_op_{false};
   bool first_epoch_{true};
   bool has_run_{false};
 


### PR DESCRIPTION
每个Instruction由一个op来创建，这个op是否是feed/fetch op，其实在该Instruction定义的时候就已经确定了，不需要在`RuntimeProgram::Run()`中反复地判断。该判断在FeedGR单独RNN预测时，占了不小的一部分时间。这个从vtune的hotspots数据可以看出来。

![图片](https://agroup-bos.cdn.bcebos.com/9997a368d3cdae846708f52ef71a98e25b79e568)

这个PR在Instruction中增加一个`bool is_feed_fetch_op_`的成员变量和一个`bool is_feed_fetch_op() const`的成员函数，来避免反复的`std::string::compare`操作。

- 基于develop测试FeedGR单步RNN的性能：

| 优化前 | 优化后 |
|---|---|
| 0.0423 ms | 0.0396 ms |

- 基于https://github.com/PaddlePaddle/Paddle-Lite/pull/2679 测试FeedGR单步RNN的性能：

| #2679 | #2679 + #2703 |
|---|---|
| 0.0255 ms | 0.0216 ms |