### PR TITLE
[operator] add InferShapeImpl method

### DIFF
--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -36,9 +36,10 @@ bool OpLite::InferShape() {
       new_hash =
           lite::hash_combine(new_hash, static_cast<int>(element_dims[i]));
     }
+    // combine lod value into new_hash valud.
     auto emement_lods = (*iter)->lod();
     for (auto lod_iter = emement_lods.begin(); lod_iter != emement_lods.end();
-         lod_iter++) {  // combine lod value into new_hash valud.
+         lod_iter++) {
       for (int i = 0; i < lod_iter->size(); i++) {
         new_hash =
             lite::hash_combine(new_hash, static_cast<int>(lod_iter->at(i)));

--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -58,6 +58,7 @@ bool OpLite::InferShape() {
     }
   } else {
     // If current hash value is changed, InferShapeImpl is operated.
+    io_shape_lod_hash_ = new_hash;
     this->InferShapeImpl();
     auto current_outputs = param_.output_tensor_ptrs();
     for (int i = 0; i < current_outputs->size(); i++) {

--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -22,6 +22,24 @@
 namespace paddle {
 namespace lite {
 
+bool OpLite::InferShape() {
+  if (!last_input_shapes.empty() && last_input_shapes == param_.inputs_dims() &&
+      last_input_lods == param_.inputs_lods()) {
+    for (int i = 0; i < param_.output_tensor_ptrs()->size(); i++) {
+      param_.output_tensor_ptrs()->at(i)->Resize(last_output_shapes[i]);
+      param_.output_tensor_ptrs()->at(i)->set_lod(last_output_lods[i]);
+    }
+    return true;
+  }
+
+  this->InferShapeImpl();
+  last_input_shapes = param_.inputs_dims();
+  last_input_lods = param_.inputs_lods();
+  last_output_shapes = param_.outputs_dims();
+  last_output_lods = param_.outputs_lods();
+  return true;
+}
+
 std::vector<std::unique_ptr<KernelBase>> OpLite::CreateKernels(
     const std::vector<Place> &places, const std::string &kernel_type) {
   std::vector<std::unique_ptr<KernelBase>> kernels;

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <functional>
 #include <list>
 #include <map>
 #include <memory>
@@ -153,10 +154,9 @@ class OpLite : public Registry {
   Place kernel_place_{TARGET(kHost), PRECISION(kFloat)};
   std::unique_ptr<OpInfo> op_info_;
 
-  std::vector<DDimLite> last_input_shapes;
-  std::vector<DDimLite> last_output_shapes;
-  std::vector<std::vector<std::vector<uint64_t>>> last_output_lods;
-  std::vector<std::vector<std::vector<uint64_t>>> last_input_lods;
+  std::vector<DDimLite> last_output_shapes{};
+  std::vector<std::vector<std::vector<uint64_t>>> last_output_lods{};
+  size_t io_shape_lod_hash_{};
   mutable operators::ParamBase param_;
 };
 

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -158,6 +158,11 @@ class OpLite : public Registry {
   std::vector<std::vector<std::vector<uint64_t>>> last_output_lods{};
   size_t io_shape_lod_hash_{};
   mutable operators::ParamBase param_;
+
+ private:
+  // Infer Shape according to memory, if current input shapes are consistent
+  // with that of previous inputs, output shapes of last time will be reused.
+  bool InferShapeByMemoryInternal();
 };
 
 /*

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -24,6 +24,7 @@
 #include "lite/core/kernel.h"
 #include "lite/core/scope.h"
 #include "lite/model_parser/cpp/op_desc.h"
+#include "lite/operators/op_params.h"
 
 namespace paddle {
 namespace lite {
@@ -64,8 +65,8 @@ class OpLite : public Registry {
   // Check the shape.
   virtual bool CheckShape() const { return true; }
   // Inference the outputs' shape.
-  virtual bool InferShape() const { return true; }
-  virtual bool SmartInferShape() { return this->InferShape(); }
+  virtual bool InferShapeImpl() const { return true; }
+  virtual bool InferShape();
   // Run this operator.
   virtual bool Run();
   // Indicate whether the Op runs only once or not
@@ -151,10 +152,12 @@ class OpLite : public Registry {
   std::vector<Place> valid_places_;
   Place kernel_place_{TARGET(kHost), PRECISION(kFloat)};
   std::unique_ptr<OpInfo> op_info_;
+
   std::vector<DDimLite> last_input_shapes;
   std::vector<DDimLite> last_output_shapes;
   std::vector<std::vector<std::vector<uint64_t>>> last_output_lods;
   std::vector<std::vector<std::vector<uint64_t>>> last_input_lods;
+  mutable operators::ParamBase param_;
 };
 
 /*

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -162,7 +162,7 @@ class OpLite : public Registry {
  private:
   // Infer Shape according to memory, if current input shapes are consistent
   // with that of previous inputs, output shapes of last time will be reused.
-  bool InferShapeByMemoryInternal();
+  bool InferShapeWithCache();
 };
 
 /*

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -286,8 +286,7 @@ void Instruction::Run() {
     return;
   }
 
-  // op_->InferShape();
-  op_->SmartInferShape();
+  op_->InferShape();
   kernel_->Launch();
   has_run_ = true;
 }

--- a/lite/operators/activation_grad_ops.cc
+++ b/lite/operators/activation_grad_ops.cc
@@ -25,7 +25,7 @@ bool ActivationGradOp::CheckShape() const {
   return true;
 }
 
-bool ActivationGradOp::InferShape() const {
+bool ActivationGradOp::InferShapeImpl() const {
   param_.X_grad->Resize(param_.Out_grad->dims());
   return true;
 }

--- a/lite/operators/activation_grad_ops.h
+++ b/lite/operators/activation_grad_ops.h
@@ -26,7 +26,7 @@ class ActivationGradOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) override;
 

--- a/lite/operators/activation_ops.cc
+++ b/lite/operators/activation_ops.cc
@@ -25,7 +25,7 @@ bool ActivationOp::CheckShape() const {
   return true;
 }
 
-bool ActivationOp::InferShape() const {
+bool ActivationOp::InferShapeImpl() const {
   param_.Out->Resize(param_.X->dims());
   auto out_lod = param_.Out->mutable_lod();
   *out_lod = param_.X->lod();

--- a/lite/operators/activation_ops.h
+++ b/lite/operators/activation_ops.h
@@ -26,7 +26,7 @@ class ActivationOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) override;
 

--- a/lite/operators/affine_channel_op.cc
+++ b/lite/operators/affine_channel_op.cc
@@ -44,7 +44,7 @@ bool AffineChannelOpLite::CheckShape() const {
   return true;
 }
 
-bool AffineChannelOpLite::InferShape() const {
+bool AffineChannelOpLite::InferShapeImpl() const {
   const auto x_dims = param_.X->dims();
   param_.Out->Resize(x_dims);
   return true;

--- a/lite/operators/affine_channel_op.h
+++ b/lite/operators/affine_channel_op.h
@@ -31,7 +31,7 @@ class AffineChannelOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/anchor_generator_op.cc
+++ b/lite/operators/anchor_generator_op.cc
@@ -31,7 +31,7 @@ bool AnchorGeneratorOpLite::CheckShape() const {
   return true;
 }
 
-bool AnchorGeneratorOpLite::InferShape() const {
+bool AnchorGeneratorOpLite::InferShapeImpl() const {
   auto input_dims = param_.Input->dims();
   size_t num_anchors = param_.aspect_ratios.size() * param_.anchor_sizes.size();
   std::vector<int64_t> output_shape(

--- a/lite/operators/anchor_generator_op.h
+++ b/lite/operators/anchor_generator_op.h
@@ -32,7 +32,7 @@ class AnchorGeneratorOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/argmax_op.cc
+++ b/lite/operators/argmax_op.cc
@@ -29,7 +29,7 @@ bool ArgmaxOpLite::CheckShape() const {
   return true;
 }
 
-bool ArgmaxOpLite::InferShape() const {
+bool ArgmaxOpLite::InferShapeImpl() const {
   auto x_dims = param_.X->dims();
   int x_rank = x_dims.size();
   int axis = param_.Axis;

--- a/lite/operators/argmax_op.h
+++ b/lite/operators/argmax_op.h
@@ -31,7 +31,7 @@ class ArgmaxOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/assign_op.cc
+++ b/lite/operators/assign_op.cc
@@ -26,7 +26,7 @@ bool AssignOpLite::CheckShape() const {
   return true;
 }
 
-bool AssignOpLite::InferShape() const {
+bool AssignOpLite::InferShapeImpl() const {
   lite::DDim input_dims;
   input_dims = param_.X->dims();
   param_.Out->Resize(lite::DDim(input_dims));

--- a/lite/operators/assign_op.h
+++ b/lite/operators/assign_op.h
@@ -30,7 +30,7 @@ class AssignOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/assign_value_op.cc
+++ b/lite/operators/assign_value_op.cc
@@ -35,7 +35,7 @@ bool AssignValueOpLite::CheckShape() const {
   return true;
 }
 
-bool AssignValueOpLite::InferShape() const {
+bool AssignValueOpLite::InferShapeImpl() const {
   std::vector<int> shape = param_.shape;
   std::vector<int64_t> out_shape;
   for (size_t i = 0; i < shape.size(); i++) out_shape.push_back(shape[i]);

--- a/lite/operators/assign_value_op.h
+++ b/lite/operators/assign_value_op.h
@@ -31,7 +31,7 @@ class AssignValueOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/attention_padding_mask_op.cc
+++ b/lite/operators/attention_padding_mask_op.cc
@@ -28,7 +28,7 @@ bool AttentionPaddingMaskOp::CheckShape() const {
   return true;
 }
 
-bool AttentionPaddingMaskOp::InferShape() const {
+bool AttentionPaddingMaskOp::InferShapeImpl() const {
   auto src_len = param_.X->lod()[0][1];
   CHECK_EQ(src_len, param_.X->dims()[1])
       << "Mismatch source length, expect: " << src_len

--- a/lite/operators/attention_padding_mask_op.h
+++ b/lite/operators/attention_padding_mask_op.h
@@ -29,7 +29,7 @@ class AttentionPaddingMaskOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/axpy_op.cc
+++ b/lite/operators/axpy_op.cc
@@ -34,7 +34,7 @@ bool AxpyOpLite::CheckShape() const {
   return true;
 }
 
-bool AxpyOpLite::InferShape() const {
+bool AxpyOpLite::InferShapeImpl() const {
   auto dims = param_.Bias->dims();
 
   // Set output dims

--- a/lite/operators/axpy_op.h
+++ b/lite/operators/axpy_op.h
@@ -31,7 +31,7 @@ class AxpyOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/batch_norm_op.cc
+++ b/lite/operators/batch_norm_op.cc
@@ -46,7 +46,7 @@ bool BatchNormOp::CheckShape() const {
   return true;
 }
 
-bool BatchNormOp::InferShape() const {
+bool BatchNormOp::InferShapeImpl() const {
   auto x_dims = param_.x->dims();
   int64_t channel_size = 0;
   switch (param_.data_layout) {

--- a/lite/operators/batch_norm_op.h
+++ b/lite/operators/batch_norm_op.h
@@ -30,7 +30,7 @@ class BatchNormOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/beam_search_decode_op.cc
+++ b/lite/operators/beam_search_decode_op.cc
@@ -28,7 +28,7 @@ bool BeamSearchDecodeOpLite::CheckShape() const {
   return true;
 }
 
-bool BeamSearchDecodeOpLite::InferShape() const { return true; }
+bool BeamSearchDecodeOpLite::InferShapeImpl() const { return true; }
 
 bool BeamSearchDecodeOpLite::AttachImpl(const cpp::OpDesc &op_desc,
                                         lite::Scope *scope) {

--- a/lite/operators/beam_search_decode_op.h
+++ b/lite/operators/beam_search_decode_op.h
@@ -31,7 +31,7 @@ class BeamSearchDecodeOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/beam_search_op.cc
+++ b/lite/operators/beam_search_op.cc
@@ -30,7 +30,7 @@ bool BeamSearchOp::CheckShape() const {
   return true;
 }
 
-bool BeamSearchOp::InferShape() const { return true; }
+bool BeamSearchOp::InferShapeImpl() const { return true; }
 
 bool BeamSearchOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   param_.pre_ids = scope->FindTensor(opdesc.Input("pre_ids").front());

--- a/lite/operators/beam_search_op.h
+++ b/lite/operators/beam_search_op.h
@@ -30,7 +30,7 @@ class BeamSearchOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/box_clip_op.cc
+++ b/lite/operators/box_clip_op.cc
@@ -35,7 +35,7 @@ bool BoxClipOpLite::CheckShape() const {
   return true;
 }
 
-bool BoxClipOpLite::InferShape() const {
+bool BoxClipOpLite::InferShapeImpl() const {
   auto* input = param_.Input;
   auto* output = param_.Output;
   output->Resize(input->dims());

--- a/lite/operators/box_clip_op.h
+++ b/lite/operators/box_clip_op.h
@@ -31,7 +31,7 @@ class BoxClipOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/box_coder_op.cc
+++ b/lite/operators/box_coder_op.cc
@@ -35,7 +35,7 @@ bool BoxCoderOpLite::CheckShape() const {
   return true;
 }
 
-bool BoxCoderOpLite::InferShape() const {
+bool BoxCoderOpLite::InferShapeImpl() const {
   auto prior_box_dims = param_.prior_box->dims();
   auto target_box_dims = param_.target_box->dims();
   std::string code_type = param_.code_type;

--- a/lite/operators/box_coder_op.h
+++ b/lite/operators/box_coder_op.h
@@ -29,7 +29,7 @@ class BoxCoderOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/calib_op.cc
+++ b/lite/operators/calib_op.cc
@@ -24,7 +24,7 @@ bool CalibOpLite::CheckShape() const {
   CHECK_OR_FALSE(param_.output);
   return true;
 }
-bool CalibOpLite::InferShape() const {
+bool CalibOpLite::InferShapeImpl() const {
   param_.output->Resize(param_.input->dims());
   return true;
 }

--- a/lite/operators/calib_op.h
+++ b/lite/operators/calib_op.h
@@ -42,7 +42,7 @@ class CalibOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope);
 

--- a/lite/operators/cast_op.cc
+++ b/lite/operators/cast_op.cc
@@ -25,7 +25,7 @@ bool CastOp::CheckShape() const {
   return true;
 }
 
-bool CastOp::InferShape() const {
+bool CastOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   auto out_dims = param_.X->dims();

--- a/lite/operators/cast_op.h
+++ b/lite/operators/cast_op.h
@@ -30,7 +30,7 @@ class CastOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/collect_fpn_proposals_op.cc
+++ b/lite/operators/collect_fpn_proposals_op.cc
@@ -43,7 +43,7 @@ bool CollectFpnProposalsOpLite::CheckShape() const {
   return true;
 }
 
-bool CollectFpnProposalsOpLite::InferShape() const {
+bool CollectFpnProposalsOpLite::InferShapeImpl() const {
   param_.fpn_rois->Resize({param_.post_nms_topN, 4});
 
   return true;

--- a/lite/operators/collect_fpn_proposals_op.h
+++ b/lite/operators/collect_fpn_proposals_op.h
@@ -32,7 +32,7 @@ class CollectFpnProposalsOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/compare_op.cc
+++ b/lite/operators/compare_op.cc
@@ -26,7 +26,7 @@ bool CompareOp::CheckShape() const {
   return true;
 }
 
-bool CompareOp::InferShape() const {
+bool CompareOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   auto input_dims = param_.X->dims();

--- a/lite/operators/compare_op.h
+++ b/lite/operators/compare_op.h
@@ -30,7 +30,7 @@ class CompareOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/concat_op.cc
+++ b/lite/operators/concat_op.cc
@@ -26,7 +26,7 @@ bool ConcatOpLite::CheckShape() const {
   return true;
 }
 
-bool ConcatOpLite::InferShape() const {
+bool ConcatOpLite::InferShapeImpl() const {
   const std::vector<Tensor *> &inputs = param_.x;
   const size_t n = inputs.size();
   CHECK_GT_OR_FALSE(n, 0);

--- a/lite/operators/concat_op.h
+++ b/lite/operators/concat_op.h
@@ -30,7 +30,7 @@ class ConcatOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/conditional_block_op.cc
+++ b/lite/operators/conditional_block_op.cc
@@ -27,7 +27,7 @@ bool ConditionalBlockOpLite::CheckShape() const {
   return true;
 }
 
-bool ConditionalBlockOpLite::InferShape() const { return true; }
+bool ConditionalBlockOpLite::InferShapeImpl() const { return true; }
 
 bool ConditionalBlockOpLite::AttachImpl(const cpp::OpDesc &op_desc,
                                         lite::Scope *scope) {

--- a/lite/operators/conditional_block_op.h
+++ b/lite/operators/conditional_block_op.h
@@ -31,7 +31,7 @@ class ConditionalBlockOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/conv_op.cc
+++ b/lite/operators/conv_op.cc
@@ -80,35 +80,7 @@ void UpdatePaddingAndDilation(std::vector<int>* paddings,
   }
 }
 
-bool ConvOpLite::SmartInferShape() {
-  if (!last_input_shapes.empty()) {
-    if (last_input_shapes[0] == param_.x->dims() &&
-        last_input_lods[0] == param_.x->lod()) {
-      param_.output->Resize(last_output_shapes[0]);
-      param_.output->set_lod(last_output_lods[0]);
-      return true;
-    }
-  }
-
-  this->InferShape();
-
-  if (!last_input_shapes.empty()) {
-    last_input_shapes.clear();
-    last_input_lods.clear();
-  }
-  last_input_shapes.push_back(param_.x->dims());
-  last_input_lods.push_back(param_.x->lod());
-
-  if (!last_output_shapes.empty()) {
-    last_output_shapes.clear();
-    last_output_lods.clear();
-  }
-  last_output_shapes.push_back(param_.output->dims());
-  last_output_lods.push_back(param_.output->lod());
-
-  return true;
-}
-bool ConvOpLite::InferShape() const {
+bool ConvOpLite::InferShapeImpl() const {
   const auto in_dims = param_.x->dims();
   const auto filter_dims = param_.filter->dims();
 

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -34,9 +34,7 @@ class ConvOpLite : public OpLite {
   explicit ConvOpLite(const std::string& type) : OpLite(type) {}
 
   bool CheckShape() const override;
-
-  bool InferShape() const override;
-  bool SmartInferShape() override;
+  bool InferShapeImpl() const override;
 
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {

--- a/lite/operators/conv_transpose_op.cc
+++ b/lite/operators/conv_transpose_op.cc
@@ -52,7 +52,7 @@ inline int ConvTransposeOutputSize(int input_size,
   return output_size;
 }
 
-bool ConvTransposeOpLite::InferShape() const {
+bool ConvTransposeOpLite::InferShapeImpl() const {
   const auto in_dims = param_.x->dims();
   const auto filter_dims = param_.filter->dims();
 

--- a/lite/operators/conv_transpose_op.h
+++ b/lite/operators/conv_transpose_op.h
@@ -34,7 +34,7 @@ class ConvTransposeOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/crf_decoding_op.cc
+++ b/lite/operators/crf_decoding_op.cc
@@ -60,7 +60,7 @@ bool CrfDecodingOpLite::CheckShape() const {
   return true;
 }
 
-bool CrfDecodingOpLite::InferShape() const {
+bool CrfDecodingOpLite::InferShapeImpl() const {
   auto emission_dims = param_.emission->dims();
   if (param_.length == nullptr) {
     param_.viterbi_path->Resize({emission_dims[0], 1});

--- a/lite/operators/crf_decoding_op.h
+++ b/lite/operators/crf_decoding_op.h
@@ -31,7 +31,7 @@ class CrfDecodingOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/crop_op.cc
+++ b/lite/operators/crop_op.cc
@@ -26,7 +26,7 @@ bool CropOpLite::CheckShape() const {
   return true;
 }
 
-bool CropOpLite::InferShape() const {
+bool CropOpLite::InferShapeImpl() const {
   // nchw
   auto x_dims = param_.X->dims();
   lite::DDim output_shape(x_dims);

--- a/lite/operators/crop_op.h
+++ b/lite/operators/crop_op.h
@@ -30,7 +30,7 @@ class CropOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/decode_bboxes_op.cc
+++ b/lite/operators/decode_bboxes_op.cc
@@ -29,7 +29,7 @@ bool DecodeBboxesOpLite::CheckShape() const {
   return true;
 }
 
-bool DecodeBboxesOpLite::InferShape() const {
+bool DecodeBboxesOpLite::InferShapeImpl() const {
   param_.bbox_data->Resize(param_.loc_data->dims());
   return true;
 }

--- a/lite/operators/decode_bboxes_op.h
+++ b/lite/operators/decode_bboxes_op.h
@@ -29,7 +29,7 @@ class DecodeBboxesOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/density_prior_box_op.cc
+++ b/lite/operators/density_prior_box_op.cc
@@ -27,7 +27,7 @@ bool DensityPriorBoxOpLite::CheckShape() const {
   return true;
 }
 
-bool DensityPriorBoxOpLite::InferShape() const { return true; }
+bool DensityPriorBoxOpLite::InferShapeImpl() const { return true; }
 
 bool DensityPriorBoxOpLite::AttachImpl(const cpp::OpDesc& opdesc,
                                        lite::Scope* scope) {

--- a/lite/operators/density_prior_box_op.h
+++ b/lite/operators/density_prior_box_op.h
@@ -30,7 +30,7 @@ class DensityPriorBoxOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/distribute_fpn_proposals_op.cc
+++ b/lite/operators/distribute_fpn_proposals_op.cc
@@ -32,7 +32,7 @@ bool DistributeFpnProposalsOpLite::CheckShape() const {
   return true;
 }
 
-bool DistributeFpnProposalsOpLite::InferShape() const {
+bool DistributeFpnProposalsOpLite::InferShapeImpl() const {
   int num_out_rois = param_.max_level - param_.min_level + 1;
   for (int i = 0; i < num_out_rois; i++) {
     param_.multi_fpn_rois[i]->Resize({-1, 4});

--- a/lite/operators/distribute_fpn_proposals_op.h
+++ b/lite/operators/distribute_fpn_proposals_op.h
@@ -32,7 +32,7 @@ class DistributeFpnProposalsOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/dropout_op.cc
+++ b/lite/operators/dropout_op.cc
@@ -26,7 +26,7 @@ bool DropoutOp::CheckShape() const {
   return true;
 }
 
-bool DropoutOp::InferShape() const {
+bool DropoutOp::InferShapeImpl() const {
   const auto x_dims = param_.x->dims();
   param_.output->Resize(x_dims);
   if (param_.is_test == false) {

--- a/lite/operators/dropout_op.h
+++ b/lite/operators/dropout_op.h
@@ -28,7 +28,7 @@ class DropoutOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase* kernel) override { kernel->SetParam(param_); }
   // TODO(Superjomn) replace framework::OpDesc with a lite one.

--- a/lite/operators/elementwise_grad_ops.cc
+++ b/lite/operators/elementwise_grad_ops.cc
@@ -26,7 +26,7 @@ bool ElementwiseGradOp::CheckShape() const {
   return true;
 }
 
-bool ElementwiseGradOp::InferShape() const {
+bool ElementwiseGradOp::InferShapeImpl() const {
   auto x_dim = param_.X->dims();
   auto y_dim = param_.Y->dims();
   if (param_.XGrad) {

--- a/lite/operators/elementwise_grad_ops.h
+++ b/lite/operators/elementwise_grad_ops.h
@@ -27,7 +27,7 @@ class ElementwiseGradOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) override;
 

--- a/lite/operators/elementwise_ops.cc
+++ b/lite/operators/elementwise_ops.cc
@@ -105,7 +105,7 @@ bool ElementwiseOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
 //  return true;
 //}
 
-// bool ElementwiseGradExplicitOp::InferShape() const {
+// bool ElementwiseGradExplicitOp::InferShapeImpl() const {
 //   param_.X_grad->Resize(param_.Out_grad->dims());
 //   if (param_.Y_grad) param_.Y_grad->Resize(param_.Y->dims());
 //   return true;

--- a/lite/operators/elementwise_ops.cc
+++ b/lite/operators/elementwise_ops.cc
@@ -26,39 +26,8 @@ bool ElementwiseOp::CheckShape() const {
   CHECK_OR_FALSE(param_.Out);
   return true;
 }
-bool ElementwiseOp::SmartInferShape() {
-  if (!last_input_shapes.empty()) {
-    if (last_input_shapes[0] == param_.X->dims() &&
-        last_input_shapes[1] == param_.Y->dims() &&
-        last_input_lods[0] == param_.X->lod() &&
-        last_input_lods[1] == param_.Y->lod()) {
-      param_.Out->Resize(last_output_shapes[0]);
-      param_.Out->set_lod(last_output_lods[0]);
-      return true;
-    }
-  }
 
-  this->InferShape();
-
-  if (!last_input_shapes.empty()) {
-    last_input_shapes.clear();
-    last_input_lods.clear();
-  }
-
-  last_input_shapes.push_back(param_.X->dims());
-  last_input_lods.push_back(param_.X->lod());
-  last_input_shapes.push_back(param_.Y->dims());
-  last_input_lods.push_back(param_.Y->lod());
-
-  if (!last_output_shapes.empty()) {
-    last_output_shapes.clear();
-    last_output_lods.clear();
-  }
-  last_output_shapes.push_back(param_.Out->dims());
-  last_output_lods.push_back(param_.Out->lod());
-  return true;
-}
-bool ElementwiseOp::InferShape() const {
+bool ElementwiseOp::InferShapeImpl() const {
   auto x_dim = param_.X->dims();
   auto y_dim = param_.Y->dims();
   if (x_dim == y_dim) {

--- a/lite/operators/elementwise_ops.h
+++ b/lite/operators/elementwise_ops.h
@@ -27,8 +27,7 @@ class ElementwiseOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
-  bool SmartInferShape() override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) override;
 

--- a/lite/operators/elementwise_ops.h
+++ b/lite/operators/elementwise_ops.h
@@ -47,7 +47,7 @@ class ElementwiseOp : public OpLite {
 
 //   bool CheckShape() const override;
 
-//   bool InferShape() const override;
+//   bool InferShapeImpl() const override;
 
 //   bool AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) override;
 

--- a/lite/operators/expand_op.cc
+++ b/lite/operators/expand_op.cc
@@ -32,7 +32,7 @@ bool ExpandOpLite::CheckShape() const {
   return true;
 }
 
-bool ExpandOpLite::InferShape() const {
+bool ExpandOpLite::InferShapeImpl() const {
   DDim out_dims(param_.X->dims());
   for (size_t i = 0; i < param_.expand_times.size(); ++i) {
     out_dims[i] *= param_.expand_times[i];

--- a/lite/operators/expand_op.h
+++ b/lite/operators/expand_op.h
@@ -28,7 +28,7 @@ class ExpandOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/fake_channel_wise_dequantize_max_abs.h
+++ b/lite/operators/fake_channel_wise_dequantize_max_abs.h
@@ -36,7 +36,7 @@ class FakeChannelWiseDequantizeMaxAbsOpLite : public OpLite {
 
   bool CheckShape() const override { return true; }
 
-  bool InferShape() const override { return true; }
+  bool InferShapeImpl() const override { return true; }
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
     auto x = op_desc.Input("X").front();

--- a/lite/operators/fake_dequantize_max_abs.h
+++ b/lite/operators/fake_dequantize_max_abs.h
@@ -35,7 +35,7 @@ class FakeDequantizeMaxAbsOpLite : public OpLite {
 
   bool CheckShape() const override { return true; }
 
-  bool InferShape() const override { return true; }
+  bool InferShapeImpl() const override { return true; }
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
     auto x = op_desc.Input("X").front();

--- a/lite/operators/fake_quantize_dequantize_moving_avg_max_abs.h
+++ b/lite/operators/fake_quantize_dequantize_moving_avg_max_abs.h
@@ -36,7 +36,7 @@ class FakeQuantizeDequantizeMovingAvgMaxAbsOpLite : public OpLite {
 
   bool CheckShape() const override { return true; }
 
-  bool InferShape() const override { return true; }
+  bool InferShapeImpl() const override { return true; }
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
     auto x = op_desc.Input("X").front();

--- a/lite/operators/fake_quantize_moving_avg_max_abs.h
+++ b/lite/operators/fake_quantize_moving_avg_max_abs.h
@@ -36,7 +36,7 @@ class FakeQuantizeMovingAvgMaxAbsOpLite : public OpLite {
 
   bool CheckShape() const override { return true; }
 
-  bool InferShape() const override { return true; }
+  bool InferShapeImpl() const override { return true; }
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
     auto x = op_desc.Input("X").front();

--- a/lite/operators/fake_quantize_range_abs_max.h
+++ b/lite/operators/fake_quantize_range_abs_max.h
@@ -36,7 +36,7 @@ class FakeQuantizeRangeMaxAbsOpLite : public OpLite {
 
   bool CheckShape() const override { return true; }
 
-  bool InferShape() const override { return true; }
+  bool InferShapeImpl() const override { return true; }
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
     auto x = op_desc.Input("X").front();

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -48,34 +48,7 @@ bool FcOpLite::CheckShape() const {
   return true;
 }
 
-bool FcOpLite::SmartInferShape() {
-  if (!last_input_shapes.empty() && !last_output_shapes.empty()) {
-    if (last_input_shapes[0] == param_.input->dims() &&
-        last_input_lods[0] == param_.input->lod()) {
-      param_.output->Resize(last_output_shapes[0]);
-      param_.output->set_lod(last_output_lods[0]);
-      return true;
-    }
-  }
-
-  this->InferShape();
-
-  if (!last_input_shapes.empty()) {
-    last_input_shapes.clear();
-    last_input_lods.clear();
-  }
-  last_input_shapes.push_back(param_.input->dims());
-  last_input_lods.push_back(param_.input->lod());
-  if (!last_output_shapes.empty()) {
-    last_output_shapes.clear();
-    last_output_lods.clear();
-  }
-  last_output_shapes.push_back(param_.output->dims());
-  last_output_lods.push_back(param_.output->lod());
-
-  return true;
-}
-bool FcOpLite::InferShape() const {
+bool FcOpLite::InferShapeImpl() const {
   const auto& input_dims = param_.input->dims();
   const auto& w_dims = param_.w->dims();
   int in_num_col_dims = param_.in_num_col_dims;

--- a/lite/operators/fc_op.h
+++ b/lite/operators/fc_op.h
@@ -35,8 +35,7 @@ class FcOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
-  bool SmartInferShape() override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override;
 

--- a/lite/operators/feed_op.cc
+++ b/lite/operators/feed_op.cc
@@ -29,7 +29,7 @@ class FeedOp : public OpLite {
     return true;
   }
 
-  bool InferShape() const override { return true; }
+  bool InferShapeImpl() const override { return true; }
 
   void AttachKernel(KernelBase* kernel) override { kernel->SetParam(param_); }
 

--- a/lite/operators/fetch_op.cc
+++ b/lite/operators/fetch_op.cc
@@ -29,7 +29,7 @@ class FetchOp : public OpLite {
     return true;
   }
 
-  bool InferShape() const override { return true; }
+  bool InferShapeImpl() const override { return true; }
   void AttachKernel(KernelBase* kernel) override { kernel->SetParam(param_); }
 
  protected:

--- a/lite/operators/fill_constant_batch_size_like_op.cc
+++ b/lite/operators/fill_constant_batch_size_like_op.cc
@@ -28,7 +28,7 @@ bool FillConstantBatchSizeLikeOp::CheckShape() const {
   return true;
 }
 
-bool FillConstantBatchSizeLikeOp::InferShape() const {
+bool FillConstantBatchSizeLikeOp::InferShapeImpl() const {
   std::vector<int64_t> output_dim{param_.shape.begin(), param_.shape.end()};
   if (param_.input_dim_idx == 0 && !param_.input->lod().empty()) {
     output_dim[param_.output_dim_idx] = param_.input->lod().back().size() - 1;

--- a/lite/operators/fill_constant_batch_size_like_op.h
+++ b/lite/operators/fill_constant_batch_size_like_op.h
@@ -32,7 +32,7 @@ class FillConstantBatchSizeLikeOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/fill_constant_op.cc
+++ b/lite/operators/fill_constant_op.cc
@@ -24,7 +24,7 @@ bool FillConstantOp::CheckShape() const {
   return true;
 }
 
-bool FillConstantOp::InferShape() const {
+bool FillConstantOp::InferShapeImpl() const {
   std::vector<int64_t> out_shape;
   auto shape_tensor = param_.shape_tensor;
   auto shape_tensor_list = param_.shape_tensor_list;

--- a/lite/operators/fill_constant_op.h
+++ b/lite/operators/fill_constant_op.h
@@ -31,7 +31,7 @@ class FillConstantOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/flatten_op.cc
+++ b/lite/operators/flatten_op.cc
@@ -72,7 +72,7 @@ bool Flatten2Op::CheckShape() const {
 }
 
 bool Flatten2Op::InferShapeImpl() const {
-  FlattenOp::InferShape();
+  FlattenOp::InferShapeImpl();
   auto x_dims = param_.x->dims();
   std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1, 0);
   for (size_t i = 0; i < x_dims.size(); i++) {

--- a/lite/operators/flatten_op.cc
+++ b/lite/operators/flatten_op.cc
@@ -25,7 +25,7 @@ bool FlattenOp::CheckShape() const {
   return true;
 }
 
-bool FlattenOp::InferShape() const {
+bool FlattenOp::InferShapeImpl() const {
   auto x_dims = param_.x->dims();
 
   auto out_lod = param_.output->mutable_lod();
@@ -71,7 +71,7 @@ bool Flatten2Op::CheckShape() const {
   return true;
 }
 
-bool Flatten2Op::InferShape() const {
+bool Flatten2Op::InferShapeImpl() const {
   FlattenOp::InferShape();
   auto x_dims = param_.x->dims();
   std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1, 0);

--- a/lite/operators/flatten_op.h
+++ b/lite/operators/flatten_op.h
@@ -30,7 +30,7 @@ class FlattenOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
@@ -49,7 +49,7 @@ class Flatten2Op : public FlattenOp {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/fusion_elementwise_activation_ops.cc
+++ b/lite/operators/fusion_elementwise_activation_ops.cc
@@ -27,7 +27,7 @@ bool FusionElementwiseActivationOp::CheckShape() const {
   return true;
 }
 
-bool FusionElementwiseActivationOp::InferShape() const {
+bool FusionElementwiseActivationOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.X->dims().size() >= param_.Y->dims().size());
   param_.Out->Resize(param_.X->dims());
   return true;
@@ -59,7 +59,7 @@ bool FusionElementwiseActivationOp::AttachImpl(const cpp::OpDesc& opdesc,
 //   return true;
 // }
 
-// bool FusionElementwiseActivationGradExplicitOp::InferShape() const {
+// bool FusionElementwiseActivationGradExplicitOp::InferShapeImpl() const {
 //   param_.X_grad->Resize(param_.Out_grad->dims());
 //   param_.Y_grad->Resize(param_.Y->dims());
 //   return true;

--- a/lite/operators/fusion_elementwise_activation_ops.h
+++ b/lite/operators/fusion_elementwise_activation_ops.h
@@ -29,7 +29,7 @@ class FusionElementwiseActivationOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) override;
 
@@ -51,7 +51,7 @@ class FusionElementwiseActivationOp : public OpLite {
 
 //   bool CheckShape() const override;
 
-//   bool InferShape() const override;
+//   bool InferShapeImpl() const override;
 
 //   bool AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) override;
 

--- a/lite/operators/gather_op.cc
+++ b/lite/operators/gather_op.cc
@@ -26,7 +26,7 @@ bool GatherOp::CheckShape() const {
   return true;
 }
 
-bool GatherOp::InferShape() const {
+bool GatherOp::InferShapeImpl() const {
   auto index_dims = param_.Index->dims();
   CHECK(index_dims.size() == 1 ||
         (index_dims.size() == 2 && index_dims[1] == 1))

--- a/lite/operators/gather_op.h
+++ b/lite/operators/gather_op.h
@@ -30,7 +30,7 @@ class GatherOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/generate_proposals_op.cc
+++ b/lite/operators/generate_proposals_op.cc
@@ -43,7 +43,7 @@ bool GenerateProposalsOpLite::CheckShape() const {
   return true;
 }
 
-bool GenerateProposalsOpLite::InferShape() const {
+bool GenerateProposalsOpLite::InferShapeImpl() const {
   param_.RpnRois->Resize(std::vector<int64_t>({-1, 4}));
   param_.RpnRoiProbs->Resize(std::vector<int64_t>({-1, 1}));
   return true;

--- a/lite/operators/generate_proposals_op.h
+++ b/lite/operators/generate_proposals_op.h
@@ -32,7 +32,7 @@ class GenerateProposalsOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/grid_sampler_op.cc
+++ b/lite/operators/grid_sampler_op.cc
@@ -42,7 +42,7 @@ bool GridSamplerOp::CheckShape() const {
   return true;
 }
 
-bool GridSamplerOp::InferShape() const {
+bool GridSamplerOp::InferShapeImpl() const {
   auto x_dims = param_.x->dims();
   param_.out->Resize(x_dims);
   return true;

--- a/lite/operators/grid_sampler_op.h
+++ b/lite/operators/grid_sampler_op.h
@@ -31,7 +31,7 @@ class GridSamplerOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/gru_op.cc
+++ b/lite/operators/gru_op.cc
@@ -51,7 +51,7 @@ bool GRUOpLite::CheckShape() const {
   return true;
 }
 
-bool GRUOpLite::InferShape() const {
+bool GRUOpLite::InferShapeImpl() const {
   const auto& input_dims = param_.input->dims();
   const auto& weight_dims = param_.weight->dims();
   int frame_size = weight_dims[0];

--- a/lite/operators/gru_op.h
+++ b/lite/operators/gru_op.h
@@ -30,7 +30,7 @@ class GRUOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/gru_unit_op.cc
+++ b/lite/operators/gru_unit_op.cc
@@ -51,7 +51,7 @@ bool GRUUnitOpLite::CheckShape() const {
   return true;
 }
 
-bool GRUUnitOpLite::InferShape() const {
+bool GRUUnitOpLite::InferShapeImpl() const {
   auto input_dims = param_.input->dims();
   auto hidden_prev_dims = param_.hidden_prev->dims();
   auto weight_dims = param_.weight->dims();

--- a/lite/operators/gru_unit_op.h
+++ b/lite/operators/gru_unit_op.h
@@ -30,7 +30,7 @@ class GRUUnitOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/im2sequence_op.cc
+++ b/lite/operators/im2sequence_op.cc
@@ -26,7 +26,7 @@ inline int Im2SeqOutputSize(
 }
 
 bool Im2SequenceOp::CheckShape() const { return true; }
-bool Im2SequenceOp::InferShape() const {
+bool Im2SequenceOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   auto input_dims = param_.X->dims();

--- a/lite/operators/im2sequence_op.h
+++ b/lite/operators/im2sequence_op.h
@@ -30,7 +30,7 @@ class Im2SequenceOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/increment_op.cc
+++ b/lite/operators/increment_op.cc
@@ -25,7 +25,7 @@ bool IncrementOp::CheckShape() const {
   return true;
 }
 
-bool IncrementOp::InferShape() const {
+bool IncrementOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   auto out_dims = param_.X->dims();

--- a/lite/operators/increment_op.h
+++ b/lite/operators/increment_op.h
@@ -30,7 +30,7 @@ class IncrementOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/instance_norm_op.cc
+++ b/lite/operators/instance_norm_op.cc
@@ -42,7 +42,7 @@ bool InstanceNormOp::CheckShape() const {
   return true;
 }
 
-bool InstanceNormOp::InferShape() const {
+bool InstanceNormOp::InferShapeImpl() const {
   auto x_dims = param_.x->dims();
   int64_t batch_size = x_dims[0];
   int64_t channel_size = x_dims[1];

--- a/lite/operators/instance_norm_op.h
+++ b/lite/operators/instance_norm_op.h
@@ -31,7 +31,7 @@ class InstanceNormOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/interpolate_op.cc
+++ b/lite/operators/interpolate_op.cc
@@ -34,7 +34,7 @@ bool InterpolateOp::CheckShape() const {
   return true;
 }
 
-bool InterpolateOp::InferShape() const {
+bool InterpolateOp::InferShapeImpl() const {
   auto X = param_.X;
 
   int n = X->dims()[0];

--- a/lite/operators/interpolate_op.h
+++ b/lite/operators/interpolate_op.h
@@ -31,7 +31,7 @@ class InterpolateOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/io_copy_op.cc
+++ b/lite/operators/io_copy_op.cc
@@ -24,7 +24,7 @@ bool IoCopyOp::CheckShape() const {
   CHECK_OR_FALSE(param_.y);
   return true;
 }
-bool IoCopyOp::InferShape() const {
+bool IoCopyOp::InferShapeImpl() const {
   param_.y->Resize(param_.x->dims());
   return true;
 }

--- a/lite/operators/io_copy_op.h
+++ b/lite/operators/io_copy_op.h
@@ -24,7 +24,7 @@ class IoCopyOp : public OpLite {
  public:
   explicit IoCopyOp(const std::string &type) : OpLite(type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool Run() override;
   std::string DebugString() const override;
 

--- a/lite/operators/is_empty_op.cc
+++ b/lite/operators/is_empty_op.cc
@@ -21,7 +21,7 @@ namespace operators {
 
 bool IsEmptyOp::CheckShape() const { return true; }
 
-bool IsEmptyOp::InferShape() const { return true; }
+bool IsEmptyOp::InferShapeImpl() const { return true; }
 
 bool IsEmptyOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   param_.X =

--- a/lite/operators/is_empty_op.h
+++ b/lite/operators/is_empty_op.h
@@ -30,7 +30,7 @@ class IsEmptyOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/layer_norm_op.cc
+++ b/lite/operators/layer_norm_op.cc
@@ -27,7 +27,7 @@ bool LayerNormOp::CheckShape() const {
   return true;
 }
 
-bool LayerNormOp::InferShape() const {
+bool LayerNormOp::InferShapeImpl() const {
   auto out_dims = param_.X->dims();
   param_.Y->Resize(out_dims);
   auto inner_size = out_dims.Flatten2D(param_.begin_norm_axis)[0];

--- a/lite/operators/layer_norm_op.h
+++ b/lite/operators/layer_norm_op.h
@@ -30,7 +30,7 @@ class LayerNormOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/layout_op.cc
+++ b/lite/operators/layout_op.cc
@@ -24,7 +24,7 @@ bool LayoutOp::CheckShape() const {
   CHECK_OR_FALSE(param_.y);
   return true;
 }
-bool LayoutOp::InferShape() const {
+bool LayoutOp::InferShapeImpl() const {
   param_.y->Resize(param_.x->dims());
   return true;
 }

--- a/lite/operators/layout_op.h
+++ b/lite/operators/layout_op.h
@@ -24,7 +24,7 @@ class LayoutOp : public OpLite {
  public:
   explicit LayoutOp(const std::string &type) : OpLite(type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool Run() override;
   std::string DebugString() const override;
 

--- a/lite/operators/lod_reset_op.cc
+++ b/lite/operators/lod_reset_op.cc
@@ -25,7 +25,7 @@ bool LodResetOp::CheckShape() const {
   return true;
 }
 
-bool LodResetOp::InferShape() const {
+bool LodResetOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   param_.Out->Resize(param_.X->dims());

--- a/lite/operators/lod_reset_op.h
+++ b/lite/operators/lod_reset_op.h
@@ -30,7 +30,7 @@ class LodResetOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/logical_op.cc
+++ b/lite/operators/logical_op.cc
@@ -26,7 +26,7 @@ bool BinaryLogicalOp::CheckShape() const {
   return true;
 }
 
-bool BinaryLogicalOp::InferShape() const {
+bool BinaryLogicalOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   auto input_dims = param_.X->dims();
@@ -53,7 +53,7 @@ bool UnaryLogicalOp::CheckShape() const {
   return true;
 }
 
-bool UnaryLogicalOp::InferShape() const {
+bool UnaryLogicalOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   auto input_dims = param_.X->dims();

--- a/lite/operators/logical_op.h
+++ b/lite/operators/logical_op.h
@@ -30,7 +30,7 @@ class BinaryLogicalOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
@@ -49,7 +49,7 @@ class UnaryLogicalOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/lookup_table_dequant_op.cc
+++ b/lite/operators/lookup_table_dequant_op.cc
@@ -36,7 +36,7 @@ bool LookupTableDequantOpLite::CheckShape() const {
   return true;
 }
 
-bool LookupTableDequantOpLite::InferShape() const {
+bool LookupTableDequantOpLite::InferShapeImpl() const {
   const auto& table_dims = param_.W->dims();
   const auto& ids_dims = param_.Ids->dims();
 

--- a/lite/operators/lookup_table_dequant_op.h
+++ b/lite/operators/lookup_table_dequant_op.h
@@ -31,7 +31,7 @@ class LookupTableDequantOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/lookup_table_op.cc
+++ b/lite/operators/lookup_table_op.cc
@@ -36,7 +36,7 @@ bool LookupTableOpLite::CheckShape() const {
   return true;
 }
 
-bool LookupTableOpLite::InferShape() const {
+bool LookupTableOpLite::InferShapeImpl() const {
   const auto& table_dims = param_.W->dims();
   const auto& ids_dims = param_.Ids->dims();
 

--- a/lite/operators/lookup_table_op.h
+++ b/lite/operators/lookup_table_op.h
@@ -30,7 +30,7 @@ class LookupTableOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/lookup_table_v2_op.cc
+++ b/lite/operators/lookup_table_v2_op.cc
@@ -32,7 +32,7 @@ bool LookupTableV2OpLite::CheckShape() const {
   return true;
 }
 
-bool LookupTableV2OpLite::InferShape() const {
+bool LookupTableV2OpLite::InferShapeImpl() const {
   auto table_dims = param_.W->dims();
   auto ids_dims = param_.Ids->dims();
 

--- a/lite/operators/lookup_table_v2_op.h
+++ b/lite/operators/lookup_table_v2_op.h
@@ -30,7 +30,7 @@ class LookupTableV2OpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/lrn_op.cc
+++ b/lite/operators/lrn_op.cc
@@ -27,7 +27,7 @@ bool LrnOpLite::CheckShape() const {
   return true;
 }
 
-bool LrnOpLite::InferShape() const {
+bool LrnOpLite::InferShapeImpl() const {
   param_.Out->Resize(param_.X->dims());
   return true;
 }

--- a/lite/operators/lrn_op.h
+++ b/lite/operators/lrn_op.h
@@ -28,7 +28,7 @@ class LrnOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/lstm_op.cc
+++ b/lite/operators/lstm_op.cc
@@ -26,7 +26,7 @@ bool LstmOp::CheckShape() const {
   return true;
 }
 
-bool LstmOp::InferShape() const {
+bool LstmOp::InferShapeImpl() const {
   auto in_dims = param_.Input->dims();
   if (param_.H0) {
     CHECK(param_.C0) << "lstm must has H0 and C0 in the same time";

--- a/lite/operators/lstm_op.h
+++ b/lite/operators/lstm_op.h
@@ -30,7 +30,7 @@ class LstmOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/match_matrix_tensor_op.cc
+++ b/lite/operators/match_matrix_tensor_op.cc
@@ -42,7 +42,7 @@ bool MatchMatrixTensorOpLite::CheckShape() const {
   return true;
 }
 
-bool MatchMatrixTensorOpLite::InferShape() const {
+bool MatchMatrixTensorOpLite::InferShapeImpl() const {
   const Tensor* x = param_.x;
   const Tensor* y = param_.y;
   DDim x_dims = param_.x->dims();

--- a/lite/operators/match_matrix_tensor_op.h
+++ b/lite/operators/match_matrix_tensor_op.h
@@ -32,7 +32,7 @@ class MatchMatrixTensorOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/matmul_op.cc
+++ b/lite/operators/matmul_op.cc
@@ -27,7 +27,7 @@ bool MatMulOpLite::CheckShape() const {
   return true;
 }
 
-bool MatMulOpLite::InferShape() const {
+bool MatMulOpLite::InferShapeImpl() const {
   const auto x_dims = param_.X->dims();
   const auto y_dims = param_.Y->dims();
   bool x_transpose = param_.transpose_X;

--- a/lite/operators/matmul_op.h
+++ b/lite/operators/matmul_op.h
@@ -33,7 +33,7 @@ class MatMulOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 

--- a/lite/operators/mean_grad_op.cc
+++ b/lite/operators/mean_grad_op.cc
@@ -28,7 +28,7 @@ bool MeanGradOp::CheckShape() const {
   return true;
 }
 
-bool MeanGradOp::InferShape() const {
+bool MeanGradOp::InferShapeImpl() const {
   param_.X_grad->Resize(param_.X->dims());
   return true;
 }

--- a/lite/operators/mean_grad_op.h
+++ b/lite/operators/mean_grad_op.h
@@ -27,7 +27,7 @@ class MeanGradOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override;
 

--- a/lite/operators/mean_op.cc
+++ b/lite/operators/mean_op.cc
@@ -27,7 +27,7 @@ bool MeanOp::CheckShape() const {
   return true;
 }
 
-bool MeanOp::InferShape() const {
+bool MeanOp::InferShapeImpl() const {
   param_.Out->Resize(std::vector<int64_t>{1});
   return true;
 }

--- a/lite/operators/mean_op.h
+++ b/lite/operators/mean_op.h
@@ -27,7 +27,7 @@ class MeanOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 

--- a/lite/operators/merge_lod_tensor_op.cc
+++ b/lite/operators/merge_lod_tensor_op.cc
@@ -34,7 +34,7 @@ bool MergeLodTensorOpLite::CheckShape() const {
   return true;
 }
 
-bool MergeLodTensorOpLite::InferShape() const {
+bool MergeLodTensorOpLite::InferShapeImpl() const {
   auto dims = param_.in_true->dims();
   param_.out->Resize(dims);
   return true;

--- a/lite/operators/merge_lod_tensor_op.h
+++ b/lite/operators/merge_lod_tensor_op.h
@@ -31,7 +31,7 @@ class MergeLodTensorOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/mul_grad_op.cc
+++ b/lite/operators/mul_grad_op.cc
@@ -46,7 +46,7 @@ bool MulGradOpLite::CheckShape() const {
   return true;
 }
 
-bool MulGradOpLite::InferShape() const {
+bool MulGradOpLite::InferShapeImpl() const {
   const auto x_dims = param_.x->dims();
   const auto y_dims = param_.y->dims();
   if (param_.x_grad) {

--- a/lite/operators/mul_grad_op.h
+++ b/lite/operators/mul_grad_op.h
@@ -33,7 +33,7 @@ class MulGradOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 

--- a/lite/operators/mul_op.cc
+++ b/lite/operators/mul_op.cc
@@ -35,7 +35,7 @@ bool MulOpLite::CheckShape() const {
   return true;
 }
 
-bool MulOpLite::InferShape() const {
+bool MulOpLite::InferShapeImpl() const {
   const auto x_dims = param_.x->dims();
   const auto y_dims = param_.y->dims();
 

--- a/lite/operators/mul_op.h
+++ b/lite/operators/mul_op.h
@@ -33,7 +33,7 @@ class MulOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   // TODO(Superjomn) replace framework::OpDesc with a lite one.

--- a/lite/operators/multiclass_nms_op.cc
+++ b/lite/operators/multiclass_nms_op.cc
@@ -41,7 +41,7 @@ bool MulticlassNmsOpLite::CheckShape() const {
   return true;
 }
 
-bool MulticlassNmsOpLite::InferShape() const {
+bool MulticlassNmsOpLite::InferShapeImpl() const {
   auto box_dims = param_.bboxes->dims();
   auto score_dims = param_.scores->dims();
   auto score_size = score_dims.size();

--- a/lite/operators/multiclass_nms_op.h
+++ b/lite/operators/multiclass_nms_op.h
@@ -29,7 +29,7 @@ class MulticlassNmsOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/negative_op.cc
+++ b/lite/operators/negative_op.cc
@@ -26,7 +26,7 @@ bool NegativeOpLite::CheckShape() const {
   return true;
 }
 
-bool NegativeOpLite::InferShape() const {
+bool NegativeOpLite::InferShapeImpl() const {
   lite::DDim input_dims;
   input_dims = param_.X->dims();
   param_.Out->Resize(lite::DDim(input_dims));

--- a/lite/operators/negative_op.h
+++ b/lite/operators/negative_op.h
@@ -30,7 +30,7 @@ class NegativeOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/norm_op.cc
+++ b/lite/operators/norm_op.cc
@@ -25,7 +25,7 @@ bool NormOp::CheckShape() const {
   return true;
 }
 
-bool NormOp::InferShape() const {
+bool NormOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   auto out_dims = param_.X->dims();

--- a/lite/operators/norm_op.h
+++ b/lite/operators/norm_op.h
@@ -30,7 +30,7 @@ class NormOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -34,8 +34,8 @@ namespace operators {
 
 struct ParamBase {
  public:
-  const std::vector<Tensor*>* input_tensor_ptrs() const { return {}; }
-  std::vector<Tensor*>* output_tensor_ptrs() { return {}; }
+  const std::vector<Tensor*>* input_tensor_ptrs() const { return nullptr; }
+  std::vector<Tensor*>* output_tensor_ptrs() { return nullptr; }
 
  protected:
   std::shared_ptr<std::vector<const Tensor*>> input_tensor_ptrs_cache_{nullptr};

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -24,6 +24,7 @@
 #include "lite/model_parser/cpp/block_desc.h"
 #include "lite/model_parser/desc_apis.h"
 #include "lite/utils/all.h"
+#include "lite/utils/variant.h"
 /*
  * This file contains all the argument parameter data structure for operators.
  */
@@ -108,14 +109,14 @@ struct FcParam : ParamBase {
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
   const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (!input_tensor_ptrs_cache_) {
+    if (UNLIKELY(input_tensor_ptrs_cache_)) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({input}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
   const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (!output_tensor_ptrs_cache_) {
+    if (UNLIKELY(output_tensor_ptrs_cache_)) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -235,14 +236,14 @@ struct SoftmaxParam : ParamBase {
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
   const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (!input_tensor_ptrs_cache_) {
+    if (UNLIKELY(input_tensor_ptrs_cache_)) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
   const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (!output_tensor_ptrs_cache_) {
+    if (UNLIKELY(output_tensor_ptrs_cache_)) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -338,14 +339,14 @@ struct ConvParam : ParamBase {
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
   const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (!input_tensor_ptrs_cache_) {
+    if (UNLIKELY(input_tensor_ptrs_cache_)) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
   const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (!output_tensor_ptrs_cache_) {
+    if (UNLIKELY(output_tensor_ptrs_cache_)) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -443,14 +444,14 @@ struct ElementwiseParam : ParamBase {
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
   const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (!input_tensor_ptrs_cache_) {
+    if (UNLIKELY(input_tensor_ptrs_cache_)) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X, Y}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
   const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (!output_tensor_ptrs_cache_) {
+    if (UNLIKELY(output_tensor_ptrs_cache_)) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
     }
     return output_tensor_ptrs_cache_.get();

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -39,11 +39,7 @@ struct ParamBase {
 
  protected:
   std::shared_ptr<std::vector<const Tensor*>> input_tensor_ptrs_cache_{nullptr};
-  std::vector<std::vector<std::vector<uint64_t>>> input_lods_;
-  std::vector<DDimLite> input_dims_;
   std::shared_ptr<std::vector<Tensor*>> output_tensor_ptrs_cache_{nullptr};
-  std::vector<std::vector<std::vector<uint64_t>>> output_lods_;
-  std::vector<DDimLite> output_dims_;
 };
 
 using param_t = Any;

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -34,48 +34,8 @@ namespace operators {
 
 struct ParamBase {
  public:
-  const std::vector<Tensor*>* input_tensor_ptrs() const;
-  std::vector<Tensor*>* output_tensor_ptrs();
-
-  std::vector<std::vector<std::vector<uint64_t>>> inputs_lods() {
-    input_lods_.clear();
-    if (input_tensor_ptrs_cache_) {
-      for (int i = 0; i < input_tensor_ptrs_cache_->size(); i++) {
-        input_lods_.push_back((input_tensor_ptrs_cache_->at(i))->lod());
-      }
-    }
-    return input_lods_;
-  }
-
-  std::vector<DDimLite> inputs_dims() {
-    input_lods_.clear();
-    if (input_tensor_ptrs_cache_) {
-      for (int i = 0; i < input_tensor_ptrs_cache_->size(); i++) {
-        input_dims_.push_back((input_tensor_ptrs_cache_->at(i))->dims());
-      }
-    }
-    return input_dims_;
-  }
-
-  std::vector<std::vector<std::vector<uint64_t>>> outputs_lods() {
-    output_lods_.clear();
-    if (output_tensor_ptrs_cache_) {
-      for (int i = 0; i < output_tensor_ptrs_cache_->size(); i++) {
-        output_lods_.push_back((output_tensor_ptrs_cache_->at(i))->lod());
-      }
-    }
-    return output_lods_;
-  }
-
-  std::vector<DDimLite> outputs_dims() {
-    output_lods_.clear();
-    if (output_tensor_ptrs_cache_) {
-      for (int i = 0; i < output_tensor_ptrs_cache_->size(); i++) {
-        output_dims_.push_back((output_tensor_ptrs_cache_->at(i))->dims());
-      }
-    }
-    return output_dims_;
-  }
+  const std::vector<Tensor*>* input_tensor_ptrs() const { return {}; }
+  std::vector<Tensor*>* output_tensor_ptrs() { return {}; }
 
  protected:
   std::shared_ptr<std::vector<const Tensor*>> input_tensor_ptrs_cache_{nullptr};

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -32,6 +32,60 @@ namespace paddle {
 namespace lite {
 namespace operators {
 
+struct ParamBase {
+ public:
+  const std::vector<Tensor*>* input_tensor_ptrs() const;
+  std::vector<Tensor*>* output_tensor_ptrs();
+
+  std::vector<std::vector<std::vector<uint64_t>>> inputs_lods() {
+    input_lods_.clear();
+    if (input_tensor_ptrs_cache_) {
+      for (int i = 0; i < input_tensor_ptrs_cache_->size(); i++) {
+        input_lods_.push_back((input_tensor_ptrs_cache_->at(i))->lod());
+      }
+    }
+    return input_lods_;
+  }
+
+  std::vector<DDimLite> inputs_dims() {
+    input_lods_.clear();
+    if (input_tensor_ptrs_cache_) {
+      for (int i = 0; i < input_tensor_ptrs_cache_->size(); i++) {
+        input_dims_.push_back((input_tensor_ptrs_cache_->at(i))->dims());
+      }
+    }
+    return input_dims_;
+  }
+
+  std::vector<std::vector<std::vector<uint64_t>>> outputs_lods() {
+    output_lods_.clear();
+    if (output_tensor_ptrs_cache_) {
+      for (int i = 0; i < output_tensor_ptrs_cache_->size(); i++) {
+        output_lods_.push_back((output_tensor_ptrs_cache_->at(i))->lod());
+      }
+    }
+    return output_lods_;
+  }
+
+  std::vector<DDimLite> outputs_dims() {
+    output_lods_.clear();
+    if (output_tensor_ptrs_cache_) {
+      for (int i = 0; i < output_tensor_ptrs_cache_->size(); i++) {
+        output_dims_.push_back((output_tensor_ptrs_cache_->at(i))->dims());
+      }
+    }
+    return output_dims_;
+  }
+
+ protected:
+  std::shared_ptr<std::vector<const Tensor*>> input_tensor_ptrs_cache_{nullptr};
+  std::vector<std::vector<std::vector<uint64_t>>> input_lods_;
+  std::vector<DDimLite> input_dims_;
+  std::shared_ptr<std::vector<Tensor*>> output_tensor_ptrs_cache_{nullptr};
+  std::vector<std::vector<std::vector<uint64_t>>> output_lods_;
+  std::vector<DDimLite> output_dims_;
+};
+
 using param_t = Any;
 #define WITH_INT8_CONFIG             \
   bool enable_int8{false};           \
@@ -41,38 +95,38 @@ using param_t = Any;
   int bit_length{8};
 
 /// ----------------------- Functional operators ------------------------------
-struct FeedParam {
+struct FeedParam : ParamBase {
   std::vector<lite::Tensor>* feed_list{};
   lite::Tensor* out{};
   int col;
 };
 
-struct FetchParam {
+struct FetchParam : ParamBase {
   const lite::Tensor* input{};
   std::vector<lite::Tensor>* fetch_list{};
   int col;
 };
 
 // Helper op for lite framework
-struct IoCopyParam {
+struct IoCopyParam : ParamBase {
   const lite::Tensor* x{};
   lite::Tensor* y{};
   int process_type{0};
 };
 
-struct LayoutParam {
+struct LayoutParam : ParamBase {
   const lite::Tensor* x{};
   lite::Tensor* y{};
   int process_type{0};
 };
 
-struct CalibParam {
+struct CalibParam : ParamBase {
   const lite::Tensor* input{};
   lite::Tensor* output{};
   float scale;
 };
 
-struct SubgraphParam {
+struct SubgraphParam : ParamBase {
   std::vector<std::string> input_names{};
   std::vector<std::string> output_names{};
   std::vector<std::string> input_data_names{};
@@ -84,7 +138,7 @@ struct SubgraphParam {
 
 /// -------------------------- NN operators ------------------------------------
 
-struct FcParam {
+struct FcParam : ParamBase {
   lite::Tensor* input{nullptr};
   lite::Tensor* w{nullptr};
   lite::Tensor* bias{nullptr};
@@ -95,9 +149,24 @@ struct FcParam {
   bool padding_weights{false};
   // for int8
   WITH_INT8_CONFIG
+  ///////////////////////////////////////////////////////////////////////////////////
+  // get a vector of input tensors
+  const std::vector<const Tensor*>* input_tensor_ptrs() {
+    if (!input_tensor_ptrs_cache_) {
+      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({input}));
+    }
+    return input_tensor_ptrs_cache_.get();
+  }
+  // get a vector of output tensors
+  const std::vector<Tensor*>* output_tensor_ptrs() {
+    if (!output_tensor_ptrs_cache_) {
+      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
+    }
+    return output_tensor_ptrs_cache_.get();
+  }
 };
 
-struct SearchSeqFcParam {
+struct SearchSeqFcParam : ParamBase {
   lite::Tensor* x{nullptr};
   lite::Tensor* w{nullptr};
   lite::Tensor* b{nullptr};
@@ -106,7 +175,7 @@ struct SearchSeqFcParam {
 };
 
 // For Interpolate Op
-struct InterpolateParam {
+struct InterpolateParam : ParamBase {
   lite::Tensor* X{};
   lite::Tensor* OutSize{};
   lite::Tensor* Out{};
@@ -123,7 +192,7 @@ struct InterpolateParam {
 };
 
 // For Mul Op
-struct MulParam {
+struct MulParam : ParamBase {
   const lite::Tensor* x{};
   const lite::Tensor* y{};
   lite::Tensor* output{};
@@ -134,7 +203,7 @@ struct MulParam {
   WITH_INT8_CONFIG
 };
 
-struct MulGradParam {
+struct MulGradParam : ParamBase {
   const lite::Tensor* x{};
   const lite::Tensor* y{};
   const lite::Tensor* output_grad{};
@@ -146,7 +215,7 @@ struct MulGradParam {
 };
 
 // For ReduceMean Op
-struct ReduceMeanParam {
+struct ReduceMeanParam : ParamBase {
   lite::Tensor* X{};
   lite::Tensor* Out{};
 
@@ -155,7 +224,7 @@ struct ReduceMeanParam {
 };
 
 // For Stack Op
-struct StackParam {
+struct StackParam : ParamBase {
   std::vector<lite::Tensor*> X;
   lite::Tensor* Out{};
 
@@ -163,7 +232,7 @@ struct StackParam {
 };
 
 // For Power Op
-struct PowerParam {
+struct PowerParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
 
@@ -172,7 +241,7 @@ struct PowerParam {
   float power{};
 };
 
-struct ShuffleChannelParam {
+struct ShuffleChannelParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
 
@@ -180,7 +249,7 @@ struct ShuffleChannelParam {
 };
 
 // For Yolobox
-struct YoloBoxParam {
+struct YoloBoxParam : ParamBase {
   lite::Tensor* X{};
   lite::Tensor* ImgSize{};
   lite::Tensor* Boxes{};
@@ -193,7 +262,7 @@ struct YoloBoxParam {
 };
 
 // For Scale Op
-struct ScaleParam {
+struct ScaleParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* output{};
 
@@ -203,14 +272,29 @@ struct ScaleParam {
 };
 
 // For Softmax op
-struct SoftmaxParam {
+struct SoftmaxParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* output{};
   int axis{-1};
+  ///////////////////////////////////////////////////////////////////////////////////
+  // get a vector of input tensors
+  const std::vector<const Tensor*>* input_tensor_ptrs() {
+    if (!input_tensor_ptrs_cache_) {
+      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
+    }
+    return input_tensor_ptrs_cache_.get();
+  }
+  // get a vector of output tensors
+  const std::vector<Tensor*>* output_tensor_ptrs() {
+    if (!output_tensor_ptrs_cache_) {
+      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
+    }
+    return output_tensor_ptrs_cache_.get();
+  }
 };
 
 // For Reshape and Reshape2 Op
-struct ReshapeParam {
+struct ReshapeParam : ParamBase {
   const lite::Tensor* x{};
   std::vector<const lite::Tensor*> shape_tensor_vct{};
   const lite::Tensor* shape_tensor{};
@@ -222,7 +306,7 @@ struct ReshapeParam {
 };
 
 // For Concat op
-struct ConcatParam {
+struct ConcatParam : ParamBase {
   std::vector<lite::Tensor*> x{};
   lite::Tensor* output{};
   int axis{0};
@@ -230,7 +314,7 @@ struct ConcatParam {
 };
 
 /// ----------------------- activation operators ----------------------
-struct ActivationParam {
+struct ActivationParam : ParamBase {
   const lite::Tensor* X{};
   float Leaky_relu_alpha{0};   // leaky_relu param
   float Relu_clipped_coef{6};  // relu_clipped param
@@ -245,7 +329,7 @@ struct ActivationParam {
   lite_api::ActivationType active_type;
 };
 
-struct ActivationGradParam {
+struct ActivationGradParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Out{};
   // for backward
@@ -254,7 +338,7 @@ struct ActivationGradParam {
 };
 
 // For Convolution op
-struct ConvParam {
+struct ConvParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* filter{};
   lite::Tensor* bias{nullptr};
@@ -294,10 +378,26 @@ struct ConvParam {
   std::vector<int> output_size;
   // for int8
   WITH_INT8_CONFIG
+
+  ///////////////////////////////////////////////////////////////////////////////////
+  // get a vector of input tensors
+  const std::vector<const Tensor*>* input_tensor_ptrs() {
+    if (!input_tensor_ptrs_cache_) {
+      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
+    }
+    return input_tensor_ptrs_cache_.get();
+  }
+  // get a vector of output tensors
+  const std::vector<Tensor*>* output_tensor_ptrs() {
+    if (!output_tensor_ptrs_cache_) {
+      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
+    }
+    return output_tensor_ptrs_cache_.get();
+  }
 };
 
 // For BatchNorm op
-struct BatchNormParam {
+struct BatchNormParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* bias{};
   lite::Tensor* scale{};
@@ -316,7 +416,7 @@ struct BatchNormParam {
 };
 
 // For Pooling op
-struct PoolParam {
+struct PoolParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* output{};
   std::string pooling_type{""};
@@ -340,7 +440,7 @@ struct PoolParam {
 };
 
 // For Dropout op
-struct DropoutParam {
+struct DropoutParam : ParamBase {
   const lite::Tensor* x{};
   lite::Tensor* output{};
   lite::Tensor* mask{};
@@ -352,7 +452,7 @@ struct DropoutParam {
 };
 
 // For Split op
-struct SplitParam {
+struct SplitParam : ParamBase {
   lite::Tensor* x{};
   std::vector<lite::Tensor*> output{};
   lite::Tensor* axis_tensor;
@@ -364,7 +464,7 @@ struct SplitParam {
 };
 
 // For Transpose op
-struct TransposeParam {
+struct TransposeParam : ParamBase {
   const lite::Tensor* x{};
   lite::Tensor* output{};
   lite::Tensor* xshape{};
@@ -375,7 +475,7 @@ struct TransposeParam {
 };
 
 /// ----------------------- element wise operators ----------------------
-struct ElementwiseParam {
+struct ElementwiseParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   lite::Tensor* Out{};
@@ -384,9 +484,24 @@ struct ElementwiseParam {
   WITH_INT8_CONFIG
   float x_input_scale{1.0};
   float y_input_scale{1.0};
+  ///////////////////////////////////////////////////////////////////////////////////
+  // get a vector of input tensors
+  const std::vector<const Tensor*>* input_tensor_ptrs() {
+    if (!input_tensor_ptrs_cache_) {
+      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X, Y}));
+    }
+    return input_tensor_ptrs_cache_.get();
+  }
+  // get a vector of output tensors
+  const std::vector<Tensor*>* output_tensor_ptrs() {
+    if (!output_tensor_ptrs_cache_) {
+      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
+    }
+    return output_tensor_ptrs_cache_.get();
+  }
 };
 
-struct ElementwiseGradParam {
+struct ElementwiseGradParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   const lite::Tensor* OutGrad{};
@@ -404,12 +519,12 @@ struct FusionElementwiseActivationGradParam : public ElementwiseGradParam {
 };
 
 /// ----------------------- mean operators ----------------------
-struct MeanParam {
+struct MeanParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
 };
 
-struct MeanGradParam {
+struct MeanGradParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Out_grad{};
   // for backward
@@ -417,7 +532,7 @@ struct MeanGradParam {
 };
 
 /// ----------------------- fill_constant operators ----------------------
-struct FillConstantParam {
+struct FillConstantParam : ParamBase {
   int dtype{static_cast<int>(VarDescAPI::VarDataType::FP32)};
   std::vector<int64_t> shape{};
   lite::Tensor* shape_tensor{nullptr};
@@ -429,7 +544,7 @@ struct FillConstantParam {
   lite::Tensor* out{};
 };
 
-struct FillConstantBatchSizeLikeParam {
+struct FillConstantBatchSizeLikeParam : ParamBase {
   const lite::Tensor* input{nullptr};
   lite::Tensor* out{nullptr};
 
@@ -443,7 +558,7 @@ struct FillConstantBatchSizeLikeParam {
 };
 
 //
-struct FakeQuantizeMovingAvgMaxAbsParam {
+struct FakeQuantizeMovingAvgMaxAbsParam : ParamBase {
   const lite::Tensor* x{};
   const lite::Tensor* in_scale{};
   const lite::Tensor* in_accum{};
@@ -457,14 +572,14 @@ struct FakeQuantizeMovingAvgMaxAbsParam {
   float moving_rate{0.9};
 };
 
-struct FakeDequantizeMaxAbsParam {
+struct FakeDequantizeMaxAbsParam : ParamBase {
   const lite::Tensor* x{};
   const lite::Tensor* in_scale{};
   lite::Tensor* out{};
   float max_range;
 };
 
-struct FakeChannelWiseDequantizeMaxAbsParam {
+struct FakeChannelWiseDequantizeMaxAbsParam : ParamBase {
   const lite::Tensor* x{};
   std::vector<const lite::Tensor*> scale_tensors{};
   lite::Tensor* out{};
@@ -472,7 +587,7 @@ struct FakeChannelWiseDequantizeMaxAbsParam {
 };
 
 /// ----------------------- sgd operators ----------------------
-struct SGDParam {
+struct SGDParam : ParamBase {
   int dtype{static_cast<int>(VarDescAPI::VarDataType::FP32)};
 
   const lite::Tensor* Param{};
@@ -482,7 +597,7 @@ struct SGDParam {
 };
 
 /// ----------------------- uniform_random operators ----------------------
-struct UniformRandomParam {
+struct UniformRandomParam : ParamBase {
   std::vector<int64_t> shape{};
   float min{-1.0f};
   float max{1.0f};
@@ -491,12 +606,12 @@ struct UniformRandomParam {
   lite::Tensor* Out{};
 };
 /// ----------------------- negative operators --------------
-struct NegativeParam {
+struct NegativeParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
 };
 /// ----------------------- pad2d operators ----------------------
-struct Pad2dParam {
+struct Pad2dParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   std::vector<int> paddings{0, 0, 0, 0};
@@ -506,7 +621,7 @@ struct Pad2dParam {
 };
 
 /// ----------------------- Crop operators ----------------------
-struct CropParam {
+struct CropParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   std::vector<int> offsets;
@@ -514,21 +629,21 @@ struct CropParam {
 };
 
 ///----------------------- argmax operators ----------------------
-struct ArgmaxParam {
+struct ArgmaxParam : ParamBase {
   lite::Tensor* X{};
   lite::Tensor* Out{};
   int Axis{0};
 };
 
 ///----------------------- axpy operators ----------------------
-struct AxpyParam {
+struct AxpyParam : ParamBase {
   lite::Tensor* Scale{};
   lite::Tensor* X{};
   lite::Tensor* Bias{};
   lite::Tensor* Out{};
 };
 /// ----------------------- GRU unit operators ----------------------f
-struct GRUUnitParam {
+struct GRUUnitParam : ParamBase {
   enum ActType { identity, sigmoid, tanh, relu };
   const lite::Tensor* input{nullptr};
   const lite::Tensor* hidden_prev{nullptr};
@@ -544,7 +659,7 @@ struct GRUUnitParam {
 };
 
 /// ------------------------------ lrn operators ------------------------------
-struct LrnParam {
+struct LrnParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   int n{5};
@@ -555,7 +670,7 @@ struct LrnParam {
 };
 
 /// ----------------------- decode_bboxes operators ----------------------
-struct DecodeBboxesParam {
+struct DecodeBboxesParam : ParamBase {
   const lite::Tensor* loc_data{};
   const lite::Tensor* prior_data{};
   lite::Tensor* bbox_data{};
@@ -571,7 +686,7 @@ struct DecodeBboxesParam {
 };
 
 /// ----------------------- box_coder operators ----------------------
-struct BoxCoderParam {
+struct BoxCoderParam : ParamBase {
   const lite::Tensor* prior_box{};
   const lite::Tensor* prior_box_var{};
   const lite::Tensor* target_box{};
@@ -584,7 +699,7 @@ struct BoxCoderParam {
 };
 
 /// ----------------------- multiclass_nms operators ----------------------
-struct MulticlassNmsParam {
+struct MulticlassNmsParam : ParamBase {
   const lite::Tensor* bboxes{};
   const lite::Tensor* scores{};
   lite::Tensor* out{};
@@ -599,7 +714,7 @@ struct MulticlassNmsParam {
 };
 
 /// ----------------------- priorbox operators ----------------------
-struct PriorBoxParam {
+struct PriorBoxParam : ParamBase {
   lite::Tensor* input{};
   lite::Tensor* image{};
   lite::Tensor* boxes{};
@@ -628,7 +743,7 @@ struct DensityPriorBoxParam : public PriorBoxParam {
   std::vector<int> density_sizes;
 };
 /// ----------------------- GRU operators ----------------------f
-struct GRUParam {
+struct GRUParam : ParamBase {
   const lite::Tensor* input{nullptr};
   const lite::Tensor* h0{nullptr};
   const lite::Tensor* weight{nullptr};
@@ -645,7 +760,7 @@ struct GRUParam {
 };
 
 /// ----------------------- BeamSearchDecode operators ----------------------f
-struct BeamSearchDecodeParam {
+struct BeamSearchDecodeParam : ParamBase {
   std::vector<lite::Tensor>* ids{nullptr};
   std::vector<lite::Tensor>* scores{nullptr};
   lite::Tensor* sentence_ids{nullptr};
@@ -655,21 +770,21 @@ struct BeamSearchDecodeParam {
 };
 
 /// ----------------------- LookupTable operators ----------------------f
-struct LookupTableParam {
+struct LookupTableParam : ParamBase {
   const lite::Tensor* W{nullptr};
   const lite::Tensor* Ids{nullptr};
   lite::Tensor* Out{nullptr};
   int64_t padding_idx{-1};
 };
 
-struct LookupTableDequantParam {
+struct LookupTableDequantParam : ParamBase {
   lite::Tensor* W{nullptr};
   lite::Tensor* Ids{nullptr};
   lite::Tensor* Out{nullptr};
   int64_t padding_idx{-1};
 };
 
-struct Im2SequenceParam {
+struct Im2SequenceParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   lite::Tensor* Out{};
@@ -679,19 +794,19 @@ struct Im2SequenceParam {
   std::vector<int> out_strides{1, 1};
 };
 
-struct SequenceSoftmaxParam {
+struct SequenceSoftmaxParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
 };
 
-struct NormParam {
+struct NormParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   lite::Tensor* Norm{};
   int axis{1};
   float epsilon{1e-10};
 };
-struct LayerNormParam {
+struct LayerNormParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Scale{};
   const lite::Tensor* Bias{};
@@ -702,13 +817,13 @@ struct LayerNormParam {
   float epsilon{1e-5};
 };
 
-struct LogicalParam {
+struct LogicalParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   lite::Tensor* Out{};
 };
 
-struct CompareParam {
+struct CompareParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   bool force_cpu{0};
@@ -716,7 +831,7 @@ struct CompareParam {
   lite::Tensor* Out{};
 };
 
-struct WhileParam {
+struct WhileParam : ParamBase {
   Scope* scope{};
   Tensor* cond{};
   cpp::BlockDesc* sub_block{};
@@ -724,32 +839,32 @@ struct WhileParam {
   std::vector<Tensor*> outs{};
 };
 
-struct TopkParam {
+struct TopkParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   lite::Tensor* Indices{};
   int K{1};
 };
 
-struct IncrementParam {
+struct IncrementParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   float step{1};
 };
 
-struct WriteToArrayParam {
+struct WriteToArrayParam : ParamBase {
   const lite::Tensor* X{nullptr};
   const lite::Tensor* I{nullptr};
   std::vector<lite::Tensor>* Out{nullptr};
 };
 
-struct ReadFromArrayParam {
+struct ReadFromArrayParam : ParamBase {
   const std::vector<lite::Tensor>* X{nullptr};
   const lite::Tensor* I{nullptr};
   lite::Tensor* Out{nullptr};
 };
 
-struct BeamSearchParam {
+struct BeamSearchParam : ParamBase {
   const lite::Tensor* pre_ids{};
   const lite::Tensor* pre_scores{};
   const lite::Tensor* ids{};
@@ -763,7 +878,7 @@ struct BeamSearchParam {
   bool is_accumulated;
 };
 
-struct SequencePoolParam {
+struct SequencePoolParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   std::string pool_type{"AVERAGE"};
@@ -773,7 +888,7 @@ struct SequencePoolParam {
 #endif
 };
 
-struct SequenceConvParam {
+struct SequenceConvParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Filter{};
   lite::Tensor* Out{};
@@ -782,13 +897,13 @@ struct SequenceConvParam {
   int contextLength;
 };
 
-struct SequencePoolConcatParam {
+struct SequencePoolConcatParam : ParamBase {
   std::vector<lite::Tensor*> X{};
   lite::Tensor* Out{};
   std::vector<std::string> pool_type{};
 };
 
-struct SearchGroupPaddingParam {
+struct SearchGroupPaddingParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* out_emb_padding{};
   lite::Tensor* out_new{};
@@ -796,36 +911,36 @@ struct SearchGroupPaddingParam {
   int pad_id;
 };
 
-struct SequenceReshapeParam {
+struct SequenceReshapeParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* output{};
   int new_dim;
 };
 
-struct SequenceExpandParam {
+struct SequenceExpandParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   lite::Tensor* Out{};
   int ref_level{-1};
 };
 
-struct SequenceExpandAsParam {
+struct SequenceExpandAsParam : ParamBase {
   const lite::Tensor* x{nullptr};
   const lite::Tensor* y{nullptr};
   lite::Tensor* out{nullptr};
 };
 
-struct SequenceReverseParam {
+struct SequenceReverseParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
 };
 
-struct SequenceConcatParam {
+struct SequenceConcatParam : ParamBase {
   std::vector<lite::Tensor*> X{};
   lite::Tensor* Out{};
 };
 
-struct AttentionPaddingMaskParam {
+struct AttentionPaddingMaskParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   int pad_id;
@@ -834,21 +949,21 @@ struct AttentionPaddingMaskParam {
   lite::Tensor* pad_begin{};
 };
 
-struct SequenceArithmeticParam {
+struct SequenceArithmeticParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   int op_type{1};
   lite::Tensor* Out{};
 };
 
-struct ReduceMaxParam {
+struct ReduceMaxParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   std::vector<int> dim{};
   bool keep_dim{false};
 };
 
-struct LodResetParam {
+struct LodResetParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   lite::Tensor* Out{};
@@ -856,12 +971,12 @@ struct LodResetParam {
   bool append;
 };
 
-struct IsEmptyParam {
+struct IsEmptyParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
 };
 
-struct ReduceParam {
+struct ReduceParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* output{};
   std::vector<int> dim{0};
@@ -869,7 +984,7 @@ struct ReduceParam {
   bool reduce_all{false};
 };
 
-struct VarConv2DParam {
+struct VarConv2DParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* ROW{};
   const lite::Tensor* COLUMN{};
@@ -888,19 +1003,19 @@ struct VarConv2DParam {
 };
 
 /// ----------------------- shape operators ----------------------
-struct ShapeParam {
+struct ShapeParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
 };
 
-struct CastParam {
+struct CastParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   int out_dtype{2};
   int in_dtype{2};
 };
 
-struct SliceParam {
+struct SliceParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   std::vector<int> axes{};
@@ -914,7 +1029,7 @@ struct SliceParam {
   lite::Tensor* EndsTensor{nullptr};
 };
 
-struct AffineChannelParam {
+struct AffineChannelParam : ParamBase {
   const lite::Tensor* X{};  // X is 4D tensor
   const lite::Tensor* Scale{};
   const lite::Tensor* Bias{};
@@ -922,7 +1037,7 @@ struct AffineChannelParam {
   lite::Tensor* Out{};
 };
 
-struct AnchorGeneratorParam {
+struct AnchorGeneratorParam : ParamBase {
   const lite::Tensor* Input{};
   std::vector<float> anchor_sizes{};
   std::vector<float> aspect_ratios{};
@@ -934,7 +1049,7 @@ struct AnchorGeneratorParam {
   lite::Tensor* Variances{};
 };
 
-struct GenerateProposalsParam {
+struct GenerateProposalsParam : ParamBase {
   // inputs
   const lite::Tensor* Scores{};
   const lite::Tensor* BboxDeltas{};
@@ -954,14 +1069,14 @@ struct GenerateProposalsParam {
   lite::Tensor* RpnRoiProbs{};
 };
 /// ----------------------- squeeze operators ----------------------
-struct SqueezeParam {
+struct SqueezeParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   lite::Tensor* XShape{};
   std::vector<int> axes{};
 };
 
-struct UnsqueezeParam {
+struct UnsqueezeParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   lite::Tensor* XShape{};
@@ -971,14 +1086,14 @@ struct UnsqueezeParam {
 };
 
 /// ----------------------- expand operators ----------------------
-struct ExpandParam {
+struct ExpandParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
   std::vector<int> expand_times{};
 };
 
 /// ----------------------- matmul operators ----------------------
-struct MatMulParam {
+struct MatMulParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
   lite::Tensor* Out{};
@@ -987,20 +1102,20 @@ struct MatMulParam {
   float alpha{1.0f};
 };
 
-struct GatherParam {
+struct GatherParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Index{};
   lite::Tensor* Out{};
 };
 
 /// ----------------------- assign operators -----------------------
-struct AssignParam {
+struct AssignParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
 };
 
 /// ----------------------- roi_align operators -----------------------
-struct RoiAlignParam {
+struct RoiAlignParam : ParamBase {
   lite::Tensor* X{};
   lite::Tensor* ROIs{};
   lite::Tensor* Out{};
@@ -1011,13 +1126,13 @@ struct RoiAlignParam {
 };
 
 /// ----------------------- box_clip operators -----------------------
-struct BoxClipParam {
+struct BoxClipParam : ParamBase {
   const lite::Tensor* Input{};
   const lite::Tensor* ImInfo{};
   lite::Tensor* Output{};
 };
 
-struct RangeParam {
+struct RangeParam : ParamBase {
   const lite::Tensor* Start;
   const lite::Tensor* End;
   const lite::Tensor* Step;
@@ -1025,7 +1140,7 @@ struct RangeParam {
 };
 
 /// ----------------------- assign_value operators -----------------------
-struct AssignValueParam {
+struct AssignValueParam : ParamBase {
   std::vector<int> shape{};
   int dtype{};
   std::vector<float> fp32_values{};
@@ -1034,7 +1149,7 @@ struct AssignValueParam {
 };
 
 /// --------------- sequence_topk_avg_pooling operators ------------------
-struct SequenceTopkAvgPoolingParam {
+struct SequenceTopkAvgPoolingParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* ROW{};
   const lite::Tensor* COLUMN{};
@@ -1045,7 +1160,7 @@ struct SequenceTopkAvgPoolingParam {
 };
 
 /// --------------- search_fc operators ------------------
-struct SearchFcParam {
+struct SearchFcParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* W{};
   const lite::Tensor* b{};
@@ -1053,7 +1168,7 @@ struct SearchFcParam {
   int out_size{};
 };
 /// --------------------- match_matrix_tensor operators --------------------
-struct MatchMatrixTensorParam {
+struct MatchMatrixTensorParam : ParamBase {
   const lite::Tensor* x{};
   const lite::Tensor* y{};
   const lite::Tensor* w{};
@@ -1064,14 +1179,14 @@ struct MatchMatrixTensorParam {
 };
 
 /// --------------------- search_seq_depadding operators --------------------
-struct SearchSeqDepaddingParam {
+struct SearchSeqDepaddingParam : ParamBase {
   const lite::Tensor* pad{};
   const lite::Tensor* src{};
   lite::Tensor* out{};
 };
 
 /// --------------------- search_grnn operators --------------------
-struct SearchGrnnParam {
+struct SearchGrnnParam : ParamBase {
   const lite::Tensor* x{};
   const lite::Tensor* wi{};
   const lite::Tensor* wh{};
@@ -1084,7 +1199,7 @@ struct SearchGrnnParam {
   lite::Tensor* layout_input{};
 };
 
-struct SplitLodTensorParam {
+struct SplitLodTensorParam : ParamBase {
   const lite::Tensor* x{};
   const lite::Tensor* mask{};
   lite::Tensor* out_true{};
@@ -1092,7 +1207,7 @@ struct SplitLodTensorParam {
   int level{};
 };
 
-struct MergeLodTensorParam {
+struct MergeLodTensorParam : ParamBase {
   const lite::Tensor* x{};
   const lite::Tensor* mask{};
   const lite::Tensor* in_true{};
@@ -1101,7 +1216,7 @@ struct MergeLodTensorParam {
   int level{};
 };
 
-struct ConditionalBlockParam {
+struct ConditionalBlockParam : ParamBase {
   const lite::Tensor* cond{};
   std::vector<lite::Tensor*> x{};
   std::vector<lite::Tensor*> outs{};
@@ -1110,14 +1225,14 @@ struct ConditionalBlockParam {
   bool is_scalar_condition{};
 };
 
-struct CollectFpnProposalsParam {
+struct CollectFpnProposalsParam : ParamBase {
   std::vector<lite::Tensor*> multi_level_rois{};
   std::vector<lite::Tensor*> multi_level_scores{};
   lite::Tensor* fpn_rois{};
   int post_nms_topN{};
 };
 
-struct DistributeFpnProposalsParam {
+struct DistributeFpnProposalsParam : ParamBase {
   const lite::Tensor* fpn_rois{};
   std::vector<lite::Tensor*> multi_fpn_rois{};
   lite::Tensor* restore_index{};
@@ -1128,7 +1243,7 @@ struct DistributeFpnProposalsParam {
 };
 
 /// --------------------- instance_norm operators --------------------
-struct InstanceNormParam {
+struct InstanceNormParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* out{};
   lite::Tensor* bias{};
@@ -1138,12 +1253,12 @@ struct InstanceNormParam {
   float epsilon;
 };
 /// --------------------- grid sampler operators --------------------
-struct GridSamplerParam {
+struct GridSamplerParam : ParamBase {
   lite::Tensor* x{};
   lite::Tensor* out{};
   lite::Tensor* grid{};
 };
-struct LstmParam {
+struct LstmParam : ParamBase {
   lite::Tensor* Input{};
   lite::Tensor* Weight{};
   lite::Tensor* Bias{};
@@ -1160,7 +1275,7 @@ struct LstmParam {
   std::string candidate_activation;
 };
 
-struct CrfDecodingParam {
+struct CrfDecodingParam : ParamBase {
   lite::Tensor* emission{};
   lite::Tensor* transition{};
   lite::Tensor* label{};

--- a/lite/operators/pad2d_op.cc
+++ b/lite/operators/pad2d_op.cc
@@ -30,7 +30,7 @@ bool Pad2dOpLite::CheckShape() const {
   return true;
 }
 
-bool Pad2dOpLite::InferShape() const {
+bool Pad2dOpLite::InferShapeImpl() const {
   // nchw
   auto x_dims = param_.X->dims();
   int out_h = x_dims[2] + param_.paddings[0] + param_.paddings[1];

--- a/lite/operators/pad2d_op.h
+++ b/lite/operators/pad2d_op.h
@@ -30,7 +30,7 @@ class Pad2dOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/pool_op.cc
+++ b/lite/operators/pool_op.cc
@@ -60,7 +60,7 @@ int PoolOutputSize(int input_size,
   return output_size;
 }
 
-bool PoolOpLite::InferShape() const {
+bool PoolOpLite::InferShapeImpl() const {
   const auto x_dims = param_.x->dims();
   std::vector<int>& ksize = param_.ksize;
   // dynamic update 4-pad

--- a/lite/operators/pool_op.h
+++ b/lite/operators/pool_op.h
@@ -37,7 +37,7 @@ class PoolOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {

--- a/lite/operators/power_op.cc
+++ b/lite/operators/power_op.cc
@@ -27,7 +27,7 @@ bool PowerOp::CheckShape() const {
   return true;
 }
 
-bool PowerOp::InferShape() const {
+bool PowerOp::InferShapeImpl() const {
   param_.Out->Resize(param_.X->dims());
   return true;
 }

--- a/lite/operators/power_op.h
+++ b/lite/operators/power_op.h
@@ -31,7 +31,7 @@ class PowerOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/prior_box_op.cc
+++ b/lite/operators/prior_box_op.cc
@@ -27,7 +27,7 @@ bool PriorBoxOpLite::CheckShape() const {
   return true;
 }
 
-bool PriorBoxOpLite::InferShape() const { return true; }
+bool PriorBoxOpLite::InferShapeImpl() const { return true; }
 
 bool PriorBoxOpLite::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   auto input = opdesc.Input("Input").front();

--- a/lite/operators/prior_box_op.h
+++ b/lite/operators/prior_box_op.h
@@ -29,7 +29,7 @@ class PriorBoxOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/range_op.cc
+++ b/lite/operators/range_op.cc
@@ -41,7 +41,7 @@ void GetSize(T start, T end, T step, int64_t* size) {
               : std::ceil(std::abs((end - start) / step));
 }
 
-bool RangeOpLite::InferShape() const {
+bool RangeOpLite::InferShapeImpl() const {
   int start = param_.Start->data<float>()[0];
   int end = param_.End->data<float>()[0];
   int step = param_.Step->data<float>()[0];

--- a/lite/operators/range_op.h
+++ b/lite/operators/range_op.h
@@ -29,7 +29,7 @@ class RangeOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/read_from_array_op.cc
+++ b/lite/operators/read_from_array_op.cc
@@ -26,7 +26,7 @@ bool ReadFromArrayOp::CheckShape() const {
   return true;
 }
 
-bool ReadFromArrayOp::InferShape() const {
+bool ReadFromArrayOp::InferShapeImpl() const {
   int id = param_.I->data<int64_t>()[0];
   auto out_dims = (*param_.X)[id].dims();
   param_.Out->Resize(out_dims);

--- a/lite/operators/read_from_array_op.h
+++ b/lite/operators/read_from_array_op.h
@@ -30,7 +30,7 @@ class ReadFromArrayOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/reduce_max_op.cc
+++ b/lite/operators/reduce_max_op.cc
@@ -39,7 +39,7 @@ bool ReduceMaxOp::CheckShape() const {
   return true;
 }
 
-bool ReduceMaxOp::InferShape() const {
+bool ReduceMaxOp::InferShapeImpl() const {
   auto dims = param_.dim;
   auto x_dims = param_.X->dims();
   bool reduce_all = false;

--- a/lite/operators/reduce_max_op.h
+++ b/lite/operators/reduce_max_op.h
@@ -28,7 +28,7 @@ class ReduceMaxOp : public OpLite {
   ReduceMaxOp() {}
   explicit ReduceMaxOp(const std::string &op_type) : OpLite(op_type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/reduce_mean_op.cc
+++ b/lite/operators/reduce_mean_op.cc
@@ -39,7 +39,7 @@ bool ReduceMeanOp::CheckShape() const {
   return true;
 }
 
-bool ReduceMeanOp::InferShape() const {
+bool ReduceMeanOp::InferShapeImpl() const {
   auto dims = param_.dim;
   auto x_dims = param_.X->dims();
   bool reduce_all = false;

--- a/lite/operators/reduce_mean_op.h
+++ b/lite/operators/reduce_mean_op.h
@@ -28,7 +28,7 @@ class ReduceMeanOp : public OpLite {
   ReduceMeanOp() {}
   explicit ReduceMeanOp(const std::string &op_type) : OpLite(op_type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/reduce_ops.cc
+++ b/lite/operators/reduce_ops.cc
@@ -28,7 +28,7 @@ bool ReduceOp::CheckShape() const {
   return true;
 }
 
-bool ReduceOp::InferShape() const {
+bool ReduceOp::InferShapeImpl() const {
   const auto &x_dims = param_.x->dims();
   auto x_rank = x_dims.size();
   auto dims = param_.dim;

--- a/lite/operators/reduce_ops.h
+++ b/lite/operators/reduce_ops.h
@@ -30,7 +30,7 @@ class ReduceOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/reduce_prod_op.cc
+++ b/lite/operators/reduce_prod_op.cc
@@ -28,7 +28,7 @@ bool ReduceProdOpLite::CheckShape() const {
   return true;
 }
 
-bool ReduceProdOpLite::InferShape() const {
+bool ReduceProdOpLite::InferShapeImpl() const {
   auto x = param_.x;
   auto out = param_.output;
   std::vector<int> dim = param_.dim;

--- a/lite/operators/reduce_prod_op.h
+++ b/lite/operators/reduce_prod_op.h
@@ -29,7 +29,7 @@ class ReduceProdOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/relu_op.cc
+++ b/lite/operators/relu_op.cc
@@ -20,7 +20,7 @@ namespace lite {
 namespace operators {
 
 bool ReluOp::CheckShape() const { return true; }
-bool ReluOp::InferShape() const {
+bool ReluOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.X);
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.

--- a/lite/operators/relu_op.h
+++ b/lite/operators/relu_op.h
@@ -30,7 +30,7 @@ class ReluOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/reshape_op.cc
+++ b/lite/operators/reshape_op.cc
@@ -26,7 +26,7 @@ bool ReshapeOp::CheckShape() const {
   return true;
 }
 
-bool ReshapeOp::InferShape() const {
+bool ReshapeOp::InferShapeImpl() const {
   const auto &shape_tensor_vct = param_.shape_tensor_vct;
   auto *shape_tensor = param_.shape_tensor;
   const auto &shape_vct = param_.shape_vct;
@@ -97,7 +97,7 @@ bool Reshape2Op::CheckShape() const {
   return true;
 }
 
-bool Reshape2Op::InferShape() const {
+bool Reshape2Op::InferShapeImpl() const {
   ReshapeOp::InferShape();
   const auto &x_dims = param_.x->dims();
   std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1);

--- a/lite/operators/reshape_op.cc
+++ b/lite/operators/reshape_op.cc
@@ -98,7 +98,7 @@ bool Reshape2Op::CheckShape() const {
 }
 
 bool Reshape2Op::InferShapeImpl() const {
-  ReshapeOp::InferShape();
+  ReshapeOp::InferShapeImpl();
   const auto &x_dims = param_.x->dims();
   std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1);
   xshape_dims[0] = 0;

--- a/lite/operators/reshape_op.h
+++ b/lite/operators/reshape_op.h
@@ -30,7 +30,7 @@ class ReshapeOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
@@ -48,7 +48,7 @@ class Reshape2Op : public ReshapeOp {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/roi_align_op.cc
+++ b/lite/operators/roi_align_op.cc
@@ -38,7 +38,7 @@ bool RoiAlignOpLite::CheckShape() const {
   return true;
 }
 
-bool RoiAlignOpLite::InferShape() const {
+bool RoiAlignOpLite::InferShapeImpl() const {
   auto x_dims = param_.X->dims();
   auto rois_dims = param_.ROIs->dims();
 

--- a/lite/operators/roi_align_op.h
+++ b/lite/operators/roi_align_op.h
@@ -31,7 +31,7 @@ class RoiAlignOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/scale_op.cc
+++ b/lite/operators/scale_op.cc
@@ -24,7 +24,7 @@ bool ScaleOp::CheckShape() const {
   return true;
 }
 
-bool ScaleOp::InferShape() const {
+bool ScaleOp::InferShapeImpl() const {
   param_.output->Resize(param_.x->dims());
   return true;
 }

--- a/lite/operators/scale_op.h
+++ b/lite/operators/scale_op.h
@@ -30,7 +30,7 @@ class ScaleOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/search_aligned_mat_mul_op.cc
+++ b/lite/operators/search_aligned_mat_mul_op.cc
@@ -27,7 +27,7 @@ bool SearchAlignedMatMulOpLite::CheckShape() const {
   return true;
 }
 
-bool SearchAlignedMatMulOpLite::InferShape() const {
+bool SearchAlignedMatMulOpLite::InferShapeImpl() const {
   const auto x_dims = param_.X->dims();
   const auto y_dims = param_.Y->dims();
   const auto& x_lod = param_.X->lod();

--- a/lite/operators/search_aligned_mat_mul_op.h
+++ b/lite/operators/search_aligned_mat_mul_op.h
@@ -31,7 +31,7 @@ class SearchAlignedMatMulOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 

--- a/lite/operators/search_fc_op.cc
+++ b/lite/operators/search_fc_op.cc
@@ -50,7 +50,7 @@ bool SearchFcOpLite::CheckShape() const {
   return true;
 }
 
-bool SearchFcOpLite::InferShape() const {
+bool SearchFcOpLite::InferShapeImpl() const {
   auto out_size = param_.out_size;
   lite::DDim dims(std::vector<int64_t>({-1, out_size}));
   param_.Out->Resize(dims);

--- a/lite/operators/search_fc_op.h
+++ b/lite/operators/search_fc_op.h
@@ -30,7 +30,7 @@ class SearchFcOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/search_grnn_op.cc
+++ b/lite/operators/search_grnn_op.cc
@@ -51,7 +51,7 @@ bool SearchGrnnOpLite::CheckShape() const {
   return true;
 }
 
-bool SearchGrnnOpLite::InferShape() const {
+bool SearchGrnnOpLite::InferShapeImpl() const {
   const auto& x_dims = param_.x->dims();
   const auto& x_lod = param_.x->lod();
   CHECK_OR_FALSE(!x_lod.empty());

--- a/lite/operators/search_grnn_op.h
+++ b/lite/operators/search_grnn_op.h
@@ -31,7 +31,7 @@ class SearchGrnnOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/search_group_padding_op.cc
+++ b/lite/operators/search_group_padding_op.cc
@@ -31,7 +31,7 @@ bool SearchGroupPaddingOp::CheckShape() const {
   return true;
 }
 
-bool SearchGroupPaddingOp::InferShape() const {
+bool SearchGroupPaddingOp::InferShapeImpl() const {
   std::vector<int64_t> x_dims = param_.x->dims().Vectorize();
 
   param_.out_emb_padding->Resize({-1, x_dims[1]});

--- a/lite/operators/search_group_padding_op.h
+++ b/lite/operators/search_group_padding_op.h
@@ -27,7 +27,7 @@ class SearchGroupPaddingOp : public OpLite {
   SearchGroupPaddingOp() {}
   explicit SearchGroupPaddingOp(const std::string &op_type) : OpLite(op_type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "search_group_padding"; }

--- a/lite/operators/search_seq_depadding_op.cc
+++ b/lite/operators/search_seq_depadding_op.cc
@@ -44,7 +44,7 @@ bool SearchSeqDepaddingOpLite::CheckShape() const {
   return true;
 }
 
-bool SearchSeqDepaddingOpLite::InferShape() const {
+bool SearchSeqDepaddingOpLite::InferShapeImpl() const {
   DDim pad_dims = param_.pad->dims();
   param_.out->Resize({-1, pad_dims[1]});
   return true;

--- a/lite/operators/search_seq_depadding_op.h
+++ b/lite/operators/search_seq_depadding_op.h
@@ -32,7 +32,7 @@ class SearchSeqDepaddingOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/search_seq_fc_op.cc
+++ b/lite/operators/search_seq_fc_op.cc
@@ -26,7 +26,7 @@ bool SearchSeqFcOpLite::CheckShape() const {
   return true;
 }
 
-bool SearchSeqFcOpLite::InferShape() const {
+bool SearchSeqFcOpLite::InferShapeImpl() const {
   const auto x_dims = param_.x->dims();
   const auto w_dims = param_.w->dims();
   const auto& x_lod = param_.x->lod();

--- a/lite/operators/search_seq_fc_op.h
+++ b/lite/operators/search_seq_fc_op.h
@@ -31,7 +31,7 @@ class SearchSeqFcOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 

--- a/lite/operators/search_seq_softmax_op.cc
+++ b/lite/operators/search_seq_softmax_op.cc
@@ -25,7 +25,7 @@ bool SearchSeqSoftmaxOp::CheckShape() const {
   return true;
 }
 
-bool SearchSeqSoftmaxOp::InferShape() const {
+bool SearchSeqSoftmaxOp::InferShapeImpl() const {
   param_.output->Resize(param_.x->dims());
   param_.output->set_lod(param_.x->lod());
   return true;

--- a/lite/operators/search_seq_softmax_op.h
+++ b/lite/operators/search_seq_softmax_op.h
@@ -31,7 +31,7 @@ class SearchSeqSoftmaxOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/sequence_arithmetic_op.cc
+++ b/lite/operators/sequence_arithmetic_op.cc
@@ -28,7 +28,7 @@ bool SequenceArithmeticOp::CheckShape() const {
   return true;
 }
 
-bool SequenceArithmeticOp::InferShape() const {
+bool SequenceArithmeticOp::InferShapeImpl() const {
   param_.Out->Resize(param_.X->dims());
   param_.Out->set_lod(param_.X->lod());
   return true;

--- a/lite/operators/sequence_arithmetic_op.h
+++ b/lite/operators/sequence_arithmetic_op.h
@@ -29,7 +29,7 @@ class SequenceArithmeticOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/sequence_concat_op.cc
+++ b/lite/operators/sequence_concat_op.cc
@@ -26,7 +26,7 @@ bool SequenceConcatOp::CheckShape() const {
   return true;
 }
 
-bool SequenceConcatOp::InferShape() const { return true; }
+bool SequenceConcatOp::InferShapeImpl() const { return true; }
 
 bool SequenceConcatOp::AttachImpl(const cpp::OpDesc &opdesc,
                                   lite::Scope *scope) {

--- a/lite/operators/sequence_concat_op.h
+++ b/lite/operators/sequence_concat_op.h
@@ -27,7 +27,7 @@ class SequenceConcatOp : public OpLite {
   SequenceConcatOp() {}
   explicit SequenceConcatOp(const std::string &op_type) : OpLite(op_type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "sequence_concat"; }

--- a/lite/operators/sequence_conv_op.cc
+++ b/lite/operators/sequence_conv_op.cc
@@ -44,7 +44,7 @@ bool SequenceConvOp::CheckShape() const {
   return true;
 }
 
-bool SequenceConvOp::InferShape() const {
+bool SequenceConvOp::InferShapeImpl() const {
   const auto *input = param_.X;
   const auto *filter = param_.Filter;
   auto in_dims = input->dims();

--- a/lite/operators/sequence_conv_op.h
+++ b/lite/operators/sequence_conv_op.h
@@ -28,7 +28,7 @@ class SequenceConvOp : public OpLite {
   SequenceConvOp() {}
   explicit SequenceConvOp(const std::string &op_type) : OpLite(op_type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/sequence_expand_as_op.cc
+++ b/lite/operators/sequence_expand_as_op.cc
@@ -34,7 +34,7 @@ bool SequenceExpandAsOpLite::CheckShape() const {
   return true;
 }
 
-bool SequenceExpandAsOpLite::InferShape() const {
+bool SequenceExpandAsOpLite::InferShapeImpl() const {
   auto x_dims = param_.x->dims();
   auto y_lod = param_.y->lod();
   auto out_dims = x_dims;

--- a/lite/operators/sequence_expand_as_op.h
+++ b/lite/operators/sequence_expand_as_op.h
@@ -31,7 +31,7 @@ class SequenceExpandAsOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/sequence_expand_op.cc
+++ b/lite/operators/sequence_expand_op.cc
@@ -40,7 +40,7 @@ bool SequenceExpandOp::CheckShape() const {
   return true;
 }
 
-bool SequenceExpandOp::InferShape() const {
+bool SequenceExpandOp::InferShapeImpl() const {
   const auto x_lod = param_.X->lod();
   auto x_dims = param_.X->dims();
   int ref_level = param_.ref_level;

--- a/lite/operators/sequence_expand_op.h
+++ b/lite/operators/sequence_expand_op.h
@@ -30,7 +30,7 @@ class SequenceExpandOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/sequence_pool_concat_op.cc
+++ b/lite/operators/sequence_pool_concat_op.cc
@@ -26,7 +26,7 @@ bool SequencePoolConcatOp::CheckShape() const {
   return true;
 }
 
-bool SequencePoolConcatOp::InferShape() const {
+bool SequencePoolConcatOp::InferShapeImpl() const {
   int out_dim = 0;
   for (int i = 0; i < param_.X.size(); ++i) {
     out_dim += param_.X[i]->dims().count(1, param_.X[i]->dims().size());

--- a/lite/operators/sequence_pool_concat_op.h
+++ b/lite/operators/sequence_pool_concat_op.h
@@ -28,7 +28,7 @@ class SequencePoolConcatOp : public OpLite {
   SequencePoolConcatOp() {}
   explicit SequencePoolConcatOp(const std::string &op_type) : OpLite(op_type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/sequence_pool_op.cc
+++ b/lite/operators/sequence_pool_op.cc
@@ -29,7 +29,7 @@ bool SequencePoolOp::CheckShape() const {
   return true;
 }
 
-bool SequencePoolOp::InferShape() const {
+bool SequencePoolOp::InferShapeImpl() const {
   const auto *input = param_.X;
   auto out_dims = input->dims();
   out_dims[0] = input->lod()[0].size() - 1;

--- a/lite/operators/sequence_pool_op.h
+++ b/lite/operators/sequence_pool_op.h
@@ -28,7 +28,7 @@ class SequencePoolOp : public OpLite {
   SequencePoolOp() {}
   explicit SequencePoolOp(const std::string &op_type) : OpLite(op_type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/sequence_reshape_op.cc
+++ b/lite/operators/sequence_reshape_op.cc
@@ -27,7 +27,7 @@ bool SequenceReshapeOp::CheckShape() const {
   return true;
 }
 
-bool SequenceReshapeOp::InferShape() const {
+bool SequenceReshapeOp::InferShapeImpl() const {
   int new_dim = param_.new_dim;
   auto x_numel = param_.x->dims().production();
   std::vector<int64_t> out_shape{x_numel / new_dim,

--- a/lite/operators/sequence_reshape_op.h
+++ b/lite/operators/sequence_reshape_op.h
@@ -31,7 +31,7 @@ class SequenceReshapeOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/sequence_reverse_op.cc
+++ b/lite/operators/sequence_reverse_op.cc
@@ -30,7 +30,7 @@ bool SequenceReverseOp::CheckShape() const {
   return true;
 }
 
-bool SequenceReverseOp::InferShape() const {
+bool SequenceReverseOp::InferShapeImpl() const {
   const auto *input = param_.X;
   auto out_dims = input->dims();
   param_.Out->Resize(out_dims);

--- a/lite/operators/sequence_reverse_op.h
+++ b/lite/operators/sequence_reverse_op.h
@@ -27,7 +27,7 @@ class SequenceReverseOp : public OpLite {
   SequenceReverseOp() {}
   explicit SequenceReverseOp(const std::string &op_type) : OpLite(op_type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "sequence_reverse"; }

--- a/lite/operators/sequence_softmax_op.cc
+++ b/lite/operators/sequence_softmax_op.cc
@@ -24,7 +24,7 @@ bool SequenceSoftmaxOp::CheckShape() const {
   CHECK_OR_FALSE(param_.Out);
   return true;
 }
-bool SequenceSoftmaxOp::InferShape() const {
+bool SequenceSoftmaxOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   auto input_dims = param_.X->dims();

--- a/lite/operators/sequence_softmax_op.h
+++ b/lite/operators/sequence_softmax_op.h
@@ -30,7 +30,7 @@ class SequenceSoftmaxOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/sequence_topk_avg_pooling_op.cc
+++ b/lite/operators/sequence_topk_avg_pooling_op.cc
@@ -43,7 +43,7 @@ bool SequenceTopkAvgPoolingOpLite::CheckShape() const {
   return true;
 }
 
-bool SequenceTopkAvgPoolingOpLite::InferShape() const {
+bool SequenceTopkAvgPoolingOpLite::InferShapeImpl() const {
   int channel_num = param_.channel_num;
   std::vector<int> topks = param_.topks;
   auto row_dim = param_.ROW->dims();

--- a/lite/operators/sequence_topk_avg_pooling_op.h
+++ b/lite/operators/sequence_topk_avg_pooling_op.h
@@ -31,7 +31,7 @@ class SequenceTopkAvgPoolingOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/sgd_op.cc
+++ b/lite/operators/sgd_op.cc
@@ -30,7 +30,7 @@ bool SGDOpLite::CheckShape() const {
   return true;
 }
 
-bool SGDOpLite::InferShape() const {
+bool SGDOpLite::InferShapeImpl() const {
   param_.ParamOut->Resize(param_.Param->dims());
   return true;
 }

--- a/lite/operators/sgd_op.h
+++ b/lite/operators/sgd_op.h
@@ -33,7 +33,7 @@ class SGDOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 

--- a/lite/operators/shape_op.cc
+++ b/lite/operators/shape_op.cc
@@ -25,7 +25,7 @@ bool ShapeOpLite::CheckShape() const {
   return true;
 }
 
-bool ShapeOpLite::InferShape() const {
+bool ShapeOpLite::InferShapeImpl() const {
   std::vector<int64_t> shape_vec;
   shape_vec.push_back(static_cast<int64_t>(param_.X->dims().size()));
   param_.Out->Resize(shape_vec);

--- a/lite/operators/shape_op.h
+++ b/lite/operators/shape_op.h
@@ -28,7 +28,7 @@ class ShapeOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/shuffle_channel_op.cc
+++ b/lite/operators/shuffle_channel_op.cc
@@ -27,7 +27,7 @@ bool ShuffleChannelOpLite::CheckShape() const {
   return true;
 }
 
-bool ShuffleChannelOpLite::InferShape() const {
+bool ShuffleChannelOpLite::InferShapeImpl() const {
   param_.Out->Resize(param_.X->dims());
   return true;
 }

--- a/lite/operators/shuffle_channel_op.h
+++ b/lite/operators/shuffle_channel_op.h
@@ -33,7 +33,7 @@ class ShuffleChannelOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 

--- a/lite/operators/slice_op.cc
+++ b/lite/operators/slice_op.cc
@@ -27,7 +27,7 @@ bool SliceOp::CheckShape() const {
   return true;
 }
 
-bool SliceOp::InferShape() const {
+bool SliceOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.Out);
   // TODO(Superjomn) Enable data sharing.
   auto in_dims = param_.X->dims();

--- a/lite/operators/slice_op.h
+++ b/lite/operators/slice_op.h
@@ -30,7 +30,7 @@ class SliceOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/softmax_op.cc
+++ b/lite/operators/softmax_op.cc
@@ -29,35 +29,7 @@ bool SoftmaxOp::CheckShape() const {
   return true;
 }
 
-bool SoftmaxOp::SmartInferShape() {
-  if (!last_input_shapes.empty() && !last_output_shapes.empty()) {
-    if (param_.x->dims() == last_input_shapes[0] &&
-        param_.x->lod() == last_input_lods[0]) {
-      param_.output->Resize(last_output_shapes[0]);
-      param_.output->set_lod(last_output_lods[0]);
-      return true;
-    }
-  }
-
-  this->InferShape();
-
-  if (!last_input_shapes.empty()) {
-    last_input_shapes.clear();
-    last_input_lods.clear();
-  }
-  last_input_shapes.push_back(param_.x->dims());
-  last_input_lods.push_back(param_.x->lod());
-
-  if (!last_output_shapes.empty()) {
-    last_output_shapes.clear();
-    last_output_lods.clear();
-  }
-  last_output_shapes.push_back(param_.output->dims());
-  last_output_lods.push_back(param_.output->lod());
-  return true;
-}
-
-bool SoftmaxOp::InferShape() const {
+bool SoftmaxOp::InferShapeImpl() const {
   param_.output->Resize(param_.x->dims());
   auto out_lod = param_.output->mutable_lod();
   *out_lod = param_.x->lod();

--- a/lite/operators/softmax_op.h
+++ b/lite/operators/softmax_op.h
@@ -30,8 +30,7 @@ class SoftmaxOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
-  bool SmartInferShape() override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/split_lod_tensor_op.cc
+++ b/lite/operators/split_lod_tensor_op.cc
@@ -33,7 +33,7 @@ bool SplitLodTensorOpLite::CheckShape() const {
   return true;
 }
 
-bool SplitLodTensorOpLite::InferShape() const {
+bool SplitLodTensorOpLite::InferShapeImpl() const {
   auto x_dims = param_.x->dims();
   param_.out_true->Resize(x_dims);
   param_.out_false->Resize(x_dims);

--- a/lite/operators/split_lod_tensor_op.h
+++ b/lite/operators/split_lod_tensor_op.h
@@ -31,7 +31,7 @@ class SplitLodTensorOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -29,7 +29,7 @@ bool SplitOp::CheckShape() const {
   return true;
 }
 
-bool SplitOp::InferShape() const {
+bool SplitOp::InferShapeImpl() const {
   const auto &outs = param_.output;
   auto in_dims = param_.x->dims();
   int axis = param_.axis;

--- a/lite/operators/split_op.h
+++ b/lite/operators/split_op.h
@@ -30,7 +30,7 @@ class SplitOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/squeeze_op.cc
+++ b/lite/operators/squeeze_op.cc
@@ -75,7 +75,7 @@ bool SqueezeOp::CheckShape() const {
   return true;
 }
 
-bool SqueezeOp::InferShape() const {
+bool SqueezeOp::InferShapeImpl() const {
   std::vector<int> squeeze_dims = param_.axes;
   DDim in_dims = param_.X->dims();
   DDim out_dim = GetOutputShape(squeeze_dims, in_dims, true);
@@ -105,7 +105,7 @@ bool Squeeze2Op::CheckShape() const {
   return true;
 }
 
-bool Squeeze2Op::InferShape() const {
+bool Squeeze2Op::InferShapeImpl() const {
   SqueezeOp::InferShape();
   auto x_dims = param_.X->dims();
   std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1, 1);

--- a/lite/operators/squeeze_op.cc
+++ b/lite/operators/squeeze_op.cc
@@ -106,7 +106,7 @@ bool Squeeze2Op::CheckShape() const {
 }
 
 bool Squeeze2Op::InferShapeImpl() const {
-  SqueezeOp::InferShape();
+  SqueezeOp::InferShapeImpl();
   auto x_dims = param_.X->dims();
   std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1, 1);
   for (size_t i = 0; i < x_dims.size(); i++) {

--- a/lite/operators/squeeze_op.h
+++ b/lite/operators/squeeze_op.h
@@ -30,7 +30,7 @@ class SqueezeOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
@@ -48,7 +48,7 @@ class Squeeze2Op : public SqueezeOp {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/stack_op.cc
+++ b/lite/operators/stack_op.cc
@@ -32,7 +32,7 @@ bool StackOp::CheckShape() const {
   return true;
 }
 
-bool StackOp::InferShape() const {
+bool StackOp::InferShapeImpl() const {
   auto input = param_.X;
   auto input_dims = input[0]->dims();
   int axis = param_.axis;

--- a/lite/operators/stack_op.h
+++ b/lite/operators/stack_op.h
@@ -31,7 +31,7 @@ class StackOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/subgraph_op.cc
+++ b/lite/operators/subgraph_op.cc
@@ -22,7 +22,7 @@ namespace operators {
 
 bool SubgraphOp::CheckShape() const { return true; }
 
-bool SubgraphOp::InferShape() const { return CheckShape(); /* enrich me */ }
+bool SubgraphOp::InferShapeImpl() const { return CheckShape(); /* enrich me */ }
 
 bool SubgraphOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   param_.input_names = op_desc.Input("Inputs");

--- a/lite/operators/subgraph_op.h
+++ b/lite/operators/subgraph_op.h
@@ -35,7 +35,7 @@ class SubgraphOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override;
 

--- a/lite/operators/topk_op.cc
+++ b/lite/operators/topk_op.cc
@@ -25,7 +25,7 @@ bool TopkOp::CheckShape() const {
   return true;
 }
 
-bool TopkOp::InferShape() const {
+bool TopkOp::InferShapeImpl() const {
   auto out_dims = param_.X->dims();
   out_dims[out_dims.size() - 1] = param_.K;
   auto out = param_.Out;

--- a/lite/operators/topk_op.h
+++ b/lite/operators/topk_op.h
@@ -30,7 +30,7 @@ class TopkOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/transpose_op.cc
+++ b/lite/operators/transpose_op.cc
@@ -42,7 +42,7 @@ bool TransposeOp::CheckShape() const {
   return true;
 }
 
-bool TransposeOp::InferShape() const {
+bool TransposeOp::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.x);
   CHECK_OR_FALSE(param_.output);
   auto x_dims = param_.x->dims();
@@ -111,7 +111,7 @@ bool Transpose2Op::CheckShape() const {
   return true;
 }
 
-bool Transpose2Op::InferShape() const {
+bool Transpose2Op::InferShapeImpl() const {
   CHECK_OR_FALSE(param_.x);
   CHECK_OR_FALSE(param_.output);
   auto x_dims = param_.x->dims();

--- a/lite/operators/transpose_op.h
+++ b/lite/operators/transpose_op.h
@@ -31,7 +31,7 @@ class TransposeOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
@@ -50,7 +50,7 @@ class Transpose2Op : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/uniform_random_op.cc
+++ b/lite/operators/uniform_random_op.cc
@@ -22,7 +22,7 @@ namespace operators {
 
 bool UniformRandomOpLite::CheckShape() const { return true; }
 
-bool UniformRandomOpLite::InferShape() const {
+bool UniformRandomOpLite::InferShapeImpl() const {
   param_.Out->Resize(param_.shape);
   return true;
 }

--- a/lite/operators/uniform_random_op.h
+++ b/lite/operators/uniform_random_op.h
@@ -33,7 +33,7 @@ class UniformRandomOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 

--- a/lite/operators/unsqueeze_op.cc
+++ b/lite/operators/unsqueeze_op.cc
@@ -130,7 +130,7 @@ bool Unsqueeze2Op::CheckShape() const {
 }
 
 bool Unsqueeze2Op::InferShapeImpl() const {
-  UnsqueezeOp::InferShape();
+  UnsqueezeOp::InferShapeImpl();
   auto x_dims = param_.X->dims();
   std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1, 1);
   for (size_t i = 0; i < x_dims.size(); i++) {

--- a/lite/operators/unsqueeze_op.cc
+++ b/lite/operators/unsqueeze_op.cc
@@ -62,7 +62,7 @@ bool UnsqueezeOp::CheckShape() const {
   return true;
 }
 
-bool UnsqueezeOp::InferShape() const {
+bool UnsqueezeOp::InferShapeImpl() const {
   std::vector<int> final_axes;
   auto axes = param_.axes;
   auto *axes_tensor = param_.axes_tensor;
@@ -129,7 +129,7 @@ bool Unsqueeze2Op::CheckShape() const {
   return true;
 }
 
-bool Unsqueeze2Op::InferShape() const {
+bool Unsqueeze2Op::InferShapeImpl() const {
   UnsqueezeOp::InferShape();
   auto x_dims = param_.X->dims();
   std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1, 1);

--- a/lite/operators/unsqueeze_op.h
+++ b/lite/operators/unsqueeze_op.h
@@ -30,7 +30,7 @@ class UnsqueezeOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
@@ -48,7 +48,7 @@ class Unsqueeze2Op : public UnsqueezeOp {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/var_conv_2d_op.cc
+++ b/lite/operators/var_conv_2d_op.cc
@@ -21,7 +21,7 @@ namespace operators {
 
 bool VarConv2dOp::CheckShape() const { return true; }
 
-bool VarConv2dOp::InferShape() const { return true; }
+bool VarConv2dOp::InferShapeImpl() const { return true; }
 
 bool VarConv2dOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   param_.X = const_cast<lite::Tensor *>(

--- a/lite/operators/var_conv_2d_op.h
+++ b/lite/operators/var_conv_2d_op.h
@@ -27,7 +27,7 @@ class VarConv2dOp : public OpLite {
   VarConv2dOp() {}
   explicit VarConv2dOp(const std::string &op_type) : OpLite(op_type) {}
   bool CheckShape() const override;
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "var_conv_2d"; }

--- a/lite/operators/while_op.cc
+++ b/lite/operators/while_op.cc
@@ -27,7 +27,7 @@ bool WhileOpLite::CheckShape() const {
   return true;
 }
 
-bool WhileOpLite::InferShape() const { return true; }
+bool WhileOpLite::InferShapeImpl() const { return true; }
 
 bool WhileOpLite::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
   auto inputs = op_desc.Input("X");

--- a/lite/operators/while_op.h
+++ b/lite/operators/while_op.h
@@ -30,7 +30,7 @@ class WhileOpLite : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/write_to_array_op.cc
+++ b/lite/operators/write_to_array_op.cc
@@ -26,7 +26,7 @@ bool WriteToArrayOp::CheckShape() const {
   return true;
 }
 
-bool WriteToArrayOp::InferShape() const {
+bool WriteToArrayOp::InferShapeImpl() const {
   int id = param_.I->data<int64_t>()[0];
   if (param_.Out->size() < id + 1) {
     param_.Out->resize(id + 1);

--- a/lite/operators/write_to_array_op.h
+++ b/lite/operators/write_to_array_op.h
@@ -30,7 +30,7 @@ class WriteToArrayOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/yolo_box_op.cc
+++ b/lite/operators/yolo_box_op.cc
@@ -46,7 +46,7 @@ bool YoloBoxOp::CheckShape() const {
   return true;
 }
 
-bool YoloBoxOp::InferShape() const {
+bool YoloBoxOp::InferShapeImpl() const {
   auto* X = param_.X;
   auto anchors = param_.anchors;
   int anchor_num = anchors.size() / 2;

--- a/lite/operators/yolo_box_op.h
+++ b/lite/operators/yolo_box_op.h
@@ -30,7 +30,7 @@ class YoloBoxOp : public OpLite {
 
   bool CheckShape() const override;
 
-  bool InferShape() const override;
+  bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 


### PR DESCRIPTION
【问题描述】：conv 等部分op 运行时会共享tensor，如果每次运行时都InferShape，运行耗时增加。（对比Anakin实现时，会先判断输入dims和lods是否有变化，没变化则不执行infershape）
[关联PR ]：#3240  #3283

【本PR解决方法】：为OpLite->InferShape添加“记忆功能”
`InferShape`前先检查当前InputDims和Lods是否有变化，如果无变化，跳过`InferShape`操作。
![image](https://user-images.githubusercontent.com/45189361/77849415-0c498c80-71fe-11ea-984d-f313fe3d9e1f.png)

【实现方法】：
1、 `InferShape` 拆分为`InferShape` 和`InferShapeImpl`     [op_lite.cc](https://github.com/PaddlePaddle/Paddle-Lite/pull/3294/files#diff-89950f706f5956830ec00e838f4b8716)
判断本次输入的`dims`和`lods`是否与上一次一致：
- 如果一致，直接用之前保存的`last_output_shapes`和`last_output_lods`
- 如果不一致，执行`InferShapeImpl`，更新`last_output_shapes`和`last_output_lods`，更新hash值

如何判断输入的dims和lods是否变化：
- 计算inputs_lods和inputs_dims 的hash值，作为判断依据
- InferShape 中：dims 和lods执行`combine_hash`操作，计算hash 值


2、为 `op_param` 添加基类`ParamBase`    [op_param.h](https://github.com/PaddlePaddle/Paddle-Lite/pull/3294/files#diff-8c43ac76e18cc9d361c0df0821bccfd5)
-  含有两个share_ptr ，分别保存Op的vector<input_tensor>和vector<output_tensor>
-  含有两个函数，需要使用`InferShape`记忆功能时，需要重新实现两个接口
所有的op_param继承base_param，如果该Op需要
![image](https://user-images.githubusercontent.com/45189361/77849374-bffe4c80-71fd-11ea-9353-d97f3069f2c8.png)

3、批量修改
- 将所有operator/文件夹下。op中重新实现的`InferShape` 改名为`InferShapeImpl`
- 为fc_op、elementwise_op、softmax_op、conv_ops 对应的op_param重新实现BaseParam接口，实现`根据记忆infershape`

4、如何新注册op  和 如何为op 添加 `根据记忆InferShape`

- 注册op: 重新实现` InferShapeImpl` (不需要重新实现InferShape)
- 添加记忆：重新实现`op_param` 接口，将需要记忆的input_tensor和output_tensor添加到实现中。
![image](https://user-images.githubusercontent.com/45189361/77849448-3e5aee80-71fe-11ea-9612-94a742e31ce8.png)


