### PR TITLE
[x86] change x86 compile mode into release to reduce publish lib size

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -360,6 +360,7 @@ function make_x86 {
             -DWITH_GPU=OFF \
             -DLITE_WITH_PYTHON=${BUILD_PYTHON} \
             -DLITE_BUILD_EXTRA=ON \
+            -DCMAKE_BUILD_TYPE=Release \
             -DLITE_WITH_XPU=$BUID_XPU \
             -DXPU_SDK_ROOT=$XPU_SDK_ROOT
 


### PR DESCRIPTION
【问题描述】：Paddle-Lite x86 编译出的预测库体积较大（约200M）
【问题定位】：build.sh脚本中的x86编译函数 `make_x86 {} `，默认的编译模式为 `"RelWithDebInfo"`，x86库文件中加入了较多debug信息，导致体积较大
**代码位置**：https://github.com/PaddlePaddle/Paddle-Lite/blob/3495f715061528c390350b075a9220466fb02c2e/CMakeLists.txt#L104
【本PR工作】：
将`build.sh`脚本中的`make_x86`，即x86编译函数的编译模式设置为Release模式。x86预测库体积从217M缩小到16M。

**修改前：**
![image](https://user-images.githubusercontent.com/45189361/77757778-cc06d480-706c-11ea-9d34-e0f9ee07afce.png)


**修改后：**
![image](https://user-images.githubusercontent.com/45189361/77757113-91506c80-706b-11ea-81b8-fe6194a185a4.png)
