### PR TITLE
[LITE][BUILD] fix clang compile armv8 cpu 's shared lib. test=develop

### DIFF
--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -206,7 +206,8 @@ class LITE_API MobileConfig : public ConfigBase {
 };
 
 template <typename ConfigT>
-std::shared_ptr<PaddlePredictor> CreatePaddlePredictor(const ConfigT&);
+__attribute__((visibility("default"))) std::shared_ptr<PaddlePredictor>
+CreatePaddlePredictor(const ConfigT&);
 
 }  // namespace lite_api
 }  // namespace paddle

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -206,8 +206,7 @@ class LITE_API MobileConfig : public ConfigBase {
 };
 
 template <typename ConfigT>
-__attribute__((visibility("default"))) std::shared_ptr<PaddlePredictor>
-CreatePaddlePredictor(const ConfigT&);
+LITE_API std::shared_ptr<PaddlePredictor> CreatePaddlePredictor(const ConfigT&);
 
 }  // namespace lite_api
 }  // namespace paddle


### PR DESCRIPTION
# 状态：等待review

## 主要内容

修复clang编译的armv8的cpu的动态库，在demo中调用时找不到CreatePaddlePredictor的问题。见下图：

![image](https://user-images.githubusercontent.com/7320657/76196709-adf44400-6225-11ea-815e-ff3603d0d9d1.png)

修复后，自测`demo/cxx/mobile_light`无误。