### PR TITLE
[compile] Fix the that full publish compling issue

### DIFF
--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -571,7 +571,7 @@ void SaveModelNaive(const std::string &model_dir,
          paddle_version_length);
   paddle_version_table.Consume(paddle_version_length);
   paddle_version_table.AppendToFile(prog_path);
-  VLOG(4) << "paddle_version:" << paddle_version << std::endl;
+  VLOG(4) << "paddle_version:" << paddle_version;
 
   // Save topology_size(uint64) into file
   naive_buffer::BinaryTable topology_size_table;


### PR DESCRIPTION
问题描述：full_publish编译失败，在develop 分支已经修复，本PR将修复cherry-pick 到2.3分支上。
cherry-pick自：[#2890](https://github.com/PaddlePaddle/Paddle-Lite/pull/2890)