### PR TITLE
[Core] Fix findar for Clang

### DIFF
--- a/cmake/cross_compiling/findar.cmake
+++ b/cmake/cross_compiling/findar.cmake
@@ -23,7 +23,7 @@ endif()
 
 get_filename_component(AR_PATH ${CMAKE_CXX_COMPILER} PATH)
 
-find_file(AR_TOOL NAMES llvm-ar PATHS ${AR_PATH})
+find_file(AR_TOOL NAMES llvm-ar PATHS ${AR_PATH} NO_DEFAULT_PATH)
 
 if(NOT AR_TOOL)
     message(ERROR "Failed to find AR_TOOL in ${AR_PATH}")

--- a/lite/kernels/host/feed_compute.cc
+++ b/lite/kernels/host/feed_compute.cc
@@ -20,7 +20,8 @@ namespace lite {
 namespace kernels {
 namespace host {
 
-class FeedCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
+class FeedCompute
+    : public KernelLite<TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny)> {
  public:
   using param_t = operators::FeedParam;
 
@@ -39,7 +40,7 @@ class FeedCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
 }  // namespace paddle
 
 REGISTER_LITE_KERNEL(
-    feed, kHost, kAny, kNCHW, paddle::lite::kernels::host::FeedCompute, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    feed, kHost, kAny, kAny, paddle::lite::kernels::host::FeedCompute, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost))})
     .Finalize();

--- a/lite/kernels/host/fetch_compute.cc
+++ b/lite/kernels/host/fetch_compute.cc
@@ -20,7 +20,8 @@ namespace lite {
 namespace kernels {
 namespace host {
 
-class FetchCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
+class FetchCompute
+    : public KernelLite<TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny)> {
  public:
   using param_t = operators::FeedParam;
 
@@ -42,7 +43,11 @@ class FetchCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
 }  // namespace paddle
 
 REGISTER_LITE_KERNEL(
-    fetch, kHost, kAny, kNCHW, paddle::lite::kernels::host::FetchCompute, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    fetch, kHost, kAny, kAny, paddle::lite::kernels::host::FetchCompute, def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(
+                   TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny), -1)})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(
+                    TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny), -1)})
     .Finalize();


### PR DESCRIPTION
1. Fix findar for clang.
2. Fix the missing of feed and fetch kernel when using light API to load the optimized model.