### PR TITLE
fix var_conv_2d to support cascading use. test=develop

### DIFF
--- a/lite/kernels/cuda/var_conv_2d_compute.h
+++ b/lite/kernels/cuda/var_conv_2d_compute.h
@@ -33,6 +33,7 @@ class VarConv2DCompute : public KernelLite<TARGET(kCUDA), PRECISION(kFloat)> {
  private:
   mutable operators::ConvParam conv_param_;
   std::unique_ptr<lite::cuda::math::CudnnConv2D<PRECISION(kFloat)>> conv_impl_;
+  lite::Tensor offset_;
 };
 
 }  // namespace cuda

--- a/lite/kernels/x86/var_conv_2d_compute.h
+++ b/lite/kernels/x86/var_conv_2d_compute.h
@@ -44,6 +44,7 @@ class VarConv2DCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
     // 2-D lod info.
     // const auto& offset_x = in_col->lod()[0];
     // const auto& offset_y = in_row->lod()[0];
+    CHECK_EQ(param.X->lod().size(), 3) << "input lod size should be 3!";
     const auto& offset_y = param.X->lod()[1];
     const auto& offset_x = param.X->lod()[2];
 


### PR DESCRIPTION
- 修复var_conv_2d级联使用中计算错误的bug
- x86的var_conv_2d中显示指定lod level为3

保证了一下逻辑计算的正确性
<img width="196" alt="image" src="https://user-images.githubusercontent.com/26377421/72398910-85008700-377f-11ea-868d-a35b57d09bd3.png">

支持了var_conv_2d的级联操作
<img width="274" alt="image" src="https://user-images.githubusercontent.com/26377421/72398934-921d7600-377f-11ea-8097-2d7e2dce34ca.png">
