### PR TITLE
Optimize the InferShape of several operators.

### DIFF
--- a/lite/core/tensor.cc
+++ b/lite/core/tensor.cc
@@ -47,12 +47,11 @@ value_type DDimLite::count(int start, int end) const {
 DDimLite DDimLite::Slice(int start, int end) const {
   start = std::max(start, 0);
   end = std::min(end, static_cast<int>(data_.size()));
-  DDimLite new_dim;
-  new_dim.resize(end - start);
+  std::vector<value_type> new_dim(end - start);
   for (int i = start; i < end; i++) {
     new_dim[i - start] = data_[i];
   }
-  return new_dim;
+  return DDim(new_dim);
 }
 
 std::string DDimLite::repr() const {

--- a/lite/core/tensor.cc
+++ b/lite/core/tensor.cc
@@ -25,21 +25,17 @@ using value_type = int64_t;
 
 value_type DDimLite::production() const {
   value_type res = 1;
-  for (size_t i = 0; i < this->size(); i++) {
-    res *= (*this)[i];
+  for (size_t i = 0; i < data_.size(); i++) {
+    res *= data_[i];
   }
   return res;
 }
 
 value_type DDimLite::count(int start, int end) const {
-  if (start < 0) {
-    start = 0;
-  }
-  if (end > size()) {
-    end = size();
-  }
+  start = std::max(start, 0);
+  end = std::min(end, static_cast<int>(data_.size()));
   if (end < start) {
-    end = start;
+    return 0;
   }
   value_type sum = 1;
   for (auto i = start; i < end; ++i) {
@@ -49,11 +45,14 @@ value_type DDimLite::count(int start, int end) const {
 }
 
 DDimLite DDimLite::Slice(int start, int end) const {
-  std::vector<value_type> vec;
+  start = std::max(start, 0);
+  end = std::min(end, static_cast<int>(data_.size()));
+  DDimLite new_dim;
+  new_dim.resize(end - start);
   for (int i = start; i < end; i++) {
-    vec.push_back((*this)[i]);
+    new_dim[i - start] = data_[i];
   }
-  return DDimLite(vec);
+  return new_dim;
 }
 
 std::string DDimLite::repr() const {

--- a/lite/core/tensor.h
+++ b/lite/core/tensor.h
@@ -55,7 +55,6 @@ class DDimLite {
   std::vector<int64_t> Vectorize() const { return data_; }
 
   size_t size() const { return data_.size(); }
-  void resize(size_t size) { data_.resize(size); }
   bool empty() const { return data_.empty(); }
 
   value_type production() const;
@@ -64,15 +63,6 @@ class DDimLite {
   value_type count(int start, int end) const;
 
   DDimLite Slice(int start, int end) const;
-
-  bool CheckPositive() const {
-    for (size_t i = 0; i < size(); ++i) {
-      if (data_[i] <= 0) {
-        return false;
-      }
-    }
-    return true;
-  }
 
   DDimLite Flatten2D(int col) const {
     return DDimLite(std::vector<value_type>(
@@ -132,7 +122,7 @@ class TensorLite {
   }
 
   void Resize(const DDimLite &ddim) { dims_ = ddim; }
-  void Resize(const std::vector<int64_t> &x) { dims_ = DDimLite(x); }
+  void Resize(const std::vector<int64_t> &x) { dims_.ConstructFrom(x); }
 
   const DDimLite &dims() const { return dims_; }
   int64_t numel() const { return dims_.production(); }

--- a/lite/core/tensor.h
+++ b/lite/core/tensor.h
@@ -55,6 +55,7 @@ class DDimLite {
   std::vector<int64_t> Vectorize() const { return data_; }
 
   size_t size() const { return data_.size(); }
+  void resize(size_t size) { data_.resize(size); }
   bool empty() const { return data_.empty(); }
 
   value_type production() const;
@@ -63,6 +64,15 @@ class DDimLite {
   value_type count(int start, int end) const;
 
   DDimLite Slice(int start, int end) const;
+
+  bool CheckPositive() const {
+    for (size_t i = 0; i < size(); ++i) {
+      if (data_[i] <= 0) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   DDimLite Flatten2D(int col) const {
     return DDimLite(std::vector<value_type>(
@@ -85,7 +95,11 @@ class DDimLite {
   }
 
   friend bool operator!=(const DDimLite &a, const DDimLite &b) {
-    return !(a == b);
+    if (a.size() != b.size()) return true;
+    for (size_t i = 0; i < a.size(); i++) {
+      if (a[i] != b[i]) return true;
+    }
+    return false;
   }
 
  private:

--- a/lite/kernels/x86/fc_compute.h
+++ b/lite/kernels/x86/fc_compute.h
@@ -131,7 +131,6 @@ class FcCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
     auto* w = param.w;
     auto* bias = param.bias;
     auto* output = param.output;
-    int in_num_col_dims = param.in_num_col_dims;
     bool with_relu = (param.activation_type == "relu") ? true : false;
 
     bool padding_weights = param.padding_weights;
@@ -139,17 +138,7 @@ class FcCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
     auto w_dims0 = padding_weights ? w_dims[0] - 4 : w_dims[0];
     auto w_dims1 = padding_weights ? w_dims[1] - 4 : w_dims[1];
 
-    DDim out_dims;
-    out_dims.resize(static_cast<size_t>(in_num_col_dims + 1));
-    const auto& in_dims = input->dims();
-    for (int i = 0; i < in_num_col_dims; ++i) {
-      out_dims[i] = in_dims[i];
-    }
-    out_dims[in_num_col_dims] = w_dims1;
-    output->Resize(out_dims);
-    output->set_lod(input->lod());
-
-    int M = out_dims.production() / w_dims1;
+    int M = output->dims().production() / w_dims1;
 
     const T* input_data = input->data<T>();
     const T* w_data = w->data<T>();

--- a/lite/kernels/x86/reshape_compute.h
+++ b/lite/kernels/x86/reshape_compute.h
@@ -28,8 +28,9 @@ namespace x86 {
 
 template <typename T>
 void Compute(const lite::Tensor* in, lite::Tensor* out) {
+  // In CopyDataFrom, the target tensor's dims will be set to the source
+  // tensor's dims.
   auto out_dims = out->dims();
-  auto in_dims = in->dims();
   out->CopyDataFrom(*in);
   out->Resize(out_dims);
 }

--- a/lite/operators/concat_op.cc
+++ b/lite/operators/concat_op.cc
@@ -27,11 +27,8 @@ bool ConcatOpLite::CheckShape() const {
 }
 
 bool ConcatOpLite::InferShape() const {
-  std::vector<lite::DDim> input_dims;
-  for (auto p : param_.x) {
-    input_dims.push_back(p->dims());
-  }
-  const size_t n = input_dims.size();
+  const std::vector<Tensor *> &inputs = param_.x;
+  const size_t n = inputs.size();
   CHECK_GT_OR_FALSE(n, 0);
 
   int axis = 0;
@@ -42,17 +39,18 @@ bool ConcatOpLite::InferShape() const {
     axis = axis_tensor_val[0];
   }
   if (axis < 0) {
-    axis += input_dims[0].size();
+    axis += inputs[0]->dims().size();
   }
 
-  auto &out_dims = input_dims[0];
+  auto out_dims = inputs[0]->dims();
   size_t in_zero_dims_size = out_dims.size();
   for (size_t i = 1; i < n; i++) {
+    const auto &input_dims_i = inputs[i]->dims();
     for (size_t j = 0; j < in_zero_dims_size; j++) {
       if (j == static_cast<size_t>(axis)) {
-        out_dims[axis] += input_dims[i][j];
+        out_dims[axis] += input_dims_i[j];
       } else {
-        CHECK_EQ_OR_FALSE(out_dims[j], input_dims[i][j]);
+        CHECK_EQ_OR_FALSE(out_dims[j], input_dims_i[j]);
       }
     }
   }
@@ -60,7 +58,7 @@ bool ConcatOpLite::InferShape() const {
     out_dims[axis] = -1;
   }
   // Set output dims
-  param_.output->Resize(lite::DDim(out_dims));
+  param_.output->Resize(out_dims);
   auto out_lod = param_.output->mutable_lod();
   *out_lod = param_.x[0]->lod();
   return true;

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -54,8 +54,7 @@ bool FcOpLite::InferShape() const {
   int in_num_col_dims = param_.in_num_col_dims;
 
   // Set output dims
-  DDim output_dims;
-  output_dims.resize(in_num_col_dims + 1);
+  std::vector<DDim::value_type> output_dims(in_num_col_dims + 1);
   for (int i = 0; i < in_num_col_dims; ++i) {
     output_dims[i] = input_dims[i];
   }

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -49,23 +49,25 @@ bool FcOpLite::CheckShape() const {
 }
 
 bool FcOpLite::InferShape() const {
-  const auto input_dims = param_.input->dims();
-  const auto w_dims = param_.w->dims();
+  const auto& input_dims = param_.input->dims();
+  const auto& w_dims = param_.w->dims();
+  int in_num_col_dims = param_.in_num_col_dims;
 
   // Set output dims
-  std::vector<int64_t> output_dims(param_.in_num_col_dims + 1, 0);
-  for (int i = 0; i < param_.in_num_col_dims; ++i) {
+  DDim output_dims;
+  output_dims.resize(in_num_col_dims + 1);
+  for (int i = 0; i < in_num_col_dims; ++i) {
     output_dims[i] = input_dims[i];
   }
-  output_dims.back() = w_dims[1];
-  param_.output->Resize(lite::DDim(output_dims));
+  output_dims[in_num_col_dims] = w_dims[1];
+  param_.output->Resize(output_dims);
 
   // share LoD
   param_.output->set_lod(param_.input->lod());
   return true;
 }
 
-bool FcOpLite::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
+bool FcOpLite::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   auto input = op_desc.Input("Input").front();
   auto W = op_desc.Input("W").front();
   auto out = op_desc.Output("Out").front();

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -52,13 +52,14 @@ bool FcOpLite::InferShape() const {
   const auto& input_dims = param_.input->dims();
   const auto& w_dims = param_.w->dims();
   int in_num_col_dims = param_.in_num_col_dims;
+  int64_t w_dims_1 = param_.padding_weights ? w_dims[1] - 4 : w_dims[1];
 
   // Set output dims
   std::vector<DDim::value_type> output_dims(in_num_col_dims + 1);
   for (int i = 0; i < in_num_col_dims; ++i) {
     output_dims[i] = input_dims[i];
   }
-  output_dims[in_num_col_dims] = w_dims[1];
+  output_dims[in_num_col_dims] = w_dims_1;
   param_.output->Resize(output_dims);
 
   // share LoD

--- a/lite/operators/gru_op.cc
+++ b/lite/operators/gru_op.cc
@@ -28,8 +28,8 @@ bool GRUOpLite::CheckShape() const {
   CHECK_OR_FALSE(param_.batch_hidden)
   CHECK_OR_FALSE(param_.hidden)
 
-  auto input_dims = param_.input->dims();
-  auto weight_dims = param_.weight->dims();
+  const auto& input_dims = param_.input->dims();
+  const auto& weight_dims = param_.weight->dims();
   int input_size = input_dims[1];
   int frame_size = weight_dims[0];
   CHECK_EQ_OR_FALSE(input_size, frame_size * 3)
@@ -52,21 +52,23 @@ bool GRUOpLite::CheckShape() const {
 }
 
 bool GRUOpLite::InferShape() const {
-  auto input_dims = param_.input->dims();
-  auto weight_dims = param_.weight->dims();
+  const auto& input_dims = param_.input->dims();
+  const auto& weight_dims = param_.weight->dims();
   int frame_size = weight_dims[0];
   auto batch_size = input_dims[0];
 
   param_.batch_gate->Resize(input_dims);
-  param_.batch_reset_hidden_prev->Resize(lite::DDim({batch_size, frame_size}));
-  param_.batch_hidden->Resize(lite::DDim({batch_size, frame_size}));
-  param_.hidden->Resize(lite::DDim({batch_size, frame_size}));
+
+  DDim out_dims({batch_size, frame_size});
+  param_.batch_reset_hidden_prev->Resize(out_dims);
+  param_.batch_hidden->Resize(out_dims);
+  param_.hidden->Resize(out_dims);
 
   *(param_.hidden->mutable_lod()) = param_.input->lod();
   return true;
 }
 
-bool GRUOpLite::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
+bool GRUOpLite::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   auto input = op_desc.Input("Input").front();
   auto weight = op_desc.Input("Weight").front();
   auto batch_gate = op_desc.Output("BatchGate").front();

--- a/lite/operators/lookup_table_op.cc
+++ b/lite/operators/lookup_table_op.cc
@@ -25,8 +25,8 @@ bool LookupTableOpLite::CheckShape() const {
   CHECK_OR_FALSE(param_.Ids)
   CHECK_OR_FALSE(param_.Out)
 
-  auto table_dims = param_.W->dims();
-  auto ids_dims = param_.Ids->dims();
+  const auto& table_dims = param_.W->dims();
+  const auto& ids_dims = param_.Ids->dims();
 
   int ids_rank = ids_dims.size();
 
@@ -37,25 +37,20 @@ bool LookupTableOpLite::CheckShape() const {
 }
 
 bool LookupTableOpLite::InferShape() const {
-  auto table_dims = param_.W->dims();
-  auto ids_dims = param_.Ids->dims();
+  const auto& table_dims = param_.W->dims();
+  const auto& ids_dims = param_.Ids->dims();
 
+  auto out_dims = ids_dims;
   int ids_rank = ids_dims.size();
+  out_dims[ids_rank - 1] = table_dims[1];
 
-  auto output_dims = ids_dims.Slice(0, ids_rank - 1);
-
-  std::vector<int64_t> out_dims;
-  for (int i = 0; i < ids_rank - 1; ++i) {
-    out_dims.push_back(ids_dims[i]);
-  }
-  out_dims.push_back(table_dims[1]);
-  param_.Out->Resize(lite::DDim{out_dims});
+  param_.Out->Resize(out_dims);
   param_.Out->set_lod(param_.Ids->lod());
   return true;
 }
 
-bool LookupTableOpLite::AttachImpl(const cpp::OpDesc &op_desc,
-                                   lite::Scope *scope) {
+bool LookupTableOpLite::AttachImpl(const cpp::OpDesc& op_desc,
+                                   lite::Scope* scope) {
   auto input = op_desc.Input("W").front();
   auto ids = op_desc.Input("Ids").front();
   auto out = op_desc.Output("Out").front();

--- a/lite/operators/reduce_ops.cc
+++ b/lite/operators/reduce_ops.cc
@@ -29,39 +29,44 @@ bool ReduceOp::CheckShape() const {
 }
 
 bool ReduceOp::InferShape() const {
-  auto x_dims = param_.x->dims();
+  const auto &x_dims = param_.x->dims();
   auto x_rank = x_dims.size();
   auto dims = param_.dim;
   for (size_t i = 0; i < dims.size(); ++i) {
-    if (dims[i] < 0) dims[i] = x_rank + dims[i];
+    if (dims[i] < 0) {
+      dims[i] = x_rank + dims[i];
+    }
     CHECK_LT(dims[i], x_rank)
         << "The dim should be in the range [-rank(input), rank(input).";
   }
-  sort(dims.begin(), dims.end());
   bool reduce_all = param_.reduce_all;
   bool keep_dim = param_.keep_dim;
 
   if (reduce_all) {
     if (keep_dim)
-      param_.output->Resize(lite::DDim(std::vector<int64_t>(x_rank, 1)));
+      param_.output->Resize(std::vector<int64_t>(x_rank, 1));
     else
-      param_.output->Resize(lite::DDim(std::vector<int64_t>{1}));
+      param_.output->Resize(std::vector<int64_t>{1});
   } else {
-    auto dims_vector = x_dims.Vectorize();
+    size_t out_rank = keep_dim ? x_rank : x_rank - dims.size();
+    DDim out_dims;
+    out_dims.resize(out_rank);
     if (keep_dim) {
       for (size_t i = 0; i < dims.size(); ++i) {
-        dims_vector[dims[i]] = 1;
+        out_dims[dims[i]] = 1;
       }
     } else {
-      const int kDelFlag = -2;
-      for (size_t i = 0; i < dims.size(); ++i) {
-        dims_vector[dims[i]] = kDelFlag;
+      sort(dims.begin(), dims.end());
+      int dim_index = 0;
+      int out_index = 0;
+      for (size_t i = 0; i < x_rank; ++i) {
+        if (dims[dim_index] == static_cast<DDim::value_type>(i)) {
+          dim_index++;
+        } else {
+          out_dims[out_index++] = x_dims[i];
+        }
       }
-      dims_vector.erase(
-          remove(dims_vector.begin(), dims_vector.end(), kDelFlag),
-          dims_vector.end());
     }
-    auto out_dims = lite::DDim(dims_vector);
     param_.output->Resize(out_dims);
     if (dims[0] != 0) {
       param_.output->set_lod(param_.x->lod());

--- a/lite/operators/reduce_ops.cc
+++ b/lite/operators/reduce_ops.cc
@@ -49,8 +49,7 @@ bool ReduceOp::InferShape() const {
       param_.output->Resize(std::vector<int64_t>{1});
   } else {
     size_t out_rank = keep_dim ? x_rank : x_rank - dims.size();
-    DDim out_dims;
-    out_dims.resize(out_rank);
+    std::vector<DDim::value_type> out_dims(out_rank);
     if (keep_dim) {
       for (size_t i = 0; i < dims.size(); ++i) {
         out_dims[dims[i]] = 1;

--- a/lite/operators/reshape_op.h
+++ b/lite/operators/reshape_op.h
@@ -56,7 +56,8 @@ class Reshape2Op : public ReshapeOp {
   std::string DebugString() const override { return "reshape2"; }
 };
 
-DDim ValidateShape(const std::vector<int> &shape, const DDim &input_dims);
+std::vector<DDim::value_type> ValidateShape(const std::vector<int> &shape,
+                                            const DDim &input_dims);
 
 }  // namespace operators
 }  // namespace lite

--- a/lite/tests/kernels/fc_compute_test.cc
+++ b/lite/tests/kernels/fc_compute_test.cc
@@ -47,7 +47,6 @@ void Relu(float* out, int num, int channel) {
 DDim ComputeOutDim(const DDim& dim_in, const DDim& wdim, int in_num_col_dim) {
   std::vector<int64_t> out_dim;
   out_dim.resize(in_num_col_dim + 1);
-  auto in_mat_dims = dim_in.Flatten2D(in_num_col_dim);
   for (int i = 0; i < in_num_col_dim; ++i) {
     out_dim[i] = dim_in[i];
   }


### PR DESCRIPTION
为了简化https://github.com/PaddlePaddle/Paddle-Lite/pull/2679 ，将其中对于各op InferShape的优化抽离出来。

- develop代码：
  ```
  commit e73d465254c6f25b725ed29311921f757b244e43
  Author: Yiqun Liu <liuyiqun01@baidu.com>
  Date:   Sat Feb 8 10:49:29 2020 +0800

      Implement a class PrecisionTypeTrait to get the PrecisionType of a c++ data type. (#2835)
  ```

  - StepRNN执行时间：**0.0385 ms**
  ```
  I0208 06:54:38.013775 20094 generate_program_pass.h:37] insts.size 42
  I0208 06:54:38.412828 20094 test_step_rnn_lite_x86.cc:79] warmup: 10, repeats: 10000, spend 0.0385474 ms in average.
  ```

- 优化InferShape的PR：[Paddle-Lite#2839](https://github.com/PaddlePaddle/Paddle-Lite/pull/2839)
  - StepRNN执行时间：**0.0265 ms**
  ```
  I0208 08:03:57.701424  3222 generate_program_pass.h:37] insts.size 42
  I0208 08:03:57.979542  3222 test_step_rnn_lite_x86.cc:90] warmup: 10, repeats: 10000, spend 0.0264734 ms in average.
  ```

- gperftools分析各个函数的耗时占比
  - 通用优化方法：
    - 方法一，输入Tensor的dims的使用改成引用类型，非引用类型将发生一次DDim的拷贝。
    - 方法二，避免反复调用push_back、emplace_back函数，最好先计算出元素个数，通过resize接口一次申请好空间。

| module | develop | #2839 | 优化点介绍 |
|---|---|---|---|
| Activation::InferShape | 0.99% | 1.83% |
| ConcatOpLite::InferShape | 6.93% | 2.44% | 直接使用输入Tensor的dims，而不是先拷贝到一个`std::vector<DDim>`中，若有N个Tensor，则避免了N次DDim的空间申请和拷贝。
| FcOpLite::InferShape | 0.99% | 2.44% | 
| GRUOpLite::InferShape | 1.49% | 1.22% | 3个输入Tensor的维度是一样的，显式定义一个DDim，可避免2次std::vector到DDim的拷贝。
| LookupTableOpLite::InferShape | 18.32% | 4.27% | 输出Tensor的dims直接初始化为输入Tensor的dims，然后再修改相应维度，避免1次std::vector到DDim的拷贝。
| ReduceOp::InferShape | 3.96% | 3.05% | 改变计算逻辑，避免erase函数的调用
| Reshape2Op::InferShape | 5.45% | 5.49% | - 避免调用Vectorize()函数，会发生std::vector的拷贝。<br>- 避免调用std::all_of函数。 
| SequenceReshapeOp::InferShape | 0.99% |
| KernelBase::Launch | 57.92% | 77.44% |
| ConcatCompute::Run | 0.99% | 3.05% |
| FcCompute::Run | 9.41% | 13.41% |
| GRUCompute::Run | 20.79% | 26.22% |
| LookupTableCompute::Run | 2.48% | 4.27% |
| ReduceSumCompute::Run | 4.95% | 17.07% | 
| Reshape2Compute::Run | 2.48% | 1.83% |
| SequenceReshapeCompute::Run | 1.98% | 3.66% |
| SoftmaxCompute::Run | 8.91% | 3.66% |
| SoftsignCompute::Run | 3.96% | 3.05% |
