### PR TITLE
[BUG FIX]fix armv7 model loading issue test=develop

### DIFF
--- a/lite/model_parser/naive_buffer/param_desc.cc
+++ b/lite/model_parser/naive_buffer/param_desc.cc
@@ -152,10 +152,8 @@ void ParamDesc::SetDim(const std::vector<int64_t>& dim) {
     auto& data_builder = desc_->GetField<PrimaryListBuilder<char>>("data"); \
     auto data = data_builder.data();                                        \
     size_t size = data_builder.size() / sizeof(T);                          \
-    auto* data_ptr = reinterpret_cast<const T*>(data);                      \
-    for (size_t i = 0; i < size; ++i) {                                     \
-      res.push_back(data_ptr[i]);                                           \
-    }                                                                       \
+    res.resize(size);                                                       \
+    memcpy(&res[0], data, data_builder.size());                             \
     return res;                                                             \
   }
 


### PR DESCRIPTION
【BUG FIX】
问题描述：armv7下部分model无法加载
问题定位：加载模型是armv7要求数据指针地址必须为sizeof(T)的整数倍。
解决方法：本PR中将`reinterpret_cast`方法修改为memcpy方法，避免armv7下指针地址不规范问题