### PR TITLE
[opt information]: add help information about opt and model version

### DIFF
--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -240,7 +240,7 @@ void PrintOpsInfo(std::set<std::string> valid_ops = {}) {
 /// Print help information
 void PrintHelpInfo() {
   // at least one argument should be inputed
-  const std::string opt_version = version();
+  const std::string opt_version = lite::version();
   const char help_info[] =
       "At least one argument should be inputed. Valid arguments are listed "
       "below:\n"

--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -26,6 +26,7 @@
 #include "lite/api/paddle_use_ops.h"
 #include "lite/api/paddle_use_passes.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/version.h"
 #include "lite/model_parser/compatible_pb.h"
 #include "lite/model_parser/pb/program_desc.h"
 #include "lite/utils/cp_logging.h"
@@ -239,6 +240,7 @@ void PrintOpsInfo(std::set<std::string> valid_ops = {}) {
 /// Print help information
 void PrintHelpInfo() {
   // at least one argument should be inputed
+  const std::string opt_version = version();
   const char help_info[] =
       "At least one argument should be inputed. Valid arguments are listed "
       "below:\n"
@@ -260,7 +262,8 @@ void PrintHelpInfo() {
       "        `--print_model_ops=true  --model_dir=<model_param_dir> "
       "--valid_targets=(arm|opencl|x86|npu|xpu)`"
       "  Display operators in the input model\n";
-  std::cout << help_info << std::endl;
+  std::cout << "opt version:" << opt_version << std::endl
+            << help_info << std::endl;
   exit(1);
 }
 

--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -28,6 +28,9 @@ void RunModel(std::string model_dir) {
   // 1. Set MobileConfig
   MobileConfig config;
   config.set_model_dir(model_dir);
+  // To load model transformed by opt after release/v2.3.0, plese use
+  // `set_model_from_file` listed below.
+  // config.set_model_from_file(model_dir);
 
   // 2. Create PaddlePredictor by MobileConfig
   std::shared_ptr<PaddlePredictor> predictor =

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -696,6 +696,13 @@ void LoadModelNaive(const std::string &model_dir,
   CHECK(scope);
   cpp_prog->ClearBlocks();
 
+  LOG(WARNING)
+      << "WARNING: MobileConfig::set_model_dir and "
+         "MobileConfig::set_model_buffer are deprecated APIs "
+         "and will be removed in latter release. \n"
+         "    MobileConfig::set_model_from_file(const std::string& model_file)"
+         " and MobileConfig::set_model_from_buffer(const std::string& "
+         "model_buffer) are recommended.";
   // Load model
   const std::string prog_path = model_dir + "/__model__.nb";
   naive_buffer::BinaryTable table;
@@ -791,10 +798,11 @@ void LoadModelNaiveFromFile(const std::string &filename,
       opt_version, prog_path, &offset, opt_version_length);
   VLOG(4) << "Opt_version:" << opt_version;
 
-  // check version, opt's version should be consistent with current Paddle-Lite version.
+  // check version, opt's version should be consistent with current Paddle-Lite
+  // version.
   const std::string paddle_version = version();
   const std::string opt_version_str = opt_version;
-  if ( paddle_version == opt_version_str ) {
+  if (paddle_version == opt_version_str) {
     LOG(WARNING) << "warning: the version of opt that transformed this model "
                     "is not consistent with current Paddle-Lite version."
                     "\n      version of opt:"

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -786,10 +786,21 @@ void LoadModelNaiveFromFile(const std::string &filename,
 
   // (2)get opt version
   char opt_version[16];
-  const uint64_t paddle_version_length = 16 * sizeof(char);
+  const uint64_t opt_version_length = 16 * sizeof(char);
   ReadModelDataFromFile<char>(
-      opt_version, prog_path, &offset, paddle_version_length);
+      opt_version, prog_path, &offset, opt_version_length);
   VLOG(4) << "Opt_version:" << opt_version;
+
+  // check version, opt's version should be consistent with current Paddle-Lite version.
+  const std::string paddle_version = version();
+  const std::string opt_version_str = opt_version;
+  if ( paddle_version == opt_version_str ) {
+    LOG(WARNING) << "warning: the version of opt that transformed this model "
+                    "is not consistent with current Paddle-Lite version."
+                    "\n      version of opt:"
+                 << opt_version
+                 << "\n      version of current Paddle-Lite:" << paddle_version;
+  }
 
   // (3)get topo_size
   uint64_t topo_size;


### PR DESCRIPTION
补充新模型加载和opt工具的提示信息：
（1）opt 工具的help 信息中输出版本信息
![image](https://user-images.githubusercontent.com/45189361/74506084-c7121980-4f33-11ea-8842-9b67271131c2.png)
（2）加载模型后当model存储的opt_version与预测库的version不一致时，输出warning
  (3)   编译结果中cxx_demo，添加新接口的使用示例
![image](https://user-images.githubusercontent.com/45189361/74507201-ac8d6f80-4f36-11ea-9e03-a61de1089c6f.png)
