### PR TITLE
update symbols list of libpaddle_lite.so

### DIFF
--- a/lite/core/lite.map
+++ b/lite/core/lite.map
@@ -1,6 +1,6 @@
 {
     global:
-        *paddle*;
+        *paddle*lite*;
         *touch_*;
         *mir_pass_*;
     local:


### PR DESCRIPTION
避免暴露部分 Protobuf 符号造成字段读取混乱。