### PR TITLE
[BUG FIX] fix the issue that armlinux  can not compile

### DIFF
--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -571,7 +571,7 @@ void SaveModelNaive(const std::string &model_dir,
          paddle_version_length);
   paddle_version_table.Consume(paddle_version_length);
   paddle_version_table.AppendToFile(prog_path);
-  VLOG(4) << "paddle_version:" << paddle_version << std::endl;
+  VLOG(4) << "paddle_version:" << paddle_version;
 
   // Save topology_size(uint64) into file
   naive_buffer::BinaryTable topology_size_table;


### PR DESCRIPTION
【问题描述】： Paddle-Lite armlinux 编译失败，编译命令如下
【问题定位】：`lite/model_parser/model_parser.cc`
使用了`VLOG(4)<< std::endl;`  不规范语句
【本PR修复】：修复该问题，armlinux 编译通过
`VLOG(4)<< ...<<std::endl; `   ---->  `VLOG(4)<< ...;`