### PR TITLE
[model parser] update model_parser to adapt for probuf of high version

### DIFF
--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -382,7 +382,7 @@ void TensorToStream(std::ostream &os, const lite::Tensor &tensor) {
     pb_dims->Resize(static_cast<int>(dims.size()), 0);
     auto dims_vec = dims.Vectorize();
     std::copy(dims_vec.begin(), dims_vec.end(), pb_dims->begin());
-    int32_t size = desc.ByteSize();
+    int32_t size = desc.ByteSizeLong();
     os.write(reinterpret_cast<const char *>(&size), sizeof(size));
     auto out = desc.SerializeAsString();
     os.write(out.data(), size);


### PR DESCRIPTION
【问题描述】：https://github.com/PaddlePaddle/Paddle-Lite/issues/3292
model_parser.cc中调用了ByteSize接口，该接口在最新的protobuf仓库已废弃，编译器选项标为deprecated，使用最新的protobuf编译paddlelite会直接被Werror挂掉，建议改为替代接口ByteSizeLong，返回值为size_t，也更符合语义
【解决方法】：替换接口
`ByteSize`----->`ByteSizeLong`