### PR TITLE
Implement a class PrecisionTypeTrait to get the PrecisionType of a c++ basic data type

### DIFF
--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -116,6 +116,34 @@ static size_t PrecisionTypeLength(PrecisionType type) {
   }
 }
 
+template <typename T>
+struct PrecisionTypeTrait {
+  constexpr static PrecisionType Type() { return PrecisionType::kUnk; }
+};
+
+#define _ForEachPrecisionTypeHelper(callback, cpp_type, precision_type) \
+  callback(cpp_type, ::paddle::lite_api::PrecisionType::precision_type);
+
+#define _ForEachPrecisionType(callback)                   \
+  _ForEachPrecisionTypeHelper(callback, bool, kBool);     \
+  _ForEachPrecisionTypeHelper(callback, float, kFloat);   \
+  _ForEachPrecisionTypeHelper(callback, int8_t, kInt8);   \
+  _ForEachPrecisionTypeHelper(callback, int16_t, kInt16); \
+  _ForEachPrecisionTypeHelper(callback, int, kInt32);     \
+  _ForEachPrecisionTypeHelper(callback, int64_t, kInt64);
+
+#define DefinePrecisionTypeTrait(cpp_type, precision_type)           \
+  template <>                                                        \
+  struct PrecisionTypeTrait<cpp_type> {                              \
+    constexpr static PrecisionType Type() { return precision_type; } \
+  }
+
+_ForEachPrecisionType(DefinePrecisionTypeTrait);
+
+#undef _ForEachPrecisionTypeHelper
+#undef _ForEachPrecisionType
+#undef DefinePrecisionTypeTrait
+
 #define TARGET(item__) paddle::lite_api::TargetType::item__
 #define PRECISION(item__) paddle::lite_api::PrecisionType::item__
 #define DATALAYOUT(item__) paddle::lite_api::DataLayoutType::item__

--- a/lite/core/tensor.h
+++ b/lite/core/tensor.h
@@ -139,22 +139,7 @@ class TensorLite {
   // For other devices, T and R may be the same type.
   template <typename T, typename R = T>
   R *mutable_data() {
-    auto type_id = typeid(T).hash_code();
-    if (type_id == typeid(bool).hash_code()) {  // NOLINT
-      precision_ = PrecisionType::kBool;
-    } else if (type_id == typeid(float).hash_code()) {  // NOLINT
-      precision_ = PrecisionType::kFloat;
-    } else if (type_id == typeid(int8_t).hash_code()) {
-      precision_ = PrecisionType::kInt8;
-    } else if (type_id == typeid(int16_t).hash_code()) {
-      precision_ = PrecisionType::kInt16;
-    } else if (type_id == typeid(int32_t).hash_code()) {
-      precision_ = PrecisionType::kInt32;
-    } else if (type_id == typeid(int64_t).hash_code()) {
-      precision_ = PrecisionType::kInt64;
-    } else {
-      precision_ = PrecisionType::kUnk;
-    }
+    precision_ = lite_api::PrecisionTypeTrait<T>::Type();
     memory_size_ = dims_.production() * sizeof(T);
     buffer_->ResetLazy(target_, memory_size_);
     return reinterpret_cast<R *>(static_cast<char *>(buffer_->data()) +


### PR DESCRIPTION
develop代码中，TensorLite引入了数据类型的记录和检查，在`mutable_data<T>`时，会将模板中的数据类型转换成`PrecisionType`：
https://github.com/PaddlePaddle/Paddle-Lite/blob/3a91ca237f4d44cfd4d66417131337de982390ce/lite/core/tensor.h#L140-L157

由于反复计算基本数据类型的`hash_code`，导致StepRNN性能的回滚。develop的执行时间如下：
```
I0207 06:51:20.969707 18903 generate_program_pass.h:37] insts.size 42
I0207 06:51:21.398684 18903 test_step_rnn_lite_x86.cc:79] warmup: 10, repeats: 10000, spend 0.0416459 ms in average.
```

vtune分析tophots结果如下，可以看出`_Hash_bytes`占了不小的时间：
![image](https://user-images.githubusercontent.com/12538138/74007716-f7007080-49b9-11ea-8886-2a30940a5b5f.png)

这个PR参考Paddle中[DataTypeTrait](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/framework/data_type.h#L25)，实现了`PrecisionTypeTrait`，能够完全避免计算`hash_code`。优化后StepRNN的执行时间如下：
```
I0207 06:43:13.692117  6863 generate_program_pass.h:37] insts.size 42
I0207 06:43:14.088902  6863 test_step_rnn_lite_x86.cc:79] warmup: 10, repeats: 10000, spend 0.0384175 ms in average.
```

vtune的hotspots分析结果如下：
![image](https://user-images.githubusercontent.com/12538138/74008169-2e235180-49bb-11ea-9b6c-ba3202a15195.png)
