### PR TITLE
[ios lib] add strip lib function into ios compiling

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -291,6 +291,8 @@ function make_ios {
             -DLITE_ON_TINY_PUBLISH=ON \
             -DLITE_WITH_OPENMP=OFF \
             -DWITH_ARM_DOTPROD=OFF \
+            -DLITE_BUILD_TAILOR=$BUILD_TAILOR \
+            -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \
             -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=ON \
             -DARM_TARGET_ARCH_ABI=$abi \
             -DLITE_BUILD_EXTRA=$BUILD_EXTRA \


### PR DESCRIPTION
【问题描述】：ios编译不支持根据模型裁剪预测库功能
【本PR工作】：使ios 编译可以识别根据模型裁剪预测库的编译选项，支持根据模型裁剪预测库