### PR TITLE
[Core] Fix memory_optmize_pass for reshape/reshape2 op with inplace=True

### DIFF
--- a/lite/core/mir/memory_optimize_pass.cc
+++ b/lite/core/mir/memory_optimize_pass.cc
@@ -39,52 +39,79 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
   auto is_host = [](TargetType x) -> bool {
     return x == TARGET(kHost) || x == TARGET(kX86) || x == TARGET(kARM);
   };
-  // The vars which inputs or outputs are invalid op will not be reused.
-  auto valid_var = [&](Node* node) -> bool {
-    std::set<std::string> invalid_op = {"while",
-                                        "conditional_block",
-                                        "conditional_block_infer",
-                                        "merge_lod_tensor_infer",
-                                        "merge_lod_tensor",
-                                        "equal",
-                                        "lod_reset",
-                                        "concat",
-                                        "yolo_box",
-                                        "subgraph",
-                                        "feed",
-                                        "fetch"};
-    for (auto* tmp : node->inlinks) {
-      CHECK(tmp->IsStmt());
-      std::string op_type = tmp->AsStmt().op_info()->Type();
-      if (std::find(invalid_op.begin(), invalid_op.end(), op_type) !=
-          invalid_op.end()) {
-        return false;
+
+  // Collect the invalid input and output variables that will not be reused.
+  std::unordered_set<std::string> invalid_var_names;
+  for (auto& op_node : graph->StmtTopologicalOrder()) {
+    if (!op_node->IsStmt()) continue;
+    auto op_info = op_node->AsStmt().op_info();
+    auto op_type = op_info->Type();
+    // The all of input and output variables of the Ops will not be reused.
+    std::unordered_set<std::string> invalid_op_nodes = {
+        "while",
+        "conditional_block",
+        "conditional_block_infer",
+        "merge_lod_tensor_infer",
+        "merge_lod_tensor",
+        "equal",
+        "lod_reset",
+        "concat",
+        "yolo_box",
+        "subgraph",
+        "feed",
+        "fetch"};
+    auto invalid_op_node = invalid_op_nodes.find(op_type);
+    if (invalid_op_node != invalid_op_nodes.end()) {
+      for (auto in_var_node : op_node->inlinks) {
+        CHECK(in_var_node->IsArg());
+        invalid_var_names.insert(in_var_node->AsArg().name);
+      }
+      for (auto out_var_node : op_node->outlinks) {
+        CHECK(out_var_node->IsArg());
+        invalid_var_names.insert(out_var_node->AsArg().name);
+      }
+      continue;
+    }
+    // The specified input and output variables of the Ops whose 'inplace' attr
+    // is true will not be reused, such as reshape/reshape2's X and Out
+    // variables
+    std::unordered_map<std::string,
+                       std::pair<std::unordered_set<std::string>,
+                                 std::unordered_set<std::string>>>
+        inplace_op_nodes = {{"reshape", {{"X"}, {"Out"}}},
+                            {"reshape2", {{"X"}, {"Out"}}}};
+    auto inplace_op_node = inplace_op_nodes.find(op_type);
+    if (inplace_op_node != inplace_op_nodes.end()) {
+      bool inplace = false;
+      if (op_info->HasAttr("inplace")) {
+        inplace = op_info->GetAttr<bool>("inplace");
+      }
+      if (inplace) {
+        for (auto& in_param_name : inplace_op_node->second.first) {
+          const auto& in_arg_names = op_info->Input(in_param_name);
+          invalid_var_names.insert(in_arg_names.begin(), in_arg_names.end());
+        }
+        for (auto& out_param_name : inplace_op_node->second.second) {
+          const auto& out_arg_names = op_info->Output(out_param_name);
+          invalid_var_names.insert(out_arg_names.begin(), out_arg_names.end());
+        }
       }
     }
-    for (auto* tmp : node->outlinks) {
-      CHECK(tmp->IsStmt());
-      std::string op_type = tmp->AsStmt().op_info()->Type();
-      if (std::find(invalid_op.begin(), invalid_op.end(), op_type) !=
-          invalid_op.end()) {
-        return false;
-      }
-    }
-    return true;
-  };
+  }
 
   for (auto& op_node : graph->StmtTopologicalOrder()) {
     if (op_node->IsStmt()) {
-      auto inputs = op_node->inlinks;
-      auto outputs = op_node->outlinks;
-      std::vector<Node*> requires(inputs.begin(), inputs.end());
-      requires.insert(requires.end(), outputs.begin(), outputs.end());
-      for (Node* node : requires) {
-        CHECK(node->IsArg());
-        auto& arg = node->AsArg();
+      std::vector<Node*> var_nodes(op_node->inlinks.begin(),
+                                   op_node->inlinks.end());
+      var_nodes.insert(
+          var_nodes.end(), op_node->outlinks.begin(), op_node->outlinks.end());
+      for (auto* var_node : var_nodes) {
+        CHECK(var_node->IsArg());
+        auto& arg = var_node->AsArg();
         if (arg.is_weight || arg.is_persist) continue;
-        if (!valid_var(node)) continue;
         std::string var_name = arg.name;
-        TargetType target_type = node->AsArg().type->target();
+        if (invalid_var_names.count(var_name)) continue;
+        TargetType target_type = arg.type->target();
         if (is_host(target_type)) target_type = TARGET(kHost);
 
         if (!(*lifecycles)[TargetToStr(target_type)].count(var_name)) {


### PR DESCRIPTION
**问题**
基于model_optimize_tool优化的[models repo](https://github.com/PaddlePaddle/models/tree/develop/PaddleCV/ssd) 预训练模型
[ssd_mobilenet_v1_pascalvoc](http://paddlemodels.bj.bcebos.com/ssd_mobilenet_v1_pascalvoc.tar.gz)，预测结果出现大量错误的框。
![ssd_mobilenet_error_result](https://user-images.githubusercontent.com/9973393/75538603-cf01ab80-5a53-11ea-83b8-5bddfc66282a.jpg)

**原因**
该模型存在reshape op且inplace属性设置为true，memory_optimize_pass未考虑该情况，导致Tensor数据被覆盖。例如下图所示的优化后的计算图，红线画出来的三个reshape op的输入均共享softmax_0.tmp_0，导致reshape_7.tmp_0、reshape_9.tmp_0和rehape_11.tmp_0的数据均被覆盖。
![image](https://user-images.githubusercontent.com/9973393/75538044-f4da8080-5a52-11ea-8601-cfa2ba374b56.png)

**解决办法**
在memory_optimize_pass对variables统计life cycle时，过滤reshape op（且inplace=True）的input&output variables.
