### PR TITLE
split subgraph by config file

### DIFF
--- a/lite/core/mir/subgraph/subgraph_detector.cc
+++ b/lite/core/mir/subgraph/subgraph_detector.cc
@@ -212,56 +212,76 @@ void SubgraphDetector::FlexibleDFS(
   }
 }
 
-std::vector<const Node *> SubgraphDetector::GetNodesExclude() {
-  std::vector<const Node *> nodes_exclude{};
-  std::string config_dir = GetStringFromEnv("CONFIG_SPLIT");
-  if (!IsFileExists(config_dir)) {
-    return nodes_exclude;
+std::unordered_set<Node *> SubgraphDetector::GetExcludedNodesFromConfigFile() {
+  // get exclude nodes from config file
+  std::unordered_set<Node *> excluded_nodes;
+  std::string config_file_path =
+      GetStringFromEnv(SUBGRAPH_CUSTOM_PARTITION_CONFIG_FILE);
+  if (!IsFileExists(config_file_path)) {
+    return excluded_nodes;
   }
-  std::vector<std::string> config_file = ReadLines(config_dir);
+  std::vector<std::string> lines = ReadLines(config_file_path);
 
-  for (std::string line : config_file) {
+  for (std::string line : lines) {
     std::vector<std::string> node_info = Split(line, " ");
     std::string op_type = node_info.at(0);
-    std::vector<std::string> in_vars = Split(node_info.at(1), ",");
-    std::vector<std::string> out_vars = Split(node_info.at(2), ",");
+    std::vector<std::string> in_vars_name = Split(node_info.at(1), ",");
+    std::vector<std::string> out_vars_name = Split(node_info.at(2), ",");
 
-    for (auto &node : graph_->nodes()) {
+    for (auto &node : graph_->mutable_nodes()) {
       if (node.IsArg()) continue;
       auto stmt = node.stmt();
       if (op_type != stmt->op_type()) continue;
       auto in_nodes = node.inlinks;
       auto out_nodes = node.outlinks;
-      if (in_nodes.size() != in_vars.size() ||
-          out_nodes.size() != out_vars.size()) {
+      if (in_vars_name.size() > in_nodes.size() ||
+          out_vars_name.size() > out_nodes.size()) {
         continue;
       }
+
       bool matched = true;
-      for (auto *var : in_nodes) {
-        if (std::find(in_vars.begin(), in_vars.end(), var->arg()->name) ==
-            in_vars.end()) {
+
+      for (auto in_var_name : in_vars_name) {
+        bool find_var = false;
+        for (auto *in_node : in_nodes) {
+          if (in_node->arg()->name == in_var_name) {
+            find_var = true;
+            break;
+          }
+        }
+        if (!find_var) {
           matched = false;
           break;
         }
       }
-      for (auto *var : out_nodes) {
-        if (std::find(out_vars.begin(), out_vars.end(), var->arg()->name) ==
-            out_vars.end()) {
+
+      for (auto out_var_name : out_vars_name) {
+        bool find_var = false;
+        for (auto *out_node : out_nodes) {
+          if (out_node->arg()->name == out_var_name) {
+            find_var = true;
+            break;
+          }
+        }
+        if (!find_var) {
           matched = false;
           break;
         }
       }
+
       if (matched) {
-        nodes_exclude.push_back(&node);
+        excluded_nodes.insert(&node);
+        break;
       }
     }
   }
-  return nodes_exclude;
+
+  return excluded_nodes;
 }
 
-void SubgraphDetector::InitNodes(node_map_t *nodes,
-                                 std::vector<const Node *> *nodes_exclude) {
+void SubgraphDetector::InitNodes(node_map_t *nodes) {
   // Initialize and mark the subgraph detector nodes based on teller.
+  std::unordered_set<Node *> excluded_nodes = GetExcludedNodesFromConfigFile();
   for (auto &it : *nodes) {
     for (auto &in_node : it.first->inlinks) {
       it.second->inlinks.push_back((*nodes)[in_node]);
@@ -269,11 +289,7 @@ void SubgraphDetector::InitNodes(node_map_t *nodes,
     for (auto &out_node : it.first->outlinks) {
       it.second->outlinks.push_back((*nodes)[out_node]);
     }
-    if (teller_(it.first)) {
-      if (std::find(nodes_exclude->begin(), nodes_exclude->end(), it.first) !=
-          nodes_exclude->end()) {
-        continue;
-      }
+    if (teller_(it.first) && excluded_nodes.count(it.first) == 0) {
       it.second->marked = true;
       if (it.first->IsStmt()) {
         // If a function is inside the subgraph, mark all the output variables
@@ -368,10 +384,8 @@ std::vector<std::vector<Node *>> SubgraphDetector::operator()() {
     nodes[&node] = new node_dat_t(&node);
     CHECK(nodes[&node]);
   }
-  // get exclude nodes from config file
-  std::vector<const Node *> nodes_exclude = GetNodesExclude();
   // Initialize and mark the subgraph detector nodes based on teller.
-  InitNodes(&nodes, &nodes_exclude);
+  InitNodes(&nodes);
   // Run the Extract algorithm to find all subgraphs.
   std::vector<std::vector<Node *>> subgraphs = ExtractSubgraphs(&nodes);
   for (auto &it : nodes) {

--- a/lite/core/mir/subgraph/subgraph_detector.cc
+++ b/lite/core/mir/subgraph/subgraph_detector.cc
@@ -223,10 +223,16 @@ std::unordered_set<Node *> SubgraphDetector::GetExcludedNodesFromConfigFile() {
   std::vector<std::string> lines = ReadLines(config_file_path);
 
   for (std::string line : lines) {
-    std::vector<std::string> node_info = Split(line, " ");
+    std::vector<std::string> node_info = Split(line, ":");
     std::string op_type = node_info.at(0);
-    std::vector<std::string> in_vars_name = Split(node_info.at(1), ",");
-    std::vector<std::string> out_vars_name = Split(node_info.at(2), ",");
+    std::vector<std::string> in_vars_name;
+    if (node_info.size() > 1) {
+      in_vars_name = Split(node_info.at(1), ",");
+    }
+    std::vector<std::string> out_vars_name;
+    if (node_info.size() > 2) {
+      out_vars_name = Split(node_info.at(2), ",");
+    }
 
     for (auto &node : graph_->mutable_nodes()) {
       if (node.IsArg()) continue;
@@ -271,7 +277,6 @@ std::unordered_set<Node *> SubgraphDetector::GetExcludedNodesFromConfigFile() {
 
       if (matched) {
         excluded_nodes.insert(&node);
-        break;
       }
     }
   }

--- a/lite/core/mir/subgraph/subgraph_detector.h
+++ b/lite/core/mir/subgraph/subgraph_detector.h
@@ -51,7 +51,6 @@ class SubgraphDetector {
   // pointer of the Node. This is to avoid changing the original graph in the
   // process of graph analysis.
   struct node_dat_t;
-  struct node_exclude_t;
   using node_map_t = std::unordered_map<Node*, node_dat_t*>;
   using node_set_t = std::vector<node_dat_t*>;
   struct node_dat_t {
@@ -74,9 +73,9 @@ class SubgraphDetector {
                    const std::function<bool(const node_dat_t*)>& enter,
                    const std::function<bool(const node_dat_t*)>& leave);
 
-  std::vector<const Node*> GetNodesExclude();
+  std::unordered_set<Node*> GetExcludedNodesFromConfigFile();
 
-  void InitNodes(node_map_t* nodes, std::vector<const Node*>* nodes_exclude);
+  void InitNodes(node_map_t* nodes);
 
   std::vector<std::vector<Node*>> ExtractSubgraphs(node_map_t* nodes);
 

--- a/lite/core/mir/subgraph/subgraph_detector.h
+++ b/lite/core/mir/subgraph/subgraph_detector.h
@@ -51,6 +51,7 @@ class SubgraphDetector {
   // pointer of the Node. This is to avoid changing the original graph in the
   // process of graph analysis.
   struct node_dat_t;
+  struct node_exclude_t;
   using node_map_t = std::unordered_map<Node*, node_dat_t*>;
   using node_set_t = std::vector<node_dat_t*>;
   struct node_dat_t {
@@ -63,6 +64,7 @@ class SubgraphDetector {
     node_dat_t* UnionFindAncestor();
     void UnionFindCombine(node_dat_t* candidate);
   };
+
   SubgraphDetector(SSAGraph* graph, const SubgraphTeller& teller)
       : graph_(graph), teller_(teller) {}
   std::vector<std::vector<Node*>> operator()();
@@ -71,7 +73,11 @@ class SubgraphDetector {
                    bool reverse,
                    const std::function<bool(const node_dat_t*)>& enter,
                    const std::function<bool(const node_dat_t*)>& leave);
-  void InitNodes(node_map_t* nodes);
+
+  std::vector<const Node*> GetNodesExclude();
+
+  void InitNodes(node_map_t* nodes, std::vector<const Node*>* nodes_exclude);
+
   std::vector<std::vector<Node*>> ExtractSubgraphs(node_map_t* nodes);
 
  protected:

--- a/lite/core/mir/subgraph/subgraph_detector_test.cc
+++ b/lite/core/mir/subgraph/subgraph_detector_test.cc
@@ -220,8 +220,8 @@ TEST(Subgraph, detect_custom_model) {
   };
   std::vector<std::vector<mir::Node*>> subgraphs =
       mir::SubgraphDetector(graph.get(), teller)();
-  ASSERT_EQ(subgraphs.size(), 1);
   mir::SubgraphVisualizer(graph.get(), subgraphs)();
+  ASSERT_EQ(subgraphs.size(), 1);
 }
 
 }  // namespace lite

--- a/lite/utils/env.h
+++ b/lite/utils/env.h
@@ -19,7 +19,8 @@
 #include <iostream>
 #include <string>
 
-#define SUBGRAPH_CUSTOM_PARTITION_CONFIG_FILE "CONFIG_SPLIT"
+#define SUBGRAPH_CUSTOM_PARTITION_CONFIG_FILE \
+  "SUBGRAPH_CUSTOM_PARTITION_CONFIG_FILE"
 
 namespace paddle {
 namespace lite {

--- a/lite/utils/env.h
+++ b/lite/utils/env.h
@@ -19,6 +19,8 @@
 #include <iostream>
 #include <string>
 
+#define SUBGRAPH_CUSTOM_PARTITION_CONFIG_FILE "CONFIG_SPLIT"
+
 namespace paddle {
 namespace lite {
 


### PR DESCRIPTION
- 通过配置文件分割子图，配置文件的每条记录描述需要指定在host上运行的op
- 配置文件通过环境变量```CONFIG_SPLIT```指定文件路径
- 配置文件格式：每行一条OP的描述，以":"分隔 "op名称:op输入名:op输出名"，以","分隔"op输入名"和"op输出名"中的不同var名。分隔满足此条件的所有OP。
```
op0:in0_var0,in0_var1:out0_var0,out0_var1
op1:in1_var0,in1_var1:out1_var0,out1_var1
op2::out2_var0
op3:in3_var0
op4
...
```
---
由于该pass在fuse pass之后进行，可能导致某些op被fuse而无法分割