### PR TITLE
[Windows compile] change core/types name to avoid corruption on windows

### DIFF
--- a/lite/core/types.cc
+++ b/lite/core/types.cc
@@ -67,31 +67,31 @@ STL::ostream& operator<<(STL::ostream& os, const KernelPickFactor& k) {
 
 template <>
 Type StdTypeToRepr<int32_t>() {
-  return Type::_int32;
+  return Type::INT32;
 }
 template <>
 Type StdTypeToRepr<int64_t>() {
-  return Type::_int64;
+  return Type::INT64;
 }
 template <>
 Type StdTypeToRepr<float>() {
-  return Type::_float32;
+  return Type::FLOAT32;
 }
 template <>
 Type StdTypeToRepr<double>() {
-  return Type::_float64;
+  return Type::Float64;
 }
 template <>
 Type StdTypeToRepr<std::vector<char>>() {
-  return Type::_char_list;
+  return Type::CHARLIST;
 }
 template <>
 Type StdTypeToRepr<std::string>() {
-  return Type::_string;
+  return Type::STRING;
 }
 template <>
 Type StdTypeToRepr<bool>() {
-  return Type::_bool;
+  return Type::BOOL;
 }
 
 }  // namespace core

--- a/lite/core/types.h
+++ b/lite/core/types.h
@@ -29,23 +29,23 @@ namespace core {
  */
 // TODO(Superjomn) unify all the type representation across the lite framework.
 enum class Type {
-  _unk = -1,
+  UNK = -1,
   // primary types
-  _int32,
-  _int64,
-  _float32,
-  _float64,
-  _bool,
-  _string,
+  INT32,
+  INT64,
+  FLOAT32,
+  Float64,
+  BOOL,
+  STRING,
   // primary list type
-  _char_list,
+  CHARLIST,
   // list types
-  _list,
+  LIST,
   // enum type
-  _enum,
-  _float16,
+  ENUM,
+  FLOAT16,
   // number of types
-  __num__,
+  NUM,
 };
 
 enum class FluidType {

--- a/lite/core/types.h
+++ b/lite/core/types.h
@@ -81,7 +81,7 @@ enum class FluidType {
 
 template <typename T>
 Type StdTypeToRepr() {
-  return Type::_unk;
+  return Type::UNK;
 }
 template <>
 Type StdTypeToRepr<int32_t>();

--- a/lite/model_parser/naive_buffer/naive_buffer.h
+++ b/lite/model_parser/naive_buffer/naive_buffer.h
@@ -192,7 +192,7 @@ class EnumBuilder : public FieldBuilder {
 
   ~EnumBuilder() = default;
 
-  Type type() const override { return Type::_enum; }
+  Type type() const override { return Type::ENUM; }
 };
 
 class StringBuilder : public FieldBuilder {
@@ -211,7 +211,7 @@ class StringBuilder : public FieldBuilder {
 
   void Load() override;
 
-  Type type() const override { return Type::_string; }
+  Type type() const override { return Type::STRING; }
 };
 
 /*
@@ -327,7 +327,7 @@ class ListBuilder : public FieldBuilder {
   }
 
   // Get element type.
-  Type type() const override { return Type::_list; }
+  Type type() const override { return Type::LIST; }
 
   /// Persist information to the corresponding BinaryTable.
   void Save() override;

--- a/lite/model_parser/naive_buffer/naive_buffer.h
+++ b/lite/model_parser/naive_buffer/naive_buffer.h
@@ -266,7 +266,7 @@ class StructBuilder : public FieldBuilder {
 
   /// Type of this struct.
   // TODO(Superjomn) The customized type is not supported yet.
-  Type type() const override { return Type::_unk; }
+  Type type() const override { return Type::UNK; }
 
   /// Get a field by `name`.
   template <typename T>

--- a/lite/model_parser/naive_buffer/naive_buffer_test.cc
+++ b/lite/model_parser/naive_buffer/naive_buffer_test.cc
@@ -24,7 +24,7 @@ TEST(NaiveBuffer, primary) {
   PrimaryBuilder<int32_t> p0(&table);
   PrimaryBuilder<float> p1(&table);
   StringBuilder p2(&table);
-  ASSERT_EQ(p0.type(), Type::_int32);
+  ASSERT_EQ(p0.type(), Type::INT32);
   ASSERT_EQ(p1.type(), Type::FLOAT32);
   ASSERT_EQ(p2.type(), Type::STRING);
 

--- a/lite/model_parser/naive_buffer/naive_buffer_test.cc
+++ b/lite/model_parser/naive_buffer/naive_buffer_test.cc
@@ -25,8 +25,8 @@ TEST(NaiveBuffer, primary) {
   PrimaryBuilder<float> p1(&table);
   StringBuilder p2(&table);
   ASSERT_EQ(p0.type(), Type::_int32);
-  ASSERT_EQ(p1.type(), Type::_float32);
-  ASSERT_EQ(p2.type(), Type::_string);
+  ASSERT_EQ(p1.type(), Type::FLOAT32);
+  ASSERT_EQ(p2.type(), Type::STRING);
 
   p0.set(2008);
   p0.Save();
@@ -129,7 +129,7 @@ TEST(NBTestMsg, msg1) {
   int0->set(2008);
   int0->Save();
 
-  enum0->set(Type::_int64);
+  enum0->set(Type::INT64);
   enum0->Save();
 
   SetMsg0(msg0);
@@ -143,7 +143,7 @@ TEST(NBTestMsg, msg1) {
   msg1.Load();
 
   ASSERT_EQ(msg.GetField<Int32Builder>("int0").data(), 2008);
-  ASSERT_EQ(msg.GetField<enum_builder>("enum0").data(), Type::_int64);
+  ASSERT_EQ(msg.GetField<enum_builder>("enum0").data(), Type::INT64);
   TestMsg0(msg1.GetField<NBTestMsg0>("msg0"));
 }
 


### PR DESCRIPTION
【问题描述】：`lite/core/types.h`文件中定义的`Type`类中含有 `_int32`、`_int64` 在windows下为系统特殊符号，不可以定义为该名称，会导致编译错误
【本PR工作】： 修改`lite/core/types.h`文件中定义的`Type`类中元素为对应类型的全大写名称
```
_int32 --> INT32
_int64-->INT63
_float32--> FLOAT32
...
```
并修改相关文件中的引用