### PR TITLE
[ARMLINUX] Fix armlinux compiling error

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -43,6 +43,7 @@ void Predictor::SaveModel(const std::string &dir,
       LOG(FATAL) << "Unknown model type";
   }
   if (record_info) {
+    MkDirRecur(dir);
     SaveOpKernelInfo(dir);
   }
 }

--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -240,7 +240,7 @@ void PrintOpsInfo(std::set<std::string> valid_ops = {}) {
 /// Print help information
 void PrintHelpInfo() {
   // at least one argument should be inputed
-  const std::string opt_version = version();
+  const std::string opt_version = lite::version();
   const char help_info[] =
       "At least one argument should be inputed. Valid arguments are listed "
       "below:\n"

--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -26,6 +26,7 @@
 #include "lite/api/paddle_use_ops.h"
 #include "lite/api/paddle_use_passes.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/version.h"
 #include "lite/model_parser/compatible_pb.h"
 #include "lite/model_parser/pb/program_desc.h"
 #include "lite/utils/cp_logging.h"
@@ -239,6 +240,7 @@ void PrintOpsInfo(std::set<std::string> valid_ops = {}) {
 /// Print help information
 void PrintHelpInfo() {
   // at least one argument should be inputed
+  const std::string opt_version = version();
   const char help_info[] =
       "At least one argument should be inputed. Valid arguments are listed "
       "below:\n"
@@ -260,7 +262,8 @@ void PrintHelpInfo() {
       "        `--print_model_ops=true  --model_dir=<model_param_dir> "
       "--valid_targets=(arm|opencl|x86|npu|xpu)`"
       "  Display operators in the input model\n";
-  std::cout << help_info << std::endl;
+  std::cout << "opt version:" << opt_version << std::endl
+            << help_info << std::endl;
   exit(1);
 }
 

--- a/lite/core/mir/subgraph/subgraph_pass_test.cc
+++ b/lite/core/mir/subgraph/subgraph_pass_test.cc
@@ -203,7 +203,7 @@ TEST(Subgraph, generate_model_and_check_precision) {
                                  valid_places,
                                  input_tensor_shape,
                                  input_tensor_type,
-                                 FLAGS_optimized_model_dir + "/ref_opt_model");
+                                 FLAGS_optimized_model_dir + "_ref_opt_model");
 // Generate and run optimized model on NPU/XPU as the target predictor
 #ifdef LITE_WITH_NPU
   valid_places.push_back(lite_api::Place{TARGET(kNPU), PRECISION(kFloat)});
@@ -217,7 +217,7 @@ TEST(Subgraph, generate_model_and_check_precision) {
                                  valid_places,
                                  input_tensor_shape,
                                  input_tensor_type,
-                                 FLAGS_optimized_model_dir + "/tar_opt_model");
+                                 FLAGS_optimized_model_dir + "_tar_opt_model");
   // Check the difference of the output tensors between reference predictor and
   // target predictor
   CheckOutputTensors(tar_predictor, ref_predictor, output_tensor_type);

--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -28,6 +28,9 @@ void RunModel(std::string model_dir) {
   // 1. Set MobileConfig
   MobileConfig config;
   config.set_model_dir(model_dir);
+  // To load model transformed by opt after release/v2.3.0, plese use
+  // `set_model_from_file` listed below.
+  // config.set_model_from_file(model_dir);
 
   // 2. Create PaddlePredictor by MobileConfig
   std::shared_ptr<PaddlePredictor> predictor =

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -696,6 +696,13 @@ void LoadModelNaive(const std::string &model_dir,
   CHECK(scope);
   cpp_prog->ClearBlocks();
 
+  LOG(WARNING)
+      << "WARNING: MobileConfig::set_model_dir and "
+         "MobileConfig::set_model_buffer are deprecated APIs "
+         "and will be removed in latter release. \n"
+         "    MobileConfig::set_model_from_file(const std::string& model_file)"
+         " and MobileConfig::set_model_from_buffer(const std::string& "
+         "model_buffer) are recommended.";
   // Load model
   const std::string prog_path = model_dir + "/__model__.nb";
   naive_buffer::BinaryTable table;
@@ -791,10 +798,11 @@ void LoadModelNaiveFromFile(const std::string &filename,
       opt_version, prog_path, &offset, opt_version_length);
   VLOG(4) << "Opt_version:" << opt_version;
 
-  // check version, opt's version should be consistent with current Paddle-Lite version.
+  // check version, opt's version should be consistent with current Paddle-Lite
+  // version.
   const std::string paddle_version = version();
   const std::string opt_version_str = opt_version;
-  if ( paddle_version == opt_version_str ) {
+  if (paddle_version == opt_version_str) {
     LOG(WARNING) << "warning: the version of opt that transformed this model "
                     "is not consistent with current Paddle-Lite version."
                     "\n      version of opt:"

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -786,10 +786,21 @@ void LoadModelNaiveFromFile(const std::string &filename,
 
   // (2)get opt version
   char opt_version[16];
-  const uint64_t paddle_version_length = 16 * sizeof(char);
+  const uint64_t opt_version_length = 16 * sizeof(char);
   ReadModelDataFromFile<char>(
-      opt_version, prog_path, &offset, paddle_version_length);
+      opt_version, prog_path, &offset, opt_version_length);
   VLOG(4) << "Opt_version:" << opt_version;
+
+  // check version, opt's version should be consistent with current Paddle-Lite version.
+  const std::string paddle_version = version();
+  const std::string opt_version_str = opt_version;
+  if ( paddle_version == opt_version_str ) {
+    LOG(WARNING) << "warning: the version of opt that transformed this model "
+                    "is not consistent with current Paddle-Lite version."
+                    "\n      version of opt:"
+                 << opt_version
+                 << "\n      version of current Paddle-Lite:" << paddle_version;
+  }
 
   // (3)get topo_size
   uint64_t topo_size;

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -802,7 +802,7 @@ void LoadModelNaiveFromFile(const std::string &filename,
   // version.
   const std::string paddle_version = version();
   const std::string opt_version_str = opt_version;
-  if (paddle_version == opt_version_str) {
+  if (paddle_version != opt_version_str) {
     LOG(WARNING) << "warning: the version of opt that transformed this model "
                     "is not consistent with current Paddle-Lite version."
                     "\n      version of opt:"

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -571,7 +571,7 @@ void SaveModelNaive(const std::string &model_dir,
          paddle_version_length);
   paddle_version_table.Consume(paddle_version_length);
   paddle_version_table.AppendToFile(prog_path);
-  VLOG(4) << "paddle_version:" << paddle_version << std::endl;
+  VLOG(4) << "paddle_version:" << paddle_version;
 
   // Save topology_size(uint64) into file
   naive_buffer::BinaryTable topology_size_table;

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -544,7 +544,6 @@ void SaveModelNaive(const std::string &model_dir,
                     const Scope &exec_scope,
                     const cpp::ProgramDesc &cpp_prog,
                     bool combined) {
-  MkDirRecur(model_dir);
   // Save program
   const std::string prog_path = model_dir + ".nb";
   naive_buffer::BinaryTable table;
@@ -586,7 +585,8 @@ void SaveModelNaive(const std::string &model_dir,
   // Save Params
   SaveCombinedParamsNaive(prog_path, exec_scope, cpp_prog);
 
-  LOG(INFO) << "Save naive buffer model in '" << model_dir << "' successfully";
+  LOG(INFO) << "Save naive buffer model in '" << model_dir
+            << ".nb' successfully";
 }
 #endif
 


### PR DESCRIPTION
cherry-pick develop分支中的修复PR到 release/v2.3分支上。来源PR：[#2890](https://github.com/PaddlePaddle/Paddle-Lite/pull/2890)，[#2892](https://github.com/PaddlePaddle/Paddle-Lite/pull/2892)
(1) [#2890](https://github.com/PaddlePaddle/Paddle-Lite/pull/2890)
【问题描述】release/v2.3 Paddle-Lite armlinux的full_publish编译失败。
【问题定位】使用了 LOG(INFO)<< ... << std::endl；语法不规范
【修复】修改为 LOG(INFO)<< ...; 

(2) [#2892](https://github.com/PaddlePaddle/Paddle-Lite/pull/2892)
【问题描述】opt转化模型时回同时保存.nb文件和一个空文件夹
【修复】转化模型时只保存nb文件，不创建文件夹，当--record_info=true时创建文件夹保存info信息。


