### PR TITLE
[LITE][OPENCL] add opencl image2d elementwise_mul. test=develop

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/elementwise_mul_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/elementwise_mul_kernel.cl
@@ -112,20 +112,6 @@ __kernel void channel_mul_d2(__global image2d_t input, __global image2d_t bias,
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
 }
 
-__kernel void channel_mul_d4(__global image2d_t input, __global image2d_t bias,
-                          __write_only image2d_t outputImage, int w) {
-  int x = get_global_id(0);
-  int y = get_global_id(1);
-  const sampler_t sampler =
-      CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
-  int2 coords;
-  coords.x = x;
-  coords.y = y;
-  int2 coords_bias;
-  coords_bias.x = x / w;
-  coords_bias.y = 0;
-  CL_DTYPE4 in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
-  CL_DTYPE4 biase = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias);
-  CL_DTYPE4 output = in * biase;
-  WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
-} 
+// kernel `channel_mul`(y_dims.size() == 1) is same as `channel_mul_d4`(y_dims.size() == 4)
+// __kernel void channel_mul_d4(__global image2d_t input, __global image2d_t bias,
+//                              __write_only image2d_t outputImage, int w)

--- a/lite/backends/opencl/cl_kernel/image/elementwise_mul_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/elementwise_mul_kernel.cl
@@ -1,0 +1,131 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cl_common.h>
+
+__kernel void elementwise_mul(__global image2d_t input, __global image2d_t bias,
+                              __write_only image2d_t outputImage) {
+  int x = get_global_id(0);
+  int y = get_global_id(1);
+  const sampler_t sampler =
+      CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+  int2 coords;
+  coords.x = x;
+  coords.y = y;
+  CL_DTYPE4 in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
+  CL_DTYPE4 biase = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords);
+  CL_DTYPE4 output = in * biase;
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
+}
+
+__kernel void channel_mul(__global image2d_t input, __global image2d_t bias,
+                          __write_only image2d_t outputImage, int w) {
+  int x = get_global_id(0);
+  int y = get_global_id(1);
+  const sampler_t sampler =
+      CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+  int2 coords;
+  coords.x = x;
+  coords.y = y;
+  int2 coords_bias;
+  coords_bias.x = x / w;
+  coords_bias.y = 0;
+  CL_DTYPE4 in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
+  CL_DTYPE4 biase = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias);
+  CL_DTYPE4 output = in * biase;
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
+}
+
+// etc : 1 1 1 72
+// run time Y  [value,0,0,0] * 72
+__kernel void channel_mul_d2(__global image2d_t input, __global image2d_t bias,
+                             __write_only image2d_t outputImage, int w) {
+  int x = get_global_id(0);
+  int y = get_global_id(1);
+  const sampler_t sampler =
+      CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+  int2 coords;
+  coords.x = x;
+  coords.y = y;
+
+  int2 coords_bias0;
+  int2 coords_bias1;
+  int2 coords_bias2;
+  int2 coords_bias3;
+
+  /*  if (x == 0 && y == 0) {
+      CL_DTYPE4 b = (CL_DTYPE4){0, 0, 0, 0};
+  #define PPI(j, k)                                                          \
+    b = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, (int2){j, k});                            \
+    printf("bias(%d,%d)={ %f , %f , %f , %f }\n ", j, k, convert_float(b.x), \
+           convert_float(b.y), convert_float(b.z), convert_float(b.w));
+      for (int i = 0; i < 73; ++i) {
+        PPI(i, 0);
+      }
+  #undef PPI
+    }*/
+
+  coords_bias0.x = x / w * 4;
+  coords_bias0.y = 0;
+
+  coords_bias1.x = x / w * 4 + 1;
+  coords_bias1.y = 0;
+
+  coords_bias2.x = x / w * 4 + 2;
+  coords_bias2.y = 0;
+
+  coords_bias3.x = x / w * 4 + 3;
+  coords_bias3.y = 0;
+
+  CL_DTYPE4 biase0 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias0);
+  CL_DTYPE4 biase1 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias1);
+  CL_DTYPE4 biase2 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias2);
+  CL_DTYPE4 biase3 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias3);
+  /*  if (x == 0 && y == 0) {
+      printf("bias0={ %f , %f , %f , %f }\n ",
+             convert_float(biase0.x), convert_float(biase0.y),
+             convert_float(biase0.z), convert_float(biase0.w));
+      printf("bias1={ %f , %f , %f , %f }\n ",
+             convert_float(biase1.x), convert_float(biase1.y),
+             convert_float(biase1.z), convert_float(biase1.w));
+      printf("bias2={ %f , %f , %f , %f }\n ",
+             convert_float(biase2.x), convert_float(biase2.y),
+             convert_float(biase2.z), convert_float(biase2.w));
+      printf("bias3={ %f , %f , %f , %f }\n ",
+             convert_float(biase3.x), convert_float(biase3.y),
+             convert_float(biase3.z), convert_float(biase3.w));
+    }*/
+  CL_DTYPE4 biase = {biase0.x, biase1.x, biase2.x, biase3.x};
+  CL_DTYPE4 in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
+  CL_DTYPE4 output = mad(in, biase, 0);
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
+}
+
+__kernel void channel_mul_d4(__global image2d_t input, __global image2d_t bias,
+                          __write_only image2d_t outputImage, int w) {
+  int x = get_global_id(0);
+  int y = get_global_id(1);
+  const sampler_t sampler =
+      CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+  int2 coords;
+  coords.x = x;
+  coords.y = y;
+  int2 coords_bias;
+  coords_bias.x = x / w;
+  coords_bias.y = 0;
+  CL_DTYPE4 in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
+  CL_DTYPE4 biase = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias);
+  CL_DTYPE4 output = in * biase;
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
+} 

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -2,14 +2,15 @@ if ((NOT LITE_ON_MODEL_OPTIMIZE_TOOL) AND (NOT LITE_WITH_OPENCL))
     return ()
 endif()
 
-set(cl_kernel_deps op_params cl_runtime cl_context cl_wrapper cl_target_wrapper)
+set(cl_kernel_deps op_params cl_runtime cl_context cl_wrapper cl_target_wrapper cl_image_converter)
 
 add_kernel(fc_opencl OPENCL basic SRCS fc_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(mul_opencl OPENCL basic SRCS mul_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(elementwise_add_opencl OPENCL basic SRCS elementwise_add_compute.cc DEPS ${cl_kernel_deps})
+add_kernel(elementwise_mul_opencl OPENCL basic SRCS elementwise_mul_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(fusion_elementwise_add_activation_opencl
-        OPENCL basic SRCS fusion_elementwise_add_activation_compute.cc
-        DEPS elementwise_add_opencl ${cl_kernel_deps})
+           OPENCL basic SRCS fusion_elementwise_add_activation_compute.cc
+           DEPS elementwise_add_opencl ${cl_kernel_deps})
 add_kernel(pool_opencl OPENCL basic SRCS pool_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(io_copy_compute_opencl OPENCL basic SRCS io_copy_compute.cc DEPS ${tensor_lite} ${cl_kernel_deps})
 add_kernel(relu_opencl OPENCL basic SRCS relu_compute.cc DEPS ${cl_kernel_deps})
@@ -20,16 +21,20 @@ add_kernel(conv_opencl OPENCL basic SRCS conv_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(layout_opencl OPENCL basic SRCS layout_compute.cc DEPS ${cl_kernel_deps})
 
 lite_cc_test(test_elementwise_add_opencl SRCS elementwise_add_compute_test.cc
-        DEPS elementwise_add_opencl fusion_elementwise_add_activation_opencl op_registry program context
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS elementwise_add_opencl fusion_elementwise_add_activation_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+
+lite_cc_test(test_elementwise_mul_opencl SRCS elementwise_mul_compute_test.cc
+             DEPS elementwise_mul_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 lite_cc_test(test_pool_opencl SRCS pool_compute_test.cc
-        DEPS pool_opencl op_registry program context cl_image_converter
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS pool_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 lite_cc_test(test_fc_opencl SRCS fc_compute_test.cc
-        DEPS fc_opencl op_registry program context
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS fc_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 # TODO(ysh329): comment for buffer-impl mul
 #lite_cc_test(test_mul_opencl SRCS mul_compute_test.cc
@@ -37,34 +42,34 @@ lite_cc_test(test_fc_opencl SRCS fc_compute_test.cc
 #        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 lite_cc_test(test_io_copy_compute_opencl SRCS io_copy_compute_test.cc
-        DEPS io_copy_compute_opencl op_registry program context
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS io_copy_compute_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 #TODO(ysh329): comment buffer-impl relu
 lite_cc_test(test_relu_opencl SRCS relu_compute_test.cc
-        DEPS relu_opencl layout_opencl op_registry program context
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS relu_opencl layout_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 lite_cc_test(test_depthwise_conv2d_opencl SRCS depthwise_conv2d_compute_test.cc
-        DEPS depthwise_conv2d_opencl op_registry program context cl_image_converter
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS depthwise_conv2d_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 lite_cc_test(test_depthwise_conv2d_basic_opencl SRCS depthwise_conv2d_basic_compute_test.cc
-        DEPS depthwise_conv2d_opencl op_registry program context cl_image_converter
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS depthwise_conv2d_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 #lite_cc_test(test_conv2d_1x1_opencl SRCS conv2d_1x1_compute_test.cc
-#        DEPS conv2d_1x1_opencl cl_image_converter op_registry program context
-#        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+#             DEPS conv2d_1x1_opencl op_registry program context
+#             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 lite_cc_test(test_reshape_opencl SRCS reshape_compute_test.cc
-        DEPS reshape_opencl cl_image_converter op_registry program context
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS reshape_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 lite_cc_test(test_conv_opencl SRCS conv_compute_test.cc
-        DEPS conv_opencl op_registry program context
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS conv_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
 
 lite_cc_test(test_layout_opencl SRCS layout_compute_test.cc
-        DEPS layout_opencl op_registry program context cl_image_converter
-        ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)
+             DEPS layout_opencl op_registry program context
+             ARGS --cl_path=${CMAKE_SOURCE_DIR}/lite/backends/opencl)

--- a/lite/kernels/opencl/elementwise_mul_compute.cc
+++ b/lite/kernels/opencl/elementwise_mul_compute.cc
@@ -1,0 +1,181 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/opencl/elementwise_mul_compute.h"
+#include <memory>
+#include "lite/backends/opencl/cl_include.h"
+#include "lite/core/op_registry.h"
+#include "lite/utils/replace_stl/stream.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace opencl {
+
+void ElementwiseMulFloatImageCompute::PrepareForRun() {
+  ele_param_ = param_.get_mutable<param_t>();
+  auto* y = ele_param_->Y;
+  auto y_dims = y->dims();
+  if (y_dims == ele_param_->X->dims()) {
+    VLOG(4) << "elementwise_mul";
+    kernel_func_name_ = "elementwise_mul";
+  } else if (y_dims.size() == 1) {
+    VLOG(4) << "channel_mul";
+    kernel_func_name_ = "channel_mul";
+  } else if (y_dims.size() == 2) {
+    VLOG(4) << "channel_mul_d2";
+    kernel_func_name_ = "channel_mul_d2";
+  } else if (y_dims.size() == 4) {
+    VLOG(4) << "channel_mul_d4";
+    kernel_func_name_ = "channel_mul_d4";
+  } else {
+    LOG(FATAL) << "ElementwiseMul not supported y_dims.size():"
+               << y_dims.size();
+  }
+
+  auto& context = ctx_->As<OpenCLContext>();
+  context.cl_context()->AddKernel(
+      kernel_func_name_, "image/elementwise_mul_kernel.cl", build_options_);
+
+  //  UpdateParams();
+}
+
+void ElementwiseMulFloatImageCompute::Run() {
+  auto& context = ctx_->As<OpenCLContext>();
+  CHECK(context.cl_context() != nullptr);
+
+  auto* x = ele_param_->X;
+  auto* y = ele_param_->Y;
+  auto* out = ele_param_->Out;
+
+  VLOG(4) << "x->target():" << TargetToStr(x->target());
+  VLOG(4) << "y->target():" << TargetToStr(y->target());
+  VLOG(4) << "out->target():" << TargetToStr(out->target());
+  VLOG(4) << "x->dims():" << x->dims();
+  VLOG(4) << "y->dims():" << y->dims();
+  VLOG(4) << "out->dims():" << out->dims();
+
+  paddle::lite::CLImageConverterDefault default_convertor;
+  auto x_img_shape = default_convertor.InitImageDimInfoWith(x->dims());  // w, h
+  auto x_img_width = x_img_shape[0];
+  auto x_img_height = x_img_shape[1];
+  auto out_img_shape =
+      default_convertor.InitImageDimInfoWith(out->dims());  // w, h
+
+  auto* x_img = x->data<float, cl::Image2D>();
+  auto* y_img = y->data<float, cl::Image2D>();
+  auto* out_img =
+      out->mutable_data<float, cl::Image2D>(out_img_shape[0], out_img_shape[1]);
+
+  STL::stringstream kernel_key;
+  kernel_key << kernel_func_name_ << build_options_;
+  auto kernel = context.cl_context()->GetKernel(kernel_key.str());
+
+  int arg_idx = 0;
+  auto y_dims = y->dims();
+  if (y_dims == ele_param_->X->dims()) {
+    // elementwise_mul
+    cl_int status = kernel.setArg(arg_idx, *x_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, *y_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, *out_img);
+    CL_CHECK_FATAL(status);
+  } else if (y_dims.size() == 1 || y_dims.size() == 2 || y_dims.size() == 4) {
+    if (y_dims.size() == 1) {
+      // channel_mul
+      VLOG(4) << "channel_mul";
+    } else if (y_dims.size() == 2) {
+      // channel_mul_d2
+      VLOG(4) << "channel_mul_d2";
+    } else if (y_dims.size() == 4) {
+      // channel_mul_d4
+      VLOG(4) << "channel_mul_d4";
+    }
+
+    auto tensor_w = x->dims()[x->dims().size() - 1];
+    cl_int status = kernel.setArg(arg_idx, *x_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, *y_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, *out_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, tensor_w);
+    CL_CHECK_FATAL(status);
+  } else {
+    LOG(FATAL) << "ElementwiseMul not supported y_dims.size():"
+               << y_dims.size();
+  }
+
+  auto global_work_size = cl::NDRange{static_cast<cl::size_type>(x_img_width),
+                                      static_cast<cl::size_type>(x_img_height)};
+  auto status = context.cl_context()->GetCommandQueue().enqueueNDRangeKernel(
+      kernel,
+      cl::NullRange,
+      global_work_size,
+      cl::NullRange,
+      nullptr,
+      event_.get());
+  CL_CHECK_FATAL(status);
+  context.cl_wait_list()->emplace(out_img, event_);
+}
+
+void ElementwiseMulFloatImageCompute::UpdateParams() {
+  auto axis = ele_param_->axis;
+  const auto& x_dims = ele_param_->X->dims();
+  const auto& y_dims = ele_param_->Y->dims();
+  const auto& out_dims = ele_param_->Out->dims();
+  if (axis < 0) {
+    axis = static_cast<int>(x_dims.size() - y_dims.size());
+  }
+  for (int i = 0; i < axis; ++i) {
+    batch_ *= x_dims[i];
+  }
+  for (int i = 0; i < y_dims.size(); ++i) {
+    channels_ *= y_dims[i];
+  }
+  for (int i = static_cast<int>(y_dims.size() + axis); i < x_dims.size(); ++i) {
+    num_ *= x_dims[i];
+  }
+  VLOG(4) << "axis: " << axis;
+  VLOG(4) << "batch: " << batch_;
+  VLOG(4) << "channels: " << channels_;
+  VLOG(4) << "num: " << num_;
+}
+
+}  // namespace opencl
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+namespace ocl = paddle::lite::kernels::opencl;
+REGISTER_LITE_KERNEL(elementwise_mul,
+                     kOpenCL,
+                     kFloat,
+                     kImageDefault,
+                     ocl::ElementwiseMulFloatImageCompute,
+                     def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kFloat),
+                                      DATALAYOUT(kImageDefault))})
+    .BindInput("Y",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kFloat),
+                                      DATALAYOUT(kImageDefault))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kFloat),
+                                       DATALAYOUT(kImageDefault))})
+    .Finalize();

--- a/lite/kernels/opencl/elementwise_mul_compute.cc
+++ b/lite/kernels/opencl/elementwise_mul_compute.cc
@@ -44,8 +44,6 @@ void ElementwiseMulFloatImageCompute::PrepareForRun() {
   auto& context = ctx_->As<OpenCLContext>();
   context.cl_context()->AddKernel(
       kernel_func_name_, "image/elementwise_mul_kernel.cl", build_options_);
-
-  //  UpdateParams();
 }
 
 void ElementwiseMulFloatImageCompute::Run() {
@@ -88,7 +86,7 @@ void ElementwiseMulFloatImageCompute::Run() {
   int arg_idx = 0;
   auto y_dims = y->dims();
   if (y_dims == ele_param_->X->dims()) {
-    // elementwise_mul
+    // kernel: elementwise_mul
     cl_int status = kernel.setArg(arg_idx, *x_img);
     CL_CHECK_FATAL(status);
     status = kernel.setArg(++arg_idx, *y_img);
@@ -96,18 +94,8 @@ void ElementwiseMulFloatImageCompute::Run() {
     status = kernel.setArg(++arg_idx, *out_img);
     CL_CHECK_FATAL(status);
   } else if (y_dims.size() == 1 || y_dims.size() == 2 || y_dims.size() == 4) {
-    if (y_dims.size() == 1) {
-      // channel_mul
-      VLOG(4) << "channel_mul";
-    } else if (y_dims.size() == 2) {
-      // channel_mul_d2
-      VLOG(4) << "channel_mul_d2";
-    } else if (y_dims.size() == 4) {
-      // channel_mul_d4
-      VLOG(4) << "channel_mul_d4";
-    }
-
     auto tensor_w = x->dims()[x->dims().size() - 1];
+    // kernel: channel_mul / channel_mul_d2 / channel_mul_d4
     cl_int status = kernel.setArg(arg_idx, *x_img);
     CL_CHECK_FATAL(status);
     status = kernel.setArg(++arg_idx, *y_img);

--- a/lite/kernels/opencl/elementwise_mul_compute.cc
+++ b/lite/kernels/opencl/elementwise_mul_compute.cc
@@ -28,21 +28,18 @@ void ElementwiseMulFloatImageCompute::PrepareForRun() {
   auto* y = ele_param_->Y;
   auto y_dims = y->dims();
   if (y_dims == ele_param_->X->dims()) {
-    VLOG(4) << "elementwise_mul";
     kernel_func_name_ = "elementwise_mul";
-  } else if (y_dims.size() == 1) {
-    VLOG(4) << "channel_mul";
+  } else if (y_dims.size() == 1 || y_dims.size() == 4) {
     kernel_func_name_ = "channel_mul";
   } else if (y_dims.size() == 2) {
-    VLOG(4) << "channel_mul_d2";
     kernel_func_name_ = "channel_mul_d2";
-  } else if (y_dims.size() == 4) {
-    VLOG(4) << "channel_mul_d4";
-    kernel_func_name_ = "channel_mul_d4";
   } else {
     LOG(FATAL) << "ElementwiseMul not supported y_dims.size():"
                << y_dims.size();
   }
+  VLOG(4) << "kernel_func_name_:" << kernel_func_name_;
+  VLOG(4) << "y_dims:" << y_dims;
+  VLOG(4) << "y_dims.size():" << y_dims.size();
 
   auto& context = ctx_->As<OpenCLContext>();
   context.cl_context()->AddKernel(
@@ -72,11 +69,17 @@ void ElementwiseMulFloatImageCompute::Run() {
   auto x_img_height = x_img_shape[1];
   auto out_img_shape =
       default_convertor.InitImageDimInfoWith(out->dims());  // w, h
+  auto y_img_shape = default_convertor.InitImageDimInfoWith(y->dims());
 
   auto* x_img = x->data<float, cl::Image2D>();
   auto* y_img = y->data<float, cl::Image2D>();
   auto* out_img =
       out->mutable_data<float, cl::Image2D>(out_img_shape[0], out_img_shape[1]);
+
+  VLOG(4) << "x_img_shape[w,h]:" << x_img_width << " " << x_img_height;
+  VLOG(4) << "y_img_shape[w,h]:" << y_img_shape[0] << " " << y_img_shape[1];
+  VLOG(4) << "out_img_shape[w,h]:" << out_img_shape[0] << " "
+          << out_img_shape[1];
 
   STL::stringstream kernel_key;
   kernel_key << kernel_func_name_ << build_options_;

--- a/lite/kernels/opencl/elementwise_mul_compute.h
+++ b/lite/kernels/opencl/elementwise_mul_compute.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <memory>
+#include <string>
+#include "lite/backends/opencl/cl_image_converter.h"
+#include "lite/core/kernel.h"
+#include "lite/operators/op_params.h"
+#include "lite/utils/cp_logging.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace opencl {
+
+class ElementwiseMulFloatImageCompute
+    : public KernelLite<TARGET(kOpenCL),
+                        PRECISION(kFloat),
+                        DATALAYOUT(kImageDefault)> {
+ public:
+  using param_t = operators::ElementwiseParam;
+
+  std::string doc() const override {
+    return "ElementwiseMul using cl::Image2D(ImageDefault/RGBA), kFP32";
+  }
+
+  void PrepareForRun() override;
+
+  void Run() override;
+
+ protected:
+  void UpdateParams();
+
+  size_t batch_{1};
+  size_t channels_{1};
+  size_t num_{1};
+  param_t* ele_param_{nullptr};
+  std::string kernel_func_name_{"elementwise_mul"};
+  std::string build_options_{"-DCL_DTYPE_float"};
+  std::shared_ptr<cl::Event> event_{new cl::Event};
+};
+
+}  // namespace opencl
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/opencl/elementwise_mul_compute.h
+++ b/lite/kernels/opencl/elementwise_mul_compute.h
@@ -41,11 +41,6 @@ class ElementwiseMulFloatImageCompute
   void Run() override;
 
  protected:
-  void UpdateParams();
-
-  size_t batch_{1};
-  size_t channels_{1};
-  size_t num_{1};
   param_t* ele_param_{nullptr};
   std::string kernel_func_name_{"elementwise_mul"};
   std::string build_options_{"-DCL_DTYPE_float"};

--- a/lite/kernels/opencl/elementwise_mul_compute_test.cc
+++ b/lite/kernels/opencl/elementwise_mul_compute_test.cc
@@ -109,7 +109,8 @@ TEST(elemul_image2d_fp32, compute_kernel_elemenwise_mul) {
 
   const DDim x_dim = DDim(std::vector<DDim::value_type>{n, c, h, w});
   auto out_dim = x_dim;
-  std::vector<DDim> y_dim_v{DDim(std::vector<DDim::value_type>{n, c, h, w}),
+  std::vector<DDim> y_dim_v{DDim(std::vector<DDim::value_type>{n, c, 1, 1}),
+                            DDim(std::vector<DDim::value_type>{n, c, h, w}),
                             DDim(std::vector<DDim::value_type>{h, w}),
                             DDim(std::vector<DDim::value_type>{w})};
   for (auto y_dim : y_dim_v) {

--- a/lite/kernels/opencl/elementwise_mul_compute_test.cc
+++ b/lite/kernels/opencl/elementwise_mul_compute_test.cc
@@ -23,6 +23,19 @@ namespace paddle {
 namespace lite {
 
 template <typename dtype>
+void fill_data(dtype *x, const int length, int set_value = -1) {
+  if (set_value == -1) {
+    for (size_t idx = 0; idx < length; ++idx) {
+      x[idx] = idx;
+    }
+  } else if (set_value != -1) {
+    for (size_t idx = 0; idx < length; ++idx) {
+      x[idx] = set_value;
+    }
+  }
+}
+
+template <typename dtype>
 void elementwise_compute_ref(const dtype *x_data,
                              const dtype *y_data,
                              dtype *out_data,
@@ -46,42 +59,8 @@ void elementwise_compute_ref(const dtype *x_data,
   for (int i = y_dims.size() + axis; i < x_dims.size(); ++i) {
     num *= x_dims[i];
   }
-  // do elementwise add/sub/max/...
-  if (elt_type == "add") {
-    for (int i = 0; i < batch; ++i) {
-      for (int j = 0; j < channels; ++j) {
-        int offset = (i * channels + j) * num;
-        const dtype *din_ptr = x_data + offset;
-        const dtype diny_data = y_data[j];
-        dtype *dout_ptr = out_data + offset;
-        for (int k = 0; k < num; ++k) {
-          *dout_ptr = *din_ptr + diny_data;
-          if (use_relu) {
-            *dout_ptr = std::max(*dout_ptr, static_cast<dtype>(0));
-          }
-          dout_ptr++;
-          din_ptr++;
-        }
-      }
-    }
-  } else if (elt_type == "sub") {
-    for (int i = 0; i < batch; ++i) {
-      for (int j = 0; j < channels; ++j) {
-        int offset = (i * channels + j) * num;
-        const dtype *din_ptr = x_data + offset;
-        const dtype diny_data = y_data[j];
-        dtype *dout_ptr = out_data + offset;
-        for (int k = 0; k < num; ++k) {
-          *dout_ptr = *din_ptr - diny_data;
-          if (use_relu) {
-            *dout_ptr = std::max(*dout_ptr, static_cast<dtype>(0));
-          }
-          dout_ptr++;
-          din_ptr++;
-        }
-      }
-    }
-  } else if (elt_type == "mul") {
+
+  if (elt_type == "mul") {
     for (int i = 0; i < batch; ++i) {
       for (int j = 0; j < channels; ++j) {
         int offset = (i * channels + j) * num;
@@ -103,244 +82,155 @@ void elementwise_compute_ref(const dtype *x_data,
   }
 }
 
-#if 0
-TEST(elementwise_mul_image_fp32, compute) {
-  LOG(INFO) << "to get kernel ...";
-  auto kernels = KernelRegistry::Global().Create(
-      "elementwise_mul", TARGET(kOpenCL), PRECISION(kFloat),
-      DATALAYOUT(kImageDefault));
-  ASSERT_FALSE(kernels.empty());
-
-  auto kernel = std::move(kernels.front());
-
-  LOG(INFO) << "get kernel" << kernel->doc();
-
-  lite::Tensor x, y, out;
-  operators::ElementwiseParam param;
-  param.X = &x;
-  param.Y = &y;
-  param.Out = &out;
-  param.axis = -1;
-
-  std::unique_ptr<KernelContext> context(new KernelContext);
-  context->As<OpenCLContext>().InitOnce();
-
-  kernel->SetParam(param);
-  std::unique_ptr<KernelContext> ele_context(new KernelContext);
-  context->As<OpenCLContext>().CopySharedTo(
-      &(ele_context->As<OpenCLContext>()));
-  kernel->SetContext(std::move(ele_context));
-
-  const DDim x_dim = DDim(std::vector<DDim::value_type>{3, 2, 1, 5});
-  const DDim y_dim = DDim(std::vector<DDim::value_type>{2, 1, 5});
-  const DDim out_dim = DDim(std::vector<DDim::value_type>{3, 2, 1, 5});
-  x.Resize(x_dim);
-  y.Resize(y_dim);
-  out.Resize(out_dim);
-
-  auto *x_data = x.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
-  auto *y_data = y.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
-
-  std::default_random_engine engine;
-  std::uniform_real_distribution<float> dist(-10, 10);
-  auto *mapped_x = static_cast<float *>(
-      TargetWrapperCL::Map(x_data, 0, sizeof(float) * x_dim.production()));
-  for (int i = 0; i < x_dim.production(); i++) {
-    mapped_x[i] = dist(engine);
-  }
-  auto *mapped_y = static_cast<float *>(
-      TargetWrapperCL::Map(y_data, 0, sizeof(float) * y_dim.production()));
-  for (int i = 0; i < y_dim.production(); i++) {
-    mapped_y[i] = dist(engine);
-  }
-
-  kernel->Launch();
-
-  auto *wait_list = context->As<OpenCLContext>().cl_wait_list();
-  auto *out_ptr = param.Out->data<float, cl::Buffer>();
-  auto it = wait_list->find(out_ptr);
-  if (it != wait_list->end()) {
-    VLOG(4) << "--- Find the sync event for the target cl tensor. ---";
-    auto &event = *(it->second);
-    event.wait();
-  } else {
-    LOG(FATAL) << "Could not find the sync event for the target cl tensor.";
-  }
-
-  std::unique_ptr<float[]> out_ref(new float[out_dim.production()]);
-  elementwise_compute_ref<float>(
-      mapped_x, mapped_y, out_ref.get(), x_dim, y_dim, param.axis, "add");
-
-  TargetWrapperCL::Unmap(x_data, mapped_x);
-  TargetWrapperCL::Unmap(y_data, mapped_y);
-  auto *out_data = out.mutable_data<float, cl::Buffer>();
-  auto *mapped_out = static_cast<float *>(
-      TargetWrapperCL::Map(out_data, 0, sizeof(float) * out_dim.production()));
-  for (int i = 0; i < out_dim.production(); i++) {
-    EXPECT_NEAR(mapped_out[i], out_ref[i], 1e-6);
-  }
-  TargetWrapperCL::Unmap(out_data, mapped_out);
-}
-
-// #define LOOP_TEST
 // #define PRINT_RESULT
-TEST(elemul_image2d_fp32, compute) {
-  LOG(INFO) << "main steps of test: host -> layout(buf2img) -> elemul(img) -> "
-               "layout(img2buf) "
-               "-> host";
+TEST(elemul_image2d_fp32, compute_kernel_elemenwise_mul) {
+  LOG(INFO)
+      << "main steps of test: host -> layout(buf2img on cpu) -> elemul(img) -> "
+         "layout(img2buf on cpu) "
+         "-> host";
 
-#ifdef LOOP_TEST
-  for (int n = 1; n <= 100; n += 33) {
-    for (auto c : {1, 3}) {
-      for (int h = 12; h <= 100; h += 13) {
-        for (int w = 12; w <= 100; w += 25) {
-#else
   const int n = 1;
   const int c = 2;
   const int h = 3;
   const int w = 4;
-#endif  // LOOP_TEST
 
-          LOG(INFO) << "======== input shape[n,c,h,w]:" << n << " " << c << " "
-                    << h << " " << w << " ========";
-          // set layout kernels
-          auto buf_to_img_kernels =
-              KernelRegistry::Global().Create("layout",
-                                              TARGET(kOpenCL),
-                                              PRECISION(kAny),
-                                              DATALAYOUT(kImageDefault));
-          auto img_to_buf_kernels = KernelRegistry::Global().Create(
-              "layout", TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW));
-          auto elemul_img_kernels =
-              KernelRegistry::Global().Create("elemul",
-                                              TARGET(kOpenCL),
-                                              PRECISION(kFloat),
-                                              DATALAYOUT(kImageDefault));
-          ASSERT_FALSE(buf_to_img_kernels.empty());
-          ASSERT_FALSE(buf_to_img_kernels.empty());
-          ASSERT_FALSE(elemul_img_kernels.empty());
+  LOG(INFO) << "======== input shape[n,c,h,w]:" << n << " " << c << " " << h
+            << " " << w << " ========";
 
-          auto buf_to_img_kernel = std::move(buf_to_img_kernels.front());
-          auto img_to_buf_kernel = std::move(img_to_buf_kernels.front());
-          auto elemul_img_kernel = std::move(elemul_img_kernels.front());
-          LOG(INFO) << "get 1st kernel: " << buf_to_img_kernel->doc();
-          LOG(INFO) << "get 2nd kernel: " << img_to_buf_kernel->doc();
-          LOG(INFO) << "get 3rd kernel: " << elemul_img_kernel->doc();
+  const DDim x_dim = DDim(std::vector<DDim::value_type>{n, c, h, w});
+  auto y_dim = x_dim;
+  auto out_dim = x_dim;
 
-          // set tensors about op param
-          LOG(INFO) << "set tensors about op param";
-          // layout(buf->img): x -> elemul_in
-          // elemul(img): elemul_in -> elemul_out
-          // layout(img->buf): elemul_out -> y
-          lite::Tensor x, y, elemul_in, elemul_out, y_ref;
-          operators::LayoutParam BufferToImageParam;
-          operators::LayoutParam ImageToBufferParam;
-          BufferToImageParam.x = &x;
-          BufferToImageParam.y = &elemul_in;
-          ImageToBufferParam.x = &elemul_out;
-          ImageToBufferParam.y = &y;
-          operators::ActivationParam elemulParam;
-          elemulParam.X = &elemul_in;
-          elemulParam.Out = &elemul_out;
+  LOG(INFO) << "set tensors about op param";
+  lite::Tensor x, y, out;     // cpu
+  lite::Tensor x_img, y_img;  // cpu
+  lite::Tensor elemul_x, elemul_y, elemul_out;
 
-          const DDim x_dim = DDim(std::vector<DDim::value_type>{n, c, h, w});
-          x.Resize(x_dim);
-          y.Resize(x_dim);
-          elemul_in.Resize(x_dim);
-          elemul_out.Resize(x_dim);
-          y_ref.Resize(x_dim);
-          auto elemul_image2d_shape =
-              paddle::lite::kernels::opencl::InitImageDimInfoWith(x_dim);
+  x.Resize(x_dim);
+  y.Resize(y_dim);
+  out.Resize(out_dim);
 
-          // initialize tensors
-          LOG(INFO) << "initialize tensors";
-          auto *x_data = x.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
-          auto *y_data = y.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
-          auto *y_data_ref = y_ref.mutable_data<float>(TARGET(kARM));
-          auto *mapped_x = static_cast<float *>(TargetWrapperCL::Map(
-              x_data, 0, sizeof(float) * x_dim.production()));
-          auto *mapped_y = static_cast<float *>(TargetWrapperCL::Map(
-              y_data, 0, sizeof(float) * x_dim.production()));
-          for (int i = 0; i < x_dim.production(); ++i) {
-            mapped_x[i] = static_cast<int>(i) - x_dim.production() / 2;
-            mapped_y[i] = static_cast<int>(0);
-          }
-          auto *elemul_in_data = elemul_in.mutable_data<float, cl::Image2D>(
-              elemul_image2d_shape["width"], elemul_image2d_shape["height"]);
-          auto *elemul_out_data = elemul_out.mutable_data<float, cl::Image2D>(
-              elemul_image2d_shape["width"], elemul_image2d_shape["height"]);
+  elemul_x.Resize(x_dim);
+  elemul_y.Resize(y_dim);
+  elemul_out.Resize(out_dim);
 
-          // set context and kernel args
-          LOG(INFO) << "set context and kernel args";
-          std::unique_ptr<KernelContext> context(new KernelContext);
-          context->As<OpenCLContext>().InitOnce();
+  paddle::lite::CLImageConverterDefault default_convertor;
 
-          buf_to_img_kernel->SetParam(BufferToImageParam);
-          std::unique_ptr<KernelContext> buf_to_img_context(new KernelContext);
-          context->As<OpenCLContext>().CopySharedTo(
-              &(buf_to_img_context->As<OpenCLContext>()));
-          buf_to_img_kernel->SetContext(std::move(buf_to_img_context));
+  // initialize tensors
+  LOG(INFO) << "initialize tensors";
+  auto *x_data = x.mutable_data<float>();
+  fill_data<float>(x_data, x.dims().production());
+  auto *y_data = y.mutable_data<float>();
+  fill_data<float>(y_data, y.dims().production());
+  auto *out_data = out.mutable_data<float>();
+  fill_data<float>(out_data, out.dims().production(), 0);
 
-          img_to_buf_kernel->SetParam(ImageToBufferParam);
-          std::unique_ptr<KernelContext> img_to_buf_context(new KernelContext);
-          context->As<OpenCLContext>().CopySharedTo(
-              &(img_to_buf_context->As<OpenCLContext>()));
-          img_to_buf_kernel->SetContext(std::move(img_to_buf_context));
+  // x
+  std::vector<float> x_v(x_dim.production());
+  fill_data<float>(x_v.data(), x_v.size());  // fill with index value
+  auto x_img_shape = default_convertor.InitImageDimInfoWith(x_dim);  // w, h
+  auto x_img_w = x_img_shape[0];
+  auto x_img_h = x_img_shape[1];
+  std::vector<float> x_img_v(x_img_w * x_img_h * 4);  // 4: RGBA
+  default_convertor.NCHWToImage(x_v.data(), x_img_v.data(), x_dim);
+  elemul_x.mutable_data<float, cl::Image2D>(x_img_w, x_img_h, x_img_v.data());
 
-          elemul_img_kernel->SetParam(elemulParam);
-          std::unique_ptr<KernelContext> elemul_img_context(new KernelContext);
-          context->As<OpenCLContext>().CopySharedTo(
-              &(elemul_img_context->As<OpenCLContext>()));
-          elemul_img_kernel->SetContext(std::move(elemul_img_context));
+  // y
+  std::vector<float> y_v(y_dim.production());
+  fill_data<float>(y_v.data(), y_v.size());  // fill with index value
+  auto y_img_shape = default_convertor.InitImageDimInfoWith(y_dim);  // w, h
+  auto y_img_w = y_img_shape[0];
+  auto y_img_h = y_img_shape[1];
+  std::vector<float> y_img_v(y_img_shape[0] * y_img_shape[1] * 4);  // 4: RGBA
+  default_convertor.NCHWToImage(y_v.data(), y_img_v.data(), y_dim);
+  elemul_y.mutable_data<float, cl::Image2D>(y_img_w, y_img_h, y_img_v.data());
 
-          // run kernels
-          LOG(INFO) << "run kernel: buf_to_img_kernel";
-          buf_to_img_kernel->Launch();
-          LOG(INFO) << "run kernel: elemul_img_kernel";
-          elemul_img_kernel->Launch();
-          LOG(INFO) << "run kernel: img_to_buf_kernel";
-          img_to_buf_kernel->Launch();
+  // out
+  auto out_img_shape = default_convertor.InitImageDimInfoWith(out_dim);  // w, h
+  auto out_img_w = out_img_shape[0];
+  auto out_img_h = out_img_shape[1];
+  // elemul_out.mutable_data<float, cl::Image2D>(out_img_w, out_img_h);
 
-          // compute ref cpu
-          elementwise_compute_ref<float>(
-              mapped_x, mapped_y, out_ref.get(), x_dim, y_dim, param.axis,
-               "mul");
-//`          elementwise_compute_ref<float>(mapped_x, x_dim, y_data_ref);
-// result
-#ifdef PRINT_RESULT
-          LOG(INFO) << "---- print kernel result (input -> output) ----";
-          for (int eidx = 0; eidx < x_dim.production(); ++eidx) {
-            std::cout << mapped_x[eidx] << " -> " << mapped_y[eidx]
-                      << std::endl;
-          }
-#endif  // PRINT_RESULT
+  std::vector<float> out_img_v(out_img_w * out_img_h * 4);
+  fill_data<float>(
+      out_img_v.data(), out_img_v.size(), 0);  // fill with zero value
 
-          // check result: compare kernel output and cpu output(y_data_ref)
-          for (int eidx = 0; eidx < x_dim.production(); eidx++) {
-            EXPECT_NEAR(y_data_ref[eidx], mapped_y[eidx], 1e-6);
-            if (abs(y_data_ref[eidx] - mapped_y[eidx]) > 1e-6) {
-              LOG(INFO) << "1st diff in this case at eidx[from 0]:" << eidx
-                        << " / " << x_dim.production() << ", y_data_ref["
-                        << eidx << "]:" << y_data_ref[eidx] << ", mapped_y["
-                        << eidx << "]:" << mapped_y[eidx];
-              break;
-            }
-          }
+  std::vector<float> out_v(out_dim.production());
 
-          // free
-          LOG(INFO) << "free: unmap x, y";
-          TargetWrapperCL::Unmap(x_data, mapped_x);
-          TargetWrapperCL::Unmap(y_data, mapped_y);
-#ifdef LOOP_TEST
-        }  // w
-      }    // h
-    }      // c
-  }        // n
-#else
-// nothing to do.
+  // operator param
+  operators::ElementwiseParam elemulParam;
+  elemulParam.X = &elemul_x;
+  elemulParam.Y = &elemul_y;
+  elemulParam.Out = &elemul_out;
+  elemulParam.axis = -1;
+
+  // set kernel
+  auto elemul_img_kernels =
+      KernelRegistry::Global().Create("elementwise_mul",
+                                      TARGET(kOpenCL),
+                                      PRECISION(kFloat),
+                                      DATALAYOUT(kImageDefault));
+  ASSERT_FALSE(elemul_img_kernels.empty());
+
+  auto elemul_img_kernel = std::move(elemul_img_kernels.front());
+  LOG(INFO) << "get elemul kernel: " << elemul_img_kernel->doc();
+
+  // set context and kernel args
+  LOG(INFO) << "set context and kernel args";
+  std::unique_ptr<KernelContext> context(new KernelContext);
+  context->As<OpenCLContext>().InitOnce();
+
+  elemul_img_kernel->SetParam(elemulParam);
+  std::unique_ptr<KernelContext> elemul_img_context(new KernelContext);
+  context->As<OpenCLContext>().CopySharedTo(
+      &(elemul_img_context->As<OpenCLContext>()));
+  elemul_img_kernel->SetContext(std::move(elemul_img_context));
+
+  // run kernel
+  LOG(INFO) << "run kernel: elemul_img_kernel";
+  elemul_img_kernel->Launch();
+
+  // download gpu result to cpu
+  const size_t cl_image2d_row_pitch{0};
+  const size_t cl_image2d_slice_pitch{0};
+  TargetWrapperCL::ImgcpySync(out_img_v.data(),
+                              elemul_out.data<float, cl::Image2D>(),
+                              out_img_w,
+                              out_img_h,
+                              cl_image2d_row_pitch,
+                              cl_image2d_slice_pitch,
+                              IoDirection::DtoH);
+  default_convertor.ImageToNCHW(
+      out_img_v.data(), out_v.data(), out_img_shape, out_dim);
+
+#ifdef PRINT_RESULT  // top10
+  for (int i = 0; i < 10; i++) {
+    LOG(INFO) << "x_v[" << i << "]:" << x_v[i] << "\tout_v[" << i
+              << "]:" << out_v[i];
+  }
+  for (int i = 0; i < 10; i++) {
+    LOG(INFO) << "x_img_v[" << i << "]:" << x_img_v[i] << "\tout_img_v[" << i
+              << "]:" << out_img_v.data()[i];
+  }
 #endif
+
+  // compute cpu reference
+  std::unique_ptr<float[]> out_ref(new float[out_dim.production()]);
+  elementwise_compute_ref<float>(
+      x_data, y_data, out_ref.get(), x_dim, y_dim, elemulParam.axis, "mul");
+
+  for (int eidx = 0; eidx < out_dim.production(); eidx++) {
+    auto value = out_v[eidx];
+    auto ref_value = out_ref.get()[eidx];
+    EXPECT_NEAR(value, ref_value, 1e-6);
+    if (abs(value - ref_value) > 1e-6) {
+      LOG(INFO) << "1st diff in this case at eidx[from 0]:" << eidx << " / "
+                << out_dim.production() << ", value[" << eidx << "]:" << value
+                << ", ref_value[" << eidx << "]:" << ref_value;
+      break;
+    }
+  }
 }
-#endif
 
 }  // namespace lite
 }  // namespace paddle

--- a/lite/kernels/opencl/elementwise_mul_compute_test.cc
+++ b/lite/kernels/opencl/elementwise_mul_compute_test.cc
@@ -80,9 +80,9 @@ void elementwise_compute_ref(const dtype *x_data,
   } else if (y_dims.size() == 4) {
     // eg: x_dims: [1, 3, 2, 2]
     //     y_dims: [1, 3, 1, 1]
-    ASSERT_EQ(y_dims[2] == y_dims[3]);
-    ASSERT_EQ(y_dims[2] == 1);
-    ASSERT_EQ(y_dims[0] == 1);
+    ASSERT_EQ(y_dims[2], y_dims[3]);
+    ASSERT_EQ(y_dims[2], 1);
+    ASSERT_EQ(y_dims[0], 1);
     auto y_offset = y_dims.production();
     auto x_offset = x_dims.production() / y_offset;
     for (auto x = 0; x < x_dims.production(); ++x) {

--- a/lite/kernels/opencl/elementwise_mul_compute_test.cc
+++ b/lite/kernels/opencl/elementwise_mul_compute_test.cc
@@ -60,7 +60,7 @@ void elementwise_compute_ref(const dtype *x_data,
     num *= x_dims[i];
   }
 
-  if (elt_type == "mul") {
+  if (x_dims == y_dims || y_dims.size() == 2 || y_dims.size() == 1) {
     for (int i = 0; i < batch; ++i) {
       for (int j = 0; j < channels; ++j) {
         int offset = (i * channels + j) * num;
@@ -77,6 +77,18 @@ void elementwise_compute_ref(const dtype *x_data,
         }
       }
     }
+  } else if (y_dims.size() == 4) {
+    // eg: x_dims: [1, 3, 2, 2]
+    //     y_dims: [1, 3, 1, 1]
+    ASSERT_EQ(y_dims[2] == y_dims[3]);
+    ASSERT_EQ(y_dims[2] == 1);
+    ASSERT_EQ(y_dims[0] == 1);
+    auto y_offset = y_dims.production();
+    auto x_offset = x_dims.production() / y_offset;
+    for (auto x = 0; x < x_dims.production(); ++x) {
+      auto y = x / x_offset;
+      out_data[x] = x_data[x] * y_data[y];
+    }
   } else {
     LOG(FATAL) << "unsupported Elementwise type: " << elt_type << std::endl;
   }
@@ -89,145 +101,146 @@ TEST(elemul_image2d_fp32, compute_kernel_elemenwise_mul) {
          "layout(img2buf on cpu) "
          "-> host";
 
+  // dims
   const int n = 1;
-  const int c = 2;
-  const int h = 3;
-  const int w = 4;
-
-  LOG(INFO) << "======== input shape[n,c,h,w]:" << n << " " << c << " " << h
-            << " " << w << " ========";
+  const int c = 3;
+  const int h = 2;
+  const int w = 2;
 
   const DDim x_dim = DDim(std::vector<DDim::value_type>{n, c, h, w});
-  auto y_dim = x_dim;
   auto out_dim = x_dim;
+  std::vector<DDim> y_dim_v{DDim(std::vector<DDim::value_type>{n, c, h, w}),
+                            DDim(std::vector<DDim::value_type>{h, w}),
+                            DDim(std::vector<DDim::value_type>{w})};
+  for (auto y_dim : y_dim_v) {
+    LOG(INFO) << "================== elementwise_mul ===================";
+    LOG(INFO) << "x_dim:" << x_dim << "\ty_dim:" << y_dim
+              << "\tout_dim:" << out_dim;
 
-  LOG(INFO) << "set tensors about op param";
-  lite::Tensor x, y, out;     // cpu
-  lite::Tensor x_img, y_img;  // cpu
-  lite::Tensor elemul_x, elemul_y, elemul_out;
+    // tensor
+    LOG(INFO) << "set tensors about op param";
+    lite::Tensor elemul_x, elemul_y, elemul_out;
+    elemul_x.Resize(x_dim);
+    elemul_y.Resize(y_dim);
+    elemul_out.Resize(out_dim);
 
-  x.Resize(x_dim);
-  y.Resize(y_dim);
-  out.Resize(out_dim);
+    // initialize tensors
+    VLOG(4) << "initialize tensors";
+    paddle::lite::CLImageConverterDefault default_convertor;
+    // x
+    std::vector<float> x_v(x_dim.production());
+    fill_data<float>(x_v.data(), x_v.size());  // fill with index value
+    auto x_img_shape = default_convertor.InitImageDimInfoWith(x_dim);  // w, h
+    auto x_img_w = x_img_shape[0];
+    auto x_img_h = x_img_shape[1];
+    std::vector<float> x_img_v(x_img_w * x_img_h * 4);  // 4: RGBA
+    default_convertor.NCHWToImage(x_v.data(), x_img_v.data(), x_dim);
+    elemul_x.mutable_data<float, cl::Image2D>(x_img_w, x_img_h, x_img_v.data());
 
-  elemul_x.Resize(x_dim);
-  elemul_y.Resize(y_dim);
-  elemul_out.Resize(out_dim);
+    // y
+    std::vector<float> y_v(y_dim.production());
+    fill_data<float>(y_v.data(), y_v.size());  // fill with index value
+    auto y_img_shape = default_convertor.InitImageDimInfoWith(y_dim);  // w, h
+    auto y_img_w = y_img_shape[0];
+    auto y_img_h = y_img_shape[1];
+    std::vector<float> y_img_v(y_img_shape[0] * y_img_shape[1] * 4);  // 4: RGBA
+    default_convertor.NCHWToImage(y_v.data(), y_img_v.data(), y_dim);
+    elemul_y.mutable_data<float, cl::Image2D>(y_img_w, y_img_h, y_img_v.data());
 
-  paddle::lite::CLImageConverterDefault default_convertor;
+    // out
+    auto out_img_shape =
+        default_convertor.InitImageDimInfoWith(out_dim);  // w, h
+    auto out_img_w = out_img_shape[0];
+    auto out_img_h = out_img_shape[1];
+    elemul_out.mutable_data<float, cl::Image2D>(out_img_w, out_img_h);
 
-  // initialize tensors
-  LOG(INFO) << "initialize tensors";
-  auto *x_data = x.mutable_data<float>();
-  fill_data<float>(x_data, x.dims().production());
-  auto *y_data = y.mutable_data<float>();
-  fill_data<float>(y_data, y.dims().production());
-  auto *out_data = out.mutable_data<float>();
-  fill_data<float>(out_data, out.dims().production(), 0);
+    std::vector<float> out_img_v(out_img_w * out_img_h * 4);
+    fill_data<float>(
+        out_img_v.data(), out_img_v.size(), 0);  // fill with zero value
 
-  // x
-  std::vector<float> x_v(x_dim.production());
-  fill_data<float>(x_v.data(), x_v.size());  // fill with index value
-  auto x_img_shape = default_convertor.InitImageDimInfoWith(x_dim);  // w, h
-  auto x_img_w = x_img_shape[0];
-  auto x_img_h = x_img_shape[1];
-  std::vector<float> x_img_v(x_img_w * x_img_h * 4);  // 4: RGBA
-  default_convertor.NCHWToImage(x_v.data(), x_img_v.data(), x_dim);
-  elemul_x.mutable_data<float, cl::Image2D>(x_img_w, x_img_h, x_img_v.data());
+    std::vector<float> out_v(out_dim.production());
 
-  // y
-  std::vector<float> y_v(y_dim.production());
-  fill_data<float>(y_v.data(), y_v.size());  // fill with index value
-  auto y_img_shape = default_convertor.InitImageDimInfoWith(y_dim);  // w, h
-  auto y_img_w = y_img_shape[0];
-  auto y_img_h = y_img_shape[1];
-  std::vector<float> y_img_v(y_img_shape[0] * y_img_shape[1] * 4);  // 4: RGBA
-  default_convertor.NCHWToImage(y_v.data(), y_img_v.data(), y_dim);
-  elemul_y.mutable_data<float, cl::Image2D>(y_img_w, y_img_h, y_img_v.data());
+    // operator param
+    operators::ElementwiseParam elemulParam;
+    elemulParam.X = &elemul_x;
+    elemulParam.Y = &elemul_y;
+    elemulParam.Out = &elemul_out;
+    elemulParam.axis = -1;
 
-  // out
-  auto out_img_shape = default_convertor.InitImageDimInfoWith(out_dim);  // w, h
-  auto out_img_w = out_img_shape[0];
-  auto out_img_h = out_img_shape[1];
-  // elemul_out.mutable_data<float, cl::Image2D>(out_img_w, out_img_h);
+    // set kernel
+    auto elemul_img_kernels =
+        KernelRegistry::Global().Create("elementwise_mul",
+                                        TARGET(kOpenCL),
+                                        PRECISION(kFloat),
+                                        DATALAYOUT(kImageDefault));
+    ASSERT_FALSE(elemul_img_kernels.empty());
 
-  std::vector<float> out_img_v(out_img_w * out_img_h * 4);
-  fill_data<float>(
-      out_img_v.data(), out_img_v.size(), 0);  // fill with zero value
+    auto elemul_img_kernel = std::move(elemul_img_kernels.front());
+    VLOG(4) << "get elemul kernel: " << elemul_img_kernel->doc();
 
-  std::vector<float> out_v(out_dim.production());
+    // set context and kernel args
+    VLOG(4) << "set context and kernel args";
+    std::unique_ptr<KernelContext> context(new KernelContext);
+    context->As<OpenCLContext>().InitOnce();
 
-  // operator param
-  operators::ElementwiseParam elemulParam;
-  elemulParam.X = &elemul_x;
-  elemulParam.Y = &elemul_y;
-  elemulParam.Out = &elemul_out;
-  elemulParam.axis = -1;
+    elemul_img_kernel->SetParam(elemulParam);
+    std::unique_ptr<KernelContext> elemul_img_context(new KernelContext);
+    context->As<OpenCLContext>().CopySharedTo(
+        &(elemul_img_context->As<OpenCLContext>()));
+    elemul_img_kernel->SetContext(std::move(elemul_img_context));
 
-  // set kernel
-  auto elemul_img_kernels =
-      KernelRegistry::Global().Create("elementwise_mul",
-                                      TARGET(kOpenCL),
-                                      PRECISION(kFloat),
-                                      DATALAYOUT(kImageDefault));
-  ASSERT_FALSE(elemul_img_kernels.empty());
+    // run kernel
+    VLOG(4) << "run kernel";
+    elemul_img_kernel->Launch();
 
-  auto elemul_img_kernel = std::move(elemul_img_kernels.front());
-  LOG(INFO) << "get elemul kernel: " << elemul_img_kernel->doc();
+    // download gpu result to cpu
+    const size_t cl_image2d_row_pitch{0};
+    const size_t cl_image2d_slice_pitch{0};
+    TargetWrapperCL::ImgcpySync(out_img_v.data(),
+                                elemul_out.data<float, cl::Image2D>(),
+                                out_img_w,
+                                out_img_h,
+                                cl_image2d_row_pitch,
+                                cl_image2d_slice_pitch,
+                                IoDirection::DtoH);
+    default_convertor.ImageToNCHW(
+        out_img_v.data(), out_v.data(), out_img_shape, out_dim);
 
-  // set context and kernel args
-  LOG(INFO) << "set context and kernel args";
-  std::unique_ptr<KernelContext> context(new KernelContext);
-  context->As<OpenCLContext>().InitOnce();
+    // compute cpu reference
+    std::unique_ptr<float[]> out_ref(new float[out_dim.production()]);
+    elementwise_compute_ref<float>(x_v.data(),
+                                   y_v.data(),
+                                   out_ref.get(),
+                                   x_dim,
+                                   y_dim,
+                                   elemulParam.axis,
+                                   "mul");
 
-  elemul_img_kernel->SetParam(elemulParam);
-  std::unique_ptr<KernelContext> elemul_img_context(new KernelContext);
-  context->As<OpenCLContext>().CopySharedTo(
-      &(elemul_img_context->As<OpenCLContext>()));
-  elemul_img_kernel->SetContext(std::move(elemul_img_context));
+#if 0  // enable to check value of x and y
+    for (int eidx = 0; eidx < out_dim.production(); eidx++) {
+      auto value = out_v[eidx];
+      auto ref_value = out_ref.get()[eidx];
+        LOG(INFO) << "1st diff in this case at eidx[from 0]:" << eidx << " / "
+                  << out_dim.production() << ", x_v[" << eidx << "]:"
+                  << x_v[eidx] << ", value[" << eidx << "]:" << value
+                  << ", ref_value[" << eidx << "]:" << ref_value;
+    }
 
-  // run kernel
-  LOG(INFO) << "run kernel: elemul_img_kernel";
-  elemul_img_kernel->Launch();
-
-  // download gpu result to cpu
-  const size_t cl_image2d_row_pitch{0};
-  const size_t cl_image2d_slice_pitch{0};
-  TargetWrapperCL::ImgcpySync(out_img_v.data(),
-                              elemul_out.data<float, cl::Image2D>(),
-                              out_img_w,
-                              out_img_h,
-                              cl_image2d_row_pitch,
-                              cl_image2d_slice_pitch,
-                              IoDirection::DtoH);
-  default_convertor.ImageToNCHW(
-      out_img_v.data(), out_v.data(), out_img_shape, out_dim);
-
-#ifdef PRINT_RESULT  // top10
-  for (int i = 0; i < 10; i++) {
-    LOG(INFO) << "x_v[" << i << "]:" << x_v[i] << "\tout_v[" << i
-              << "]:" << out_v[i];
-  }
-  for (int i = 0; i < 10; i++) {
-    LOG(INFO) << "x_img_v[" << i << "]:" << x_img_v[i] << "\tout_img_v[" << i
-              << "]:" << out_img_v.data()[i];
-  }
+    for (int i = 0; i < y_v.size(); i++) {
+      LOG(INFO) << "y_v[" << i << "]:" << y_v[i];
+    }
 #endif
 
-  // compute cpu reference
-  std::unique_ptr<float[]> out_ref(new float[out_dim.production()]);
-  elementwise_compute_ref<float>(
-      x_data, y_data, out_ref.get(), x_dim, y_dim, elemulParam.axis, "mul");
-
-  for (int eidx = 0; eidx < out_dim.production(); eidx++) {
-    auto value = out_v[eidx];
-    auto ref_value = out_ref.get()[eidx];
-    EXPECT_NEAR(value, ref_value, 1e-6);
-    if (abs(value - ref_value) > 1e-6) {
-      LOG(INFO) << "1st diff in this case at eidx[from 0]:" << eidx << " / "
-                << out_dim.production() << ", value[" << eidx << "]:" << value
-                << ", ref_value[" << eidx << "]:" << ref_value;
-      break;
+    for (int eidx = 0; eidx < out_dim.production(); eidx++) {
+      auto value = out_v[eidx];
+      auto ref_value = out_ref.get()[eidx];
+      EXPECT_NEAR(value, ref_value, 1e-6);
+      if (abs(value - ref_value) > 1e-6) {
+        LOG(INFO) << "1st diff in this case at eidx[from 0]:" << eidx << " / "
+                  << out_dim.production() << ", value[" << eidx << "]:" << value
+                  << ", ref_value[" << eidx << "]:" << ref_value;
+        break;
+      }
     }
   }
 }

--- a/lite/kernels/opencl/elementwise_mul_compute_test.cc
+++ b/lite/kernels/opencl/elementwise_mul_compute_test.cc
@@ -1,0 +1,348 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <random>
+#include "lite/backends/opencl/target_wrapper.h"
+#include "lite/core/op_registry.h"
+#include "lite/core/tensor.h"
+
+namespace paddle {
+namespace lite {
+
+template <typename dtype>
+void elementwise_compute_ref(const dtype *x_data,
+                             const dtype *y_data,
+                             dtype *out_data,
+                             const DDim &x_dims,
+                             const DDim &y_dims,
+                             int axis,
+                             const std::string elt_type,
+                             bool use_relu = false) {
+  if (axis < 0) {
+    axis = x_dims.size() - y_dims.size();
+  }
+  int batch = 1;
+  int channels = 1;
+  int num = 1;
+  for (int i = 0; i < axis; ++i) {
+    batch *= x_dims[i];
+  }
+  for (int i = 0; i < y_dims.size(); ++i) {
+    channels *= y_dims[i];
+  }
+  for (int i = y_dims.size() + axis; i < x_dims.size(); ++i) {
+    num *= x_dims[i];
+  }
+  // do elementwise add/sub/max/...
+  if (elt_type == "add") {
+    for (int i = 0; i < batch; ++i) {
+      for (int j = 0; j < channels; ++j) {
+        int offset = (i * channels + j) * num;
+        const dtype *din_ptr = x_data + offset;
+        const dtype diny_data = y_data[j];
+        dtype *dout_ptr = out_data + offset;
+        for (int k = 0; k < num; ++k) {
+          *dout_ptr = *din_ptr + diny_data;
+          if (use_relu) {
+            *dout_ptr = std::max(*dout_ptr, static_cast<dtype>(0));
+          }
+          dout_ptr++;
+          din_ptr++;
+        }
+      }
+    }
+  } else if (elt_type == "sub") {
+    for (int i = 0; i < batch; ++i) {
+      for (int j = 0; j < channels; ++j) {
+        int offset = (i * channels + j) * num;
+        const dtype *din_ptr = x_data + offset;
+        const dtype diny_data = y_data[j];
+        dtype *dout_ptr = out_data + offset;
+        for (int k = 0; k < num; ++k) {
+          *dout_ptr = *din_ptr - diny_data;
+          if (use_relu) {
+            *dout_ptr = std::max(*dout_ptr, static_cast<dtype>(0));
+          }
+          dout_ptr++;
+          din_ptr++;
+        }
+      }
+    }
+  } else if (elt_type == "mul") {
+    for (int i = 0; i < batch; ++i) {
+      for (int j = 0; j < channels; ++j) {
+        int offset = (i * channels + j) * num;
+        const dtype *din_ptr = x_data + offset;
+        const dtype diny_data = y_data[j];
+        dtype *dout_ptr = out_data + offset;
+        for (int k = 0; k < num; ++k) {
+          *dout_ptr = *din_ptr * diny_data;
+          if (use_relu) {
+            *dout_ptr = std::max(*dout_ptr, static_cast<dtype>(0));
+          }
+          dout_ptr++;
+          din_ptr++;
+        }
+      }
+    }
+  } else {
+    LOG(FATAL) << "unsupported Elementwise type: " << elt_type << std::endl;
+  }
+}
+
+#if 0
+TEST(elementwise_mul_image_fp32, compute) {
+  LOG(INFO) << "to get kernel ...";
+  auto kernels = KernelRegistry::Global().Create(
+      "elementwise_mul", TARGET(kOpenCL), PRECISION(kFloat),
+      DATALAYOUT(kImageDefault));
+  ASSERT_FALSE(kernels.empty());
+
+  auto kernel = std::move(kernels.front());
+
+  LOG(INFO) << "get kernel" << kernel->doc();
+
+  lite::Tensor x, y, out;
+  operators::ElementwiseParam param;
+  param.X = &x;
+  param.Y = &y;
+  param.Out = &out;
+  param.axis = -1;
+
+  std::unique_ptr<KernelContext> context(new KernelContext);
+  context->As<OpenCLContext>().InitOnce();
+
+  kernel->SetParam(param);
+  std::unique_ptr<KernelContext> ele_context(new KernelContext);
+  context->As<OpenCLContext>().CopySharedTo(
+      &(ele_context->As<OpenCLContext>()));
+  kernel->SetContext(std::move(ele_context));
+
+  const DDim x_dim = DDim(std::vector<DDim::value_type>{3, 2, 1, 5});
+  const DDim y_dim = DDim(std::vector<DDim::value_type>{2, 1, 5});
+  const DDim out_dim = DDim(std::vector<DDim::value_type>{3, 2, 1, 5});
+  x.Resize(x_dim);
+  y.Resize(y_dim);
+  out.Resize(out_dim);
+
+  auto *x_data = x.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+  auto *y_data = y.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+
+  std::default_random_engine engine;
+  std::uniform_real_distribution<float> dist(-10, 10);
+  auto *mapped_x = static_cast<float *>(
+      TargetWrapperCL::Map(x_data, 0, sizeof(float) * x_dim.production()));
+  for (int i = 0; i < x_dim.production(); i++) {
+    mapped_x[i] = dist(engine);
+  }
+  auto *mapped_y = static_cast<float *>(
+      TargetWrapperCL::Map(y_data, 0, sizeof(float) * y_dim.production()));
+  for (int i = 0; i < y_dim.production(); i++) {
+    mapped_y[i] = dist(engine);
+  }
+
+  kernel->Launch();
+
+  auto *wait_list = context->As<OpenCLContext>().cl_wait_list();
+  auto *out_ptr = param.Out->data<float, cl::Buffer>();
+  auto it = wait_list->find(out_ptr);
+  if (it != wait_list->end()) {
+    VLOG(4) << "--- Find the sync event for the target cl tensor. ---";
+    auto &event = *(it->second);
+    event.wait();
+  } else {
+    LOG(FATAL) << "Could not find the sync event for the target cl tensor.";
+  }
+
+  std::unique_ptr<float[]> out_ref(new float[out_dim.production()]);
+  elementwise_compute_ref<float>(
+      mapped_x, mapped_y, out_ref.get(), x_dim, y_dim, param.axis, "add");
+
+  TargetWrapperCL::Unmap(x_data, mapped_x);
+  TargetWrapperCL::Unmap(y_data, mapped_y);
+  auto *out_data = out.mutable_data<float, cl::Buffer>();
+  auto *mapped_out = static_cast<float *>(
+      TargetWrapperCL::Map(out_data, 0, sizeof(float) * out_dim.production()));
+  for (int i = 0; i < out_dim.production(); i++) {
+    EXPECT_NEAR(mapped_out[i], out_ref[i], 1e-6);
+  }
+  TargetWrapperCL::Unmap(out_data, mapped_out);
+}
+
+// #define LOOP_TEST
+// #define PRINT_RESULT
+TEST(elemul_image2d_fp32, compute) {
+  LOG(INFO) << "main steps of test: host -> layout(buf2img) -> elemul(img) -> "
+               "layout(img2buf) "
+               "-> host";
+
+#ifdef LOOP_TEST
+  for (int n = 1; n <= 100; n += 33) {
+    for (auto c : {1, 3}) {
+      for (int h = 12; h <= 100; h += 13) {
+        for (int w = 12; w <= 100; w += 25) {
+#else
+  const int n = 1;
+  const int c = 2;
+  const int h = 3;
+  const int w = 4;
+#endif  // LOOP_TEST
+
+          LOG(INFO) << "======== input shape[n,c,h,w]:" << n << " " << c << " "
+                    << h << " " << w << " ========";
+          // set layout kernels
+          auto buf_to_img_kernels =
+              KernelRegistry::Global().Create("layout",
+                                              TARGET(kOpenCL),
+                                              PRECISION(kAny),
+                                              DATALAYOUT(kImageDefault));
+          auto img_to_buf_kernels = KernelRegistry::Global().Create(
+              "layout", TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW));
+          auto elemul_img_kernels =
+              KernelRegistry::Global().Create("elemul",
+                                              TARGET(kOpenCL),
+                                              PRECISION(kFloat),
+                                              DATALAYOUT(kImageDefault));
+          ASSERT_FALSE(buf_to_img_kernels.empty());
+          ASSERT_FALSE(buf_to_img_kernels.empty());
+          ASSERT_FALSE(elemul_img_kernels.empty());
+
+          auto buf_to_img_kernel = std::move(buf_to_img_kernels.front());
+          auto img_to_buf_kernel = std::move(img_to_buf_kernels.front());
+          auto elemul_img_kernel = std::move(elemul_img_kernels.front());
+          LOG(INFO) << "get 1st kernel: " << buf_to_img_kernel->doc();
+          LOG(INFO) << "get 2nd kernel: " << img_to_buf_kernel->doc();
+          LOG(INFO) << "get 3rd kernel: " << elemul_img_kernel->doc();
+
+          // set tensors about op param
+          LOG(INFO) << "set tensors about op param";
+          // layout(buf->img): x -> elemul_in
+          // elemul(img): elemul_in -> elemul_out
+          // layout(img->buf): elemul_out -> y
+          lite::Tensor x, y, elemul_in, elemul_out, y_ref;
+          operators::LayoutParam BufferToImageParam;
+          operators::LayoutParam ImageToBufferParam;
+          BufferToImageParam.x = &x;
+          BufferToImageParam.y = &elemul_in;
+          ImageToBufferParam.x = &elemul_out;
+          ImageToBufferParam.y = &y;
+          operators::ActivationParam elemulParam;
+          elemulParam.X = &elemul_in;
+          elemulParam.Out = &elemul_out;
+
+          const DDim x_dim = DDim(std::vector<DDim::value_type>{n, c, h, w});
+          x.Resize(x_dim);
+          y.Resize(x_dim);
+          elemul_in.Resize(x_dim);
+          elemul_out.Resize(x_dim);
+          y_ref.Resize(x_dim);
+          auto elemul_image2d_shape =
+              paddle::lite::kernels::opencl::InitImageDimInfoWith(x_dim);
+
+          // initialize tensors
+          LOG(INFO) << "initialize tensors";
+          auto *x_data = x.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+          auto *y_data = y.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+          auto *y_data_ref = y_ref.mutable_data<float>(TARGET(kARM));
+          auto *mapped_x = static_cast<float *>(TargetWrapperCL::Map(
+              x_data, 0, sizeof(float) * x_dim.production()));
+          auto *mapped_y = static_cast<float *>(TargetWrapperCL::Map(
+              y_data, 0, sizeof(float) * x_dim.production()));
+          for (int i = 0; i < x_dim.production(); ++i) {
+            mapped_x[i] = static_cast<int>(i) - x_dim.production() / 2;
+            mapped_y[i] = static_cast<int>(0);
+          }
+          auto *elemul_in_data = elemul_in.mutable_data<float, cl::Image2D>(
+              elemul_image2d_shape["width"], elemul_image2d_shape["height"]);
+          auto *elemul_out_data = elemul_out.mutable_data<float, cl::Image2D>(
+              elemul_image2d_shape["width"], elemul_image2d_shape["height"]);
+
+          // set context and kernel args
+          LOG(INFO) << "set context and kernel args";
+          std::unique_ptr<KernelContext> context(new KernelContext);
+          context->As<OpenCLContext>().InitOnce();
+
+          buf_to_img_kernel->SetParam(BufferToImageParam);
+          std::unique_ptr<KernelContext> buf_to_img_context(new KernelContext);
+          context->As<OpenCLContext>().CopySharedTo(
+              &(buf_to_img_context->As<OpenCLContext>()));
+          buf_to_img_kernel->SetContext(std::move(buf_to_img_context));
+
+          img_to_buf_kernel->SetParam(ImageToBufferParam);
+          std::unique_ptr<KernelContext> img_to_buf_context(new KernelContext);
+          context->As<OpenCLContext>().CopySharedTo(
+              &(img_to_buf_context->As<OpenCLContext>()));
+          img_to_buf_kernel->SetContext(std::move(img_to_buf_context));
+
+          elemul_img_kernel->SetParam(elemulParam);
+          std::unique_ptr<KernelContext> elemul_img_context(new KernelContext);
+          context->As<OpenCLContext>().CopySharedTo(
+              &(elemul_img_context->As<OpenCLContext>()));
+          elemul_img_kernel->SetContext(std::move(elemul_img_context));
+
+          // run kernels
+          LOG(INFO) << "run kernel: buf_to_img_kernel";
+          buf_to_img_kernel->Launch();
+          LOG(INFO) << "run kernel: elemul_img_kernel";
+          elemul_img_kernel->Launch();
+          LOG(INFO) << "run kernel: img_to_buf_kernel";
+          img_to_buf_kernel->Launch();
+
+          // compute ref cpu
+          elementwise_compute_ref<float>(
+              mapped_x, mapped_y, out_ref.get(), x_dim, y_dim, param.axis,
+               "mul");
+//`          elementwise_compute_ref<float>(mapped_x, x_dim, y_data_ref);
+// result
+#ifdef PRINT_RESULT
+          LOG(INFO) << "---- print kernel result (input -> output) ----";
+          for (int eidx = 0; eidx < x_dim.production(); ++eidx) {
+            std::cout << mapped_x[eidx] << " -> " << mapped_y[eidx]
+                      << std::endl;
+          }
+#endif  // PRINT_RESULT
+
+          // check result: compare kernel output and cpu output(y_data_ref)
+          for (int eidx = 0; eidx < x_dim.production(); eidx++) {
+            EXPECT_NEAR(y_data_ref[eidx], mapped_y[eidx], 1e-6);
+            if (abs(y_data_ref[eidx] - mapped_y[eidx]) > 1e-6) {
+              LOG(INFO) << "1st diff in this case at eidx[from 0]:" << eidx
+                        << " / " << x_dim.production() << ", y_data_ref["
+                        << eidx << "]:" << y_data_ref[eidx] << ", mapped_y["
+                        << eidx << "]:" << mapped_y[eidx];
+              break;
+            }
+          }
+
+          // free
+          LOG(INFO) << "free: unmap x, y";
+          TargetWrapperCL::Unmap(x_data, mapped_x);
+          TargetWrapperCL::Unmap(y_data, mapped_y);
+#ifdef LOOP_TEST
+        }  // w
+      }    // h
+    }      // c
+  }        // n
+#else
+// nothing to do.
+#endif
+}
+#endif
+
+}  // namespace lite
+}  // namespace paddle
+
+USE_LITE_KERNEL(elementwise_mul, kOpenCL, kFloat, kImageDefault, def);


### PR DESCRIPTION
# 状态：4个kernel，对应单测也已完成。等待review

## 主要内容

1. 迁移paddle-mobile中的elemenwise_mul的4个opencl image2d kernel，到paddle-lite中；
2. 针对4个kernel的情况，实现对应单测。

单测针对下面四种y的情况：

```cpp
  const DDim x_dim = DDim(std::vector<DDim::value_type>{n, c, h, w});
  auto out_dim = x_dim;
  std::vector<DDim> y_dim_v{DDim(std::vector<DDim::value_type>{n, c, 1, 1}),
                            DDim(std::vector<DDim::value_type>{n, c, h, w}),
                            DDim(std::vector<DDim::value_type>{h, w}),
                            DDim(std::vector<DDim::value_type>{w})};
```