### PR TITLE
[JS DEMO] Demo of modify passes for model optimizing

### DIFF
--- a/lite/core/mir/fusion/conv_activation_fuser.cc
+++ b/lite/core/mir/fusion/conv_activation_fuser.cc
@@ -53,6 +53,8 @@ void ConvActivationFuser::BuildPattern() {
 
 void ConvActivationFuser::InsertNewNode(SSAGraph* graph,
                                         const key2nodes_t& matched) {
+  LOG(INFO) << "lite_conv_activation_fuse_pass applied: fused into `conv2d or "
+               "depthwise_conv2d or conv2d_transpose`";
   auto op_desc = GenOpDesc(matched);
   auto conv_op = LiteOpRegistry::Global().Create(conv_type_);
   auto conv_old = matched.at("conv2d")->stmt()->op();

--- a/lite/core/mir/fusion/conv_bn_fuser.cc
+++ b/lite/core/mir/fusion/conv_bn_fuser.cc
@@ -77,6 +77,8 @@ void ConvBNFuser::BuildPattern() {
 }
 
 void ConvBNFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
+  LOG(INFO) << "lite_conv_bn_fuse_pass applied: fused into `conv2d or "
+               "depthwise_conv2d`";
   auto conv_instruct = matched.at("conv2d")->stmt();
   auto conv_op_desc = conv_instruct->mutable_op_info();
   auto conv = conv_instruct->op();

--- a/lite/core/mir/fusion/conv_elementwise_fuser.cc
+++ b/lite/core/mir/fusion/conv_elementwise_fuser.cc
@@ -64,6 +64,7 @@ void ConvElementwiseFuser::BuildPattern() {
 
 void ConvElementwiseFuser::InsertNewNode(SSAGraph* graph,
                                          const key2nodes_t& matched) {
+  LOG(INFO) << "lite_conv_elementwise_fuse_pass applied: fused into conv2d";
   auto conv_instruct = matched.at("conv2d")->stmt();
   auto conv_op_desc = conv_instruct->mutable_op_info();
   auto* scope = conv_instruct->op()->scope();

--- a/lite/core/mir/fusion/elementwise_add_activation_fuser.cc
+++ b/lite/core/mir/fusion/elementwise_add_activation_fuser.cc
@@ -51,6 +51,8 @@ void ElementwiseAddActivationFuser::BuildPattern() {
 
 void ElementwiseAddActivationFuser::InsertNewNode(SSAGraph* graph,
                                                   const key2nodes_t& matched) {
+  LOG(INFO) << "lite_elementwise_add_activation_fuse_pass appiled: fused into "
+               "fusion_elementwise_add_activation";
   auto op_desc = GenOpDesc(matched);
   auto op =
       LiteOpRegistry::Global().Create("fusion_elementwise_add_activation");

--- a/lite/core/mir/fusion/fc_fuser.cc
+++ b/lite/core/mir/fusion/fc_fuser.cc
@@ -55,6 +55,7 @@ void FcFuser::BuildPattern() {
 }
 
 void FcFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
+  LOG(INFO) << "lite_fc_fuse_pass applied: fused into fc";
   auto op_desc = GenOpDesc(matched);
   auto fc_op = LiteOpRegistry::Global().Create("fc");
   auto mul = matched.at("mul")->stmt()->op();

--- a/lite/core/mir/fusion/interpolate_fuser.cc
+++ b/lite/core/mir/fusion/interpolate_fuser.cc
@@ -67,6 +67,8 @@ void InterpolateFuser::BuildPattern() {
 
 void InterpolateFuser::InsertNewNode(SSAGraph* graph,
                                      const key2nodes_t& matched) {
+  LOG(INFO) << "lite_interpolate_fuse_pass appiled: fused into "
+               "`bilinear_interp or earest_interp`";
   auto op_desc = GenOpDesc(matched);
   auto interp_op = LiteOpRegistry::Global().Create(interp_type_);
   auto interp_old = matched.at("interpolate")->stmt()->op();

--- a/lite/core/mir/fusion/sequence_pool_concat_fuser.cc
+++ b/lite/core/mir/fusion/sequence_pool_concat_fuser.cc
@@ -77,6 +77,8 @@ void SequencePoolConcatFuser::BuildPattern() {
 
 void SequencePoolConcatFuser::InsertNewNode(SSAGraph* graph,
                                             const key2nodes_t& matched) {
+  LOG(INFO) << "lite_sequence_pool_concat_fuse_pass appiled: fused into "
+               "sequence_pool_concat";
   auto op_desc = GenOpDesc(matched);
   auto sequence_pool_concat_op =
       LiteOpRegistry::Global().Create("sequence_pool_concat");

--- a/lite/core/mir/fusion/shuffle_channel_fuser.cc
+++ b/lite/core/mir/fusion/shuffle_channel_fuser.cc
@@ -76,6 +76,8 @@ void ShuffleChannelFuser::BuildPattern() {
 
 void ShuffleChannelFuser::InsertNewNode(SSAGraph* graph,
                                         const key2nodes_t& matched) {
+  LOG(INFO)
+      << "lite_shuffle_channel_fuse_pass appiled: fused into shuffle_channel";
   auto op_desc = GenOpDesc(matched);
   auto shuffle_channel_op = LiteOpRegistry::Global().Create("shuffle_channel");
   auto transpose = matched.at("transpose_op")->stmt()->op();

--- a/lite/core/mir/fusion/transpose_softmax_transpose_fuser.cc
+++ b/lite/core/mir/fusion/transpose_softmax_transpose_fuser.cc
@@ -64,6 +64,8 @@ void TransposeSoftmaxTransposeFuser::BuildPattern() {
 
 void TransposeSoftmaxTransposeFuser::InsertNewNode(SSAGraph* graph,
                                                    const key2nodes_t& matched) {
+  LOG(INFO) << "lite_transpose_softmax_transpose_fuse_pass appiled: fused into "
+               "softmax";
   auto op_desc = GenOpDesc(matched);
   auto softmax_op = LiteOpRegistry::Global().Create(softmax_type_);
   auto softmax_old = matched.at("softmax")->stmt()->op();

--- a/lite/core/mir/fusion/var_conv_2d_activation_fuser.cc
+++ b/lite/core/mir/fusion/var_conv_2d_activation_fuser.cc
@@ -49,6 +49,8 @@ void VarConvActivationFuser::BuildPattern() {
 
 void VarConvActivationFuser::InsertNewNode(SSAGraph* graph,
                                            const key2nodes_t& matched) {
+  LOG(INFO) << "lite_var_conv_2d_activation_fuse_pass applied: fused into "
+               "var_conv_2d";
   auto op_desc = GenOpDesc(matched);
   auto conv_op = LiteOpRegistry::Global().Create(conv_type_);
   auto conv_old = matched.at("var_conv_2d")->stmt()->op();

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -55,8 +55,7 @@ class Optimizer {
 
     if (passes.empty() || passes.size() == 1) {
       std::vector<std::string> passes_local{
-          {"lite_quant_dequant_fuse_pass",         //
-           "weight_quantization_preprocess_pass",  //
+          {"weight_quantization_preprocess_pass",  //
            "lite_conv_elementwise_fuse_pass",      // conv-elemwise-bn
            "lite_conv_bn_fuse_pass",               //
            "lite_conv_elementwise_fuse_pass",      // conv-bn-elemwise
@@ -71,19 +70,7 @@ class Optimizer {
            "identity_scale_eliminate_pass",               //
            "elementwise_mul_constant_eliminate_pass",     //
            "lite_sequence_pool_concat_fuse_pass",         //
-#if (defined LITE_WITH_LIGHT_WEIGHT_FRAMEWORK) || (defined LITE_WITH_CUDA) || \
-    (defined LITE_WITH_ARM)
-           "lite_elementwise_add_activation_fuse_pass",  //
-#endif
-           "quantized_op_attributes_inference_pass",  // Only for fully
-                                                      // quantized model, infer
-                                                      // the output scale and
-                                                      // fix the attribute
-                                                      // 'enable_int8' for all
-                                                      // of the quantized ops.
-           "npu_subgraph_pass",
-           "xpu_subgraph_pass",
-           "bm_subgraph_pass",
+           "lite_elementwise_add_activation_fuse_pass",   //
            "static_kernel_pick_pass",        // pick original kernel from graph
            "variable_place_inference_pass",  // inference arg/var's
            // info(target/precision/layout/device)
@@ -118,9 +105,6 @@ class Optimizer {
            "runtime_context_assign_pass",
            "argument_type_display_pass",
            "memory_optimize_pass"}};
-      if (passes.size() == 1) {
-        passes_local.push_back(passes[0]);
-      }
       RunPasses(passes_local);
     } else {
       RunPasses(passes);


### PR DESCRIPTION
【目的】：本PR作为示例讲述了如何删除部分pass ，修改Paddle-Lite的图优化方法
【本PR工作】：
- 删除量化模型相关处理Pass :  
     - `weight_quantization_preprocess_pass`
     - `quantized_op_attributes_inference_pass`
- 删除子图Pass 
     - "npu_subgraph_pass",	  npu子图
     - "xpu_subgraph_pass",	  xpu子图
     - "bm_subgraph_pass",        寒武纪子图

- 标记执行了哪些fuser
    - 在fuser型 pass对应的fuser源文件中，在 `InsertNewNode`函数出输出LOG 信息，标记某个图结构被替换为fused_op了

![image](https://user-images.githubusercontent.com/45189361/78648071-0d5d7680-78ee-11ea-9d32-8fd17769610a.png)
