### PR TITLE
[LITE][DEMO] Enhance mobile_light demo. test=develop

### DIFF
--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -114,8 +114,8 @@ void RunModel(std::string model_dir,
     for (int i = 0; i < ShapeProduction(out_shape); ++i) {
       sum += output_tensor->data<float>()[i];
     }
-    std::cout << "out_dims.production():" << ShapeProduction(out_shape)
-              << std::endl;
+    std::cout << "output tensor " << tidx
+              << " elem num:" << ShapeProduction(out_shape) << std::endl;
     std::cout << "output tensor " << tidx << " sum value:" << sum << std::endl;
     std::cout << "output tensor " << tidx
               << " mean value:" << sum / ShapeProduction(out_shape)

--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <sys/time.h>
+#include <time.h>
 #include <iostream>
+#include <string>
 #include <vector>
+
 #include "paddle_api.h"  // NOLINT
 
 using namespace paddle::lite_api;  // NOLINT
@@ -24,7 +28,25 @@ int64_t ShapeProduction(const shape_t& shape) {
   return res;
 }
 
-void RunModel(std::string model_dir) {
+std::string ShapePrint(const shape_t& shape) {
+  std::string shape_str{""};
+  for (auto i : shape) {
+    shape_str = shape_str + std::to_string(i) + " ";
+  }
+  return shape_str;
+}
+
+inline double GetCurrentUS() {
+  struct timeval time;
+  gettimeofday(&time, NULL);
+  return 1e+6 * time.tv_sec + time.tv_usec;
+}
+
+void RunModel(std::string model_dir,
+              const shape_t& input_shape,
+              int repeats,
+              int warmup,
+              int print_output_elem) {
   // 1. Set MobileConfig
   MobileConfig config;
   config.set_model_from_file(model_dir);
@@ -38,31 +60,108 @@ void RunModel(std::string model_dir) {
 
   // 3. Prepare input data
   std::unique_ptr<Tensor> input_tensor(std::move(predictor->GetInput(0)));
-  input_tensor->Resize({1, 3, 224, 224});
+  input_tensor->Resize(
+      {input_shape[0], input_shape[1], input_shape[2], input_shape[3]});
   auto* data = input_tensor->mutable_data<float>();
   for (int i = 0; i < ShapeProduction(input_tensor->shape()); ++i) {
     data[i] = 1;
   }
 
   // 4. Run predictor
-  predictor->Run();
+  for (size_t widx = 0; widx < warmup; ++widx) {
+    predictor->Run();
+  }
+
+  double sum_duration = 0.0;  // millisecond;
+  double max_duration = 1e-5;
+  double min_duration = 1e5;
+  double avg_duration = -1;
+  for (size_t ridx = 0; ridx < repeats; ++ridx) {
+    auto start = GetCurrentUS();
+
+    predictor->Run();
+
+    auto duration = (GetCurrentUS() - start) / 1000.0;
+    sum_duration += duration;
+    max_duration = duration > max_duration ? duration : max_duration;
+    min_duration = duration < min_duration ? duration : min_duration;
+    std::cout << "run_idx:" << ridx + 1 << " / " << repeats << ": " << duration
+              << " ms" << std::endl;
+  }
+  avg_duration = sum_duration / static_cast<float>(repeats);
+  std::cout << "\n======= benchmark summary =======\n"
+            << "input_shape(NCHW):" << ShapePrint(input_shape) << "\n"
+            << "model_dir:" << model_dir << "\n"
+            << "warmup:" << warmup << "\n"
+            << "repeats:" << repeats << "\n"
+            << "max_duration:" << max_duration << "\n"
+            << "min_duration:" << min_duration << "\n"
+            << "avg_duration:" << avg_duration << "\n";
 
   // 5. Get output
-  std::unique_ptr<const Tensor> output_tensor(
-      std::move(predictor->GetOutput(0)));
-  std::cout << "Output shape " << output_tensor->shape()[1] << std::endl;
-  for (int i = 0; i < ShapeProduction(output_tensor->shape()); i += 100) {
-    std::cout << "Output[" << i << "]: " << output_tensor->data<float>()[i]
+  std::cout << "\n====== output summary ====== " << std::endl;
+  size_t output_tensor_num = predictor->GetOutputNames().size();
+  std::cout << "output tesnor num:" << output_tensor_num << std::endl;
+
+  for (size_t tidx = 0; tidx < output_tensor_num; ++tidx) {
+    std::unique_ptr<const paddle::lite_api::Tensor> output_tensor =
+        predictor->GetOutput(tidx);
+    std::cout << "\n--- output tensor " << tidx << " ---" << std::endl;
+    auto out_shape = output_tensor->shape();
+    std::cout << "out_shape(NCHW):" << ShapePrint(out_shape) << std::endl;
+
+    float sum = 0.f;
+    for (int i = 0; i < ShapeProduction(out_shape); ++i) {
+      sum += output_tensor->data<float>()[i];
+    }
+    std::cout << "out_dims.production():" << ShapeProduction(out_shape)
               << std::endl;
+    std::cout << "output tensor " << tidx << " sum value:" << sum << std::endl;
+    std::cout << "output tensor " << tidx
+              << " mean value:" << sum / ShapeProduction(out_shape)
+              << std::endl;
+
+    // print output
+    if (print_output_elem) {
+      for (int i = 0; i < ShapeProduction(out_shape); ++i) {
+        std::cout << "out[" << tidx << "][" << i
+                  << "]:" << output_tensor->data<float>()[i] << std::endl;
+      }
+    }
   }
 }
 
 int main(int argc, char** argv) {
-  if (argc < 2) {
-    std::cerr << "[ERROR] usage: ./" << argv[0] << " naive_buffer_model_dir\n";
-    exit(1);
+  shape_t input_shape{1, 3, 224, 224};  // shape_t ==> std::vector<int64_t>
+  int repeats = 10;
+  int warmup = 10;
+  int print_output_elem = 0;
+
+  if (argc > 2 && argc < 9) {
+    std::cerr << "usage: ./" << argv[0] << "\n"
+              << "  <naive_buffer_model_dir>\n"
+              << "  <input_n>\n"
+              << "  <input_c>\n"
+              << "  <input_h>\n"
+              << "  <input_w>\n"
+              << "  <repeats>\n"
+              << "  <warmup>\n"
+              << "  <print_output>" << std::endl;
+    return 0;
   }
+
   std::string model_dir = argv[1];
-  RunModel(model_dir);
+  if (argc >= 9) {
+    input_shape[0] = atoi(argv[2]);
+    input_shape[1] = atoi(argv[4]);
+    input_shape[2] = atoi(argv[5]);
+    input_shape[3] = atoi(argv[6]);
+    repeats = atoi(argv[6]);
+    warmup = atoi(argv[7]);
+    print_output_elem = atoi(argv[8]);
+  }
+
+  RunModel(model_dir, input_shape, repeats, warmup, print_output_elem);
+
   return 0;
 }


### PR DESCRIPTION
# 状态：等待review

## 主要内容

强化demo的mobile_light，除了支持命令行默认的传参方式外，还支持更多参数用于benchmark。

```shell
usage: .//data/local/tmp/opencl/mobilenetv1_light_api
  <naive_buffer_model_dir>
  <input_n>
  <input_c>
  <input_h>
  <input_w>
  <repeats>
  <warmup>
  <print_output>
```

## 如何使用

参数说明

1. naive_buffer_model_dir[str]：模型文件的路径；
2. `input_n / input_c / input_h / input_w`[int]：输入维度；
3. repeats[int]：benchmark性能的统计总执行次数；
4. warmup[int]：跑benchmark的repeats前，先热身使CPU频率提升；
5. print_output[int:0|1]：是否打印网络执行结果的每个元素值。

因有两种传参方式：
1. 只传入模型路径：默认`input_shape=1,3,224,224，repeats=10，warmup=10，print_output=0`；
2. 完整的所有参数传递。

## 使用示例1：仅有模型路径参数

```shell
adb shell "export LD_LIBRARY_PATH=/data/local/tmp/opencl/; \
  /data/local/tmp/opencl/mobilenetv1_light_api \
  /data/local/tmp/opencl/mobilenetv1_cpu_dev_b601d81f.nb"
```



## 使用示例2：完整benchmark参数

```shell
adb shell "export LD_LIBRARY_PATH=/data/local/tmp/opencl/;
  /data/local/tmp/opencl/mobilenetv1_light_api \
  /data/local/tmp/opencl/mobilenetv1_cpu_dev_b601d81f.nb \
  1 3 224 224 10 10 0"

# 执行结果
run_idx:1 / 10: 19.822 ms
run_idx:2 / 10: 22.199 ms
run_idx:3 / 10: 23.228 ms
run_idx:4 / 10: 25.409 ms
run_idx:5 / 10: 22.038 ms
run_idx:6 / 10: 15.561 ms
run_idx:7 / 10: 17.925 ms
run_idx:8 / 10: 18.298 ms
run_idx:9 / 10: 19.894 ms
run_idx:10 / 10: 19.629 ms

======= benchmark summary =======
input_shape(NCHW):1 224 224 10
model_dir:/data/local/tmp/opencl/mobilenetv1_cpu_dev_b601d81f.nb
warmup:10
repeats:10
max_duration:25.409
min_duration:15.561
avg_duration:20.4003

====== output summary ======
output tesnor num:1

--- output tensor 0 ---
out_shape(NCHW):1 1000
output tensor 0 elem num:1000
output tensor 0 sum value:1
output tensor 0 mean value:0.001
```

