### PR TITLE
[BUG FIX] fix demo compiling bug

### DIFF
--- a/lite/demo/cxx/mask_detection/mask_detection.cc
+++ b/lite/demo/cxx/mask_detection/mask_detection.cc
@@ -241,7 +241,7 @@ void RunModel(std::string det_model_file,
       roi_color = cv::Scalar(0, 0, 255);
       prob = 1 - prob;
     }
-    std::string prob_str = paddle::lite::to_string(prob * 100);
+    std::string prob_str = std::to_string(prob * 100);
     int point_idx = prob_str.find_last_of(".");
 
     text += prob_str.substr(0, point_idx + 3) + "%";

--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -32,7 +32,7 @@ int64_t ShapeProduction(const shape_t& shape) {
 std::string ShapePrint(const shape_t& shape) {
   std::string shape_str{""};
   for (auto i : shape) {
-    shape_str += paddle::lite::to_string(i) + " ";
+    shape_str += std::to_string(i) + " ";
   }
   return shape_str;
 }

--- a/lite/demo/cxx/ssd_detection/ssd_detection.cc
+++ b/lite/demo/cxx/ssd_detection/ssd_detection.cc
@@ -126,7 +126,7 @@ std::vector<Object> detect_object(const float* data,
       if (w > 0 && h > 0 && obj.prob <= 1) {
         rect_out.push_back(obj);
         cv::rectangle(image, rec_clip, cv::Scalar(0, 0, 255), 2, cv::LINE_AA);
-        std::string str_prob = paddle::lite::to_string(obj.prob);
+        std::string str_prob = std::to_string(obj.prob);
         std::string text = std::string(class_names[obj.class_id]) + ": " +
                            str_prob.substr(0, str_prob.find(".") + 4);
         int font_face = cv::FONT_HERSHEY_COMPLEX_SMALL;

--- a/lite/demo/cxx/yolov3_detection/yolov3_detection.cc
+++ b/lite/demo/cxx/yolov3_detection/yolov3_detection.cc
@@ -146,7 +146,7 @@ std::vector<Object> detect_object(const float* data,
       if (w > 0 && h > 0 && obj.prob <= 1) {
         rect_out.push_back(obj);
         cv::rectangle(image, rec_clip, cv::Scalar(0, 0, 255), 1, cv::LINE_AA);
-        std::string str_prob = paddle::lite::to_string(obj.prob);
+        std::string str_prob = std::to_string(obj.prob);
         std::string text = std::string(class_names[obj.class_id]) + ": " +
                            str_prob.substr(0, str_prob.find(".") + 4);
         int font_face = cv::FONT_HERSHEY_COMPLEX_SMALL;


### PR DESCRIPTION
【问题描述】 c++ demo编译失败，定位问题为paddle:lite:to_string为内部函数，在预测库中未开放接口，倒是undefination
【解决方法】 将cxx demo中`paddle::lite::to_string`替换为 `std::to_string`。测试可以编译通过，运行正常