### PR TITLE
[opt info]fix opt info

### DIFF
--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -802,7 +802,7 @@ void LoadModelNaiveFromFile(const std::string &filename,
   // version.
   const std::string paddle_version = version();
   const std::string opt_version_str = opt_version;
-  if (paddle_version == opt_version_str) {
+  if (paddle_version != opt_version_str) {
     LOG(WARNING) << "warning: the version of opt that transformed this model "
                     "is not consistent with current Paddle-Lite version."
                     "\n      version of opt:"


### PR DESCRIPTION
问题描述：加载模型时，当Paddle-Lite预测库的版本与opt的版本不一致时，会输出warning 信息，但是代码中这一部分判断出错，写成了当两者的version一致时，输出warning信息。
本PR：修复为当预测库与opt 的version 不一致时，输出warning 信息