### PR TITLE
[doc] release doc and java API 

### DIFF
--- a/docs/api_reference/java_api_doc.md
+++ b/docs/api_reference/java_api_doc.md
@@ -301,6 +301,12 @@ Tensor是Paddle-Lite的数据组织形式，用于对底层数据进行封装并
 示例：
 
 ```java
+// 导入Java API
+import com.baidu.paddle.lite.MobileConfig;
+import com.baidu.paddle.lite.Tensor;
+import com.baidu.paddle.lite.Predictor;
+import com.baidu.paddle.lite.PowerMode;
+
 // 设置MobileConfig
 MobileConfig config = new MobileConfig();
 config.setModelDir(modelPath);
@@ -325,7 +331,7 @@ input.setData(inputBuffer);
 predictor.run();
 
 // 获取输出Tensor
-Tensor output = predictor.getOutput(0);
+Tensor result = predictor.getOutput(0);
 // 获取输出数据
 float[] output = result.getFloatData();
 for (int i = 0; i < 1000; ++i) {

--- a/docs/demo_guides/android_app_demo.md
+++ b/docs/demo_guides/android_app_demo.md
@@ -125,7 +125,7 @@ input.setData(inputBuffer);
 predictor.run();
 
 // 5. 获取输出数据
-Tensor output = predictor.getOutput(0);
+Tensor result = predictor.getOutput(0);
 float[] output = result.getFloatData();
 for (int i = 0; i < 1000; ++i) {
     System.out.println(output[i]);

--- a/docs/user_guides/model_optimize_tool.md
+++ b/docs/user_guides/model_optimize_tool.md
@@ -13,7 +13,7 @@ Paddle-Lite 提供了多种策略来自动优化原始的训练模型，其中�
 1. **推荐！** 可以进入Paddle-Lite Github仓库的[release界面](https://github.com/PaddlePaddle/Paddle-Lite/releases)，选择release版本下载对应的转化工具`opt`    
    (release/v2.2.0之前的转化工具为model_optimize_tool、release/v2.3.0之后为opt)
 
-2. 我们提供`release/v2.3`编译结果下载：[opt](https://github.com/PaddlePaddle/Paddle-Lite/releases/download/v2.3.0/opt)、[opt_mac](https://github.com/PaddlePaddle/Paddle-Lite/releases/download/v2.3.0/opt_mac)
+2. 我们提供`release/v2.3`编译结果下载：[opt](https://paddlelite-data.bj.bcebos.com/model_optimize_tool/opt)、[opt_mac](https://paddlelite-data.bj.bcebos.com/model_optimize_tool/opt_mac)
 `release/v2.2.0`版本的model_optimize_tool: [model_optimize_tool](https://paddlelite-data.bj.bcebos.com/model_optimize_tool/model_optimize_tool)、[model_optimize_tool_mac](https://paddlelite-data.bj.bcebos.com/model_optimize_tool/model_optimize_tool_mac)
 
 

--- a/docs/user_guides/release_lib.md
+++ b/docs/user_guides/release_lib.md
@@ -52,8 +52,8 @@
 
 | 运行系统 |      下载       |
 | :---------: |  :--------------: |
-|    Linux    |  [release/v2.3](https://github.com/PaddlePaddle/Paddle-Lite/releases/download/v2.3.0/opt) |
-|    MacOs   |  [release/v2.3](https://github.com/PaddlePaddle/Paddle-Lite/releases/download/v2.3.0/opt_mac) |
+|    Linux    | [release/v2.3](https://paddlelite-data.bj.bcebos.com/model_optimize_tool/opt) |
+|    MacOs   | [release/v2.3](https://paddlelite-data.bj.bcebos.com/model_optimize_tool/opt_mac) |
 
 
 


### PR DESCRIPTION
【1】修改release文档中opt的下载链接地址，改为国内地址，加速下载速度
【2】Java API文档中的demo代码书写错误，本PR中修复