### PR TITLE
[proto model name] change the optimized param file name from `params` into `param`

### DIFF
--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -290,7 +290,7 @@ void SaveModelPb(const std::string &model_dir,
   // Save Params
   // NOTE: Only main block be used now.
   if (combined) {
-    const std::string combined_params_path = model_dir + "/params";
+    const std::string combined_params_path = model_dir + "/param";
     SaveCombinedParamsPb(combined_params_path, exec_scope, cpp_prog);
   } else {
     for (auto &item : pb_proto_prog.blocks(0).vars()) {


### PR DESCRIPTION
[问题描述]： Paddle-Lite `CxxPredictor->SaveOptimizedModel `接口保存的优化后proto格式模型为 `model + params` ，对比Fluid中保存的模型文件为 `model + param` 。 两者实现不一致。
[本PR工作]： 将Paddle-Lite `CxxPredictor->SaveOptimizedModel ` 接口保存的proto格式模型修改为 `model + param`，使与PaddleFluid实现一致