### PR TITLE
[LITE][OPENCL] Add ReleaseResource for OpenCL when Predictor dead

### DIFF
--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -43,6 +43,16 @@ class LITE_API Predictor {
  public:
   // Create an empty predictor.
   Predictor() { scope_ = std::make_shared<Scope>(); }
+  ~Predictor() {
+#ifdef LITE_WITH_OPENCL
+    CLRuntime::Global()->ReleaseResources();
+#endif
+    scope_.reset();
+    exec_scope_ = nullptr;
+    program_.reset();
+    input_names_.clear();
+    output_names_.clear();
+  }
   // Create a predictor with the weight variable scope set.
   explicit Predictor(const std::shared_ptr<lite::Scope>& root_scope)
       : scope_(root_scope) {}
@@ -124,12 +134,6 @@ class LITE_API Predictor {
 class CxxPaddleApiImpl : public lite_api::PaddlePredictor {
  public:
   CxxPaddleApiImpl() {}
-
-  ~CxxPaddleApiImpl() {
-#ifdef LITE_WITH_OPENCL
-    CLRuntime::Global()->ReleaseResources();
-#endif
-  }
 
   /// Create a new predictor from a config.
   void Init(const lite_api::CxxConfig& config);

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -125,6 +125,8 @@ class CxxPaddleApiImpl : public lite_api::PaddlePredictor {
  public:
   CxxPaddleApiImpl() {}
 
+  ~CxxPaddleApiImpl();
+
   /// Create a new predictor from a config.
   void Init(const lite_api::CxxConfig& config);
 

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -125,7 +125,11 @@ class CxxPaddleApiImpl : public lite_api::PaddlePredictor {
  public:
   CxxPaddleApiImpl() {}
 
-  ~CxxPaddleApiImpl();
+  ~CxxPaddleApiImpl() {
+#ifdef LITE_WITH_OPENCL
+    CLRuntime::Global()->ReleaseResources();
+#endif
+  }
 
   /// Create a new predictor from a config.
   void Init(const lite_api::CxxConfig& config);

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -29,6 +29,12 @@
 namespace paddle {
 namespace lite {
 
+void CxxPaddleApiImp::~CxxPaddleApiImp() {
+#ifdef LITE_WITH_OPENCL
+  CLRuntime::Global()->ReleaseResources();
+#endif
+}
+
 void CxxPaddleApiImpl::Init(const lite_api::CxxConfig &config) {
   config_ = config;
 #ifdef LITE_WITH_CUDA

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -29,14 +29,6 @@
 namespace paddle {
 namespace lite {
 
-#if 0
-CxxPaddleApiImp::~CxxPaddleApiImp() {
-#ifdef LITE_WITH_OPENCL
-  CLRuntime::Global()->ReleaseResources();
-#endif
-}
-#endif
-
 void CxxPaddleApiImpl::Init(const lite_api::CxxConfig &config) {
   config_ = config;
 #ifdef LITE_WITH_CUDA

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -29,7 +29,7 @@
 namespace paddle {
 namespace lite {
 
-void CxxPaddleApiImp::~CxxPaddleApiImp() {
+CxxPaddleApiImp::~CxxPaddleApiImp() {
 #ifdef LITE_WITH_OPENCL
   CLRuntime::Global()->ReleaseResources();
 #endif

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -29,11 +29,13 @@
 namespace paddle {
 namespace lite {
 
+#if 0
 CxxPaddleApiImp::~CxxPaddleApiImp() {
 #ifdef LITE_WITH_OPENCL
   CLRuntime::Global()->ReleaseResources();
 #endif
 }
+#endif
 
 void CxxPaddleApiImpl::Init(const lite_api::CxxConfig &config) {
   config_ = config;

--- a/lite/api/light_api.h
+++ b/lite/api/light_api.h
@@ -107,6 +107,8 @@ class LightPredictorImpl : public lite_api::PaddlePredictor {
  public:
   LightPredictorImpl() = default;
 
+  ~LightPredictorImpl();
+
   std::unique_ptr<lite_api::Tensor> GetInput(int i) override;
 
   std::unique_ptr<const lite_api::Tensor> GetOutput(int i) const override;

--- a/lite/api/light_api_impl.cc
+++ b/lite/api/light_api_impl.cc
@@ -21,6 +21,13 @@
 namespace paddle {
 namespace lite {
 
+void LightPredictorImpl::~LightPredictorImpl() {
+  raw_predictor_.reset();
+#ifdef LITE_WITH_OPENCL
+  CLRuntime::Global()->ReleaseResources();
+#endif
+}
+
 void LightPredictorImpl::Init(const lite_api::MobileConfig& config) {
   // LightPredictor Only support NaiveBuffer backend in publish lib
   if (config.lite_model_file().empty()) {

--- a/lite/api/light_api_impl.cc
+++ b/lite/api/light_api_impl.cc
@@ -21,7 +21,7 @@
 namespace paddle {
 namespace lite {
 
-void LightPredictorImpl::~LightPredictorImpl() {
+LightPredictorImpl::~LightPredictorImpl() {
   raw_predictor_.reset();
 #ifdef LITE_WITH_OPENCL
   CLRuntime::Global()->ReleaseResources();

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -30,10 +30,7 @@ CLRuntime* CLRuntime::Global() {
 
 CLRuntime::~CLRuntime() {
   LOG(INFO) << "CLRuntime::~CLRuntime()";
-// Note: do ReleaseResources() in predictor
-#ifdef PADDLE_WITH_TESTING
-  ReleaseResources();
-#endif
+  // Note: do ReleaseResources() in predictor
   command_queue_&& clReleaseCommandQueue(command_queue_->get());
   command_queue_.reset();
   context_&& clReleaseContext(context_->get());
@@ -44,6 +41,10 @@ CLRuntime::~CLRuntime() {
 }
 
 void CLRuntime::ReleaseResources() {
+  if (is_resources_released_) {
+    return;
+  }
+
   if (command_queue_ != nullptr) {
     command_queue_->flush();
     command_queue_->finish();
@@ -59,6 +60,7 @@ void CLRuntime::ReleaseResources() {
   }
   programs_.clear();
   LOG(INFO) << "release resources finished.";
+  is_resources_released_ = true;
 }
 
 bool CLRuntime::Init() {

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -30,7 +30,10 @@ CLRuntime* CLRuntime::Global() {
 
 CLRuntime::~CLRuntime() {
   LOG(INFO) << "CLRuntime::~CLRuntime()";
-  // Note: do releaseResources() in predictor
+// Note: do ReleaseResources() in predictor
+#ifdef PADDLE_WITH_TESTING
+  ReleaseResources();
+#endif
   command_queue_&& clReleaseCommandQueue(command_queue_->get());
   command_queue_.reset();
   context_&& clReleaseContext(context_->get());

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -40,7 +40,7 @@ CLRuntime::~CLRuntime() {
   initialized_ = false;
 }
 
-void CLRuntime::ReleaseResouces() {
+void CLRuntime::ReleaseResources() {
   if (command_queue_ != nullptr) {
     command_queue_->flush();
     command_queue_->finish();

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -29,30 +29,33 @@ CLRuntime* CLRuntime::Global() {
 }
 
 CLRuntime::~CLRuntime() {
-  if (command_queue_ != nullptr) {
-    command_queue_->flush();
-    command_queue_->finish();
-  }
-
-  for (size_t kidx = 0; kidx < kernels_.size(); ++kidx) {
-    clReleaseKernel(kernels_[kidx]->get());
-    kernels_[kidx].reset();
-  }
-  kernels_.clear();
-  kernel_offset_.clear();
-
-  for (auto& p : programs_) {
-    clReleaseProgram(p.second->get());
-  }
-  programs_.clear();
-
-  // For controlling the destruction order
+  LOG(INFO) << "CLRuntime::~CLRuntime()";
+  // Note: do releaseResources() in predictor
   command_queue_&& clReleaseCommandQueue(command_queue_->get());
   command_queue_.reset();
   context_&& clReleaseContext(context_->get());
   context_.reset();
   device_.reset();
   platform_.reset();
+  initialized_ = false;
+}
+
+void CLRuntime::ReleaseResouces() {
+  if (command_queue_ != nullptr) {
+    command_queue_->flush();
+    command_queue_->finish();
+  }
+  for (size_t kidx = 0; kidx < kernels_.size(); ++kidx) {
+    clReleaseKernel(kernels_[kidx]->get());
+    kernels_[kidx].reset();
+  }
+  kernels_.clear();
+  kernel_offset_.clear();
+  for (auto& p : programs_) {
+    clReleaseProgram(p.second->get());
+  }
+  programs_.clear();
+  LOG(INFO) << "release resources finished.";
 }
 
 bool CLRuntime::Init() {

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -41,9 +41,9 @@ CLRuntime::~CLRuntime() {
 }
 
 void CLRuntime::ReleaseResources() {
-  if (is_resources_released_) {
-    return;
-  }
+  //  if (is_resources_released_) {
+  //    return;
+  //  }
 
   if (command_queue_ != nullptr) {
     command_queue_->flush();

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -33,7 +33,7 @@ class CLRuntime {
  public:
   static CLRuntime* Global();
 
-  void ReleaseResouces();
+  void ReleaseResources();
 
   bool Init();
 

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -33,6 +33,8 @@ class CLRuntime {
  public:
   static CLRuntime* Global();
 
+  void ReleaseResouces();
+
   bool Init();
 
   cl::Platform& platform();

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -118,6 +118,8 @@ class CLRuntime {
   bool initialized_{false};
 
   bool is_init_success_{false};
+
+  bool is_resources_released_{false};
 };
 
 }  // namespace lite

--- a/lite/core/memory.h
+++ b/lite/core/memory.h
@@ -126,7 +126,7 @@ class Buffer {
                         const size_t img_h,
                         void* host_ptr = nullptr) {
     if (target != target_ || cl_image2d_width_ < img_w ||
-        cl_image2d_height_ < img_h) {
+        cl_image2d_height_ < img_h || host_ptr != nullptr) {
       CHECK_EQ(own_data_, true) << "Can not reset unowned buffer.";
       Free();
       data_ = TargetWrapperCL::MallocImage<T>(img_w, img_h, host_ptr);


### PR DESCRIPTION
# 状态：等待review

## 主要内容

1. 原有`CLRuntime::~CLRuntime()`拆分为`~CLRuntime()`和`ReleaseResouces `。前者释放device、platform等，后者释放`cl::Kernel`、`cl::Program`；
2. CXX和Light api impl加入`CLRuntime::Global()->ReleaseResources();`，用于释放`cl::Kernel`、`cl::Program`；
3. OpenCL `Image`的内存部分，针对如果是`host_ptr`不为`nullptr`时，申请空间。