### PR TITLE
[develop API] add `GetMutableTensor` API into `cxx_predictor`

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -152,7 +152,7 @@ std::vector<std::string> Predictor::GetOutputNames() { return output_names_; }
 
 // get param names
 std::vector<std::string> Predictor::GetParamNames() {
-  return exec_scope_->VarNames();
+  return exec_scope_->AttributeVarNames();
 }
 
 // append the names of inputs and outputs into input_names_ and output_names_

--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -318,7 +318,7 @@ const lite::Tensor *Predictor::GetTensor(const std::string &name) const {
   return &var->Get<lite::Tensor>();
 }
 
-lite::Tensor *Predictor::GetMutableTensor(const std::string &name) const {
+lite::Tensor *Predictor::GetMutableTensor(const std::string &name) {
   auto *var = exec_scope_->FindVar(name);
   CHECK(var) << "no variable named with " << name << " in exec_scope";
   return var->GetMutable<lite::Tensor>();

--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -150,6 +150,11 @@ std::vector<std::string> Predictor::GetInputNames() { return input_names_; }
 // get outputnames
 std::vector<std::string> Predictor::GetOutputNames() { return output_names_; }
 
+// get param names
+std::vector<std::string> Predictor::GetParamNames() {
+  return exec_scope_->LocalVarNames();
+}
+
 // append the names of inputs and outputs into input_names_ and output_names_
 void Predictor::PrepareFeedFetch() {
   if (!program_) {

--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -314,7 +314,14 @@ void Predictor::GenRuntimeProgram() {
 
 const lite::Tensor *Predictor::GetTensor(const std::string &name) const {
   auto *var = exec_scope_->FindVar(name);
+  CHECK(var) << "no variable named with " << name << " in exec_scope";
   return &var->Get<lite::Tensor>();
+}
+
+lite::Tensor *Predictor::GetMutableTensor(const std::string &name) const {
+  auto *var = exec_scope_->FindVar(name);
+  CHECK(var) << "no variable named with " << name << " in exec_scope";
+  return var->GetMutable<lite::Tensor>();
 }
 
 // get input by name

--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -152,7 +152,7 @@ std::vector<std::string> Predictor::GetOutputNames() { return output_names_; }
 
 // get param names
 std::vector<std::string> Predictor::GetParamNames() {
-  return exec_scope_->LocalVarNames();
+  return exec_scope_->VarNames();
 }
 
 // append the names of inputs and outputs into input_names_ and output_names_

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -91,6 +91,9 @@ class LITE_API Predictor {
   std::vector<const lite::Tensor*> GetOutputs() const;
 
   const cpp::ProgramDesc& program_desc() const;
+  // get a mutable tensor according to its name
+  lite::Tensor* GetMutableTensor(const std::string& name);
+  // get a const tensor according to its name
   const lite::Tensor* GetTensor(const std::string& name) const;
   const RuntimeProgram& runtime_program() const;
 
@@ -142,8 +145,12 @@ class CxxPaddleApiImpl : public lite_api::PaddlePredictor {
   std::vector<std::string> GetInputNames() override;
   std::vector<std::string> GetOutputNames() override;
 
+  // get tensor according to tensor's name
   std::unique_ptr<const lite_api::Tensor> GetTensor(
       const std::string& name) const override;
+  // get a mutable tensor according to tensor's name
+  std::unique_ptr<lite_api::Tensor> GetMutableTensor(
+      const std::string& name) override;
 
   // Get InputTebsor by name
   std::unique_ptr<lite_api::Tensor> GetInputByName(

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -84,6 +84,9 @@ class LITE_API Predictor {
   // get inputnames and get outputnames.
   std::vector<std::string> GetInputNames();
   std::vector<std::string> GetOutputNames();
+  // get param names
+  std::vector<std::string> GetParamNames();
+
   void PrepareFeedFetch();
 
   // Get offset-th col of fetch results.
@@ -144,6 +147,8 @@ class CxxPaddleApiImpl : public lite_api::PaddlePredictor {
   // get inputs names and get outputs names
   std::vector<std::string> GetInputNames() override;
   std::vector<std::string> GetOutputNames() override;
+  // get param names
+  std::vector<std::string> GetParamNames() override;
 
   // get tensor according to tensor's name
   std::unique_ptr<const lite_api::Tensor> GetTensor(

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -101,6 +101,12 @@ std::unique_ptr<const lite_api::Tensor> CxxPaddleApiImpl::GetTensor(
   return std::unique_ptr<const lite_api::Tensor>(new lite_api::Tensor(x));
 }
 
+std::unique_ptr<lite_api::Tensor> CxxPaddleApiImpl::GetMutableTensor(
+    const std::string &name) {
+  return std::unique_ptr<lite_api::Tensor>(
+      new lite_api::Tensor(raw_predictor_.GetMutableTensor(name)));
+}
+
 std::unique_ptr<lite_api::Tensor> CxxPaddleApiImpl::GetInputByName(
     const std::string &name) {
   return std::unique_ptr<lite_api::Tensor>(

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -75,6 +75,10 @@ std::vector<std::string> CxxPaddleApiImpl::GetInputNames() {
   return raw_predictor_.GetInputNames();
 }
 
+std::vector<std::string> CxxPaddleApiImpl::GetParamNames() {
+  return raw_predictor_.GetParamNames();
+}
+
 std::vector<std::string> CxxPaddleApiImpl::GetOutputNames() {
   return raw_predictor_.GetOutputNames();
 }

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -174,8 +174,10 @@ std::unique_ptr<Tensor> PaddlePredictor::GetMutableTensor(
 }
 
 std::vector<std::string> PaddlePredictor::GetParamNames() {
+  std::vector<std::string> null_result = {};
   LOG(FATAL)
       << "The GetParamNames API is only supported by CxxConfig predictor.";
+  return null_result;
 }
 
 void PaddlePredictor::SaveOptimizedModel(const std::string &model_dir,

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -173,6 +173,11 @@ std::unique_ptr<Tensor> PaddlePredictor::GetMutableTensor(
   return nullptr;
 }
 
+std::vector<std::string> PaddlePredictor::GetParamNames() {
+  LOG(FATAL)
+      << "The GetParamNames API is only supported by CxxConfig predictor.";
+}
+
 void PaddlePredictor::SaveOptimizedModel(const std::string &model_dir,
                                          LiteModelType model_type,
                                          bool record_info) {

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -169,6 +169,7 @@ void Tensor::SetLoD(const lod_t &lod) { tensor(raw_tensor_)->set_lod(lod); }
 std::unique_ptr<Tensor> GetMutableTensor(const std::string &name) {
   LOG(FATAL)
       << "The GetMutableTensor API is only supported by CxxConfig predictor.";
+  return nullptr;
 }
 
 void PaddlePredictor::SaveOptimizedModel(const std::string &model_dir,

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -166,6 +166,11 @@ lod_t Tensor::lod() const { return ctensor(raw_tensor_)->lod(); }
 
 void Tensor::SetLoD(const lod_t &lod) { tensor(raw_tensor_)->set_lod(lod); }
 
+std::unique_ptr<Tensor> GetMutableTensor(const std::string &name) {
+  LOG(FATAL)
+      << "The GetMutableTensor API is only supported by CxxConfig predictor.";
+}
+
 void PaddlePredictor::SaveOptimizedModel(const std::string &model_dir,
                                          LiteModelType model_type,
                                          bool record_info) {

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -166,7 +166,8 @@ lod_t Tensor::lod() const { return ctensor(raw_tensor_)->lod(); }
 
 void Tensor::SetLoD(const lod_t &lod) { tensor(raw_tensor_)->set_lod(lod); }
 
-std::unique_ptr<Tensor> GetMutableTensor(const std::string &name) {
+std::unique_ptr<Tensor> PaddlePredictor::GetMutableTensor(
+    const std::string &name) {
   LOG(FATAL)
       << "The GetMutableTensor API is only supported by CxxConfig predictor.";
   return nullptr;

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -86,6 +86,8 @@ class LITE_API PaddlePredictor {
   virtual std::vector<std::string> GetInputNames() = 0;
   // Get output names
   virtual std::vector<std::string> GetOutputNames() = 0;
+  // Get output names
+  virtual std::vector<std::string> GetParamNames();
 
   // Get Input by name
   virtual std::unique_ptr<Tensor> GetInputByName(const std::string& name) = 0;

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -94,6 +94,14 @@ class LITE_API PaddlePredictor {
   virtual std::unique_ptr<const Tensor> GetTensor(
       const std::string& name) const = 0;
 
+  /// Get a readonly tensor, return null if no one called `name` exists.
+  virtual std::unique_ptr<const Tensor> GetTensor(
+      const std::string& name) const = 0;
+  /// Get a mutable tensor, return null if on one called `name` exists
+  /// internal infereces API, not recommanded.
+  virtual std::unique_ptr<Tensor> GetMutableTensor(
+      const std::string& name) const = 0;
+
   /// Persist the optimized model to disk. This API is only supported by
   /// CxxConfig, and the persisted model can be reused for MobileConfig.
   virtual void SaveOptimizedModel(

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -93,10 +93,6 @@ class LITE_API PaddlePredictor {
   /// Get a readonly tensor, return null if no one called `name` exists.
   virtual std::unique_ptr<const Tensor> GetTensor(
       const std::string& name) const = 0;
-
-  /// Get a readonly tensor, return null if no one called `name` exists.
-  virtual std::unique_ptr<const Tensor> GetTensor(
-      const std::string& name) const = 0;
   /// Get a mutable tensor, return null if on one called `name` exists
   /// internal infereces API, not recommanded.
   virtual std::unique_ptr<Tensor> GetMutableTensor(

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -95,8 +95,7 @@ class LITE_API PaddlePredictor {
       const std::string& name) const = 0;
   /// Get a mutable tensor, return null if on one called `name` exists
   /// internal infereces API, not recommanded.
-  virtual std::unique_ptr<Tensor> GetMutableTensor(
-      const std::string& name) const = 0;
+  virtual std::unique_ptr<Tensor> GetMutableTensor(const std::string& name);
 
   /// Persist the optimized model to disk. This API is only supported by
   /// CxxConfig, and the persisted model can be reused for MobileConfig.

--- a/lite/core/scope.cc
+++ b/lite/core/scope.cc
@@ -60,6 +60,19 @@ Variable *Scope::FindLocalVar(const std::string &name) const {
   return nullptr;
 }
 
+std::vector<std::string> Scope::VarNames() const {
+  std::vector<std::string> resulted_keys;
+  auto keys = LocalVarNames();
+  resulted_keys.insert(resulted_keys.end(), keys.begin(), keys.end());
+  const Scope *cur_scope = this;
+  while (cur_scope->parent()) {
+    cur_scope = cur_scope->parent();
+    keys = cur_scope->LocalVarNames();
+    resulted_keys.insert(resulted_keys.end(), keys.begin(), keys.end());
+  }
+  return resulted_keys;
+}
+
 std::vector<std::string> Scope::LocalVarNames() const {
   std::vector<std::string> keys;
   for (const auto &item : vars_) {

--- a/lite/core/scope.cc
+++ b/lite/core/scope.cc
@@ -60,14 +60,12 @@ Variable *Scope::FindLocalVar(const std::string &name) const {
   return nullptr;
 }
 
-std::vector<std::string> Scope::VarNames() const {
+std::vector<std::string> Scope::AttributeVarNames() const {
   std::vector<std::string> resulted_keys;
-  auto keys = LocalVarNames();
-  resulted_keys.insert(resulted_keys.end(), keys.begin(), keys.end());
   const Scope *cur_scope = this;
   while (cur_scope->parent()) {
     cur_scope = cur_scope->parent();
-    keys = cur_scope->LocalVarNames();
+    auto keys = cur_scope->LocalVarNames();
     resulted_keys.insert(resulted_keys.end(), keys.begin(), keys.end());
   }
   return resulted_keys;

--- a/lite/core/scope.cc
+++ b/lite/core/scope.cc
@@ -70,10 +70,16 @@ std::vector<std::string> Scope::AttributeVarNames() const {
     resulted_keys.insert(resulted_keys.end(), keys.begin(), keys.end());
   }
   // remove feed and fetch
-  auto iter=std::find(resulted_keys.begin(), resulted_keys.end(), "feed");
-  resulted_keys.erase(iter);
-  iter=std::find(resulted_keys.begin(), resulted_keys.end(), "fetch");
-  resulted_keys.erase(iter);
+  std::vector<std::string> skiped_vars = {"feed", "fetch"};
+  for (int i = 0; i < skiped_vars.size(); i++) {
+    auto iter =
+        std::find(resulted_keys.begin(), resulted_keys.end(), skiped_vars[i]);
+    while (iter != resulted_keys.end()) {
+      resulted_keys.erase(iter);
+      auto iter =
+          std::find(resulted_keys.begin(), resulted_keys.end(), skiped_vars[i]);
+    }
+  }
   return resulted_keys;
 }
 

--- a/lite/core/scope.cc
+++ b/lite/core/scope.cc
@@ -60,6 +60,7 @@ Variable *Scope::FindLocalVar(const std::string &name) const {
   return nullptr;
 }
 
+// AttributeVarNames will get persistive attribute names stored in parent scope
 std::vector<std::string> Scope::AttributeVarNames() const {
   std::vector<std::string> resulted_keys;
   const Scope *cur_scope = this;
@@ -68,6 +69,11 @@ std::vector<std::string> Scope::AttributeVarNames() const {
     auto keys = cur_scope->LocalVarNames();
     resulted_keys.insert(resulted_keys.end(), keys.begin(), keys.end());
   }
+  // remove feed and fetch
+  auto iter=std::find(resulted_keys.begin(), resulted_keys.end(), "feed");
+  resulted_keys.erase(iter);
+  iter=std::find(resulted_keys.begin(), resulted_keys.end(), "fetch");
+  resulted_keys.erase(iter);
   return resulted_keys;
 }
 

--- a/lite/core/scope.cc
+++ b/lite/core/scope.cc
@@ -76,7 +76,7 @@ std::vector<std::string> Scope::AttributeVarNames() const {
         std::find(resulted_keys.begin(), resulted_keys.end(), skiped_vars[i]);
     while (iter != resulted_keys.end()) {
       resulted_keys.erase(iter);
-      auto iter =
+      iter =
           std::find(resulted_keys.begin(), resulted_keys.end(), skiped_vars[i]);
     }
   }

--- a/lite/core/scope.h
+++ b/lite/core/scope.h
@@ -45,6 +45,8 @@ class Scope final {
 
   const Scope* parent() const { return parent_; }
 
+  // Get all params in each scope.
+  std::vector<std::string> VarNames() const;
   // Following the legacy scope interface.
   std::vector<std::string> LocalVarNames() const;
 

--- a/lite/core/scope.h
+++ b/lite/core/scope.h
@@ -45,8 +45,8 @@ class Scope final {
 
   const Scope* parent() const { return parent_; }
 
-  // Get all params in each scope.
-  std::vector<std::string> VarNames() const;
+  // Get attribute params stored in parent scopes.
+  std::vector<std::string> AttributeVarNames() const;
   // Following the legacy scope interface.
   std::vector<std::string> LocalVarNames() const;
 


### PR DESCRIPTION
(1) 添加接口`GetMutableTensor(name)`
【问题描述】NLP业务需要在加载模型后修改模型终端权重参数，之后再运行。需要接口： GetMutableTensor(name)返回一个可修改的张量
【方案设计】在模型加载后修改权重在多线程下有风险，可能导致不确定输出；且当前只有x86 平台下提出该需求，不推荐一般用户使用
【本PR工作】设计一个内部develop接口，Cxx_predictor->GetMutableTensor(std::string “varname”)。该接口只有cxx_predictor可以调用，而且不对外开放使用文档。为内部调试接口。

(2) 添加接口 `const std::vector<std::string> Predictor::GetParamNames()`
【方案设计】接口只输出模型的权重参数的名称，不输出`输入变量`、`输出变量`、`中间变量`和`feed/fetch`名称
【本PR工作】设计一个内部develop接口，`const std::vector<std::string> Cxx_predictor->GetParamNames()`。

该接口只有cxx_predictor可以调用，而且不对外开放使用文档。为内部调试接口。