### PR TITLE
fix sgemm bug: ldc should be n

### DIFF
--- a/lite/kernels/arm/sequence_conv_compute.cc
+++ b/lite/kernels/arm/sequence_conv_compute.cc
@@ -126,7 +126,7 @@ void SequenceConvCompute::Run() {
                                  kernel_num,                // ldb: n
                                  0.f,                       // beta
                                  out_data,                  // C
-                                 sequence_len,              // ldc: m
+                                 kernel_num,                // ldc: n
                                  NULL,                      // bias
                                  false,                     // is_bias
                                  act_param,                 // act_param

--- a/lite/tests/kernels/sequence_conv_compute_test.cc
+++ b/lite/tests/kernels/sequence_conv_compute_test.cc
@@ -106,7 +106,7 @@ class SequenceConvComputeTester : public arena::TestCase {
     }
     for (int i = 0; i < output_shape[0]; i++) {
       for (int j = 0; j < output_shape[1]; j++) {
-        output_data[i * output_shape[0] + j] = res[i][j];
+        output_data[i * output_shape[1] + j] = res[i][j];
       }
     }
     (output->mutable_lod())->push_back(lod_[0]);


### PR DESCRIPTION
Fix bugs of the wrong param when using sgemm API. The `ldc` should be set to `N`.