### PR TITLE
[opt] add kInt32 precision type into opt's default arm places

### DIFF
--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -88,7 +88,10 @@ std::vector<Place> ParserValidPlaces() {
   auto target_reprs = lite::Split(FLAGS_valid_targets, ",");
   for (auto& target_repr : target_reprs) {
     if (target_repr == "arm") {
-      valid_places.emplace_back(TARGET(kARM));
+      valid_places.emplace_back(
+          Place{TARGET(kARM), PRECISION(kFloat), DATALAYOUT(kNCHW)});
+      valid_places.emplace_back(
+          Place{TARGET(kARM), PRECISION(kInt32), DATALAYOUT(kNCHW)});
     } else if (target_repr == "opencl") {
       valid_places.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault)});


### PR DESCRIPTION
【问题描述】：opt转化含有`slice` OP 的模型时出现错误：
![image](https://user-images.githubusercontent.com/45189361/76400346-1cb6d600-63bb-11ea-9b21-8a822fd9334e.png)


【问题定位】： slice OP精度值注册为了kInt32，opt不支持kInt32精度
【解决方法】（本PR工作）： 在opt的默认valid_places中添加 `kInt32` Precision type，如下

```
       Place{TARGET(kARM), PRECISION(kInt32), DATALAYOUT(kNCHW)})
```