### PR TITLE
[BUG FIX] Fix write_to_array OP

### DIFF
--- a/lite/kernels/arm/write_to_array_compute.cc
+++ b/lite/kernels/arm/write_to_array_compute.cc
@@ -65,6 +65,6 @@ REGISTER_LITE_KERNEL(write_to_array,
                      paddle::lite::kernels::arm::WriteToArrayCompute,
                      def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
-    .BindInput("I", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("I", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
     .BindOutput("Out", {LiteType::GetTensorListTy(TARGET(kARM))})
     .Finalize();


### PR DESCRIPTION
解决Lite`write_to_array `op 的输入未与FLuid对齐的问题，对应[Issue#2885](https://github.com/PaddlePaddle/Paddle-Lite/issues/2885)
Fluid中`write_to_array`的I输入为int64_t，Lite中注册为float类型，导致部分模型不能正常运行
本PR修复：将Lite 中`write_to_array`的I输入修改为kAny，可以接受多种数据类型。