### PR TITLE
【BUG FIX】 modify cxx_demo to support linux and macos

### DIFF
--- a/lite/demo/cxx/Makefile.def
+++ b/lite/demo/cxx/Makefile.def
@@ -1,5 +1,5 @@
 # get the name of current operation system: Linux or Darwin
-SYSTEM=$(shell "uname -s")
+SYSTEM=$(shell "uname")
 
 CXX_DEFINES = -DARM_WITH_OMP -DHPPL_STUB_FUNC -DLITE_WITH_ARM -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK \
               -DLITE_WITH_LINUX -DPADDLE_DISABLE_PROFILER -DPADDLE_NO_PYTHON -DPADDLE_WITH_TESTING


### PR DESCRIPTION
【问题描述】：Paddle-Lite的cxx_demo无法编译成功
【问题定位】：Makefile.def文件中的语法问题
【本PR工作】：修复Makefile.def语法问题，使cxx_demo可以编译通过