### PR TITLE
[LITE][OPENCL] Add opencl image2d conv3x3. test=develop

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/conv2d_3x3_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_3x3_kernel.cl
@@ -1,0 +1,788 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cl_common.h>
+
+#define DEBUG
+__kernel void conv2d_3x3(__private const int global_size_dim0,
+                         __private const int global_size_dim1,
+                         __private const int global_size_dim2,
+                         __read_only image2d_t input_image,
+                         __read_only image2d_t filter,
+#if defined(BIASE_CH) || defined(BIASE_ELE)
+                         __read_only image2d_t bias,
+#endif
+                         __write_only image2d_t output_image,
+                         __private const int stride,
+                         __private const int offset,
+                         __private const int input_c,
+                         __private const int dilation,
+                         __private const int input_width,/* of one block */
+                         __private const int input_height,/* of one block */
+                         __private const int output_width,
+                         __private const int output_height,
+                         __private const int output_c,
+                         __private const int filter_channel,
+						 __private const int filter_width,
+						 __private const int filter_height,
+                         __private const int group) {
+
+    const int out_c = get_global_id(0);
+    const int out_w = get_global_id(1);
+    const int out_nh = get_global_id(2);
+
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE |
+                              CLK_ADDRESS_CLAMP          |
+                              CLK_FILTER_NEAREST;
+
+
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+      printf("kkkkkkkkkkkkkkkkkkkkkkkkk\n");
+      printf("global_size_dim0:%d\n", global_size_dim0); 
+      printf("global_size_dim1:%d\n", global_size_dim1);
+      printf("global_size_dim2:%d\n", global_size_dim2);
+
+      printf("stride:%d\n", stride);
+      printf("offset:%d\n", offset);
+      printf("input_c:%d\n", input_c);
+      printf("dilation:%d\n", dilation);
+      printf("input_width:%d\n", input_width);
+      printf("input_height:%d\n", input_height);
+      printf("output_width:%d\n", output_width);
+      printf("output_height:%d\n", output_height);
+      printf("output_c:%d\n", output_c);
+      printf("filter_channel:%d\n", filter_channel);
+      printf("filter_height:%d\n", filter_height);
+      printf("filter_width:%d\n", filter_width);
+      printf("group:%d\n", group);
+
+     // filter
+     printf("================================== filter ==============================\n");
+     int2 print_pos;
+     CL_DTYPE4 ff;
+     print_pos.x = 0;
+     print_pos.y = 0;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 0;
+     print_pos.y = 1;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 0;
+     print_pos.y = 2;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 0;
+     print_pos.y = 3;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 0;
+     print_pos.y = 4;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 0;
+     print_pos.y = 5;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+
+     print_pos.x = 1;
+     print_pos.y = 0;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 1;
+     print_pos.y = 1;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 1;
+     print_pos.y = 2;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 1;
+     print_pos.y = 3;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 1;
+     print_pos.y = 4;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 1;
+     print_pos.y = 5;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+
+     print_pos.x = 2;
+     print_pos.y = 0;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 2;
+     print_pos.y = 1;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 2;
+     print_pos.y = 2;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 2;
+     print_pos.y = 3;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 2;
+     print_pos.y = 4;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+     print_pos.x = 2;
+     print_pos.y = 5;
+     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
+
+
+
+     // 00,01,02
+     printf("======================================= input ======================================\n");
+     CL_DTYPE4 ii;
+     print_pos.x = 0;
+     print_pos.y = 0;
+     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
+     print_pos.x = 0;
+     print_pos.y = 1;
+     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
+     print_pos.x = 0;
+     print_pos.y = 2;
+     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
+     // 10,11,12
+     print_pos.x = 1;
+     print_pos.y = 0;
+     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
+     print_pos.x = 1;
+     print_pos.y = 1;
+     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
+     print_pos.x = 1;
+     print_pos.y = 2;
+     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
+     // 20,21,22
+     print_pos.x = 2;
+     print_pos.y = 0;
+     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
+     print_pos.x = 2;
+     print_pos.y = 1;
+     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
+     print_pos.x = 2;
+     print_pos.y = 2;
+     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
+     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
+
+#if 0
+     printf("input[0]:%.0f %.0f %.0f %.0f\n", input[0].x, input[0].y, input[0].z, input[0].w);
+     printf("input[1]:%.0f %.0f %.0f %.0f\n", input[1].x, input[1].y, input[1].z, input[1].w);
+     printf("input[2]:%.0f %.0f %.0f %.0f\n", input[2].x, input[2].y, input[2].z, input[2].w);
+     printf("input[3]:%.0f %.0f %.0f %.0f\n", input[3].x, input[3].y, input[3].z, input[3].w);
+     printf("input[4]:%.0f %.0f %.0f %.0f\n", input[4].x, input[4].y, input[4].z, input[4].w);
+     printf("input[5]:%.0f %.0f %.0f %.0f\n", input[5].x, input[5].y, input[5].z, input[5].w);
+     printf("input[6]:%.0f %.0f %.0f %.0f\n", input[6].x, input[6].y, input[6].z, input[6].w);
+     printf("input[7]:%.0f %.0f %.0f %.0f\n", input[7].x, input[7].y, input[7].z, input[7].w);
+     printf("input[8]:%.0f %.0f %.0f %.0f\n", input[8].x, input[8].y, input[8].z, input[8].w);
+#endif
+
+/*
+global_size_dim0:1
+global_size_dim1:2
+global_size_dim2:2
+stride:2
+offset:0
+input_c:1
+dilation:1
+input_width:3
+input_height:3
+output_width:2
+output_height:2
+output_c:1
+filter_channel:1
+group:1
+*/
+    }
+#endif
+
+    int2 output_pos = (int2)(out_c * global_size_dim1 + out_w, out_nh);
+
+    if (out_c >= global_size_dim0 ||
+        out_w >= global_size_dim1 ||
+        out_nh >= global_size_dim2) {
+        return;
+    }
+
+
+    int2 stride_xy;
+    stride_xy.x = stride;
+    stride_xy.y = stride;
+
+    int2 ouput_pos_in_one_block;
+    ouput_pos_in_one_block.x = out_w;
+    ouput_pos_in_one_block.y = out_nh;
+
+    int2 in_pos_in_one_block;
+    in_pos_in_one_block.x = ouput_pos_in_one_block.x * stride + offset;
+    in_pos_in_one_block.y = ouput_pos_in_one_block.y * stride + offset;
+
+#ifdef BIASE_CH
+    CL_DTYPE4 output = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, (int2)(out_c, 0));
+#elif defined(BIASE_ELE)
+    CL_DTYPE4 output = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, output_pos);
+#else
+    CL_DTYPE4 output = 0.0f;
+#endif
+
+    CL_DTYPE4 input[9]; // 3x3 region of input
+    if (group == 1) {
+        for (int i = 0; i < input_c; ++i) { // each run for 3x3
+            int2 pos_in = (int2)(i * input_width + in_pos_in_one_block.x, in_pos_in_one_block.y);
+            input[0] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                                (int2)(pos_in.x - dilation, pos_in.y - dilation)),
+                                (CL_DTYPE4)(0.0f),
+                                (ushort4)((in_pos_in_one_block.x - dilation < 0 || in_pos_in_one_block.y - dilation < 0 || in_pos_in_one_block.x - dilation >= input_width || in_pos_in_one_block.y - dilation >= input_height) << 15));
+
+            input[1] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                              (int2)(pos_in.x, pos_in.y - dilation)),
+                              (CL_DTYPE4)(0.0f),
+                              (ushort4)((in_pos_in_one_block.x < 0 || in_pos_in_one_block.y - dilation < 0 || in_pos_in_one_block.x >= input_width || in_pos_in_one_block.y - dilation >= input_height) << 15));
+
+            input[2] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                              (int2)(pos_in.x + dilation, pos_in.y - dilation)),
+                              (CL_DTYPE4)(0.0f),
+                              (ushort4)((in_pos_in_one_block.x + dilation < 0 || in_pos_in_one_block.y - dilation < 0 || in_pos_in_one_block.x + dilation >= input_width || in_pos_in_one_block.y - dilation >= input_height) << 15));
+
+            input[3] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                              (int2)(pos_in.x - dilation, pos_in.y)),
+                              (CL_DTYPE4)(0.0f),
+                              (ushort4)((in_pos_in_one_block.x - dilation < 0 || in_pos_in_one_block.y < 0 || in_pos_in_one_block.x - dilation >= input_width || in_pos_in_one_block.y >= input_height) << 15));
+
+            input[4] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                              (int2)(pos_in.x, pos_in.y)),
+                              (CL_DTYPE4)(0.0f),
+                              (ushort4)((in_pos_in_one_block.x < 0 || in_pos_in_one_block.y < 0 || in_pos_in_one_block.x >= input_width || in_pos_in_one_block.y >= input_height) << 15));
+
+            input[5] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                              (int2)(pos_in.x + dilation, pos_in.y)),
+                              (CL_DTYPE4)(0.0f),
+                              (ushort4)((in_pos_in_one_block.x + dilation < 0 || in_pos_in_one_block.y < 0 || in_pos_in_one_block.x + dilation >= input_width || in_pos_in_one_block.y >= input_height) << 15));
+
+            input[6] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                              (int2)(pos_in.x - dilation, pos_in.y + dilation)),
+                              (CL_DTYPE4)(0.0f),
+                              (ushort4)((in_pos_in_one_block.x - dilation < 0 || in_pos_in_one_block.y + dilation < 0 || in_pos_in_one_block.x - dilation >= input_width || in_pos_in_one_block.y + dilation >= input_height) << 15));
+
+            input[7] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                              (int2)(pos_in.x, pos_in.y + dilation)),
+                              (CL_DTYPE4)(0.0f),
+                              (ushort4)((in_pos_in_one_block.x < 0 || in_pos_in_one_block.y + dilation < 0 || in_pos_in_one_block.x >= input_width || in_pos_in_one_block.y + dilation >= input_height) << 15));
+
+            input[8] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                              (int2)(pos_in.x + dilation, pos_in.y + dilation)),
+                              (CL_DTYPE4)(0.0f),
+                              (ushort4)((in_pos_in_one_block.x + dilation < 0 || in_pos_in_one_block.y + dilation < 0 || in_pos_in_one_block.x + dilation >= input_width || in_pos_in_one_block.y + dilation >= input_height) << 15));
+
+                int j = 0;
+                int2 pos_of_weight;
+                pos_of_weight.x = i * 3 + j % 3;
+                pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
+                //pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+                CL_DTYPE4 weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.x += dot(input[j], weight_x);
+
+                pos_of_weight.y += 3;
+                // pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               CL_DTYPE4 weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.y += dot(input[j], weight_y);
+
+                pos_of_weight.y += 3;
+                // pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               CL_DTYPE4 weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.z += dot(input[j], weight_z);
+
+                pos_of_weight.y += 3;
+                // pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               CL_DTYPE4 weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.w += dot(input[j], weight_w);
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+                printf("---- j:%d ----\n", j);
+                printf("000 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
+                printf("000 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
+				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
+                printf("000 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
+                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
+                printf("000 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
+                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
+                printf("000 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
+                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
+                printf("000 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
+    }
+#endif
+
+
+                j = 1;
+                pos_of_weight.x = i * 3 + j % 3;
+                pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
+                // pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.x += dot(input[j], weight_x);
+
+                pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.y += dot(input[j], weight_y);
+
+                pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
+               //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.z += dot(input[j], weight_z);
+
+                pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.w += dot(input[j], weight_w);
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+                printf("---- j:%d ----\n", j);
+                printf("111 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
+                printf("filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
+				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
+                printf("111 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
+                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
+                printf("111 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
+                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
+                printf("111 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
+                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
+                printf("111 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
+    }
+#endif
+
+
+
+                j = 2;
+                pos_of_weight.x = i * 3 + j % 3;
+                pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
+                //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.x += dot(input[j], weight_x);
+
+                pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.y += dot(input[j], weight_y);
+
+                pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
+               //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.z += dot(input[j], weight_z);
+
+                pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
+               //    pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+             weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.w += dot(input[j], weight_w);
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+                printf("---- j:%d ----\n", j);
+                printf("222 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
+                printf("222 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
+				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
+                printf("222 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
+                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
+                printf("222 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
+                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
+                printf("222 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
+                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
+                printf("222 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
+    }
+#endif
+
+
+
+                j = 3;
+                pos_of_weight.x = i * 3 + j % 3;
+                pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.x += dot(input[j], weight_x);
+
+                pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.y += dot(input[j], weight_y);
+
+                pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.z += dot(input[j], weight_z);
+
+                pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.w += dot(input[j], weight_w);
+
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+                printf("---- j:%d ----\n", j);
+                printf("333 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
+                printf("333 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
+				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
+                printf("333 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
+                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
+                printf("333 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
+                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
+                printf("333 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
+                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
+                printf("333 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
+    }
+#endif
+
+                j = 4;
+                pos_of_weight.x = i * 3 + j % 3;
+                pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.x += dot(input[j], weight_x);
+
+                pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.y += dot(input[j], weight_y);
+
+                pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
+               //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.z += dot(input[j], weight_z);
+
+                pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.w += dot(input[j], weight_w);
+
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+                printf("---- j:%d ----\n", j);
+                printf("444 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
+                printf("444 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
+				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
+                printf("444 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
+                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
+                printf("444 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
+                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
+                printf("444 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
+                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
+                printf("444 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
+    }
+#endif
+
+                j = 5;
+                pos_of_weight.x = i * 3 + j % 3;
+                pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.x += dot(input[j], weight_x);
+
+                pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.y += dot(input[j], weight_y);
+
+                pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.z += dot(input[j], weight_z);
+
+                pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                output.w += dot(input[j], weight_w);
+
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+                printf("---- j:%d ----\n", j);
+                printf("555 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
+                printf("555 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
+				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
+                printf("555 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
+                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
+                printf("555 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
+                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
+                printf("555 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
+                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
+                printf("555 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
+    }
+#endif
+
+               j = 6;
+               pos_of_weight.x = i * 3 + j % 3;
+               pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1 : pos_of_weight.y;
+              weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.x += dot(input[j], weight_x);
+
+               pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
+              //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.y += dot(input[j], weight_y);
+
+               pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
+              //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.z += dot(input[j], weight_z);
+
+               pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.w += dot(input[j], weight_w);
+
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+                printf("---- j:%d ----\n", j);
+                printf("666 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
+                printf("666 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
+				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
+                printf("666 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
+                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
+                printf("666 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
+                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
+                printf("666 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
+                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
+                printf("666 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
+    }
+#endif
+
+               j = 7;
+               pos_of_weight.x = i * 3 + j % 3;
+               pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1 : pos_of_weight.y;
+              weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.x += dot(input[j], weight_x);
+
+               pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.y += dot(input[j], weight_y);
+
+               pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.z += dot(input[j], weight_z);
+
+               pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.w += dot(input[j], weight_w);
+
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+                printf("---- j:%d ----\n", j);
+                printf("777 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
+                printf("777 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
+				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
+                printf("777 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
+                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
+                printf("777 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
+                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
+                printf("777 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
+                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
+                printf("777 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
+    }
+#endif
+
+               j = 8;
+               pos_of_weight.x = i * 3 + j % 3;
+               pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1 : pos_of_weight.y;
+              weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.x += dot(input[j], weight_x);
+
+               pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.y += dot(input[j], weight_y);
+
+               pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.z += dot(input[j], weight_z);
+
+               pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
+               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
+              weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               output.w += dot(input[j], weight_w);
+
+#ifdef DEBUG
+    if (out_c == 0 && out_w == 0 && out_nh == 0) {
+                printf("---- j:%d ----\n", j);
+                printf("888 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
+                //printf("weight_x:%.0f %.0f %.0f %.0f\n", weight_x.x, weight_x.y, weight_x.z, weight_x.w);
+                //printf("output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
+    }
+               printf("===> out[%d %d]:%.2f %.2f %.2f %.2f\n", pos_of_weight.x, pos_of_weight.y, output.x, output.x, output.z, output.w);
+#endif
+        }
+    } else { // group != 1
+      for (int i = 0; i < 4; i++) {
+        int used_input_channel_num =
+          (out_c * 4 + i) / (output_c / group) * filter_channel;
+        for (int f_c = 0; f_c < filter_channel; ++f_c) {
+          int input_c = used_input_channel_num + f_c;
+          int input_block = input_c / 4;
+          int2 pos_in = (int2)(input_block * input_width + in_pos_in_one_block.x,
+                               in_pos_in_one_block.y);
+          input[0] = select(
+              READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                          (int2)(pos_in.x - dilation, pos_in.y - dilation)),
+              (CL_DTYPE4)(0.0f),
+              (ushort4)((in_pos_in_one_block.x - dilation < 0 ||
+                         in_pos_in_one_block.y - dilation < 0 ||
+                         in_pos_in_one_block.x - dilation >= input_width ||
+                         in_pos_in_one_block.y - dilation >= input_height)
+                        << 15));
+          input[1] =
+              select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                                 (int2)(pos_in.x, pos_in.y - dilation)),
+                     (CL_DTYPE4)(0.0f),
+                     (ushort4)((in_pos_in_one_block.x < 0 ||
+                                in_pos_in_one_block.y - dilation < 0 ||
+                                in_pos_in_one_block.x >= input_width ||
+                                in_pos_in_one_block.y - dilation >= input_height)
+                               << 15));
+          input[2] = select(
+              READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                          (int2)(pos_in.x + dilation, pos_in.y - dilation)),
+                          (CL_DTYPE4)(0.0f),
+                          (ushort4)((in_pos_in_one_block.x + dilation < 0 ||
+                         in_pos_in_one_block.y - dilation < 0 ||
+                         in_pos_in_one_block.x + dilation >= input_width ||
+                         in_pos_in_one_block.y - dilation >= input_height)
+                        << 15));
+          input[3] = select(
+              READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                          (int2)(pos_in.x - dilation, pos_in.y)),
+                          (CL_DTYPE4)(0.0f),
+                          (ushort4)((in_pos_in_one_block.x - dilation < 0 ||
+                                     in_pos_in_one_block.y < 0 ||
+                                     in_pos_in_one_block.x - dilation >= input_width ||
+                                     in_pos_in_one_block.y >= input_height)
+                                    << 15));
+          input[4] = select(
+              READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, (int2)(pos_in.x, pos_in.y)),
+                          (CL_DTYPE4)(0.0f),
+                          (ushort4)((in_pos_in_one_block.x < 0 || in_pos_in_one_block.y < 0 ||
+                                     in_pos_in_one_block.x >= input_width ||
+                                     in_pos_in_one_block.y >= input_height)
+                                     << 15));
+          input[5] =
+            select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                               (int2)(pos_in.x + dilation, pos_in.y)),
+                   (CL_DTYPE4)(0.0f),
+                   (ushort4)((in_pos_in_one_block.x + dilation < 0 ||
+                              in_pos_in_one_block.y < 0 ||
+                              in_pos_in_one_block.x + dilation >= input_width ||
+                              in_pos_in_one_block.y >= input_height)
+                             << 15));
+          input[6] = select(
+              READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                          (int2)(pos_in.x - dilation, pos_in.y + dilation)),
+                          (CL_DTYPE4)(0.0f),
+                          (ushort4)((in_pos_in_one_block.x - dilation < 0 ||
+                                     in_pos_in_one_block.y + dilation < 0 ||
+                                     in_pos_in_one_block.x - dilation >= input_width ||
+                                     in_pos_in_one_block.y + dilation >= input_height)
+                                     << 15));
+          input[7] =
+              select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                                 (int2)(pos_in.x, pos_in.y + dilation)),
+                     (CL_DTYPE4)(0.0f),
+                     (ushort4)((in_pos_in_one_block.x < 0 ||
+                                in_pos_in_one_block.y + dilation < 0 ||
+                                in_pos_in_one_block.x >= input_width ||
+                                in_pos_in_one_block.y + dilation >= input_height)
+                                 << 15));
+          input[8] = select(
+              READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
+                          (int2)(pos_in.x + dilation, pos_in.y + dilation)),
+                          (CL_DTYPE4)(0.0f),
+                          (ushort4)((in_pos_in_one_block.x + dilation < 0 ||
+                                     in_pos_in_one_block.y + dilation < 0 ||
+                                     in_pos_in_one_block.x + dilation >= input_width ||
+                                     in_pos_in_one_block.y + dilation >= input_height)
+                                      << 15));
+
+          CL_DTYPE tmp_out = 0;
+          for (int j = 0; j < 9; j++) {
+            int2 pos_of_weight;
+            pos_of_weight.x = (f_c / 4) * 3 + j % 3;
+            pos_of_weight.y = out_c * 4 * 3 + i * 3 + j / 3;
+            CL_DTYPE4 weight = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+
+            int f_c_offset = f_c % 4;
+            CL_DTYPE f_value;
+            if (f_c_offset == 0) {
+              f_value = weight.x;
+            } else if (f_c_offset == 1) {
+              f_value = weight.y;
+            } else if (f_c_offset == 2) {
+              f_value = weight.z;
+            } else if (f_c_offset == 3) {
+              f_value = weight.w;
+            }
+
+            int input_c_offset = input_c % 4;
+            CL_DTYPE input_value;
+            if (input_c_offset == 0) {
+              input_value = input[j].x;
+            } else if (input_c_offset == 1) {
+              input_value = input[j].y;
+            } else if (input_c_offset == 2) {
+              input_value = input[j].z;
+            } else if (input_c_offset == 3) {
+              input_value = input[j].w;
+            }
+            tmp_out += f_value * input_value;
+          }
+
+          if (i == 0) {
+            output.x += tmp_out;
+          } else if (i == 1) {
+            output.y += tmp_out;
+          } else if (i == 2) {
+            output.z += tmp_out;
+          } else if (i == 3) {
+            output.w += tmp_out;
+          }
+        }
+      }
+    }
+
+#ifdef RELU
+	output = activation_type4(output);
+#endif
+
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output_image, output_pos, output);
+
+//#ifdef DEBUG
+	printf("output(%d, %d):%f %f %f %f\n", output_pos.x, output_pos.y, output.x, output.y, output.z, output.w);
+//#endif
+}
+
+#undef DEBUG

--- a/lite/backends/opencl/cl_kernel/image/conv2d_3x3_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_3x3_kernel.cl
@@ -14,7 +14,6 @@ limitations under the License. */
 
 #include <cl_common.h>
 
-#define DEBUG
 __kernel void conv2d_3x3(__private const int global_size_dim0,
                          __private const int global_size_dim1,
                          __private const int global_size_dim2,
@@ -45,182 +44,6 @@ __kernel void conv2d_3x3(__private const int global_size_dim0,
     const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE |
                               CLK_ADDRESS_CLAMP          |
                               CLK_FILTER_NEAREST;
-
-
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-      printf("kkkkkkkkkkkkkkkkkkkkkkkkk\n");
-      printf("global_size_dim0:%d\n", global_size_dim0); 
-      printf("global_size_dim1:%d\n", global_size_dim1);
-      printf("global_size_dim2:%d\n", global_size_dim2);
-
-      printf("stride:%d\n", stride);
-      printf("offset:%d\n", offset);
-      printf("input_c:%d\n", input_c);
-      printf("dilation:%d\n", dilation);
-      printf("input_width:%d\n", input_width);
-      printf("input_height:%d\n", input_height);
-      printf("output_width:%d\n", output_width);
-      printf("output_height:%d\n", output_height);
-      printf("output_c:%d\n", output_c);
-      printf("filter_channel:%d\n", filter_channel);
-      printf("filter_height:%d\n", filter_height);
-      printf("filter_width:%d\n", filter_width);
-      printf("group:%d\n", group);
-
-     // filter
-     printf("================================== filter ==============================\n");
-     int2 print_pos;
-     CL_DTYPE4 ff;
-     print_pos.x = 0;
-     print_pos.y = 0;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 0;
-     print_pos.y = 1;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 0;
-     print_pos.y = 2;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 0;
-     print_pos.y = 3;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 0;
-     print_pos.y = 4;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 0;
-     print_pos.y = 5;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-
-     print_pos.x = 1;
-     print_pos.y = 0;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 1;
-     print_pos.y = 1;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 1;
-     print_pos.y = 2;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 1;
-     print_pos.y = 3;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 1;
-     print_pos.y = 4;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 1;
-     print_pos.y = 5;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-
-     print_pos.x = 2;
-     print_pos.y = 0;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 2;
-     print_pos.y = 1;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 2;
-     print_pos.y = 2;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 2;
-     print_pos.y = 3;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 2;
-     print_pos.y = 4;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-     print_pos.x = 2;
-     print_pos.y = 5;
-     ff = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tfilter(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ff.x, ff.y, ff.z, ff.w);
-
-
-
-     // 00,01,02
-     printf("======================================= input ======================================\n");
-     CL_DTYPE4 ii;
-     print_pos.x = 0;
-     print_pos.y = 0;
-     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
-     print_pos.x = 0;
-     print_pos.y = 1;
-     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
-     print_pos.x = 0;
-     print_pos.y = 2;
-     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
-     // 10,11,12
-     print_pos.x = 1;
-     print_pos.y = 0;
-     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
-     print_pos.x = 1;
-     print_pos.y = 1;
-     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
-     print_pos.x = 1;
-     print_pos.y = 2;
-     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
-     // 20,21,22
-     print_pos.x = 2;
-     print_pos.y = 0;
-     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
-     print_pos.x = 2;
-     print_pos.y = 1;
-     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
-     print_pos.x = 2;
-     print_pos.y = 2;
-     ii = READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler, print_pos);
-     printf("out[c|w|nh]:%d %d %d\tinput(%d.%d): %f %f %f %f\n", out_c, out_w, out_nh, print_pos.x, print_pos.y, ii.x, ii.y, ii.z, ii.w);
-
-#if 0
-     printf("input[0]:%.0f %.0f %.0f %.0f\n", input[0].x, input[0].y, input[0].z, input[0].w);
-     printf("input[1]:%.0f %.0f %.0f %.0f\n", input[1].x, input[1].y, input[1].z, input[1].w);
-     printf("input[2]:%.0f %.0f %.0f %.0f\n", input[2].x, input[2].y, input[2].z, input[2].w);
-     printf("input[3]:%.0f %.0f %.0f %.0f\n", input[3].x, input[3].y, input[3].z, input[3].w);
-     printf("input[4]:%.0f %.0f %.0f %.0f\n", input[4].x, input[4].y, input[4].z, input[4].w);
-     printf("input[5]:%.0f %.0f %.0f %.0f\n", input[5].x, input[5].y, input[5].z, input[5].w);
-     printf("input[6]:%.0f %.0f %.0f %.0f\n", input[6].x, input[6].y, input[6].z, input[6].w);
-     printf("input[7]:%.0f %.0f %.0f %.0f\n", input[7].x, input[7].y, input[7].z, input[7].w);
-     printf("input[8]:%.0f %.0f %.0f %.0f\n", input[8].x, input[8].y, input[8].z, input[8].w);
-#endif
-
-/*
-global_size_dim0:1
-global_size_dim1:2
-global_size_dim2:2
-stride:2
-offset:0
-input_c:1
-dilation:1
-input_width:3
-input_height:3
-output_width:2
-output_height:2
-output_c:1
-filter_channel:1
-group:1
-*/
-    }
-#endif
 
     int2 output_pos = (int2)(out_c * global_size_dim1 + out_w, out_nh);
 
@@ -255,6 +78,7 @@ group:1
     if (group == 1) {
         for (int i = 0; i < input_c; ++i) { // each run for 3x3
             int2 pos_in = (int2)(i * input_width + in_pos_in_one_block.x, in_pos_in_one_block.y);
+
             input[0] = select(READ_IMG_TYPE(CL_DTYPE_CHAR, input_image, sampler,
                                 (int2)(pos_in.x - dilation, pos_in.y - dilation)),
                                 (CL_DTYPE4)(0.0f),
@@ -304,340 +128,164 @@ group:1
                 int2 pos_of_weight;
                 pos_of_weight.x = i * 3 + j % 3;
                 pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
-                //pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
                 CL_DTYPE4 weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.x += dot(input[j], weight_x);
 
                 pos_of_weight.y += 3;
-                // pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               CL_DTYPE4 weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                CL_DTYPE4 weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.y += dot(input[j], weight_y);
 
                 pos_of_weight.y += 3;
-                // pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               CL_DTYPE4 weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                CL_DTYPE4 weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.z += dot(input[j], weight_z);
 
                 pos_of_weight.y += 3;
-                // pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               CL_DTYPE4 weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                CL_DTYPE4 weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.w += dot(input[j], weight_w);
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-                printf("---- j:%d ----\n", j);
-                printf("000 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
-                printf("000 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
-				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
-                printf("000 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
-                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
-                printf("000 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
-                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
-                printf("000 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
-                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
-                printf("000 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
-    }
-#endif
-
 
                 j = 1;
                 pos_of_weight.x = i * 3 + j % 3;
                 pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
-                // pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.x += dot(input[j], weight_x);
 
                 pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.y += dot(input[j], weight_y);
 
                 pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
-               //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.z += dot(input[j], weight_z);
 
                 pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.w += dot(input[j], weight_w);
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-                printf("---- j:%d ----\n", j);
-                printf("111 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
-                printf("filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
-				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
-                printf("111 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
-                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
-                printf("111 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
-                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
-                printf("111 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
-                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
-                printf("111 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
-    }
-#endif
-
-
 
                 j = 2;
                 pos_of_weight.x = i * 3 + j % 3;
                 pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
-                //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.x += dot(input[j], weight_x);
 
                 pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.y += dot(input[j], weight_y);
 
                 pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
-               //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.z += dot(input[j], weight_z);
 
                 pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
-               //    pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-             weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.w += dot(input[j], weight_w);
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-                printf("---- j:%d ----\n", j);
-                printf("222 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
-                printf("222 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
-				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
-                printf("222 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
-                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
-                printf("222 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
-                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
-                printf("222 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
-                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
-                printf("222 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
-    }
-#endif
-
-
 
                 j = 3;
                 pos_of_weight.x = i * 3 + j % 3;
                 pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.x += dot(input[j], weight_x);
 
                 pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.y += dot(input[j], weight_y);
 
                 pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.z += dot(input[j], weight_z);
 
                 pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.w += dot(input[j], weight_w);
-
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-                printf("---- j:%d ----\n", j);
-                printf("333 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
-                printf("333 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
-				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
-                printf("333 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
-                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
-                printf("333 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
-                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
-                printf("333 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
-                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
-                printf("333 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
-    }
-#endif
 
                 j = 4;
                 pos_of_weight.x = i * 3 + j % 3;
                 pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.x += dot(input[j], weight_x);
 
                 pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.y += dot(input[j], weight_y);
 
                 pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
-               //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.z += dot(input[j], weight_z);
 
                 pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.w += dot(input[j], weight_w);
-
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-                printf("---- j:%d ----\n", j);
-                printf("444 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
-                printf("444 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
-				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
-                printf("444 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
-                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
-                printf("444 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
-                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
-                printf("444 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
-                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
-                printf("444 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
-    }
-#endif
 
                 j = 5;
                 pos_of_weight.x = i * 3 + j % 3;
                 pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.x += dot(input[j], weight_x);
 
                 pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.y += dot(input[j], weight_y);
 
                 pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.z += dot(input[j], weight_z);
 
                 pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+                weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                 output.w += dot(input[j], weight_w);
-
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-                printf("---- j:%d ----\n", j);
-                printf("555 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
-                printf("555 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
-				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
-                printf("555 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
-                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
-                printf("555 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
-                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
-                printf("555 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
-                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
-                printf("555 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
-    }
-#endif
 
                j = 6;
                pos_of_weight.x = i * 3 + j % 3;
                pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1 : pos_of_weight.y;
-              weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.x += dot(input[j], weight_x);
 
                pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
-              //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.y += dot(input[j], weight_y);
 
                pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
-              //   pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.z += dot(input[j], weight_z);
 
                pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.w += dot(input[j], weight_w);
-
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-                printf("---- j:%d ----\n", j);
-                printf("666 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
-                printf("666 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
-				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
-                printf("666 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
-                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
-                printf("666 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
-                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
-                printf("666 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
-                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
-                printf("666 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
-    }
-#endif
 
                j = 7;
                pos_of_weight.x = i * 3 + j % 3;
                pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1 : pos_of_weight.y;
-              weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.x += dot(input[j], weight_x);
 
                pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.y += dot(input[j], weight_y);
 
                pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.z += dot(input[j], weight_z);
 
                pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.w += dot(input[j], weight_w);
-
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-                printf("---- j:%d ----\n", j);
-                printf("777 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
-                printf("777 filter(%d,%d):weight_x:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 3 * 3,
-				       weight_x.x, weight_x.y, weight_x.z, weight_x.w);
-                printf("777 filter(%d,%d):weight_y:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 2 * 3,
-                       weight_y.x, weight_y.y, weight_y.z, weight_y.w);
-                printf("777 filter(%d,%d):weight_z:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 1 * 3,
-                       weight_z.x, weight_z.y, weight_z.z, weight_z.w);
-                printf("777 filter(%d,%d):weight_w:%.0f %.0f %.0f %.0f\n", pos_of_weight.x, pos_of_weight.y - 0 * 3,
-                       weight_w.x, weight_w.y, weight_w.z, weight_w.w);
-                printf("777 output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
-    }
-#endif
 
                j = 8;
                pos_of_weight.x = i * 3 + j % 3;
                pos_of_weight.y = out_c * 4 * 3 + 0 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1 : pos_of_weight.y;
-              weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_x = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.x += dot(input[j], weight_x);
 
                pos_of_weight.y = out_c * 4 * 3 + 1 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_y = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.y += dot(input[j], weight_y);
 
                pos_of_weight.y = out_c * 4 * 3 + 2 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_z = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.z += dot(input[j], weight_z);
 
                pos_of_weight.y = out_c * 4 * 3 + 3 * 3 + j / 3;
-               //  pos_of_weight.y = pos_of_weight.y >= filter_channel ? filter_channel - 1: pos_of_weight.y;
-              weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
+               weight_w = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, sampler, pos_of_weight);
                output.w += dot(input[j], weight_w);
-
-#ifdef DEBUG
-    if (out_c == 0 && out_w == 0 && out_nh == 0) {
-                printf("---- j:%d ----\n", j);
-                printf("888 input[%d]:%.0f %.0f %.0f %.0f\n", j, input[j].x, input[j].y, input[j].z, input[j].w);
-                //printf("weight_x:%.0f %.0f %.0f %.0f\n", weight_x.x, weight_x.y, weight_x.z, weight_x.w);
-                //printf("output:%.0f %.0f %.0f %.0f\n", output.x, output.y, output.z, output.w);
-    }
-               printf("===> out[%d %d]:%.2f %.2f %.2f %.2f\n", pos_of_weight.x, pos_of_weight.y, output.x, output.x, output.z, output.w);
-#endif
         }
     } else { // group != 1
       for (int i = 0; i < 4; i++) {
@@ -774,15 +422,7 @@ group:1
       }
     }
 
-#ifdef RELU
 	output = activation_type4(output);
-#endif
 
     WRITE_IMG_TYPE(CL_DTYPE_CHAR, output_image, output_pos, output);
-
-//#ifdef DEBUG
-	printf("output(%d, %d):%f %f %f %f\n", output_pos.x, output_pos.y, output.x, output.y, output.z, output.w);
-//#endif
 }
-
-#undef DEBUG

--- a/lite/kernels/opencl/conv_compute.cc
+++ b/lite/kernels/opencl/conv_compute.cc
@@ -639,11 +639,15 @@ void ConvImageCompute::Conv2d3x3() {
     new_groups = 1;
   } else if (!(filter_dims[0] == input_dims[1] && filter_dims[1] == 1)) {
     new_groups = input_channel / filter_channel;
-  } else {
-    LOG(FATAL) << "Not support conv3x3 case with"
-               << " input_dims:" << input_dims << " output_dims:" << output_dims
-               << " filter_dims:" << filter_dims;
   }
+  /* TODO(ysh329): mobile has no case below
+     else {
+      LOG(FATAL) << "Not support conv3x3 case with"
+                 << " input_dims:" << input_dims << " output_dims:" <<
+    output_dims
+                 << " filter_dims:" << filter_dims;
+    }
+  */
 
   const std::vector<size_t>& default_work_size =
       DefaultWorkSize(output_dims,

--- a/lite/kernels/opencl/conv_compute.h
+++ b/lite/kernels/opencl/conv_compute.h
@@ -71,6 +71,7 @@ class ConvImageCompute : public KernelLite<TARGET(kOpenCL),
 
  private:
   void Conv2d1x1();
+  void Conv2d3x3();
   void Conv2d5x5();
   void Conv2d7x7();
 

--- a/lite/kernels/opencl/conv_image2d_compute_test.cc
+++ b/lite/kernels/opencl/conv_image2d_compute_test.cc
@@ -446,7 +446,7 @@ TEST(conv2d, compute_image2d_1x1) {
 #undef LOOP_TEST
 #undef PRINT_RESULT
 
-#define PRINT_RESULT
+// #define PRINT_RESULT
 // #define LOOP_TEST
 TEST(conv2d, compute_image2d_3x3) {
   // conv infos
@@ -472,7 +472,7 @@ TEST(conv2d, compute_image2d_3x3) {
                 const int group = 2;
 
                 const int batch_size = 1;
-                const int ic = 2;
+                const int ic = 1;
                 const int ih = 3;
                 const int iw = 3;
                 const int oc = 2;

--- a/lite/kernels/opencl/conv_image2d_compute_test.cc
+++ b/lite/kernels/opencl/conv_image2d_compute_test.cc
@@ -446,7 +446,7 @@ TEST(conv2d, compute_image2d_1x1) {
 #undef LOOP_TEST
 #undef PRINT_RESULT
 
-// #define PRINT_RESULT
+#define PRINT_RESULT
 // #define LOOP_TEST
 TEST(conv2d, compute_image2d_3x3) {
   // conv infos
@@ -468,7 +468,7 @@ TEST(conv2d, compute_image2d_3x3) {
 #else
                 const int pad = 1;
                 const int dilation = 1;
-                const int stride = 1;
+                const int stride = 2;
                 const int group = 2;
 
                 const int batch_size = 1;
@@ -476,7 +476,7 @@ TEST(conv2d, compute_image2d_3x3) {
                 const int ih = 3;
                 const int iw = 3;
                 const int oc = 2;
-                const bool bias_flag = true;
+                const bool bias_flag = false;
                 const std::string relu_flag = "relu";
 #endif
 
@@ -503,6 +503,7 @@ TEST(conv2d, compute_image2d_3x3) {
               param.x = &input;
               param.filter = &filter;
               param.output = &output;
+              param.groups = group;
               if (bias_flag) {
                 param.bias = &bias;
               }
@@ -580,11 +581,11 @@ TEST(conv2d, compute_image2d_3x3) {
               std::vector<float> bias_v(oc);
 
               SHADOW_LOG << "gen input and filter ...";
-              for (auto& i : input_v) {
-                i = gen(engine);
+              for (int i = 0; i < input_v.size(); ++i) {
+                input_v[i] = i;  // gen(engine);
               }
-              for (auto& f : filter_v) {
-                f = gen(engine);
+              for (int i = 0; i < filter_v.size(); ++i) {
+                filter_v[i] = 1;  // gen(engine);
               }
 
               SHADOW_LOG << "after gen input and filter ...";
@@ -598,6 +599,10 @@ TEST(conv2d, compute_image2d_3x3) {
                          << filter_dim.production();
               SHADOW_LOG << "out_dim.production(): " << out_dim.production();
               SHADOW_LOG << "bias_dim.production(): " << bias_dim.production();
+              SHADOW_LOG << "input_image_height:" << input_image_height
+                         << " input_image_width:" << input_image_width;
+              SHADOW_LOG << "filter_image_height:" << filter_image_height
+                         << " filter_image_width:" << filter_image_width;
               SHADOW_LOG << "4 * input_image_height *input_image_width: "
                          << 4 * input_image_height * input_image_width;
               SHADOW_LOG << "4 * filter_image_width * filter_image_height: "

--- a/lite/kernels/opencl/conv_image2d_compute_test.cc
+++ b/lite/kernels/opencl/conv_image2d_compute_test.cc
@@ -448,6 +448,334 @@ TEST(conv2d, compute_image2d_1x1) {
 
 // #define PRINT_RESULT
 // #define LOOP_TEST
+TEST(conv2d, compute_image2d_3x3) {
+  // conv infos
+  const int ksize = 3;
+  const int stride = 1;
+  const int pad = 2;
+  const int group = 1;
+  const int dilation = 1;
+//  int loop_cnt = 0;
+
+#ifdef LOOP_TEST
+  for (int batch_size = 2; batch_size < 4; ++batch_size) {
+    for (int oc = 1; oc < 10; oc += 1) {   // oc
+      for (int ih = 5; ih < 9; ih += 1) {  // ih
+        int iw = ih;
+        for (int ic = 1; ic < 10; ic += 1) {  // ic
+          for (bool bias_flag : {true, false}) {
+            for (std::string relu_flag : {/*true,*/ "relu"}) {
+#else
+                const int batch_size = 2;
+                const int oc = 1;
+                const int ih = 3;
+                const int iw = 3;
+                const int ic = 1;
+                const bool bias_flag = false;
+                const std::string relu_flag = "relu";
+#endif
+
+              const int oh =
+                  ConvOutputSize(ih, ksize, dilation, pad, pad, stride);
+              const int ow =
+                  ConvOutputSize(iw, ksize, dilation, pad, pad, stride);
+              SHADOW_LOG << "to get kernel ...";
+              auto kernels =
+                  KernelRegistry::Global().Create("conv2d",
+                                                  TARGET(kOpenCL),
+                                                  PRECISION(kFloat),
+                                                  DATALAYOUT(kImageDefault));
+              ASSERT_FALSE(kernels.empty());
+
+              auto kernel = std::move(kernels.front());
+              SHADOW_LOG << "created conv2d kernel";
+
+              SHADOW_LOG << "prepare kernel ------";
+
+              lite::Tensor input, filter, bias, output;
+              operators::ConvParam param;
+              param.x = &input;
+              param.filter = &filter;
+              param.output = &output;
+              if (bias_flag) {
+                param.bias = &bias;
+              }
+              if (relu_flag == "relu") {
+                param.fuse_relu = true;
+              } else if (relu_flag == "None") {
+                param.fuse_relu = false;
+              } else if (relu_flag == "relu6") {
+                param.activation_param.Relu_clipped_coef = 6.f;
+                param.activation_param.has_active = true;
+                param.activation_param.active_type =
+                    lite_api::ActivationType::kRelu6;
+              }
+
+              std::vector<int> paddings = {pad, pad, pad, pad};
+              std::vector<int> dilations = {dilation, dilation};
+
+              param.paddings = std::make_shared<std::vector<int>>(paddings);
+              param.dilations = std::make_shared<std::vector<int>>(dilations);
+              param.strides = std::vector<int>{stride, stride};
+
+              std::unique_ptr<KernelContext> context(new KernelContext);
+              context->As<OpenCLContext>().InitOnce();
+
+              std::unique_ptr<KernelContext> conv_1x1_context(
+                  new KernelContext);
+              context->As<OpenCLContext>().CopySharedTo(
+                  &(conv_1x1_context->As<OpenCLContext>()));
+              kernel->SetContext(std::move(conv_1x1_context));
+
+              const DDim& input_dim =
+                  lite::DDim{std::vector<int64_t>({batch_size, ic, ih, iw})};
+
+              const DDim& filter_dim =
+                  lite::DDim{std::vector<int64_t>({oc, ic, ksize, ksize})};
+              const DDim& out_dim =
+                  lite::DDim{std::vector<int64_t>({batch_size, oc, oh, ow})};
+              // element wise bias
+              const DDim& bias_dim = lite::DDim{std::vector<int64_t>({oc})};
+
+              param.x->Resize(input_dim);
+              param.filter->Resize(filter_dim);
+              param.output->Resize(out_dim);
+              if (bias_flag) {
+                param.bias->Resize(bias_dim);
+              }
+
+              kernel->SetParam(param);
+
+              size_t input_image_width = iw * ((ic + 3) / 4);
+              size_t input_image_height = ih * batch_size;
+
+              size_t out_image_width = ow * ((oc + 3) / 4);
+              size_t out_image_height = oh * batch_size;
+
+              size_t bias_image_width = ow * ((oc + 3) / 4);
+              size_t bias_image_height = oh * batch_size;
+
+              size_t filter_image_width = ksize * ((ic + 3) / 4);
+              size_t filter_image_height = oc * ksize;
+
+              const size_t cl_image2d_row_pitch{0};
+              const size_t cl_image2d_slice_pitch{0};
+
+              std::default_random_engine engine;
+              std::uniform_real_distribution<float> gen(-5, 5);
+
+              std::vector<float> input_v(batch_size * ic * ih * iw);
+              std::vector<float> filter_v(oc * ic * ksize * ksize);
+              std::vector<float> output_v(batch_size * oc * oh * ow);
+              std::vector<float> bias_v(oc);
+
+              SHADOW_LOG << "gen input and filter ...";
+              for (auto& i : input_v) {
+                i = gen(engine);
+              }
+              for (auto& f : filter_v) {
+                f = gen(engine);
+              }
+
+              SHADOW_LOG << "after gen input and filter ...";
+              SHADOW_LOG << "input_v.size(): " << input_v.size();
+              SHADOW_LOG << "filter_v.size(): " << filter_v.size();
+              SHADOW_LOG << "output_v.size(): " << output_v.size();
+              SHADOW_LOG << "bias_v.size(): " << bias_v.size();
+              SHADOW_LOG << "input_dim.production(): "
+                         << input_dim.production();
+              SHADOW_LOG << "filter_dim.production(): "
+                         << filter_dim.production();
+              SHADOW_LOG << "out_dim.production(): " << out_dim.production();
+              SHADOW_LOG << "bias_dim.production(): " << bias_dim.production();
+              SHADOW_LOG << "4 * input_image_height *input_image_width: "
+                         << 4 * input_image_height * input_image_width;
+              SHADOW_LOG << "4 * filter_image_width * filter_image_height: "
+                         << 4 * filter_image_width * filter_image_height;
+
+              CHECK(input_dim.production() == input_v.size());
+              CHECK_LE(input_dim.production(),
+                       4 * input_image_height * input_image_width);
+              CHECK(filter_dim.production() == filter_v.size());
+              CHECK_LE(filter_dim.production(),
+                       4 * filter_image_width * filter_image_height);
+
+              paddle::lite::CLImageConverterDefault default_convertor;
+              SHADOW_LOG << "set mapped input  ...";
+              std::vector<float> x_image_v(input_image_width *
+                                           input_image_height * 4);  // 4 :RGBA
+              std::vector<float> filter_image_v(
+                  filter_image_width * filter_image_height * 4);  // 4 : RGBA
+              std::vector<float> bias_image_v(
+                  bias_image_width * bias_image_height * 4);  // 4 : RGBA
+              std::vector<float> out_image_v(out_image_width *
+                                             out_image_height * 4);  // 4 :RGBA
+
+              default_convertor.NCHWToImage(
+                  input_v.data(), x_image_v.data(), input_dim);
+              SHADOW_LOG << "输入: ----  ";
+              for (int i = 0; i < input_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << input_v[i];
+              }
+              SHADOW_LOG << "输入image : ----  ";
+              for (int i = 0; i < x_image_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << x_image_v[i];
+              }
+              SHADOW_LOG << "set mapped filter  ...";
+              CLImageConverterFolder folder_convertor;
+
+              folder_convertor.NCHWToImage(
+                  filter_v.data(), filter_image_v.data(), filter_dim);
+              SHADOW_LOG << "卷积核: ----  ";
+              for (int i = 0; i < filter_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << filter_v[i];
+              }
+              SHADOW_LOG << "卷积核image: ----  ";
+              for (int i = 0; i < filter_image_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << filter_image_v[i];
+              }
+              auto* input_image2d = input.mutable_data<float, cl::Image2D>(
+                  input_image_width, input_image_height, x_image_v.data());
+              // assign filter as target arm
+              filter.Assign<float, lite::DDim, TARGET(kARM)>(filter_v.data(),
+                                                             filter_dim);
+              // filter kernel
+              //              auto* filter_image2d = filter.mutable_data<float,
+              //              cl::Image2D>(
+              //                  filter_image_width,
+              //                  filter_image_height,
+              //                  filter_image_v.data());
+
+              if (bias_flag) {
+                for (int i = 0; i < bias_dim.production(); ++i) {
+                  bias_v[i] = static_cast<int>(gen(engine));
+                }
+                bias.Assign<float, lite::DDim, TARGET(kARM)>(bias_v.data(),
+                                                             bias_dim);
+                //                CLImageConverterFolder folder_convertor;
+                //                folder_convertor.NCHWToImage(
+                //                    bias_v.data(), bias_image_v.data(),
+                //                    bias_dim);
+                //
+                //                auto* bias_data = bias.mutable_data<float,
+                //                cl::Image2D>(
+                //                    bias_image_width, bias_image_height,
+                //                    bias_image_v.data());
+              }
+
+              SHADOW_LOG << "resize output  ...";
+              output.Resize(out_dim);
+
+              // cpu conv basic calc
+              lite::Tensor out_ref;
+              out_ref.Resize(out_dim);
+
+              SHADOW_LOG << "prepare kernel ready";
+
+              SHADOW_LOG << "kernel launch ...";
+              kernel->Launch();
+              SHADOW_LOG << "mutable output ...";
+              auto* output_image2d = output.mutable_data<float, cl::Image2D>(
+                  out_image_width, out_image_height);
+
+              auto* wait_list = context->As<OpenCLContext>().cl_wait_list();
+              auto* out_ptr = param.output->data<float, cl::Image2D>();
+              auto it = wait_list->find(out_ptr);
+
+              if (it != wait_list->end()) {
+                SHADOW_LOG << "--- Find the sync event for the target cl "
+                              "tensor. ---";
+                auto& event = *(it->second);
+                event.wait();
+              } else {
+                LOG(FATAL) << "Could not find the sync event for the target "
+                              "cl tensor.";
+              }
+
+              TargetWrapperCL::ImgcpySync(out_image_v.data(),
+                                          output.data<float, cl::Image2D>(),
+                                          out_image_width,
+                                          out_image_height,
+                                          cl_image2d_row_pitch,
+                                          cl_image2d_slice_pitch,
+                                          IoDirection::DtoH);
+
+              DDim out_image_shape =
+                  default_convertor.InitImageDimInfoWith(output.dims());
+
+              default_convertor.ImageToNCHW(out_image_v.data(),
+                                            output_v.data(),
+                                            out_image_shape,
+                                            output.dims());
+
+              SHADOW_LOG << "输出: ----  ";
+              for (int i = 0; i < output_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << output_v[i];
+              }
+
+              SHADOW_LOG << "输出image: ----  ";
+              for (int i = 0; i < out_image_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << out_image_v[i];
+              }
+              SHADOW_LOG << "mutable_data out_ref_data: ";
+
+              // run cpu ref
+              auto* out_ref_data = out_ref.mutable_data<float>(TARGET(kARM));
+
+              SHADOW_LOG << " conv_basic beigin ..... ";
+
+              conv_basic<float, float>(input_v.data(),
+                                       out_ref_data,
+                                       batch_size,
+                                       oc,
+                                       oh,
+                                       ow,
+                                       ic,
+                                       ih,
+                                       iw,
+                                       filter_v.data(),
+                                       bias_v.data(),  // mapped_bias,
+                                       group,
+                                       ksize,
+                                       ksize,
+                                       stride,
+                                       stride,
+                                       dilation,
+                                       dilation,
+                                       pad,
+                                       pad,
+                                       bias_flag,
+                                       relu_flag);
+              SHADOW_LOG << " conv_basic end ..... ";
+
+              SHADOW_LOG << " out_dim: " << out_dim;
+              const DDim& out_image_dims = lite::DDim{std::vector<int64_t>(
+                  {static_cast<int64_t>(out_image_width),
+                   static_cast<int64_t>(out_image_height)})};
+
+              for (int i = 0; i < out_dim.production(); i++) {
+                EXPECT_NEAR(output_v[i], out_ref_data[i], 1e-2);
+                if (abs(output_v[i] - out_ref_data[i]) > 1e-2) {
+                  LOG(FATAL) << "error idx:" << i;
+                }
+              }
+
+#ifdef LOOP_TEST
+            }
+          }
+        }
+      }
+    }
+  }
+#else
+// nothing to do.
+#endif
+}
+#undef LOOP_TEST
+#undef PRINT_RESULT
+
+// #define PRINT_RESULT
+// #define LOOP_TEST
 TEST(conv2d, compute_image2d_5x5) {
   // conv infos
   const int ksize = 5;


### PR DESCRIPTION
# 状态：等待review

----

1. 增加image2d opencl conv3x3的kernel以及单测；
2. 需要注意也是之前发现的一个问题：带group的情况，filter_dims不能自动指定，否则计算有误。下面是两个例子：

```cpp
// small scale with group
                const int stride = 2;
                const int group = 2;
                const int batch_size = 1;
                const int ic = 1;
                const int ih = 3;
                const int iw = 3;
                const int oc = 2;
// big scale with group
                const int stride = 1;
                const int group = 32;
                const int batch_size = 1;
                const int ic = 32;
                const int ih = 112;
                const int iw = 112;
                const int oc = 32;

// 注意下面这里
int filter_channel = ic;
if (group > 1) {
  filter_channel = 1;
}
```

以上两种带group的情况，在单测中的计算都是正确的。

注：convOp和DepthwiseOp都是卷积，DepthwiseOp是ConvOp的一种特殊情况，而分组卷积，和Depthwise又不一样。