### PR TITLE
[LITE][PASS][OPENCL] Fix memory_resuse for opencl

### DIFF
--- a/lite/core/mir/memory_optimize_pass.cc
+++ b/lite/core/mir/memory_optimize_pass.cc
@@ -40,26 +40,50 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
     return x == TARGET(kHost) || x == TARGET(kX86) || x == TARGET(kARM);
   };
 
+  // The all of input and output variables of the Ops will not be reused.
+  std::unordered_set<std::string> invalid_op_nodes = {"while",
+                                                      "conditional_block",
+                                                      "conditional_block_infer",
+                                                      "merge_lod_tensor_infer",
+                                                      "merge_lod_tensor",
+                                                      "equal",
+                                                      "lod_reset",
+                                                      "concat",
+                                                      "yolo_box",
+                                                      "subgraph",
+                                                      "feed",
+                                                      "fetch"};
+
+  auto insert_invalid_op_nodes_for_specific_target = [&](
+      std::unordered_set<std::string> op_node_set, TargetType specific_target) {
+    std::unordered_set<std::string> invalid_op_nodes_opencl = {"layout", "fc"};
+    for (auto& op_node : graph->StmtTopologicalOrder()) {
+      if (!op_node->IsStmt()) continue;
+      TargetType op_target_type = op_node->AsStmt().place().target;
+      if (op_target_type == specific_target &&
+          specific_target == TARGET(kOpenCL)) {
+        invalid_op_nodes.insert(invalid_op_nodes_opencl.begin(),
+                                invalid_op_nodes_opencl.end());
+        break;
+      }
+      // else if // you can add more targets
+    }
+  };
+
+  VLOG(4) << "invalid_op_nodes.size();" << invalid_op_nodes.size();
+  insert_invalid_op_nodes_for_specific_target(invalid_op_nodes,
+                                              TARGET(kOpenCL));
+  VLOG(4) << "invalid_op_nodes.size();" << invalid_op_nodes.size();
+
   // Collect the invalid input and output variables that will not be reused.
   std::unordered_set<std::string> invalid_var_names;
   for (auto& op_node : graph->StmtTopologicalOrder()) {
     if (!op_node->IsStmt()) continue;
+    Place place = op_node->AsStmt().place();
+    TargetType target_type = op_node->AsStmt().place().target;
+
     auto op_info = op_node->AsStmt().op_info();
     auto op_type = op_info->Type();
-    // The all of input and output variables of the Ops will not be reused.
-    std::unordered_set<std::string> invalid_op_nodes = {
-        "while",
-        "conditional_block",
-        "conditional_block_infer",
-        "merge_lod_tensor_infer",
-        "merge_lod_tensor",
-        "equal",
-        "lod_reset",
-        "concat",
-        "yolo_box",
-        "subgraph",
-        "feed",
-        "fetch"};
     auto invalid_op_node = invalid_op_nodes.find(op_type);
     if (invalid_op_node != invalid_op_nodes.end()) {
       for (auto in_var_node : op_node->inlinks) {
@@ -282,5 +306,5 @@ void MemoryOptimizePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 }  // namespace paddle
 
 REGISTER_MIR_PASS(memory_optimize_pass, paddle::lite::mir::MemoryOptimizePass)
-    .BindTargets({TARGET(kARM)})
-    .ExcludeTargets({TARGET(kOpenCL), TARGET(kNPU), TARGET(kXPU), TARGET(kBM)});
+    .BindTargets({TARGET(kARM), TARGET(kOpenCL)})
+    .ExcludeTargets({TARGET(kNPU), TARGET(kXPU), TARGET(kBM)});

--- a/lite/core/mir/memory_optimize_pass.cc
+++ b/lite/core/mir/memory_optimize_pass.cc
@@ -79,9 +79,6 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
   std::unordered_set<std::string> invalid_var_names;
   for (auto& op_node : graph->StmtTopologicalOrder()) {
     if (!op_node->IsStmt()) continue;
-    Place place = op_node->AsStmt().place();
-    TargetType target_type = op_node->AsStmt().place().target;
-
     auto op_info = op_node->AsStmt().op_info();
     auto op_type = op_info->Type();
     auto invalid_op_node = invalid_op_nodes.find(op_type);

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -174,11 +174,11 @@ function build_opencl {
     cd $build_dir
 
     cmake_opencl ${os} ${abi} ${lang}
-    make opencl_clhpp
+    make opencl_clhpp -j$NUM_CORES_FOR_COMPILE
     build $TESTS_FILE
 
     # test publish inference lib
-    make publish_inference
+    make publish_inference -j$NUM_CORES_FOR_COMPILE
 }
 
 # This method is only called in CI.


### PR DESCRIPTION
# 状态：等待review

## 主要工作

1. 修复memeory_reuse pass对OpenCL在多层内存复用的支持，昨天由于代码冲突了，今天重新改了一版；
2. `ci_build.sh`多线程编译OpenCL。