### PR TITLE
[cv lib] add option for cv_compiling

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -407,6 +407,10 @@ function main {
                 BUILD_EXTRA="${i#*=}"
                 shift
                 ;;
+            --build_cv=*)
+                BUILD_CV="${i#*=}"
+                shift
+                ;;
             --build_python=*)
                 BUILD_PYTHON="${i#*=}"
                 shift


### PR DESCRIPTION
【问题描述】：cv 库的编译的编译选项之前未加入到build.sh 脚本。（用户需要手动设置环境变量，容易造成误解）
【本PR的工作】：加入编译选项 `--build_cv=ON/OFF`来控制 cv库的编译
- 当`--build_cv=ON`编译CV依赖库
- 当`--build_cv=OFF`不编译CV依赖库（默认）