### PR TITLE
[LITE][OPENCL] fix fetch crash during layout pass, add opencl fetch kernel

### DIFF
--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -4,9 +4,15 @@ endif()
 
 set(cl_kernel_deps op_params cl_runtime cl_context cl_wrapper cl_target_wrapper cl_image_converter)
 
-#####################
-# image kernel      #
-#####################
+#########################
+# opencl special kernel #
+#########################
+add_kernel(fetch_opencl OPENCL basic SRCS fetch_compute.cc DEPS ${cl_kernel_deps})
+
+
+#########################
+# image kernel          #
+#########################
 # basic
 add_kernel(elementwise_add_opencl OPENCL basic SRCS elementwise_add_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(elementwise_sub_opencl OPENCL basic SRCS elementwise_sub_image_compute.cc DEPS ${cl_kernel_deps})
@@ -39,10 +45,9 @@ add_kernel(pad2d_opencl OPENCL basic SRCS pad2d_image_compute.cc DEPS ${cl_kerne
 
 
 
-
-######################
-# image kernel test  #
-######################
+#########################
+# image kernel test     #
+#########################
 lite_cc_test(test_activation_image_opencl SRCS activation_image_compute_test.cc
              DEPS activation_opencl layout_opencl op_registry program context)
 
@@ -97,9 +102,10 @@ lite_cc_test(test_dropout_image_opencl SRCS dropout_image_compute_test.cc
                  
 lite_cc_test(test_pad2d_image_opencl SRCS pad2d_image_compute_test.cc
                  DEPS pad2d_opencl layout_opencl op_registry program context)
-######################
-# buffer kernel      #
-######################
+
+#########################
+# buffer kernel         #
+#########################
 # basic
 #add_kernel(activation_opencl OPENCL basic SRCS activation_buffer_compute.cc DEPS ${cl_kernel_deps})
 #add_kernel(conv_opencl OPENCL basic SRCS conv_buffer_compute.cc DEPS ${cl_kernel_deps})
@@ -119,9 +125,9 @@ add_kernel(io_copy_opencl OPENCL basic SRCS io_copy_buffer_compute.cc DEPS ${ten
 
 
 
-######################
-# buffer kernel test #
-######################
+#########################
+# buffer kernel test    #
+#########################
 #lite_cc_test(test_activation_buffer_opencl SRCS activation_buffer_compute_test.cc
 #             DEPS activation_opencl op_registry program context)
 

--- a/lite/kernels/opencl/fetch_compute.cc
+++ b/lite/kernels/opencl/fetch_compute.cc
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/op_registry.h"
+#include "lite/core/type_system.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+class FetchComputeDLAny
+    : public KernelLite<TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny)> {
+ public:
+  using param_t = operators::FeedParam;
+
+  void Run() override {
+    auto& param = Param<operators::FetchParam>();
+    auto* fetch_list = param.fetch_list;
+    if (fetch_list->size() <= static_cast<size_t>(param.col)) {
+      fetch_list->resize(param.col + 1);
+    }
+
+    auto& dst = fetch_list->at(param.col);
+    dst.ShareDataWith(*param.input);
+  }
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(fetch,
+                     kHost,
+                     kAny,
+                     kAny,
+                     paddle::lite::kernels::host::FetchComputeDLAny,
+                     def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(
+                   TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny), -1)})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(
+                    TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny), -1)})
+    .Finalize();


### PR DESCRIPTION
# 状态：等待review

## 主要内容

修复由于RK MTK的PR（`lite/kernels/host`下的的fetch只支持NCHW的格式），导致opt优化opencl模型时，出现fetch选不到的问题。


![image](https://user-images.githubusercontent.com/7320657/76503336-ab415b00-6480-11ea-92c3-193bbb6f5d4c.png)



因此，增加DataLayout为kAny的fetch，只针对OpenCL使用。