### PR TITLE
【JAVA API】Fix Java API

### DIFF
--- a/lite/api/android/jni/src/com/baidu/paddle/lite/MobileConfig.java
+++ b/lite/api/android/jni/src/com/baidu/paddle/lite/MobileConfig.java
@@ -78,7 +78,7 @@ public class MobileConfig extends ConfigBase {
      *  
      * @return liteModelFile
      */
-    public String getModelFile() {
+    public String getModelFromFile() {
         return liteModelFile;
     }
 
@@ -96,7 +96,7 @@ public class MobileConfig extends ConfigBase {
      *  
      * @return liteModelBuffer
      */
-    public String getModelBuffer() {
+    public String getModelFromBuffer() {
         return liteModelBuffer;
     }
 


### PR DESCRIPTION
【问题描述】Paddle-Lite的Java API调用出现问题
【问题原因】API中调用的接口(getModelFromFile)与注册的接口不一致(getModelFile)
本PR已经修复