### PR TITLE
rename elementwise_sub_grad

### DIFF
--- a/lite/operators/elementwise_grad_ops.cc
+++ b/lite/operators/elementwise_grad_ops.cc
@@ -56,9 +56,9 @@ bool ElementwiseGradOp::AttachImpl(const cpp::OpDesc& opdesc,
 }  // namespace lite
 }  // namespace paddle
 
-REGISTER_LITE_OP(elementwise_grad_sub,
+REGISTER_LITE_OP(elementwise_sub_grad,
                  paddle::lite::operators::ElementwiseGradOp);
-REGISTER_LITE_OP(elementwise_grad_add,
+REGISTER_LITE_OP(elementwise_add_grad,
                  paddle::lite::operators::ElementwiseGradOp);
 
 REGISTER_LITE_OP(elementwise_grad_mul,


### PR DESCRIPTION
the name of `elementwise_sub_grad` and `elementwise_add_grad` is inconsistent with the paddle's, raising a 'segmentation fault' error when `CreatePaddlePredictor()`.

the input name of `elementwise_add_grad` should be consistent with the paddle's, such as `X@GRAD`, or a `terminating with uncaught exception of type std::length_error: vector` will rise.