### PR TITLE
fix the compile errors, test=develop

### DIFF
--- a/lite/core/framework.proto
+++ b/lite/core/framework.proto
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 syntax = "proto2";
-option optimize_for = LITE_RUNTIME;
 package paddle.framework.proto;
 
 // Any incompatible changes to ProgramDesc and its dependencies should

--- a/lite/core/mir/subgraph/CMakeLists.txt
+++ b/lite/core/mir/subgraph/CMakeLists.txt
@@ -4,7 +4,7 @@ lite_cc_library(subgraph_detector
 lite_cc_library(subgraph_pass
     SRCS subgraph_pass.cc
     DEPS mir_pass types context ${mir_fusers} subgraph_detector)
-if (WITH_TESTING)
+if (WITH_TESTING AND NOT LITE_WITH_CUDA)
     lite_cc_test(test_subgraph_detector
         SRCS subgraph_detector_test.cc
         DEPS subgraph_detector mir_passes gflags model_parser cxx_api

--- a/lite/kernels/cuda/conv_compute_test.cc
+++ b/lite/kernels/cuda/conv_compute_test.cc
@@ -15,6 +15,7 @@
 #include "lite/kernels/cuda/conv_compute.h"
 #include <gtest/gtest.h>
 #include <memory>
+#include <random>
 #include <utility>
 #include <vector>
 

--- a/lite/kernels/x86/layer_norm_compute.h
+++ b/lite/kernels/x86/layer_norm_compute.h
@@ -78,7 +78,7 @@ class LayerNormCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
         Scale->data<T>(),
         Bias->data<T>(),
         static_cast<int>(left),
-        static_cast<const float>(epsilon),
+        epsilon,
         right);
   }
 


### PR DESCRIPTION
1、gcc8 编译语法问题修复；
2、framework.proto 与 fluid 对齐。