### PR TITLE
【do not merge】Remove HeadFiles-version1

### DIFF
--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -232,6 +232,7 @@ if (LITE_ON_TINY_PUBLISH)
 else()
     lite_cc_library(paddle_api_light SRCS light_api_impl.cc DEPS light_api paddle_api)
 endif()
+add_dependencies(paddle_api_light op_list_h kernel_list_h)
 if (NOT LITE_ON_TINY_PUBLISH)
     lite_cc_library(paddle_api_full SRCS cxx_api_impl.cc DEPS cxx_api paddle_api_light
         ${ops}
@@ -240,6 +241,7 @@ if (NOT LITE_ON_TINY_PUBLISH)
         NPU_DEPS ${npu_kernels}
         CL_DEPS ${opencl_kernels}
         FPGA_DEPS ${fpga_kernels})
+    add_dependencies(paddle_api_full op_list_h kernel_list_h)
     # The final inference library for just MobileConfig.
     bundle_static_library(paddle_api_full paddle_api_full_bundled bundle_full_api)
     get_property(fluid_modules GLOBAL PROPERTY FLUID_MODULES)

--- a/lite/api/android/jni/native/paddle_lite_jni.h
+++ b/lite/api/android/jni/native/paddle_lite_jni.h
@@ -17,11 +17,6 @@
 #include <jni.h>
 /* Header for class com_baidu_paddle_lite_PaddlePredictor */
 #include "lite/api/paddle_lite_factory_helper.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#ifndef LITE_ON_TINY_PUBLISH
-#include "lite/api/paddle_use_passes.h"
-#endif
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lite/api/light_api_shared.cc
+++ b/lite/api/light_api_shared.cc
@@ -12,11 +12,6 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#ifndef LITE_ON_TINY_PUBLISH
-#include "lite/api/paddle_use_passes.h"
-#endif
 
 namespace paddle {
 namespace lite_api {

--- a/lite/api/model_test.cc
+++ b/lite/api/model_test.cc
@@ -16,9 +16,6 @@
 #include <string>
 #include <vector>
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 #include "lite/api/test_helper.h"
 #include "lite/core/device_info.h"
 #include "lite/core/profile/timer.h"

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -16,7 +16,11 @@
 #include "lite/core/device_info.h"
 #include "lite/core/target_wrapper.h"
 #include "lite/core/tensor.h"
-
+#include "paddle_use_kernels.h"  // NOLINT
+#include "paddle_use_ops.h"      // NOLINT
+#ifndef LITE_ON_TINY_PUBLISH
+#include "lite/api/paddle_use_passes.h"
+#endif
 #ifdef LITE_WITH_CUDA
 #include "lite/backends/cuda/target_wrapper.h"
 #endif


### PR DESCRIPTION
针对问题：（1）当前Paddle-Lite 预测库需要引用以下头文件。但只有`paddle_api.h`头文件中声明用户接口。
```
paddle_use_ops.h  
paddle_use_kernels.h  
paddle_use_passes.h      
paddle_api.h
```
（2）当前Paddle-Lite动态库不需要调用`paddle_use_**.h`头文件，动态库静态库调用方法不对齐。
本PR解决方案：将`paddle_use_**.h`三个头文件放入`paddle_api.cc`代码中，用户调用paddle_api预测库不需要额外引用`paddle_use_**.h`三个头文件。
