### PR TITLE
【BUG FIX】FIX Batch norm op 

### DIFF
--- a/lite/operators/batch_norm_op.cc
+++ b/lite/operators/batch_norm_op.cc
@@ -83,11 +83,11 @@ bool BatchNormOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
       scope->FindVar(op_desc.Input("Variance").front())->GetMutable<Tensor>();
   param_.y = scope->FindVar(op_desc.Output("Y").front())->GetMutable<Tensor>();
 
-  auto is_test_type = desc.GetAttrType("is_test");
+  auto is_test_type = op_desc.GetAttrType("is_test");
   switch (is_test_type) {
-      case AttrType::INT:
+      case OpDescAPI::AttrType::INT:
         param_.is_test = op_desc.GetAttr<int>("is_test");
-      case AttrType::BOOLEAN:
+      case OpDescAPI::AttrType::BOOLEAN:
         param_.is_test = op_desc.GetAttr<bool>("is_test");
       default:
         LOG(FATAL) << "Unsupported attribute type: the type of attribute `is_test` in BatchNormOP should be int or bool.";

--- a/lite/operators/batch_norm_op.cc
+++ b/lite/operators/batch_norm_op.cc
@@ -85,12 +85,15 @@ bool BatchNormOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
 
   auto is_test_type = op_desc.GetAttrType("is_test");
   switch (is_test_type) {
-      case OpDescAPI::AttrType::INT:
-        param_.is_test = op_desc.GetAttr<int>("is_test");
-      case OpDescAPI::AttrType::BOOLEAN:
-        param_.is_test = op_desc.GetAttr<bool>("is_test");
-      default:
-        LOG(FATAL) << "Unsupported attribute type: the type of attribute `is_test` in BatchNormOP should be int or bool.";
+    case OpDescAPI::AttrType::INT:
+      param_.is_test = op_desc.GetAttr<int>("is_test");
+      break;
+    case OpDescAPI::AttrType::BOOLEAN:
+      param_.is_test = op_desc.GetAttr<bool>("is_test");
+      break;
+    default:
+      LOG(FATAL) << "Unsupported attribute type: the type of attribute "
+                    "`is_test` in BatchNormOP should be int or bool.";
   }
 
   if (op_desc.HasAttr("use_global_stats")) {

--- a/lite/operators/batch_norm_op.cc
+++ b/lite/operators/batch_norm_op.cc
@@ -82,7 +82,7 @@ bool BatchNormOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
   param_.variance =
       scope->FindVar(op_desc.Input("Variance").front())->GetMutable<Tensor>();
   param_.y = scope->FindVar(op_desc.Output("Y").front())->GetMutable<Tensor>();
-  param_.is_test = op_desc.GetAttr<int>("is_test");
+  param_.is_test = op_desc.GetAttr<bool>("is_test");
   if (op_desc.HasAttr("use_global_stats")) {
     param_.use_global_stats = op_desc.GetAttr<bool>("use_global_stats");
   }

--- a/lite/operators/batch_norm_op.cc
+++ b/lite/operators/batch_norm_op.cc
@@ -82,6 +82,17 @@ bool BatchNormOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
   param_.variance =
       scope->FindVar(op_desc.Input("Variance").front())->GetMutable<Tensor>();
   param_.y = scope->FindVar(op_desc.Output("Y").front())->GetMutable<Tensor>();
+
+  auto is_test_type = desc.GetAttrType("is_test");
+  switch (is_test_type) {
+      case AttrType::INT:
+        param_.is_test = op_desc.GetAttr<int>("is_test");
+      case AttrType::BOOLEAN:
+        param_.is_test = op_desc.GetAttr<bool>("is_test");
+      default:
+        LOG(FATAL) << "Unsupported attribute type: the type of attribute `is_test` in BatchNormOP should be int or bool.";
+  }
+
   param_.is_test = op_desc.GetAttr<bool>("is_test");
   if (op_desc.HasAttr("use_global_stats")) {
     param_.use_global_stats = op_desc.GetAttr<bool>("use_global_stats");

--- a/lite/operators/batch_norm_op.cc
+++ b/lite/operators/batch_norm_op.cc
@@ -93,7 +93,6 @@ bool BatchNormOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
         LOG(FATAL) << "Unsupported attribute type: the type of attribute `is_test` in BatchNormOP should be int or bool.";
   }
 
-  param_.is_test = op_desc.GetAttr<bool>("is_test");
   if (op_desc.HasAttr("use_global_stats")) {
     param_.use_global_stats = op_desc.GetAttr<bool>("use_global_stats");
   }

--- a/lite/operators/batch_norm_op_test.cc
+++ b/lite/operators/batch_norm_op_test.cc
@@ -46,7 +46,7 @@ TEST(batch_norm_op_lite, test) {
   desc.SetInput("Mean", {"mean"});
   desc.SetInput("Variance", {"variance"});
   desc.SetOutput("Y", {"y"});
-  desc.SetAttr("is_test", static_cast<int>(1));
+  desc.SetAttr("is_test", static_cast<bool>(true));
   desc.SetAttr("use_global_stats", false);
   desc.SetAttr("epsilon", 1e-5f);
   desc.SetAttr("momentum", 0.9f);
@@ -101,7 +101,7 @@ TEST(batch_norm_op_lite, test_enable_is_test) {
   desc.SetOutput("VarianceOut", {"variance_out"});
   desc.SetOutput("SavedMean", {"saved_mean"});
   desc.SetOutput("SavedVariance", {"saved_variance"});
-  desc.SetAttr("is_test", static_cast<int>(0));
+  desc.SetAttr("is_test", static_cast<bool>(false));
   desc.SetAttr("use_global_stats", false);
   desc.SetAttr("epsilon", 1e-5f);
   desc.SetAttr("momentum", 0.9f);


### PR DESCRIPTION
【问题描述】：基于动态图的模型mobilenet_v1在Lite下加载失败。
【原因查找】：错误定位在batch_norm OP的 is_test 参数定义的数据类型与Fluid中batch_norm的is_test数据类型不一致。  Fluid为bool，lite中按照int读取。
【本PR解决方法】：batch_norm OP的 is_test 参数修改为按bool类型读取