### PR TITLE
avoid reusing non-tensor in memery_optimize_pass

### DIFF
--- a/lite/core/mir/memory_optimize_pass.cc
+++ b/lite/core/mir/memory_optimize_pass.cc
@@ -50,6 +50,8 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
                                                       "lod_reset",
                                                       "concat",
                                                       "yolo_box",
+                                                      "read_from_array",
+                                                      "write_to_array",
                                                       "subgraph",
                                                       "feed",
                                                       "fetch"};

--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -182,30 +182,30 @@ void ElementwiseSubActivationCompute::Run() {
 template <typename T, PrecisionType PType>
 void ElementwiseMulCompute<T, PType>::Run() {
   auto& param = this->template Param<operators::ElementwiseParam>();
-  if (PType == PRECISION(kFloat) || PType == PRECISION(kInt32)) {
-    auto* x_data = param.X->template data<T>();
-    auto* y_data = param.Y->template data<T>();
-    auto* out_data = param.Out->template mutable_data<T>();
-    int axis = param.axis;
-    auto x_dims = param.X->dims();
-    auto y_dims = param.Y->dims();
-    int pre, n, post;
-    if (x_dims.size() < y_dims.size() &&
-        is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-      lite::arm::math::elementwise_mul_broadcast<T>(
-          y_data, x_data, out_data, pre, n, post);
-    } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-      lite::arm::math::elementwise_mul_broadcast<T>(
-          x_data, y_data, out_data, pre, n, post);
-    } else {
-      lite::arm::math::elementwise_mul<T>(
-          x_data, y_data, out_data, x_dims.production());
-    }
-  } else if (PType == PRECISION(kInt64)) {
-    lite::arm::math::elementwise_compute_basic<int64_t>(param, "mul", "");
+  auto* x_data = param.X->template data<T>();
+  auto* y_data = param.Y->template data<T>();
+  auto* out_data = param.Out->template mutable_data<T>();
+  int axis = param.axis;
+  auto x_dims = param.X->dims();
+  auto y_dims = param.Y->dims();
+  int pre, n, post;
+  if (x_dims.size() < y_dims.size() &&
+      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
+    lite::arm::math::elementwise_mul_broadcast<T>(
+        y_data, x_data, out_data, pre, n, post);
+  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
+    lite::arm::math::elementwise_mul_broadcast<T>(
+        x_data, y_data, out_data, pre, n, post);
   } else {
-    LOG(FATAL) << "unsupport input type";
+    lite::arm::math::elementwise_mul<T>(
+        x_data, y_data, out_data, x_dims.production());
   }
+}
+
+template <>
+void ElementwiseMulCompute<int64_t, PRECISION(kInt64)>::Run() {
+  auto& param = this->template Param<operators::ElementwiseParam>();
+  lite::arm::math::elementwise_compute_basic<int64_t>(param, "mul", "");
 }
 
 void ElementwiseMulActivationCompute::Run() {

--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -182,26 +182,26 @@ void ElementwiseSubActivationCompute::Run() {
 template <typename T, PrecisionType PType>
 void ElementwiseMulCompute<T, PType>::Run() {
   auto& param = this->template Param<operators::ElementwiseParam>();
-  if (param.X->precision() == PRECISION(kFloat)) {
-    auto* x_data = param.X->template data<float>();
-    auto* y_data = param.Y->template data<float>();
-    auto* out_data = param.Out->template mutable_data<float>();
+  if (PType == PRECISION(kFloat) || PType == PRECISION(kInt32)) {
+    auto* x_data = param.X->template data<T>();
+    auto* y_data = param.Y->template data<T>();
+    auto* out_data = param.Out->template mutable_data<T>();
     int axis = param.axis;
     auto x_dims = param.X->dims();
     auto y_dims = param.Y->dims();
     int pre, n, post;
     if (x_dims.size() < y_dims.size() &&
         is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-      lite::arm::math::elementwise_mul_broadcast<float>(
+      lite::arm::math::elementwise_mul_broadcast<T>(
           y_data, x_data, out_data, pre, n, post);
     } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-      lite::arm::math::elementwise_mul_broadcast<float>(
+      lite::arm::math::elementwise_mul_broadcast<T>(
           x_data, y_data, out_data, pre, n, post);
     } else {
-      lite::arm::math::elementwise_mul<float>(
+      lite::arm::math::elementwise_mul<T>(
           x_data, y_data, out_data, x_dims.production());
     }
-  } else if (param.X->precision() == PRECISION(kInt64)) {
+  } else if (PType == PRECISION(kInt64)) {
     lite::arm::math::elementwise_compute_basic<int64_t>(param, "mul", "");
   } else {
     LOG(FATAL) << "unsupport input type";
@@ -418,6 +418,16 @@ REGISTER_LITE_KERNEL(
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .Finalize();
+
+using elementwise_mul_int64 =
+    paddle::lite::kernels::arm::ElementwiseMulCompute<int64_t,
+                                                      PRECISION(kInt64)>;
+REGISTER_LITE_KERNEL(
+    elementwise_mul, kARM, kInt64, kNCHW, elementwise_mul_int64, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -730,15 +730,15 @@ struct IncrementParam {
 };
 
 struct WriteToArrayParam {
-  const lite::Tensor* X{};
-  const lite::Tensor* I{};
-  std::vector<lite::Tensor>* Out{};
+  const lite::Tensor* X{nullptr};
+  const lite::Tensor* I{nullptr};
+  std::vector<lite::Tensor>* Out{nullptr};
 };
 
 struct ReadFromArrayParam {
-  const std::vector<lite::Tensor>* X{};
-  const lite::Tensor* I{};
-  lite::Tensor* Out{};
+  const std::vector<lite::Tensor>* X{nullptr};
+  const lite::Tensor* I{nullptr};
+  lite::Tensor* Out{nullptr};
 };
 
 struct BeamSearchParam {


### PR DESCRIPTION
- 内存优化pass将可复用的tensor使用同一个名称，因此存在将tensor_array当做tensor处理的可能，从而导致bug。因此，在内存优化pass中禁止对非tenor类型进行内存复用。
- 注册int64类型的elementwise_mul
- 修复int32类型的elementwise_mul相关bug