### PR TITLE
【FRAMEWORK】Remove HeadFiles

### DIFF
--- a/lite/api/android/jni/native/paddle_lite_jni.h
+++ b/lite/api/android/jni/native/paddle_lite_jni.h
@@ -17,11 +17,6 @@
 #include <jni.h>
 /* Header for class com_baidu_paddle_lite_PaddlePredictor */
 #include "lite/api/paddle_lite_factory_helper.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#ifndef LITE_ON_TINY_PUBLISH
-#include "lite/api/paddle_use_passes.h"
-#endif
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lite/api/apis_test.cc
+++ b/lite/api/apis_test.cc
@@ -21,9 +21,6 @@
 #include <vector>
 #include "lite/api/cxx_api.h"
 #include "lite/api/light_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 #include "lite/core/mir/pass_registry.h"
 
 DEFINE_string(model_dir, "", "");

--- a/lite/api/benchmark.cc
+++ b/lite/api/benchmark.cc
@@ -23,9 +23,6 @@
 #include <string>
 #include <vector>
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 #include "lite/core/device_info.h"
 #include "lite/utils/cp_logging.h"
 #include "lite/utils/string.h"

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 #include "lite/api/light_api.h"
+#include "paddle_use_kernels.h"  // NOLINT
+#include "paddle_use_ops.h"      // NOLINT
+#ifndef LITE_ON_TINY_PUBLISH
+#include "lite/api/paddle_use_passes.h"
+#endif
+
 #include <algorithm>
 
 namespace paddle {

--- a/lite/api/light_api_shared.cc
+++ b/lite/api/light_api_shared.cc
@@ -12,11 +12,6 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#ifndef LITE_ON_TINY_PUBLISH
-#include "lite/api/paddle_use_passes.h"
-#endif
 
 namespace paddle {
 namespace lite_api {

--- a/lite/api/light_api_test.cc
+++ b/lite/api/light_api_test.cc
@@ -15,9 +15,6 @@
 #include "lite/api/light_api.h"
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 
 DEFINE_string(optimized_model, "", "");
 

--- a/lite/api/lite_multithread_test.cc
+++ b/lite/api/lite_multithread_test.cc
@@ -16,9 +16,6 @@
 #include <string>
 #include <vector>
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 #include "lite/api/test_helper.h"
 #include "lite/core/device_info.h"
 #include "lite/core/profile/timer.h"

--- a/lite/api/model_test.cc
+++ b/lite/api/model_test.cc
@@ -17,9 +17,6 @@
 #include <string>
 #include <vector>
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 #include "lite/api/test_helper.h"
 #include "lite/core/device_info.h"
 #include "lite/core/profile/timer.h"

--- a/lite/api/model_test_classify.cc
+++ b/lite/api/model_test_classify.cc
@@ -17,9 +17,6 @@
 #include <string>
 #include <vector>
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 #include "lite/api/test_helper.h"
 #include "lite/core/device_info.h"
 #include "lite/core/profile/timer.h"

--- a/lite/api/model_test_detection.cc
+++ b/lite/api/model_test_detection.cc
@@ -17,9 +17,6 @@
 #include <string>
 #include <vector>
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 #include "lite/api/test_helper.h"
 #include "lite/core/device_info.h"
 #include "lite/core/profile/timer.h"

--- a/lite/api/paddle_api_test.cc
+++ b/lite/api/paddle_api_test.cc
@@ -15,9 +15,6 @@
 #include "lite/api/paddle_api.h"
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 #include "lite/utils/cp_logging.h"
 #include "lite/utils/io.h"
 DEFINE_string(model_dir, "", "");

--- a/lite/core/mir/subgraph/subgraph_pass_test.cc
+++ b/lite/core/mir/subgraph/subgraph_pass_test.cc
@@ -15,9 +15,6 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
-#include "lite/api/paddle_use_passes.h"
 #include "lite/api/test_helper.h"
 #include "lite/utils/cp_logging.h"
 


### PR DESCRIPTION
针对问题：（1）当前Paddle-Lite 预测库需要引用以下头文件。但只有`paddle_api.h`头文件中声明用户接口。
```
paddle_use_ops.h  
paddle_use_kernels.h  
paddle_use_passes.h      
paddle_api.h
```
（2）当前Paddle-Lite动态库不需要调用`paddle_use_**.h`头文件，动态库静态库调用方法不对齐。
本PR解决方案：将`paddle_use_**.h`三个头文件放入`light_api.cc`代码中，用户调用paddle_api预测库不需要额外引用`paddle_use_**.h`三个头文件。
