### PR TITLE
[NPU] enhance shape check in subgraph compute

### DIFF
--- a/lite/kernels/npu/bridges/reshape_op.cc
+++ b/lite/kernels/npu/bridges/reshape_op.cc
@@ -88,6 +88,7 @@ int ReshapeConverter(void* ctx, OpLite* op, KernelBase* kernel) {
   } else {
     auto shape = op_info->GetAttr<std::vector<int>>("shape");
     auto out_shape = lite::operators::ValidateShape(shape, x_dims);
+    out_shape = CvtShape(out_shape);
     if (out_shape.size() > 4) {
       LOG(WARNING) << "[NPU] HiAI DDK only supports less than 4 dimensions, "
                       "but shape has "

--- a/lite/kernels/npu/bridges/utility.cc
+++ b/lite/kernels/npu/bridges/utility.cc
@@ -151,6 +151,21 @@ int CvtActMode(std::string act_type) {
   return act_mode;
 }
 
+bool CheckShape(DDim origin_dims, hiai::TensorDimension device_dims) {
+  auto origin_shape = origin_dims.Vectorize();
+  if (origin_shape.size() < 3) {
+    origin_shape.insert(origin_shape.end(), 4 - origin_shape.size(), 1);
+  }
+  if (origin_shape.size() == 3) {
+    origin_shape.insert(origin_shape.begin(), 1);
+  }
+  CHECK_EQ(origin_shape.size(), 4);
+  return origin_shape[0] == device_dims.GetNumber() &&
+         origin_shape[1] == device_dims.GetChannel() &&
+         origin_shape[2] == device_dims.GetHeight() &&
+         origin_shape[3] == device_dims.GetWidth();
+}
+
 }  // namespace npu
 }  // namespace subgraph
 }  // namespace lite

--- a/lite/kernels/npu/bridges/utility.cc
+++ b/lite/kernels/npu/bridges/utility.cc
@@ -152,13 +152,7 @@ int CvtActMode(std::string act_type) {
 }
 
 bool CheckShape(DDim origin_dims, hiai::TensorDimension device_dims) {
-  auto origin_shape = origin_dims.Vectorize();
-  if (origin_shape.size() < 3) {
-    origin_shape.insert(origin_shape.end(), 4 - origin_shape.size(), 1);
-  }
-  if (origin_shape.size() == 3) {
-    origin_shape.insert(origin_shape.begin(), 1);
-  }
+  auto origin_shape = CvtShape(origin_dims);
   CHECK_EQ(origin_shape.size(), 4);
   return origin_shape[0] == device_dims.GetNumber() &&
          origin_shape[1] == device_dims.GetChannel() &&

--- a/lite/kernels/npu/bridges/utility.h
+++ b/lite/kernels/npu/bridges/utility.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "HiAiModelManagerService.h"
 #include "graph/buffer.h"
 #include "graph/graph.h"
 #include "graph/model.h"
@@ -144,6 +145,8 @@ ge::TensorPtr CvtTensor(const Tensor& in_tensor,
                         DataLayoutType in_layout = DATALAYOUT(kNCHW));
 
 int CvtActMode(std::string act_type);
+
+bool CheckShape(DDim origin_dims, hiai::TensorDimension device_dims);
 
 }  // namespace npu
 }  // namespace subgraph

--- a/lite/operators/conv_op.cc
+++ b/lite/operators/conv_op.cc
@@ -52,12 +52,12 @@ inline int ConvOutputSize(int input_size,
   return output_size;
 }
 
-inline void UpdatePaddingAndDilation(std::vector<int>* paddings,
-                                     std::vector<int>* dilations,
-                                     const std::vector<int>& strides,
-                                     const std::string padding_algorithm,
-                                     const lite::DDim data_dims,
-                                     const lite::DDim& ksize) {
+void UpdatePaddingAndDilation(std::vector<int>* paddings,
+                              std::vector<int>* dilations,
+                              const std::vector<int>& strides,
+                              const std::string padding_algorithm,
+                              const lite::DDim data_dims,
+                              const lite::DDim& ksize) {
   // when padding_desc is "VALID" or "SAME"
   if (padding_algorithm == "SAME") {
     for (size_t i = 0; i < strides.size(); ++i) {

--- a/lite/tests/kernels/reshape_compute_test.cc
+++ b/lite/tests/kernels/reshape_compute_test.cc
@@ -155,6 +155,47 @@ class ReshapeComputeTester : public arena::TestCase {
   }
 };
 
+void TestReshape4D(Place place, float abs_error) {
+  DDim dims{{2, 3, 4, 5}};
+  std::vector<std::vector<int>> shapes{{5, 4, 3, 2},
+                                       {2, 3, 20},
+                                       {2, 60},
+                                       {120},
+                                       {2, 3, -1},
+                                       {0, 0, 20},
+                                       {0, 0, -1}};
+  for (auto shape : shapes) {
+    std::unique_ptr<arena::TestCase> tester(
+        new ReshapeComputeTester(place, "def", dims, shape));
+    arena::Arena arena(std::move(tester), place, abs_error);
+    arena.TestPrecision({"xshape"});
+  }
+}
+
+void TestReshape3D(Place place, float abs_error) {
+  DDim dims{{2, 3, 20}};
+  std::vector<std::vector<int>> shapes{
+      {5, 4, 3, 2}, {2, 3, 20}, {2, 60}, {120}, {2, 3, -1}, {0, 60}, {0, -1}};
+  for (auto shape : shapes) {
+    std::unique_ptr<arena::TestCase> tester(
+        new ReshapeComputeTester(place, "def", dims, shape));
+    arena::Arena arena(std::move(tester), place, abs_error);
+    arena.TestPrecision({"xshape"});
+  }
+}
+
+void TestReshape2D(Place place, float abs_error) {
+  DDim dims{{6, 20}};
+  std::vector<std::vector<int>> shapes{
+      {5, 4, 3, 2}, {2, 3, 20}, {2, 60}, {120}, {-1}};
+  for (auto shape : shapes) {
+    std::unique_ptr<arena::TestCase> tester(
+        new ReshapeComputeTester(place, "def", dims, shape));
+    arena::Arena arena(std::move(tester), place, abs_error);
+    arena.TestPrecision({"xshape"});
+  }
+}
+
 TEST(Reshape, precision) {
   LOG(INFO) << "test Reshape op";
   float abs_error = 2e-5;
@@ -168,23 +209,9 @@ TEST(Reshape, precision) {
   return;
 #endif
 
-  DDim dims{{2, 3, 4, 5}};
-  std::vector<std::vector<int>> shapes{{5, 4, 3, 2},
-                                       {2, 3, 20},
-                                       {2, 60},
-                                       {120},
-                                       {2, 3, -1},
-                                       {0, 0, 20},
-                                       {0, 0, -1}};
-  for (auto shape : shapes) {
-#ifdef LITE_WITH_NPU
-    if (dims.size() > 4 || shape.size() > 4) continue;
-#endif
-    std::unique_ptr<arena::TestCase> tester(
-        new ReshapeComputeTester(place, "def", dims, shape));
-    arena::Arena arena(std::move(tester), place, abs_error);
-    arena.TestPrecision({"xshape"});
-  }
+  TestReshape4D(place, abs_error);
+  TestReshape3D(place, abs_error);
+  TestReshape2D(place, abs_error);
 }
 
 }  // namespace lite


### PR DESCRIPTION
- HIAI的shape只支持4维，小于4维会补到4维
- HIAI对于3维的情况有时候会自动解释为HWC格式，而改变本来的NCHW格式。因此在paddlelite端，全部进行统一
    - 不足4维，全部在后面补1