### PR TITLE
[FIX CI BUG] fix the issue that test_mobilenet_v2 can not pass 

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/conv2d_1x1_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_1x1_kernel.cl
@@ -191,10 +191,12 @@ __kernel void conv2d_1x1(__private const int global_size_dim0,
             READ_IMG_TYPE(CL_DTYPE_CHAR, new_biase, sampler, (int2)(out_c, 0));
 #endif
 
+#ifdef RELU
   output0 = activation_type4(output0);
   output1 = activation_type4(output1);
   output2 = activation_type4(output2);
   output3 = activation_type4(output3);
+#endif
 
   if (out_w0 < old_w) {
     WRITE_IMG_TYPE(CL_DTYPE_CHAR, output_image, output_pos0, output0);


### PR DESCRIPTION
问题描述：[#2979](https://github.com/PaddlePaddle/Paddle-Lite/pull/2979/files)的合入导致后续CI无法正常通过。
本PR修复。