### PR TITLE
[LITE][OPENCL] Fix act bug for opencl kernel

### DIFF
--- a/lite/api/paddle_place.cc
+++ b/lite/api/paddle_place.cc
@@ -45,6 +45,21 @@ std::string Place::DebugString() const {
   return os.str();
 }
 
+const std::string& ActivationTypeToStr(ActivationType act) {
+  static const std::string act2string[] = {"unk",
+                                           "Relu",
+                                           "Relu6",
+                                           "PRelu",
+                                           "LeakyRelu",
+                                           "Sigmoid",
+                                           "Tanh",
+                                           "Swish",
+                                           "Exp"};
+  auto x = static_cast<int>(act);
+  CHECK_LT(x, static_cast<int>(ActivationType::NUM));
+  return act2string[x];
+}
+
 const std::string& TargetToStr(TargetType target) {
   static const std::string target2string[] = {"unk",
                                               "host",

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -150,6 +150,8 @@ _ForEachPrecisionType(DefinePrecisionTypeTrait);
 #define PRECISION(item__) paddle::lite_api::PrecisionType::item__
 #define DATALAYOUT(item__) paddle::lite_api::DataLayoutType::item__
 
+const std::string& ActivationTypeToStr(ActivationType act);
+
 const std::string& TargetToStr(TargetType target);
 
 const std::string& PrecisionToStr(PrecisionType precision);

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -97,7 +97,8 @@ enum class ActivationType : int {
   kSigmoid = 5,
   kTanh = 6,
   kSwish = 7,
-  kExp = 8
+  kExp = 8,
+  NUM = 9,
 };
 
 static size_t PrecisionTypeLength(PrecisionType type) {

--- a/lite/kernels/opencl/activation_image_compute.cc
+++ b/lite/kernels/opencl/activation_image_compute.cc
@@ -91,10 +91,6 @@ class ActivationComputeImageDefault
     kernel_key << kernel_func_name_ << build_options_;
     auto kernel = context.cl_context()->GetKernel(kernel_key.str());
 
-    VLOG(4) << "---> build_options_:" << build_options_;
-    VLOG(4) << "---> kernel_func_name_:" << kernel_func_name_;
-    VLOG(4) << "---> kernel_key.str():" << kernel_key.str();
-
     int arg_idx = 0;
     cl_int status = kernel.setArg(arg_idx, *x_img);
     CL_CHECK_FATAL(status);

--- a/lite/kernels/opencl/activation_image_compute.cc
+++ b/lite/kernels/opencl/activation_image_compute.cc
@@ -66,9 +66,10 @@ class ActivationComputeImageDefault
         kernel_func_name_ = "exp_act";
         break;
       default:
-        printf("This act type: %d doesn't support \n", act_type);
+        LOG(FATAL) << "This act type:" << act_type << " doesn't support.";
         return;
     }
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     context.cl_context()->AddKernel(
         kernel_func_name_, "image/activation_kernel.cl", build_options_);
   }
@@ -87,6 +88,11 @@ class ActivationComputeImageDefault
     STL::stringstream kernel_key;
     kernel_key << kernel_func_name_ << build_options_;
     auto kernel = context.cl_context()->GetKernel(kernel_key.str());
+
+    VLOG(4) << "---> build_options_:" << build_options_;
+    VLOG(4) << "---> kernel_func_name_:" << kernel_func_name_;
+    VLOG(4) << "---> kernel_key.str():" << kernel_key.str();
+
     int arg_idx = 0;
     cl_int status = kernel.setArg(arg_idx, *x_img);
     CL_CHECK_FATAL(status);

--- a/lite/kernels/opencl/activation_image_compute.cc
+++ b/lite/kernels/opencl/activation_image_compute.cc
@@ -40,6 +40,8 @@ class ActivationComputeImageDefault
     auto& context = ctx_->As<OpenCLContext>();
     act_param_ = param_.get_mutable<param_t>();
     int act_type = static_cast<int>(act_param_->active_type);
+    VLOG(1) << "ActivationTypeToStr(act_param_->active_type):"
+            << ActivationTypeToStr(act_param_->active_type);
     switch (act_type) {
       case 1:
         kernel_func_name_ = "relu";

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -39,6 +39,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
     } else {
       kernel_func_name_ = "concat_mul";
     }
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     context.cl_context()->AddKernel(
         kernel_func_name_, "image/concat_kernel.cl", build_options_);
 

--- a/lite/kernels/opencl/elementwise_add_image_compute.cc
+++ b/lite/kernels/opencl/elementwise_add_image_compute.cc
@@ -46,7 +46,7 @@ void ElementwiseAddImageCompute::PrepareForRun() {
                << ", x->dims().size():" << x->dims().size()
                << ", y->dims.size():" << y->dims().size();
   }
-  VLOG(4) << "kernel_func_name_:" << kernel_func_name_;
+  VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
 
   auto& context = ctx_->As<OpenCLContext>();
   context.cl_context()->AddKernel(

--- a/lite/kernels/opencl/elementwise_mul_image_compute.cc
+++ b/lite/kernels/opencl/elementwise_mul_image_compute.cc
@@ -63,7 +63,7 @@ class ElementwiseMulImageCompute
                  << y_dims.size()
                  << ", x_dims.size():" << ele_param_->X->dims().size();
     }
-    VLOG(4) << "kernel_func_name_:" << kernel_func_name_;
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     VLOG(4) << "y_dims:" << y_dims;
     VLOG(4) << "y_dims.size():" << y_dims.size();
 

--- a/lite/kernels/opencl/fusion_elementwise_add_activation_image_compute.cc
+++ b/lite/kernels/opencl/fusion_elementwise_add_activation_image_compute.cc
@@ -38,6 +38,7 @@ class FusionElementwiseAddActivationImageCompute
     if (act_t != "relu") {
       LOG(FATAL) << "Unsupported Activation type: " << act_t;
     }
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
   }
 };
 

--- a/lite/kernels/opencl/grid_sampler_image_compute.cc
+++ b/lite/kernels/opencl/grid_sampler_image_compute.cc
@@ -44,6 +44,7 @@ class GridSamplerImageCompute : public KernelLite<TARGET(kOpenCL),
     auto& context = ctx_->As<OpenCLContext>();
     context.cl_context()->AddKernel(
         kernel_func_name_, "image/grid_sampler_kernel.cl", build_options_);
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
   }
 
   void Run() override {

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -42,7 +42,7 @@ class LayoutComputeBufferChwToImageDefault
     if (param.process_type == 1) {
       kernel_func_name_ = "buffer_to_image2d_with_pre255";
     }
-    VLOG(2) << "kernel_func_name_:" << kernel_func_name_;
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     auto& context = ctx_->As<OpenCLContext>();
     context.cl_context()->AddKernel(
         kernel_func_name_, "image/layout_kernel.cl", build_options_);
@@ -153,7 +153,7 @@ class LayoutComputeImageDefaultToBufferChw
     if (param.process_type == 1) {
       kernel_func_name_ = "image2d_to_buffer_with_post255";
     }
-    VLOG(2) << "kernel_func_name_:" << kernel_func_name_;
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     auto& context = ctx_->As<OpenCLContext>();
     context.cl_context()->AddKernel(
         kernel_func_name_, "image/layout_kernel.cl", build_options_);

--- a/lite/kernels/opencl/nearest_interp_image_compute.cc
+++ b/lite/kernels/opencl/nearest_interp_image_compute.cc
@@ -40,6 +40,7 @@ class NearestInterpComputeImageDefault
     auto& context = ctx_->As<OpenCLContext>();
     context.cl_context()->AddKernel(
         kernel_func_name_, "image/nearest_interp_kernel.cl", build_options_);
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
   }
 
   void Run() override {

--- a/lite/kernels/opencl/pool_image_compute.cc
+++ b/lite/kernels/opencl/pool_image_compute.cc
@@ -44,6 +44,7 @@ class PoolComputeImage2D : public KernelLite<TARGET(kOpenCL),
     if (global_pooling) {
       kernel_func_name_ += "_global";
     }
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     auto& context = ctx_->As<OpenCLContext>();
     context.cl_context()->AddKernel(
         kernel_func_name_, "image/pool_kernel.cl", build_options_);

--- a/lite/kernels/opencl/reshape_image_compute.cc
+++ b/lite/kernels/opencl/reshape_image_compute.cc
@@ -35,6 +35,7 @@ class ReshapeComputeFloatImage : public KernelLite<TARGET(kOpenCL),
 
   void PrepareForRun() override {
     auto& context = ctx_->As<OpenCLContext>();
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     context.cl_context()->AddKernel(
         kernel_func_name_, "image/reshape_kernel.cl", build_options_);
   }

--- a/lite/kernels/opencl/scale_image_compute.cc
+++ b/lite/kernels/opencl/scale_image_compute.cc
@@ -37,6 +37,7 @@ class ScaleComputeImage2D : public KernelLite<TARGET(kOpenCL),
 
   void PrepareForRun() override {
     auto& context = ctx_->As<OpenCLContext>();
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     context.cl_context()->AddKernel(
         kernel_func_name_, "image/scale_kernel.cl", build_options_);
   }

--- a/lite/operators/activation_ops.cc
+++ b/lite/operators/activation_ops.cc
@@ -36,26 +36,44 @@ bool ActivationOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   auto x_name = opdesc.Input("X").front();
   auto out_name = opdesc.Output("Out").front();
   param_.X = scope->FindVar(x_name)->GetMutable<lite::Tensor>();
-  if (opdesc.Type() == "leaky_relu") {
+
+  if (opdesc.Type() == "relu") {
+    // relu
+    param_.active_type = lite_api::ActivationType::kRelu;
+  } else if (opdesc.Type() == "leaky_relu") {
+    // leaky_relu
     param_.Leaky_relu_alpha = opdesc.GetAttr<float>("alpha");
-  }
-  if (opdesc.Type() == "relu_clipped") {
+    param_.active_type = lite_api::ActivationType::kLeakyRelu;
+  } else if (opdesc.Type() == "relu_clipped") {
+    // relu_clipped
     param_.Relu_clipped_coef = opdesc.GetAttr<float>("Relu_clipped_coef");
-  }
-  if (opdesc.Type() == "prelu") {
+  } else if (opdesc.Type() == "prelu") {
+    // prelu
     param_.Prelu_mode = opdesc.GetAttr<std::string>("mode");
     auto prelu_alpha_name = opdesc.Input("Alpha").front();
     param_.Prelu_alpha =
         scope->FindVar(prelu_alpha_name)->GetMutable<lite::Tensor>();
-  }
-  if (opdesc.Type() == "swish") {
+    param_.active_type = lite_api::ActivationType::kPRelu;
+  } else if (opdesc.Type() == "swish") {
+    // swish
     param_.Swish_beta = opdesc.GetAttr<float>("beta");
-  }
-
-  if (opdesc.Type() == "hard_sigmoid") {
+    param_.active_type = lite_api::ActivationType::kSwish;
+  } else if (opdesc.Type() == "hard_sigmoid") {
+    // hard_sigomid
     param_.hard_sigmoid_slope = opdesc.GetAttr<float>("slope");
     param_.hard_sigmoid_offset = opdesc.GetAttr<float>("offset");
+  } else if (opdesc.Type() == "sigmoid") {
+    // sigmoid
+    param_.active_type = lite_api::ActivationType::kSigmoid;
+  } else if (opdesc.Type() == "tanh") {
+    // tanh
+    param_.active_type = lite_api::ActivationType::kTanh;
+  } else if (opdesc.Type() == "exp") {
+    // exp
+    param_.active_type = lite_api::ActivationType::kExp;
   }
+  VLOG(4) << "opdesc.Type():" << opdesc.Type();
+
   param_.Out = scope->FindVar(out_name)->GetMutable<lite::Tensor>();
   return true;
 }


### PR DESCRIPTION
# 状态：等待review

## 主要内容

- 缺陷：修复mnasnet出现找不到kernel_func_name的问题；
- 原因：先前加激活函数kernel的同学没有在op层面建立激活函数param与激活枚举值的绑定，导致后面kernel内判断失败，此外判断失败没有`LOG(FATAL)`挂掉，而是只给出了`LOG(INFO)`级别的信息；
- 解决：在op层面`./lite/operators/activation_ops.cc`建立param与激活枚举值的绑定，在kernel层面将判断失败（找不到对应枚举值时，则FATAL挂掉程序）。

----

1. 修复上述缺陷；
2. 增强Activation枚举值的可视化打印，因为目前ActivationType是整型，难以看出是具体哪一种激活函数，加入 ActivationTypeToStr 方法后，方便打印获取具体激活函数名称；
3. 在每个opencl kernel的PrepareForRun里加入了VLOG(1)级别的`kernel_func_name_`的打印，强化debug排查。
