### PR TITLE
[LITE][OPENCL] add elementwise_mul kernel with x(nchw), y(nc). test=d…

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/elementwise_mul_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/elementwise_mul_kernel.cl
@@ -14,7 +14,8 @@ limitations under the License. */
 
 #include <cl_common.h>
 
-__kernel void elementwise_mul(__global image2d_t input, __global image2d_t bias,
+__kernel void elementwise_mul(__global image2d_t input,
+                              __global image2d_t bias,
                               __write_only image2d_t outputImage) {
   int x = get_global_id(0);
   int y = get_global_id(1);
@@ -29,8 +30,11 @@ __kernel void elementwise_mul(__global image2d_t input, __global image2d_t bias,
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
 }
 
-__kernel void channel_mul_d1(__read_only image2d_t input, __read_only image2d_t bias,
-                             __write_only image2d_t outputImage, int w) {
+
+__kernel void channel_mul_d1(__read_only image2d_t input,
+                             __read_only image2d_t bias,
+                             __write_only image2d_t outputImage,
+							 int w) {
   int x = get_global_id(0);
   int y = get_global_id(1);
 
@@ -52,8 +56,88 @@ __kernel void channel_mul_d1(__read_only image2d_t input, __read_only image2d_t 
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
 }
 
-__kernel void channel_mul_d2(__read_only image2d_t input, __read_only image2d_t bias,
-                             __write_only image2d_t outputImage, int w, int h) {
+
+// #define DEBUG
+__kernel void channel_mul_d2_nc(__read_only image2d_t input,
+                                __read_only image2d_t bias,
+                                __write_only image2d_t outputImage,
+	   						    int w) {
+  int x = get_global_id(0);
+  int y = get_global_id(1);
+
+#ifdef DEBUG
+  printf("x:%d y:%d\n", x, y);
+#endif
+
+  const sampler_t sampler =
+      CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
+  int2 coords;
+  coords.x = x;
+  coords.y = y;
+  CL_DTYPE4 in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
+
+  int2 coords_bias0 = (int2)(x / w * 4, 0);
+  int2 coords_bias1 = (int2)(x / w * 4 + 1, 0);
+  int2 coords_bias2 = (int2)(x / w * 4 + 2, 0);
+  int2 coords_bias3 = (int2)(x / w * 4 + 3, 0);
+
+  CL_DTYPE4 b0 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias0);
+  CL_DTYPE4 b1 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias1);
+  CL_DTYPE4 b2 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias2);
+  CL_DTYPE4 b3 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias3);
+
+  CL_DTYPE4 biase = {b0.x, b1.x, b2.x, b3.x};
+  CL_DTYPE4 output = mad(in, biase, 0);
+
+#ifdef DEBUG
+  if (x == 0 && y == 0) {
+    printf("w:%d\n", w);
+
+    printf("biase:%.1f %.1f %.1f %.1f\n", biase.x, biase.y, biase.z, biase.w);
+    printf("output:%.1f %.1f %.1f %.1f\n", output.x, output.y, output.z, output.w);
+
+    coords.x = 0;
+    coords.y = 0;
+    in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
+    printf("in(%d,%d):%.2f %.2f %.2f %.2f\n", coords.x, coords.y, in.x, in.y, in.z, in.w);
+    coords.x = 0;
+    coords.y = 1;
+    in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
+    printf("in(%d,%d):%.2f %.2f %.2f %.2f\n", coords.x, coords.y, in.x, in.y, in.z, in.w);
+    coords.x = 1;
+    coords.y = 0;
+    in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
+    printf("in(%d,%d):%.2f %.2f %.2f %.2f\n", coords.x, coords.y, in.x, in.y, in.z, in.w);
+    coords.x = 1;
+    coords.y = 1;
+    in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, coords);
+    printf("in(%d,%d):%.2f %.2f %.2f %.2f\n", coords.x, coords.y, in.x, in.y, in.z, in.w);
+
+    coords_bias.x = 0;
+    coords_bias.y = 0;
+    biase = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias);
+    printf("biase(%d,%d):%.2f %.2f %.2f %.2f\n", coords_bias.x, coords_bias.y, biase.x, biase.y, biase.z, biase.w);
+    coords_bias.x = 1;
+    coords_bias.y = 0;
+    biase = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias);
+    printf("biase(%d,%d):%.2f %.2f %.2f %.2f\n", coords_bias.x, coords_bias.y, biase.x, biase.y, biase.z, biase.w);
+    coords_bias.x = 2;
+    coords_bias.y = 0;
+    biase = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, sampler, coords_bias);
+    printf("biase(%d,%d):%.2f %.2f %.2f %.2f\n", coords_bias.x, coords_bias.y, biase.x, biase.y, biase.z, biase.w);
+  }
+#endif
+
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
+}
+
+
+__kernel void channel_mul_d2_hw(__read_only image2d_t input,
+                                __read_only image2d_t bias,
+                                __write_only image2d_t outputImage,
+                                int w,
+                                int h) {
   int x = get_global_id(0);
   int y = get_global_id(1);
 
@@ -75,8 +159,11 @@ __kernel void channel_mul_d2(__read_only image2d_t input, __read_only image2d_t 
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
 }
 
-__kernel void channel_mul_d4(__read_only image2d_t input, __read_only image2d_t bias,
-                             __write_only image2d_t outputImage, int w) {
+
+__kernel void channel_mul_d4(__read_only image2d_t input,
+                             __read_only image2d_t bias,
+                             __write_only image2d_t outputImage,
+							 int w) {
   int x = get_global_id(0);
   int y = get_global_id(1);
 

--- a/lite/kernels/opencl/elementwise_mul_compute.cc
+++ b/lite/kernels/opencl/elementwise_mul_compute.cc
@@ -26,13 +26,19 @@ namespace opencl {
 void ElementwiseMulFloatImageCompute::PrepareForRun() {
   ele_param_ = param_.get_mutable<param_t>();
   auto* y = ele_param_->Y;
+  auto* x = ele_param_->X;
   auto y_dims = y->dims();
-  if (y_dims == ele_param_->X->dims()) {
+  auto x_dims = x->dims();
+  if (y_dims == x_dims) {
     kernel_func_name_ = "elementwise_mul";
   } else if (y_dims.size() == 1) {
     kernel_func_name_ = "channel_mul_d1";
   } else if (y_dims.size() == 2) {
-    kernel_func_name_ = "channel_mul_d2";
+    if (x_dims[0] == y_dims[0] && x_dims[1] == y_dims[1]) {
+      kernel_func_name_ = "channel_mul_d2_nc";
+    } else {
+      kernel_func_name_ = "channel_mul_d2_hw";
+    }
   } else if (y_dims.size() == 4) {
     kernel_func_name_ = "channel_mul_d4";
   } else {
@@ -87,7 +93,8 @@ void ElementwiseMulFloatImageCompute::Run() {
 
   int arg_idx = 0;
   auto y_dims = y->dims();
-  if (y_dims == ele_param_->X->dims()) {
+  auto x_dims = x->dims();
+  if (y_dims == x_dims) {
     // kernel: elementwise_mul(channel_mul_d4)
     cl_int status = kernel.setArg(arg_idx, *x_img);
     CL_CHECK_FATAL(status);
@@ -96,7 +103,7 @@ void ElementwiseMulFloatImageCompute::Run() {
     status = kernel.setArg(++arg_idx, *out_img);
     CL_CHECK_FATAL(status);
   } else if (y_dims.size() == 1 || y_dims.size() == 4) {
-    auto tensor_w = x->dims()[x->dims().size() - 1];
+    auto tensor_w = x_dims[x_dims.size() - 1];
     VLOG(4) << "tensor_w:" << tensor_w;
     // kernel: channel_mul_d1 / channel_mul_d4
     cl_int status = kernel.setArg(arg_idx, *x_img);
@@ -108,20 +115,34 @@ void ElementwiseMulFloatImageCompute::Run() {
     status = kernel.setArg(++arg_idx, static_cast<const int>(tensor_w));
     CL_CHECK_FATAL(status);
   } else if (y_dims.size() == 2) {
-    auto y_tensor_h = y->dims()[0];
-    auto y_tensor_w = y->dims()[1];
-    VLOG(4) << "y_tensor_w:" << y_tensor_w << " y_tensor_h:" << y_tensor_h;
-    // kernel: channel_mul_d2
-    cl_int status = kernel.setArg(arg_idx, *x_img);
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, *y_img);
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, *out_img);
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(y_tensor_w));
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(y_tensor_h));
-    CL_CHECK_FATAL(status);
+    if (x_dims[0] == y_dims[0] && x_dims[1] == y_dims[1]) {
+      auto tensor_w = x_dims[x_dims.size() - 1];
+      VLOG(4) << "tensor_w:" << tensor_w;
+      // kernel: channel_mul_d2_nc
+      cl_int status = kernel.setArg(arg_idx, *x_img);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, *y_img);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, *out_img);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<const int>(tensor_w));
+      CL_CHECK_FATAL(status);
+    } else {
+      auto y_tensor_h = y->dims()[0];
+      auto y_tensor_w = y->dims()[1];
+      VLOG(4) << "y_tensor_w:" << y_tensor_w << " y_tensor_h:" << y_tensor_h;
+      // kernel: channel_mul_d2_hw
+      cl_int status = kernel.setArg(arg_idx, *x_img);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, *y_img);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, *out_img);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<const int>(y_tensor_w));
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<const int>(y_tensor_h));
+      CL_CHECK_FATAL(status);
+    }
   } else {
     LOG(FATAL) << "ElementwiseMul not supported y_dims.size():"
                << y_dims.size();


### PR DESCRIPTION
# 状态：等待review

## 主要工作

1. 增加一种elementwise_mul的kernel形式，针对：x: {n,c,h,w}，y:{n,c}；
2. 完善丰富elementwise_mul的kernel选择路由；
3. 增加针对：x: {n,c,h,w}，y:{n,c}的对应单测函数实现。

补：先前mobile的opencl代码中有这种情况，但是单测一直没有过，没有看懂对应哪一种case，单测没对应形式，和lite有一些差异。现在补上。

## test_elementwise_mul_opencl 单测执行结果

```shell
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from elemul_image2d_fp32
[ RUN      ] elemul_image2d_fp32.compute_kernel_elemenwise_mul
[I  2/20 11:48:59.901 ...s/opencl/elementwise_mul_compute_test.cc:116 TestBody] main steps of test: host -> layout(buf2img on cpu) -> elemul(img) -> layout(img2buf on cpu) -> host
[I  2/20 11:48:59.902 ...s/opencl/elementwise_mul_compute_test.cc:135 TestBody] ================== elementwise_mul ===================
[I  2/20 11:48:59.902 ...s/opencl/elementwise_mul_compute_test.cc:136 TestBody] x_dim:{1,7,2,2}	y_dim:{1,7,1,1}	out_dim:{1,7,2,2}
[I  2/20 11:48:59.902 ...s/opencl/elementwise_mul_compute_test.cc:140 TestBody] set tensors about op param
[I  2/20 11:48:59.934 ...lemul/lite/backends/opencl/cl_runtime.cc:147 InitializeDevice] Using device: QUALCOMM Adreno(TM)
[I  2/20 11:48:59.934 ...lemul/lite/backends/opencl/cl_runtime.cc:150 InitializeDevice] The chosen device supports image processing.
[I  2/20 11:48:59.934 ...lemul/lite/backends/opencl/cl_runtime.cc:158 InitializeDevice] The chosen device supports the half data type.
[I  2/20 11:48:59.934 ...lemul/lite/backends/opencl/cl_runtime.cc:163 InitializeDevice] The chosen device has 1 compute units.
[I  2/20 11:48:59.934 ...lemul/lite/backends/opencl/cl_runtime.cc:165 InitializeDevice] The local memory size of the chosen device is 32 KB.
[I  2/20 11:49: 0.187 ...s/opencl/elementwise_mul_compute_test.cc:135 TestBody] ================== elementwise_mul ===================
[I  2/20 11:49: 0.187 ...s/opencl/elementwise_mul_compute_test.cc:136 TestBody] x_dim:{1,7,2,2}	y_dim:{1,7,2,2}	out_dim:{1,7,2,2}
[I  2/20 11:49: 0.188 ...s/opencl/elementwise_mul_compute_test.cc:140 TestBody] set tensors about op param
[I  2/20 11:49: 0.411 ...s/opencl/elementwise_mul_compute_test.cc:135 TestBody] ================== elementwise_mul ===================
[I  2/20 11:49: 0.411 ...s/opencl/elementwise_mul_compute_test.cc:136 TestBody] x_dim:{1,7,2,2}	y_dim:{2,2}	out_dim:{1,7,2,2}
[I  2/20 11:49: 0.411 ...s/opencl/elementwise_mul_compute_test.cc:140 TestBody] set tensors about op param
[I  2/20 11:49: 0.634 ...s/opencl/elementwise_mul_compute_test.cc:135 TestBody] ================== elementwise_mul ===================
[I  2/20 11:49: 0.634 ...s/opencl/elementwise_mul_compute_test.cc:136 TestBody] x_dim:{1,7,2,2}	y_dim:{1,7}	out_dim:{1,7,2,2}
[I  2/20 11:49: 0.634 ...s/opencl/elementwise_mul_compute_test.cc:140 TestBody] set tensors about op param
[I  2/20 11:49: 0.857 ...s/opencl/elementwise_mul_compute_test.cc:135 TestBody] ================== elementwise_mul ===================
[I  2/20 11:49: 0.857 ...s/opencl/elementwise_mul_compute_test.cc:136 TestBody] x_dim:{1,7,2,2}	y_dim:{2}	out_dim:{1,7,2,2}
[I  2/20 11:49: 0.857 ...s/opencl/elementwise_mul_compute_test.cc:140 TestBody] set tensors about op param
[       OK ] elemul_image2d_fp32.compute_kernel_elemenwise_mul (1180 ms)
[----------] 1 test from elemul_image2d_fp32 (1180 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1180 ms total)
[  PASSED  ] 1 test.
```