### PR TITLE
[LITE][OPENCL] fix kernel of conv1x1, fc OOM in opencl buffer kernel. test=develop

### DIFF
--- a/lite/backends/opencl/cl_kernel/buffer/fc_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/buffer/fc_kernel.cl
@@ -91,11 +91,7 @@ void gemm_batch_naive(__global const CL_DTYPE* a,
     c0 += a0 * b0;
   }
 
-#ifdef RELU
   cur_c[row * N + col] = activation(c0);
-#else
-  cur_c[row * N + col] = c0;
-#endif
 }
 
 
@@ -103,7 +99,7 @@ void gemm_batch_naive(__global const CL_DTYPE* a,
 // a: filter_d
 // b: x_d
 // c: output_d
-
+#if 0 // TODO(ysh239): cause CL_OUT_OF_HOST_MEMORY on some devices(such as snapdragon 855)
 //#define PRINT_KERNEL
 __kernel
 void gemm_batch(__global const CL_DTYPE* Aptr,
@@ -213,7 +209,7 @@ void gemm_batch(__global const CL_DTYPE* Aptr,
         }
     }
 }
-
+#endif
 
 // fc_gemv_naive: keep for check
 // used for fc with M = 1

--- a/lite/kernels/opencl/conv_buffer_compute.cc
+++ b/lite/kernels/opencl/conv_buffer_compute.cc
@@ -71,7 +71,11 @@ void ConvCompute::PrepareForRun() {
   if (kernel_h == 1 && kernel_w == 1 && stride_h == 1 && stride_w == 1 &&
       zero_pad && no_dilation && pad_equal) {
     // conv2d_1x1
+    /* TODO(ysh329): CL_OUT_OF_MEMORY when use gemm_batched OpenCL kernel,
+                 use gemm_batched_naive instead.
     kernel_func_names_.push_back("gemm_batch");
+  */
+    kernel_func_names_.push_back("gemm_batch_naive");
     kernel_func_paths_.push_back("buffer/fc_kernel.cl");
     if (relu_fused) {
       build_options_.push_back("-DCL_DTYPE_float -DRELU");
@@ -84,7 +88,11 @@ void ConvCompute::PrepareForRun() {
     impl_ = &ConvCompute::Conv2d1x1;
   } else if (pad_equal) {
     kernel_func_names_.push_back("im2col");
+    /* TODO(ysh329): CL_OUT_OF_MEMORY when use gemm_batched OpenCL kernel,
+                 use gemm_batched_naive instead.
     kernel_func_names_.push_back("gemm_batch");
+  */
+    kernel_func_names_.push_back("gemm_batch_naive");
     kernel_func_paths_.push_back("buffer/im2col_kernel.cl");
     kernel_func_paths_.push_back("buffer/fc_kernel.cl");
     build_options_.push_back("-DCL_DTYPE_float");
@@ -258,8 +266,14 @@ void ConvCompute::GemmBatched(cl::Kernel& kernel,
                               const int m,
                               const int n,
                               const int k) {
-  auto global_work_size = cl::NDRange{static_cast<size_t>((m + 7) / 8),
-                                      static_cast<size_t>((n + 3) / 4),
+  /* TODO(ysh329): CL_OUT_OF_MEMORY when use gemm_batch OpenCL kernel,
+                   use gemm_batch_naive instead.
+    auto global_work_size = cl::NDRange{static_cast<size_t>((m + 7) / 8),
+                                        static_cast<size_t>((n + 3) / 4),
+                                        static_cast<size_t>(batch_size)};
+  */
+  auto global_work_size = cl::NDRange{static_cast<size_t>(m),
+                                      static_cast<size_t>(n),
                                       static_cast<size_t>(batch_size)};
   auto local_work_size = cl::NDRange{16, 16};  // cl::NullRange;
 

--- a/lite/kernels/opencl/conv_buffer_compute_test.cc
+++ b/lite/kernels/opencl/conv_buffer_compute_test.cc
@@ -168,7 +168,7 @@ void PrintData(std::string name,
 
 // buffer
 // #define PRINT_RESULT
-#define LOOP_TEST
+// #define LOOP_TEST
 TEST(conv2d, compute_conv2d_1x1) {
   // conv2d 1x1 note
   // kernel/filter size = 1x1, group = 1, pad = 0, stride = 1, dilation = 1
@@ -199,7 +199,7 @@ TEST(conv2d, compute_conv2d_1x1) {
   // output_dims:1 64 112 112
   // filter_dims:64 32 1 1
   const bool bias_flag = true;
-  const bool relu_flag = true;
+  const std::string relu_flag = "relu";
   const int batch_size = 8;
   const int oc = 64;
   const int ih = 112;


### PR DESCRIPTION
# 状态：等待review

## 主要工作

修复 Fc OOM问题，导致原因，可能是Buffer的Conv1x1的实现在OpenCL Kernel中的`gemm_batch`核函数寄存器使用过多，该函数注释掉后就好了，考虑到后面都用Image的Kernel实现，且性能更优，且当前Buffer的Conv是默认不被编译的（./lite/kernels/opencl/CMakeLists.txt中被注释掉了）。

因此，将该Buffer的Conv1x1中用到的`gemm_batch`改为naive的形式 ，即`gemm_batch_naive`，同时修改对应global_work_size，并本地自测通过（CMake等改动不提交）。