### PR TITLE
【CI BUG FIX】fix fc_test 

### DIFF
--- a/lite/tests/kernels/fc_compute_test.cc
+++ b/lite/tests/kernels/fc_compute_test.cc
@@ -245,7 +245,7 @@ void TestFCMain(Place place,
 
 TEST(FcOP, precision) {
   Place place;
-  float abs_error = 6e-5;
+  float abs_error = 1e-4;
 #if defined(LITE_WITH_NPU)
   place = TARGET(kNPU);
   abs_error = 2e-1;  // Using fp16 in NPU


### PR DESCRIPTION
【问题描述】： FC_test中，arm android 单测出现随机挂的问题
【解决方法】：降低android FC_test的adb error