### PR TITLE
[demo] Fix cxx_demo

### DIFF
--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -27,10 +27,10 @@ int64_t ShapeProduction(const shape_t& shape) {
 void RunModel(std::string model_dir) {
   // 1. Set MobileConfig
   MobileConfig config;
-  config.set_model_dir(model_dir);
-  // To load model transformed by opt after release/v2.3.0, plese use
-  // `set_model_from_file` listed below.
-  // config.set_model_from_file(model_dir);
+  config.set_model_from_file(model_dir);
+  // NOTE: To load model transformed by model_optimize_tool before
+  // release/v2.3.0, plese use `set_model_dir` API as listed below.
+  // config.set_model_dir(model_dir);
 
   // 2. Create PaddlePredictor by MobileConfig
   std::shared_ptr<PaddlePredictor> predictor =


### PR DESCRIPTION
[问题描述]Paddle-Lite release/v2.3修改模型格式，加载新的模型格式需要使用新的接口 set_model_from_file。
[本PR修复] 将cxx_mobile_light demo中修改为使用新接口加载nb模型，并提示如何使用老接口
![image](https://user-images.githubusercontent.com/45189361/74702115-e797e780-5243-11ea-8757-ea76cd6588b5.png)

