### PR TITLE
[do not merge] opencl temporary solution

### DIFF
--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -75,6 +75,7 @@ DEFINE_bool(print_all_ops,
             false,
             "Print all the valid operators of Paddle-Lite");
 DEFINE_bool(print_model_ops, false, "Print operators in the input model");
+DEFINE_bool(pre_process_type, false, "Set pre_process_type of layout op");
 
 namespace paddle {
 namespace lite_api {
@@ -157,6 +158,15 @@ void RunOptimize(const std::string& model_dir,
   OpKernelInfoCollector::Global().SetKernel2path(kernel2path_map);
   predictor->SaveOptimizedModel(
       optimize_out, model_type, record_tailoring_info);
+
+  std::string nb_model = optimize_out + ".nb";
+  if (FLAGS_pre_process_type) {
+    uint16_t meta_version = 10;
+    FILE* fp = fopen(nb_model.c_str(), "rb+");
+    fseek(fp, 0, SEEK_SET);
+    fwrite(&meta_version, sizeof(uint16_t), 1, fp);
+  }
+
   if (record_tailoring_info) {
     LOG(INFO) << "Record the information of tailored model into :"
               << optimize_out;

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -789,7 +789,7 @@ void LoadModelNaiveFromFile(const std::string &filename,
   uint16_t meta_version;
   ReadModelDataFromFile<uint16_t>(
       &meta_version, prog_path, &offset, sizeof(uint16_t));
-  VLOG(4) << "Meta_version:" << meta_version;
+  std::cout << "Meta_version:" << meta_version << std::endl;
 
   // (2)get opt version
   char opt_version[16];
@@ -827,6 +827,15 @@ void LoadModelNaiveFromFile(const std::string &filename,
 
   // (5)Load Params
   LoadCombinedParamsNaive(prog_path, offset, scope, *cpp_prog, false);
+
+  // (6) layoutparam form
+  if (meta_version == 10) {
+    auto *pre_process_type_tensor =
+        scope->Var("pre_process_type")->GetMutable<lite::Tensor>();
+    pre_process_type_tensor->Resize({1});
+    auto pre_process_type = pre_process_type_tensor->mutable_data<int>();
+    pre_process_type[0] = 1;
+  }
 
   VLOG(4) << "Load naive buffer model in '" << filename << "' successfully";
 }

--- a/lite/operators/layout_op.cc
+++ b/lite/operators/layout_op.cc
@@ -33,6 +33,9 @@ bool LayoutOp::AttachImpl(const cpp::OpDesc &opdesc,
                           paddle::lite::Scope *scope) {
   auto x = opdesc.Input("Input").front();
   auto out = opdesc.Output("Out").front();
+  if (scope->FindVar("pre_process_type") != nullptr) {
+    param_.pre_process_type = 1;
+  }
   param_.x = GetTensor(scope, x);
   param_.y = GetMutableTensor(scope, out);
   return true;

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -62,6 +62,8 @@ struct IoCopyParam {
 struct LayoutParam {
   const lite::Tensor* x{};
   lite::Tensor* y{};
+  int pre_process_type;
+  int post_process_type;
 };
 
 struct CalibParam {


### PR DESCRIPTION
(1)保存模型后，修改model的meta_version
           opt触发该功能的方法： `--pre_process_type=true`
(2)加载模型后，当meta_version=10时，加载模型后往scope中添加一个variable ：`pre_process_type `
(3)layout_op创建时(Attach_impl)，查询如果variable  `pre_process_type `存在就给param_.赋值


