### PR TITLE
[Python whl] add whl output for x86 python lib

### DIFF
--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -88,7 +88,7 @@ if (LITE_WITH_PYTHON)
             COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/setup.py" "${INFER_LITE_PUBLISH_ROOT}/python/install/"
             COMMAND cp "${CMAKE_SOURCE_DIR}/lite/api/python/__init__.py" "${INFER_LITE_PUBLISH_ROOT}/python/install/lite"
             COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/pybind/liblite_pybind.so" "${INFER_LITE_PUBLISH_ROOT}/python/install/lite/lite.so"
-            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/pybind/liblite_pybind.so" "${INFER_LITE_PUBLISH_ROOT}/python/lib/lite_core.so")
+            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/pybind/liblite_pybind.so" "${INFER_LITE_PUBLISH_ROOT}/python/lib/lite.so")
     add_custom_target(publish_inference_python_installer ${TARGET}
         COMMAND python setup.py bdist_wheel
         WORKING_DIRECTORY ${INFER_LITE_PUBLISH_ROOT}/python/install/

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -87,7 +87,7 @@ if (LITE_WITH_PYTHON)
             COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/python/install/lite"
             COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/setup.py" "${INFER_LITE_PUBLISH_ROOT}/python/install/"
             COMMAND cp "${CMAKE_SOURCE_DIR}/lite/api/python/__init__.py" "${INFER_LITE_PUBLISH_ROOT}/python/install/lite"
-            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/pybind/liblite_pybind.so" "${INFER_LITE_PUBLISH_ROOT}/python/install/lite/lite_core.so"
+            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/pybind/liblite_pybind.so" "${INFER_LITE_PUBLISH_ROOT}/python/install/lite/lite.so"
             COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/pybind/liblite_pybind.so" "${INFER_LITE_PUBLISH_ROOT}/python/lib/lite_core.so")
     add_custom_target(publish_inference_python_installer ${TARGET}
         COMMAND python setup.py bdist_wheel

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -12,6 +12,7 @@ message(STATUS "LITE_WITH_FPGA:\t${LITE_WITH_FPGA}")
 message(STATUS "LITE_WITH_BM:\t${LITE_WITH_BM}")
 message(STATUS "LITE_WITH_PROFILE:\t${LITE_WITH_PROFILE}")
 message(STATUS "LITE_WITH_CV:\t${LITE_WITH_CV}")
+message(STATUS "LITE_WITH_ARM_LANG:\t${LITE_WITH_ARM_LANG}")
 
 set(LITE_MODEL_DIR "${THIRD_PARTY_PATH}/install")
 set(LITE_ON_MOBILE ${LITE_WITH_LIGHT_WEIGHT_FRAMEWORK})
@@ -64,6 +65,9 @@ if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
     if (LITE_WITH_NPU)
         set(INFER_LITE_PUBLISH_ROOT "${INFER_LITE_PUBLISH_ROOT}.npu")
     endif(LITE_WITH_NPU)
+    if (LITE_WITH_XPU)
+        set(INFER_LITE_PUBLISH_ROOT "${INFER_LITE_PUBLISH_ROOT}.xpu")
+    endif(LITE_WITH_XPU)
     if (LITE_WITH_FPGA)
         set(INFER_LITE_PUBLISH_ROOT "${INFER_LITE_PUBLISH_ROOT}.fpga")
     endif(LITE_WITH_FPGA)
@@ -133,7 +137,29 @@ if (LITE_WITH_X86)
 endif()
 
 if(LITE_WITH_CUDA)
-    add_dependencies(publish_inference paddle_full_api_shared)
+    add_custom_target(publish_inference_cuda_cxx_lib ${TARGET}
+            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/bin"
+            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
+            COMMAND cp "${CMAKE_SOURCE_DIR}/lite/api/paddle_*.h" "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
+            COMMAND cp "${CMAKE_BINARY_DIR}/libpaddle_api_full_bundled.a" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+            COMMAND cp "${CMAKE_BINARY_DIR}/libpaddle_api_light_bundled.a" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/*.so" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+        )
+    add_dependencies(publish_inference_cuda_cxx_lib bundle_full_api)
+    add_dependencies(publish_inference_cuda_cxx_lib bundle_light_api)
+    add_dependencies(publish_inference_cuda_cxx_lib paddle_full_api_shared)
+    add_dependencies(publish_inference_cuda_cxx_lib paddle_light_api_shared)
+    add_dependencies(publish_inference publish_inference_cuda_cxx_lib)
+
+    add_custom_target(publish_inference_cuda_cxx_demos ${TARGET}
+           COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/third_party"
+           COMMAND cp -r "${CMAKE_BINARY_DIR}/third_party/install/*" "${INFER_LITE_PUBLISH_ROOT}/third_party"
+           COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/demo/cxx"
+           COMMAND cp -r "${CMAKE_SOURCE_DIR}/lite/demo/cxx/cuda_demo/*" "${INFER_LITE_PUBLISH_ROOT}/demo/cxx"
+           )
+    add_dependencies(publish_inference_cuda_cxx_lib publish_inference_cuda_cxx_demos)
+    add_dependencies(publish_inference_cuda_cxx_demos paddle_full_api_shared)
 endif(LITE_WITH_CUDA) 
 if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
     if (NOT LITE_ON_TINY_PUBLISH)

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -12,7 +12,6 @@ message(STATUS "LITE_WITH_FPGA:\t${LITE_WITH_FPGA}")
 message(STATUS "LITE_WITH_BM:\t${LITE_WITH_BM}")
 message(STATUS "LITE_WITH_PROFILE:\t${LITE_WITH_PROFILE}")
 message(STATUS "LITE_WITH_CV:\t${LITE_WITH_CV}")
-message(STATUS "LITE_WITH_ARM_LANG:\t${LITE_WITH_ARM_LANG}")
 
 set(LITE_MODEL_DIR "${THIRD_PARTY_PATH}/install")
 set(LITE_ON_MOBILE ${LITE_WITH_LIGHT_WEIGHT_FRAMEWORK})
@@ -65,9 +64,6 @@ if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
     if (LITE_WITH_NPU)
         set(INFER_LITE_PUBLISH_ROOT "${INFER_LITE_PUBLISH_ROOT}.npu")
     endif(LITE_WITH_NPU)
-    if (LITE_WITH_XPU)
-        set(INFER_LITE_PUBLISH_ROOT "${INFER_LITE_PUBLISH_ROOT}.xpu")
-    endif(LITE_WITH_XPU)
     if (LITE_WITH_FPGA)
         set(INFER_LITE_PUBLISH_ROOT "${INFER_LITE_PUBLISH_ROOT}.fpga")
     endif(LITE_WITH_FPGA)
@@ -83,7 +79,16 @@ message(STATUS "publish inference lib to ${INFER_LITE_PUBLISH_ROOT}")
 if (LITE_WITH_PYTHON)
     add_custom_target(publish_inference_python_lib ${TARGET}
             COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/python/lib"
+            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/python/install/libs"
+            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/python/install/lite"
+            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/setup.py" "${INFER_LITE_PUBLISH_ROOT}/python/install/"
+            COMMAND cp "${CMAKE_SOURCE_DIR}/lite/api/python/__init__.py" "${INFER_LITE_PUBLISH_ROOT}/python/install/lite"
+            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/pybind/liblite_pybind.so" "${INFER_LITE_PUBLISH_ROOT}/python/install/lite/lite_core.so"
             COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/python/pybind/liblite_pybind.so" "${INFER_LITE_PUBLISH_ROOT}/python/lib/lite_core.so")
+    add_custom_target(publish_inference_python_installer ${TARGET}
+        COMMAND python setup.py bdist_wheel
+        WORKING_DIRECTORY ${INFER_LITE_PUBLISH_ROOT}/python/install/
+        DEPENDS publish_inference_python_lib)
     add_custom_target(publish_inference_python_light_demo ${TARGET}
     	COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/demo/python"
     	COMMAND cp "${CMAKE_SOURCE_DIR}/lite/demo/python/mobilenetv1_light_api.py" "${INFER_LITE_PUBLISH_ROOT}/demo/python/")
@@ -95,6 +100,7 @@ if (LITE_WITH_PYTHON)
     endif()
     add_dependencies(publish_inference_python_lib lite_pybind)
     add_dependencies(publish_inference publish_inference_python_lib)
+    add_dependencies(publish_inference publish_inference_python_installer)
     add_dependencies(publish_inference publish_inference_python_light_demo)
 endif()
 
@@ -127,29 +133,7 @@ if (LITE_WITH_X86)
 endif()
 
 if(LITE_WITH_CUDA)
-    add_custom_target(publish_inference_cuda_cxx_lib ${TARGET}
-            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
-            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/bin"
-            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
-            COMMAND cp "${CMAKE_SOURCE_DIR}/lite/api/paddle_*.h" "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
-            COMMAND cp "${CMAKE_BINARY_DIR}/libpaddle_api_full_bundled.a" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
-            COMMAND cp "${CMAKE_BINARY_DIR}/libpaddle_api_light_bundled.a" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
-            COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/*.so" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
-        )
-    add_dependencies(publish_inference_cuda_cxx_lib bundle_full_api)
-    add_dependencies(publish_inference_cuda_cxx_lib bundle_light_api)
-    add_dependencies(publish_inference_cuda_cxx_lib paddle_full_api_shared)
-    add_dependencies(publish_inference_cuda_cxx_lib paddle_light_api_shared)
-    add_dependencies(publish_inference publish_inference_cuda_cxx_lib)
-
-    add_custom_target(publish_inference_cuda_cxx_demos ${TARGET}
-           COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/third_party"
-           COMMAND cp -r "${CMAKE_BINARY_DIR}/third_party/install/*" "${INFER_LITE_PUBLISH_ROOT}/third_party"
-           COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/demo/cxx"
-           COMMAND cp -r "${CMAKE_SOURCE_DIR}/lite/demo/cxx/cuda_demo/*" "${INFER_LITE_PUBLISH_ROOT}/demo/cxx"
-           )
-    add_dependencies(publish_inference_cuda_cxx_lib publish_inference_cuda_cxx_demos)
-    add_dependencies(publish_inference_cuda_cxx_demos paddle_full_api_shared)
+    add_dependencies(publish_inference paddle_full_api_shared)
 endif(LITE_WITH_CUDA) 
 if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
     if (NOT LITE_ON_TINY_PUBLISH)
@@ -212,6 +196,7 @@ if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
                 add_dependencies(publish_inference tiny_publish_cxx_lib)
                 if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
                     add_custom_command(TARGET tiny_publish_cxx_lib POST_BUILD
+                                COMMAND ${CMAKE_STRIP} "-s" ${INFER_LITE_PUBLISH_ROOT}/cxx/lib/libpaddle_api_light_bundled.a
                                 COMMAND ${CMAKE_STRIP} "-s" ${INFER_LITE_PUBLISH_ROOT}/cxx/lib/libpaddle_light_api_shared.so)
                 endif()
             endif()

--- a/lite/api/python/CMakeLists.txt
+++ b/lite/api/python/CMakeLists.txt
@@ -2,6 +2,9 @@ if (NOT LITE_WITH_PYTHON)
     return()
 endif()
 
+# to create setup.py for packeting whl for Paddle-Lite and opt
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
 
 add_subdirectory(pybind)
 #add_subdirectory(interface)

--- a/lite/api/python/CMakeLists.txt
+++ b/lite/api/python/CMakeLists.txt
@@ -3,6 +3,20 @@ if (NOT LITE_WITH_PYTHON)
 endif()
 
 # to create setup.py for packeting whl for Paddle-Lite and opt
+
+execute_process(
+  COMMAND git describe --tags --exact-match
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE PADDLE_LITE_TAG
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+  COMMAND git log -1 --format=%h
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE PADDLE_LITE_COMMIT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
     ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
 

--- a/lite/api/python/__init__.py
+++ b/lite/api/python/__init__.py
@@ -1,5 +1,5 @@
 import os
 from ctypes import *
-from lite_core.so import *
+from lite.so import *
 lib_path = os.path.join(os.path.dirname(__file__), 'lite.so')
 lib = CDLL(lib_path)

--- a/lite/api/python/__init__.py
+++ b/lite/api/python/__init__.py
@@ -1,5 +1,13 @@
-import os
-from ctypes import *
-from lite.so import *
-lib_path = os.path.join(os.path.dirname(__file__), 'lite.so')
-lib = CDLL(lib_path)
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lite/api/python/__init__.py
+++ b/lite/api/python/__init__.py
@@ -1,0 +1,5 @@
+import os
+from ctypes import *
+from lite_core.so import *
+lib_path = os.path.join(os.path.dirname(__file__), 'lite.so')
+lib = CDLL(lib_path)

--- a/lite/api/python/pybind/pybind.cc
+++ b/lite/api/python/pybind/pybind.cc
@@ -26,13 +26,10 @@
 
 #ifndef LITE_ON_TINY_PUBLISH
 #include "lite/api/cxx_api.h"
-#include "lite/api/paddle_use_passes.h"
 #endif
 
 #include "lite/api/light_api.h"
 #include "lite/api/paddle_api.h"
-#include "lite/api/paddle_use_kernels.h"
-#include "lite/api/paddle_use_ops.h"
 #include "lite/core/tensor.h"
 
 namespace py = pybind11;

--- a/lite/api/python/pybind/pybind.h
+++ b/lite/api/python/pybind/pybind.h
@@ -23,7 +23,7 @@ namespace pybind {
 
 void BindLiteApi(pybind11::module *m);
 
-PYBIND11_MODULE(lite_core, m) {
+PYBIND11_MODULE(lite, m) {
   m.doc() = "C++ core of Paddle-Lite";
 
   BindLiteApi(&m);

--- a/lite/api/python/setup.py.in
+++ b/lite/api/python/setup.py.in
@@ -11,20 +11,22 @@ class BinaryDistribution(Distribution):
 # get paddle-lite version, if it's not based on a release tag, we use commit id instead
 paddlelite_commit = "@PADDLE_LITE_COMMIT@"
 paddlelite_tag = "@PADDLE_LITE_TAG@"
-if paddlelite_tag == ""
-    paddlelite_version = paddlelite_tag
-else
+if paddlelite_tag == "":
     paddlelite_version = paddlelite_commit
+else:
+    paddlelite_version = paddlelite_tag
 
-with_mkl        = '%(with_mkl)s'
+lite_path='${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite'
+package_data = {'lite': ['lite_core.so']}
 # put all thirdparty libraries in paddle.libs
+package_data['libs']= []
 libs_path='${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/libs'
 if '${WITH_MKL}' == 'ON':
     shutil.copy('${MKLML_SHARED_IOMP_LIB}', libs_path)
+    shutil.copy('${MKLML_SHARED_LIB}', libs_path)
+    package_data['libs'] += ['libmklml_intel.so', 'libiomp5.so']
 
-lite_path='${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite'
 command = "patchelf --set-rpath '$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite/lite_core.so"
-#os.system(command)
 if os.system(command) != 0:
     raise Exception("patch third_party libs failed, command: %s" % command)
 
@@ -47,9 +49,6 @@ setup(
     description = 'Paddle-Lite Library',
     packages = ['lite','libs'],
     package_dir = package_dir,
-    package_data = {
-        'lite': ['lite_core.so'],
-        'libs': ['libiomp5.so'],
-    },
+    package_data = package_data,
     distclass = BinaryDistribution
 )

--- a/lite/api/python/setup.py.in
+++ b/lite/api/python/setup.py.in
@@ -17,16 +17,16 @@ else:
     paddlelite_version = paddlelite_tag
 
 lite_path='${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite'
-package_data = {'lite': ['lite_core.so']}
+package_data = {'paddlelite': ['lite.so']}
 # put all thirdparty libraries in paddle.libs
-package_data['libs']= []
+package_data['paddlelite.libs']= []
 libs_path='${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/libs'
 if '${WITH_MKL}' == 'ON':
     shutil.copy('${MKLML_SHARED_IOMP_LIB}', libs_path)
     shutil.copy('${MKLML_SHARED_LIB}', libs_path)
-    package_data['libs'] += ['libmklml_intel.so', 'libiomp5.so']
+    package_data['paddlelite.libs'] += ['libmklml_intel.so', 'libiomp5.so']
 
-command = "patchelf --set-rpath '$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite/lite_core.so"
+command = "patchelf --set-rpath '$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite/lite.so"
 if os.system(command) != 0:
     raise Exception("patch third_party libs failed, command: %s" % command)
 
@@ -38,8 +38,8 @@ if os.path.isfile(libs_path+'/__init__.py'):
 package_dir={
     # The paddle.fluid.proto will be generated while compiling.
     # So that package points to other directory.
-    'libs': libs_path,
-    'lite': lite_path
+    'paddlelite.libs': libs_path,
+    'paddlelite': lite_path
 }
 
 
@@ -47,7 +47,7 @@ setup(
     name = 'paddlelite',
     version = paddlelite_version,
     description = 'Paddle-Lite Library',
-    packages = ['lite','libs'],
+    packages = ['paddlelite','paddlelite.libs'],
     package_dir = package_dir,
     package_data = package_data,
     distclass = BinaryDistribution

--- a/lite/api/python/setup.py.in
+++ b/lite/api/python/setup.py.in
@@ -1,54 +1,72 @@
-from setuptools import setup, Distribution
+'module of pack whl installer for Paddle-lite'
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import shutil
 import os
+from setuptools import setup, Distribution
 
 
 class BinaryDistribution(Distribution):
+    'binary distribution'
     def has_ext_modules(foo):
         return True
 
 
 # get paddle-lite version, if it's not based on a release tag, we use commit id instead
-paddlelite_commit = "@PADDLE_LITE_COMMIT@"
-paddlelite_tag = "@PADDLE_LITE_TAG@"
-if paddlelite_tag == "":
-    paddlelite_version = paddlelite_commit
+PADDLELITE_COMMITE = "@PADDLE_LITE_COMMIT@"
+PADDLELITE_TAG = "@PADDLE_LITE_TAG@"
+if PADDLELITE_TAG == "":
+    PADDLELITE_VERSION = PADDLELITE_COMMITE
 else:
-    paddlelite_version = paddlelite_tag
+    PADDLELITE_VERSION = PADDLELITE_TAG
 
-lite_path='${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite'
-package_data = {'paddlelite': ['lite.so']}
-# put all thirdparty libraries in paddle.libs
-package_data['paddlelite.libs']= []
-libs_path='${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/libs'
+# core lib of paddlelite is stored as lite.so
+LITE_PATH = '${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite'
+PACKAGE_DATA = {'paddlelite': ['lite.so']}
+# put all thirdparty libraries in paddlelite.libs
+PACKAGE_DATA['paddlelite.libs'] = []
+LIB_PATH = '${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/libs'
 if '${WITH_MKL}' == 'ON':
-    shutil.copy('${MKLML_SHARED_IOMP_LIB}', libs_path)
-    shutil.copy('${MKLML_SHARED_LIB}', libs_path)
-    package_data['paddlelite.libs'] += ['libmklml_intel.so', 'libiomp5.so']
+    shutil.copy('${MKLML_SHARED_IOMP_LIB}', LIB_PATH)
+    shutil.copy('${MKLML_SHARED_LIB}', LIB_PATH)
+    PACKAGE_DATA['paddlelite.libs'] += ['libmklml_intel.so', 'libiomp5.so']
 
-command = "patchelf --set-rpath '$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite/lite.so"
-if os.system(command) != 0:
-    raise Exception("patch third_party libs failed, command: %s" % command)
+# link lite.so to paddlelite.libs
+COMMAND = "patchelf --set-rpath '$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}\
+/inference_lite_lib/python/install/lite/lite.so"
+if os.system(COMMAND) != 0:
+    raise Exception("patch third_party libs failed, command: %s" % COMMAND)
 
 # remove unused paddle/libs/__init__.py
-if os.path.isfile(libs_path+'/__init__.py'):
-    os.remove(libs_path+'/__init__.py')
+if os.path.isfile(LIB_PATH+'/__init__.py'):
+    os.remove(LIB_PATH+'/__init__.py')
 
-
-package_dir={
+# set dir path of each package
+PACKAGE_DIR = {
     # The paddle.fluid.proto will be generated while compiling.
     # So that package points to other directory.
-    'paddlelite.libs': libs_path,
-    'paddlelite': lite_path
+    'paddlelite.libs': LIB_PATH,
+    'paddlelite': LITE_PATH
 }
 
-
 setup(
-    name = 'paddlelite',
-    version = paddlelite_version,
-    description = 'Paddle-Lite Library',
-    packages = ['paddlelite','paddlelite.libs'],
-    package_dir = package_dir,
-    package_data = package_data,
-    distclass = BinaryDistribution
+    name='paddlelite',
+    version=PADDLELITE_VERSION,
+    description='Paddle-Lite Library',
+    packages=['paddlelite', 'paddlelite.libs'],
+    package_dir=PACKAGE_DIR,
+    package_data=PACKAGE_DATA,
+    distclass=BinaryDistribution
 )

--- a/lite/api/python/setup.py.in
+++ b/lite/api/python/setup.py.in
@@ -1,4 +1,3 @@
-'module of pack whl installer for Paddle-lite'
 # Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# module of pack whl installer for Paddle-lite
 
 import shutil
 import os

--- a/lite/api/python/setup.py.in
+++ b/lite/api/python/setup.py.in
@@ -1,0 +1,55 @@
+from setuptools import setup, Distribution
+import shutil
+import os
+
+
+class BinaryDistribution(Distribution):
+    def has_ext_modules(foo):
+        return True
+
+
+# get paddle-lite version, if it's not based on a release tag, we use commit id instead
+paddlelite_commit = "@PADDLE_LITE_COMMIT@"
+paddlelite_tag = "@PADDLE_LITE_TAG@"
+if paddlelite_tag == ""
+    paddlelite_version = paddlelite_tag
+else
+    paddlelite_version = paddlelite_commit
+
+with_mkl        = '%(with_mkl)s'
+# put all thirdparty libraries in paddle.libs
+libs_path='${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/libs'
+if '${WITH_MKL}' == 'ON':
+    shutil.copy('${MKLML_SHARED_IOMP_LIB}', libs_path)
+
+lite_path='${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite'
+command = "patchelf --set-rpath '$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/inference_lite_lib/python/install/lite/lite_core.so"
+#os.system(command)
+if os.system(command) != 0:
+    raise Exception("patch third_party libs failed, command: %s" % command)
+
+# remove unused paddle/libs/__init__.py
+if os.path.isfile(libs_path+'/__init__.py'):
+    os.remove(libs_path+'/__init__.py')
+
+
+package_dir={
+    # The paddle.fluid.proto will be generated while compiling.
+    # So that package points to other directory.
+    'libs': libs_path,
+    'lite': lite_path
+}
+
+
+setup(
+    name = 'paddlelite',
+    version = paddlelite_version,
+    description = 'Paddle-Lite Library',
+    packages = ['lite','libs'],
+    package_dir = package_dir,
+    package_data = {
+        'lite': ['lite_core.so'],
+        'libs': ['libiomp5.so'],
+    },
+    distclass = BinaryDistribution
+)

--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -354,10 +354,11 @@ function make_x86 {
             -DWITH_LITE=ON \
             -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=OFF \
             -DLITE_WITH_ARM=OFF \
+            -DLITE_WITH_PYTHON=$BUILD_PYTHON \
             -DWITH_GPU=OFF \
             -DLITE_BUILD_EXTRA=ON \
             -DLITE_WITH_XPU=$BUID_XPU \
-            -DXPU_SDK_ROOT=$XPU_SDK_ROOT \
+            -DXPU_SDK_ROOT=$XPU_SDK_ROOT
 
   make publish_inference -j$NUM_PROC
   cd -


### PR DESCRIPTION
【本PR工作】：
1. x86支持`with_python`编译
2. python 库支持whl包输出。
 
(1) `lite_core`库封装为lite.lite_core
```
import paddlelite.lite as lite
a=lite.CxxConfig()
```
(2) 将第三方库`libiomp5.so`和`libmklml_intel.so`封装到whl包中，解决第三方库引用不到的问题
```
 apt-get install patchelf
```
注意：需要注意的是编译whl包要求环境已经安装`patchelf`：（需要修改我们的docker源，该库是为whl包注册第三方依赖时使用的）

[Paddle-Lite whl设计链接](http://agroup.baidu.com/paddlepaddle/md/article/2623820)