### PR TITLE
fix segment fault bug of elementwise_grad kernel

### DIFF
--- a/lite/backends/arm/math/elementwise.cc
+++ b/lite/backends/arm/math/elementwise.cc
@@ -302,10 +302,10 @@ void elementwise_add_grad_broadcast<float>(const float* dout_grad,
                                            int pre,
                                            int n,
                                            int post) {
-  if (x_grad) {
+  if (x_grad != nullptr) {
     elementwise_add_grad(dout_grad, x_grad, pre * n * post);
   }
-  if (y_grad) {
+  if (y_grad != nullptr) {
     memset(y_grad, 0, n * sizeof(float));
 #pragma omp parallel for
     for (int i = 0; i < pre; ++i) {
@@ -582,10 +582,10 @@ void elementwise_sub_grad<float>(const float* dout_grad,
                                  float* x_grad,
                                  float* y_grad,
                                  int num) {
-  if (x_grad) {
+  if (x_grad != nullptr) {
     elementwise_add_grad(dout_grad, x_grad, num);
   }
-  if (y_grad) {
+  if (y_grad != nullptr) {
     int cnt = num >> 4;
     int remain = num & 0x0f;
     float32x4_t minus = vdupq_n_f32(-1);
@@ -624,10 +624,10 @@ void elementwise_sub_grad_broadcast<float>(const float* dout_grad,
                                            int pre,
                                            int n,
                                            int post) {
-  if (x_grad) {
+  if (x_grad != nullptr) {
     elementwise_add_grad(dout_grad, x_grad, pre * n * post);
   }
-  if (y_grad) {
+  if (y_grad != nullptr) {
     memset(y_grad, 0, n * sizeof(float));
 #pragma omp parallel for
     for (int i = 0; i < pre; ++i) {

--- a/lite/kernels/arm/elementwise_grad_compute.cc
+++ b/lite/kernels/arm/elementwise_grad_compute.cc
@@ -76,8 +76,8 @@ void ElementwiseAddGradCompute::Run() {
   const float* x_data = param.X->data<float>();
   const float* y_data = param.Y->data<float>();
   const float* out_grad_data = param.OutGrad->data<float>();
-  float* x_grad_data;
-  float* y_grad_data;
+  float* x_grad_data = nullptr;
+  float* y_grad_data = nullptr;
   if (param.XGrad) {
     x_grad_data = param.XGrad->mutable_data<float>();
   }
@@ -122,8 +122,8 @@ void ElementwiseSubGradCompute::Run() {
   const float* x_data = param.X->data<float>();
   const float* y_data = param.Y->data<float>();
   const float* out_data = param.OutGrad->data<float>();
-  float* x_grad_data;
-  float* y_grad_data;
+  float* x_grad_data = nullptr;
+  float* y_grad_data = nullptr;
   if (param.XGrad) {
     x_grad_data = param.XGrad->mutable_data<float>();
   }
@@ -137,9 +137,15 @@ void ElementwiseSubGradCompute::Run() {
 
   if (!param.XGrad || !param.YGrad) {
     CHECK(param.XGrad || param.YGrad);
-    lite::arm::math::elementwise_sub_grad(
-        out_data, x_grad_data, y_grad_data, y_dims.production());
-    return;
+    if (param.XGrad) {
+      lite::arm::math::elementwise_sub_grad(
+          out_data, x_grad_data, y_grad_data, x_dims.production());
+      return;
+    } else {
+      lite::arm::math::elementwise_sub_grad(
+          out_data, x_grad_data, y_grad_data, y_dims.production());
+      return;
+    }
   }
 
   if (x_dims.size() < y_dims.size()) {


### PR DESCRIPTION
The `x_grad_data` ptr is not initialized when declaring it, which causes a segmentation error when running it kernel. Now we initialize it to nullptr.