### PR TITLE
[bug fix] fix memory_optimize_pass

### DIFF
--- a/lite/core/mir/memory_optimize_pass.cc
+++ b/lite/core/mir/memory_optimize_pass.cc
@@ -123,7 +123,8 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
 
   // non-tensor(like tensor_array) variables will not be reused
   for (auto& node : graph->nodes()) {
-    if (node.IsArg() && !node.arg()->type->IsTensor()) {
+    if (node.IsArg() && (node.arg()->type != nullptr) &&
+        !node.arg()->type->IsTensor()) {
       invalid_var_names.insert(node.arg()->name);
     }
   }

--- a/lite/core/mir/node.h
+++ b/lite/core/mir/node.h
@@ -85,7 +85,7 @@ class Node {
   struct Arg {
     std::string name;
     int id{0};
-    const Type* type{};
+    const Type* type{nullptr};
     // Weight is a special kind of argument, it is marked as weight explicitly
     // so that some weight related optimization can take place.
     bool is_weight{false};


### PR DESCRIPTION
【问题描述】：memory_optimize_pass运行时遇到val->type为空时会出现error
【本PR工作】：添加检查，如果val->type为指定则跳过该参数