### PR TITLE
[Doc] Alter the api name for cxxconfig

### DIFF
--- a/_all_pages/develop/cxx_api_doc.md
+++ b/_all_pages/develop/cxx_api_doc.md
@@ -233,7 +233,7 @@ predictor = create_paddle_predictor(config)
 返回类型：`int`
 
 
-## `set_cpu_math_library_num_threads(threads)`
+## `set_x86_math_library_num_threads(threads)`
 
 设置CPU Math库线程数，CPU核心数支持情况下可加速预测。默认为1，并且仅在x86下有效。
 
@@ -246,7 +246,7 @@ predictor = create_paddle_predictor(config)
 返回类型：`None`
 
 
-## `cpu_math_library_num_threads()`
+## `x86_math_library_num_threads()`
 
 返回CPU Math库线程数，CPU核心数支持情况下可加速预测。仅在x86下有效。
 


### PR DESCRIPTION
According to offline advice, alter the api name for cxxconfig from `set_cpu_math_library_num_threads()` to `set_x86_math_library_num_threads()` and from `cpu_math_library_num_threads()` to `x86_math_library_num_threads()`. And only applied for develop.