### PR TITLE
temporarily remove cuda fc fuse because we don't support cuda fc now

### DIFF
--- a/lite/core/mir/fusion/fc_fuse_pass.cc
+++ b/lite/core/mir/fusion/fc_fuse_pass.cc
@@ -39,4 +39,5 @@ void FcFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 REGISTER_MIR_PASS(lite_fc_fuse_pass, paddle::lite::mir::FcFusePass)
     .BindTargets({TARGET(kAny)})
     .ExcludeTargets({TARGET(kXPU)})
+    .ExcludeTargets({TARGET(kCUDA)})
     .BindKernel("fc");


### PR DESCRIPTION
temporarily remove cuda fc fuse because we don't support cuda fc now