### PR TITLE
[X86] Optimize gru and softmax

### DIFF
--- a/lite/backends/x86/jit/more/mkl/mkl.h
+++ b/lite/backends/x86/jit/more/mkl/mkl.h
@@ -142,14 +142,13 @@ void StrideScal(const T* a, const T* x, T* y, int n, int stride);
 // remain is the product of dimension shapes after the axis dimension
 template <typename T>
 void Softmax(const T* x, T* y, int n, int bs, int remain = 1) {
-  std::vector<T> entities(bs);
   for (int i = 0; i < bs; ++i) {
-    entities[i] = x[i * n];
+    T entity = x[i * n];
     for (int c = 1; c < n; ++c) {
-      entities[i] = x[i * n + c] > entities[i] ? x[i * n + c] : entities[i];
+      entity = x[i * n + c] > entity ? x[i * n + c] : entity;
     }
     for (int c = 0; c < n; ++c) {
-      y[i * n + c] = x[i * n + c] - entities[i];
+      y[i * n + c] = x[i * n + c] - entity;
     }
   }
   VExp(y, y, n * bs);

--- a/lite/backends/x86/math/math_function.cc
+++ b/lite/backends/x86/math/math_function.cc
@@ -123,7 +123,7 @@ struct RowwiseAdd<lite::TargetType::kX86, T> {
                   const lite::Tensor& input,
                   const lite::Tensor& vector,
                   lite::Tensor* output) {
-    auto in_dims = input.dims();
+    const auto& in_dims = input.dims();
     auto size = input.numel() / in_dims[0];
     PADDLE_ENFORCE_EQ(vector.numel(), size);
     PADDLE_ENFORCE_EQ(output->dims(), in_dims);

--- a/lite/backends/x86/math/math_function.cc
+++ b/lite/backends/x86/math/math_function.cc
@@ -110,11 +110,7 @@ void set_constant(const lite::Context<Target>& context,
                   lite::Tensor* tensor,
                   float value) {
   TensorSetConstantWithTarget<Target> func(context, tensor, value);
-  // #ifdef PADDLE_WITH_CUDA
-  // tensor->target().apply_visitor(func);
-  // #else
   func();
-  // #endif
 }
 
 template <typename T>

--- a/lite/kernels/x86/gru_compute.h
+++ b/lite/kernels/x86/gru_compute.h
@@ -65,15 +65,16 @@ class GRUCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
     auto* bias = param.bias;
 
     auto* batch_gate = param.batch_gate;
-    batch_gate->mutable_data<T>();
     auto* batch_reset_hidden_prev = param.batch_reset_hidden_prev;
-    batch_reset_hidden_prev->mutable_data<T>();
     auto* batch_hidden = param.batch_hidden;
-    batch_hidden->mutable_data<T>();
+    T* batch_gate_ptr = batch_gate->mutable_data<T>();
+    T* batch_reset_hidden_prev_ptr = batch_reset_hidden_prev->mutable_data<T>();
+    T* batch_hidden_ptr = batch_hidden->mutable_data<T>();
+
     auto* hidden = param.hidden;
     hidden->mutable_data<T>();
 
-    auto hidden_dims = hidden->dims();
+    const auto& hidden_dims = hidden->dims();
 
     lite::x86::math::LoDTensor2BatchFunctor<TARGET(kX86), T> to_batch;
     to_batch(context, *input, batch_gate, true, is_reverse);
@@ -90,18 +91,17 @@ class GRUCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
         const_cast<T*>(weight_data + 2 * frame_size * frame_size);
     Tensor ordered_h0;
 
-    std::vector<size_t> order(batch_gate->lod()[2]);
-
     if (h0) {
       // Since the batch computing for GRU reorders the input sequences
       // according to their length. The initialized cell state also needs
       // to reorder.
+      const std::vector<size_t>& order(batch_gate->lod()[2]);
       ReorderInitState<T>(context, *h0, order, &ordered_h0, true);
       gru_value.prev_out_value = ordered_h0.mutable_data<T>();
     } else {
       gru_value.prev_out_value = nullptr;
     }
-    auto batch_starts = batch_gate->lod()[0];
+    const auto& batch_starts = batch_gate->lod()[0];
     size_t seq_len = batch_starts.size() - 1;
     auto active_node =
         lite::x86::math::detail::GetActivationType(param.activation);
@@ -183,18 +183,22 @@ class GRUCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
       blas.GEMM_FREE(packed_state);
     } else {
 #endif
+      int64_t batch_gate_width =
+          batch_gate->dims().count(1, batch_gate->dims().size());
+      int64_t batch_reset_hidden_prev_width =
+          batch_reset_hidden_prev->dims().count(
+              1, batch_reset_hidden_prev->dims().size());
+      int64_t batch_hidden_width =
+          batch_hidden->dims().count(1, batch_hidden->dims().size());
       for (size_t n = 0; n < seq_len; n++) {
         int64_t bstart = static_cast<int64_t>(batch_starts[n]);
         int64_t bend = static_cast<int64_t>(batch_starts[n + 1]);
         int64_t cur_batch_size = bend - bstart;
 
-        Tensor gate_t = batch_gate->Slice<T>(bstart, bend);
-        Tensor reset_hidden_prev_t =
-            batch_reset_hidden_prev->Slice<T>(bstart, bend);
-        Tensor hidden_t = batch_hidden->Slice<T>(bstart, bend);
-        gru_value.output_value = hidden_t.mutable_data<T>();
-        gru_value.gate_value = gate_t.mutable_data<T>();
-        gru_value.reset_output_value = reset_hidden_prev_t.mutable_data<T>();
+        gru_value.output_value = batch_hidden_ptr + bstart * batch_hidden_width;
+        gru_value.gate_value = batch_gate_ptr + bstart * batch_gate_width;
+        gru_value.reset_output_value = batch_reset_hidden_prev_ptr +
+                                       bstart * batch_reset_hidden_prev_width;
 
         lite::x86::math::GRUUnitFunctor<TARGET(kX86), T>::compute(
             context,


### PR DESCRIPTION
### 优化内容
- 优化了gru和softmax两个op的计算
  - gru：
    - 一些std::vector改成引用类型
    - 去掉Tensor::Slice的调用，直接计算指针
  - softmax：
    - 当输入是2-D，且axis=1时，不对输入输出进行Resize

- develop
  ```
  commit 0699ee909e0868b000f99c47f71e77a690868e48
  Author: xiaogang <txg4794@163.com>
  Date:   Fri Feb 14 10:24:00 2020 +0800

      fix: move some necessary op from extra to basic, (#2872)
  ```
  - StepRNN的运行时间：**0.0211 ms**
  ```
  I0214 04:45:03.967396  6551 generate_program_pass.h:37] insts.size 42
  I0214 04:45:06.095240  6551 test_step_rnn_lite_x86.cc:90] warmup: 10, repeats: 100000, spend 0.021101 ms in average.
  ```
- PR #2877 
  - StepRNN的运行时间：**0.0186 ms**
  ```
  I0214 05:41:01.555439 21354 generate_program_pass.h:37] insts.size 42
  I0214 05:41:03.431866 21354 test_step_rnn_lite_x86.cc:90] warmup: 10, repeats: 100000, spend 0.0186351 ms in average.
  ```

### gperftools分析结果
- develop：
  - GRUCompute::Run，14.69%
    - TensorLite::Slice、TensorLite的构造、析构函数（临时Tensor的使用），加一起占了不少时间。
    - 还有一些std::vector和DDim的构造函数
  - SoftmaxCompute::Run，7.14%
    - softmax计算的时候，会将输入输出Tensor先Resize成一个2-D Tensor，使用到了临时Tensor，并且调用`ShareDataWith`和输入、输出Tensor共享数据。profile火山图中显示`ShareDataWith`占了很大的时间比。实际上，当输入、输出Tensor本身已经是2-D Tensor，则不需要这个Resize过程。
    - `SoftmaxFunctor`中存在std::vector的使用，经分析发现，其实没有必要使用std::vector。

![image](https://user-images.githubusercontent.com/12538138/74503909-73043680-4f2d-11ea-90d0-d9c0363e3ff5.png)

![image](https://user-images.githubusercontent.com/12538138/74504273-a1364600-4f2e-11ea-934d-faff3e6665a6.png)

- PR #2877 ：
  - GRUCompute::Run，11.8%
    - 因为gru中还有移除有临时Tensor的使用，所以仍有TensorLite的构造、析构时间，但占比明显少了很多。
  - SoftmaxCompute::Run，4.35%
    - 完全去除了所有TensorLite定义、ShareDataWith和std::vector时间占用。

![image](https://user-images.githubusercontent.com/12538138/74504960-dba0e280-4f30-11ea-9085-b53d8e126102.png)

![image](https://user-images.githubusercontent.com/12538138/74504985-e9566800-4f30-11ea-9c0e-574e8852df6e.png)
