### PR TITLE
[infershape fix]

### DIFF
--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -25,7 +25,7 @@ namespace lite {
 bool OpLite::InferShape() {
   // if input_tensor_ptrs and output_tensor_ptrs are overloaded in param_
   // InferShapeByMemoryInternal will be applied.
-  if (op_param_->input_tensor_ptrs() && op_param_->output_tensor_ptrs()) {
+  if (op_param_ && op_param_->input_tensor_ptrs() && op_param_->output_tensor_ptrs()) {
     return this->InferShapeWithCache();
   } else {
     return this->InferShapeImpl();

--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -25,7 +25,8 @@ namespace lite {
 bool OpLite::InferShape() {
   // if input_tensor_ptrs and output_tensor_ptrs are overloaded in param_
   // InferShapeByMemoryInternal will be applied.
-  if (op_param_ && op_param_->input_tensor_ptrs() && op_param_->output_tensor_ptrs()) {
+  if (op_param_ && op_param_->input_tensor_ptrs() &&
+      op_param_->output_tensor_ptrs()) {
     return this->InferShapeWithCache();
   } else {
     return this->InferShapeImpl();

--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -25,16 +25,15 @@ namespace lite {
 bool OpLite::InferShape() {
   // if input_tensor_ptrs and output_tensor_ptrs are overloaded in param_
   // InferShapeByMemoryInternal will be applied.
-  if (param_.input_tensor_ptrs() && param_.output_tensor_ptrs()) {
+  if (op_param_->input_tensor_ptrs() && op_param_->output_tensor_ptrs()) {
     return this->InferShapeWithCache();
   } else {
-    // otherwise, InferShapeImpl is applied directly.
     return this->InferShapeImpl();
   }
 }
 bool OpLite::InferShapeWithCache() {
   // 1. Get vector of current input tensors
-  auto *current_inputs = param_.input_tensor_ptrs();
+  auto *current_inputs = op_param_->input_tensor_ptrs();
   // 2. Get hash value of current inputs shape and lod
   size_t new_hash = 0;
   for (auto iter = current_inputs->begin(); iter != current_inputs->end();
@@ -59,7 +58,7 @@ bool OpLite::InferShapeWithCache() {
   if (new_hash == io_shape_lod_hash_ && new_hash != 0) {
     // if current hash value is consistent with io_shape_lod_hash_,
     // previous outputs shape and lod are reused.
-    auto *current_outputs = param_.output_tensor_ptrs();
+    auto *current_outputs = op_param_->output_tensor_ptrs();
     for (size_t i = 0; i < current_outputs->size(); i++) {
       current_outputs->at(i)->Resize(last_output_shapes[i]);
       current_outputs->at(i)->set_lod(last_output_lods[i]);
@@ -68,10 +67,12 @@ bool OpLite::InferShapeWithCache() {
     // otherwise, current hash value is changed, InferShapeImpl will apply.
     io_shape_lod_hash_ = new_hash;
     this->InferShapeImpl();
-    auto *current_outputs = param_.output_tensor_ptrs();
+    auto *current_outputs = op_param_->output_tensor_ptrs();
+    last_output_shapes.clear();
+    last_output_lods.clear();
     for (size_t i = 0; i < current_outputs->size(); i++) {
-      last_output_shapes[i] = current_outputs->at(i)->dims();
-      last_output_lods[i] = current_outputs->at(i)->lod();
+      last_output_shapes.push_back(current_outputs->at(i)->dims());
+      last_output_lods.push_back(current_outputs->at(i)->lod());
     }
   }
   return true;

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -171,7 +171,7 @@ class OpLite : public Registry {
   std::vector<DDimLite> last_output_shapes{};
   std::vector<std::vector<std::vector<uint64_t>>> last_output_lods{};
   size_t io_shape_lod_hash_{};
-  mutable operators::ParamBase param_;
+  mutable std::shared_ptr<operators::ParamBase> op_param_;
 
  private:
   // Infer Shape according to memory, if current input shapes are consistent

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -123,10 +123,7 @@ class OpLite : public Registry {
 
  protected:
   // Attach it with the runtime environment.
-  virtual bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-    op_param_ = new operators::ParamBase;
-    return true;
-  }
+  virtual bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) = 0;
 
   // Specify the kernel to run by default. This will specify the value of
   // `kernel_place_`.
@@ -173,7 +170,7 @@ class OpLite : public Registry {
   std::vector<DDimLite> last_output_shapes{};
   std::vector<std::vector<std::vector<uint64_t>>> last_output_lods{};
   size_t io_shape_lod_hash_{};
-  mutable operators::ParamBase *op_param_;
+  mutable operators::ParamBase *op_param_{new operators::ParamBase};
 
  private:
   // Infer Shape according to memory, if current input shapes are consistent

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -123,7 +123,9 @@ class OpLite : public Registry {
 
  protected:
   // Attach it with the runtime environment.
-  virtual bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) = 0;
+  virtual bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
+    op_param_ = new operators::ParamBase;
+  }
 
   // Specify the kernel to run by default. This will specify the value of
   // `kernel_place_`.
@@ -167,11 +169,10 @@ class OpLite : public Registry {
   std::vector<Place> valid_places_;
   Place kernel_place_{TARGET(kHost), PRECISION(kFloat)};
   std::unique_ptr<OpInfo> op_info_;
-
   std::vector<DDimLite> last_output_shapes{};
   std::vector<std::vector<std::vector<uint64_t>>> last_output_lods{};
   size_t io_shape_lod_hash_{};
-  mutable std::shared_ptr<operators::ParamBase> op_param_;
+  mutable operators::ParamBase *op_param_;
 
  private:
   // Infer Shape according to memory, if current input shapes are consistent

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -170,7 +170,7 @@ class OpLite : public Registry {
   std::vector<DDimLite> last_output_shapes{};
   std::vector<std::vector<std::vector<uint64_t>>> last_output_lods{};
   size_t io_shape_lod_hash_{};
-  mutable operators::ParamBase *op_param_;
+  mutable operators::ParamBase *op_param_{nullptr};
 
  private:
   // Infer Shape according to memory, if current input shapes are consistent

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -170,7 +170,7 @@ class OpLite : public Registry {
   std::vector<DDimLite> last_output_shapes{};
   std::vector<std::vector<std::vector<uint64_t>>> last_output_lods{};
   size_t io_shape_lod_hash_{};
-  mutable operators::ParamBase *op_param_{new operators::ParamBase};
+  mutable operators::ParamBase *op_param_;
 
  private:
   // Infer Shape according to memory, if current input shapes are consistent

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -125,6 +125,7 @@ class OpLite : public Registry {
   // Attach it with the runtime environment.
   virtual bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
     op_param_ = new operators::ParamBase;
+    return true;
   }
 
   // Specify the kernel to run by default. This will specify the value of

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -38,7 +38,7 @@ class ConvOpLite : public OpLite {
 
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {
-    op_param_.reset(dynamic_cast<ConvParam*>(&param_));
+    op_param_ = dynamic_cast<ConvParam*>(&param_);
 
     auto X = op_desc.Input("Input").front();
     auto Filter = op_desc.Input("Filter").front();

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -38,6 +38,8 @@ class ConvOpLite : public OpLite {
 
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {
+    op_param_.reset(dynamic_cast<ConvParam*>(&param_));
+
     auto X = op_desc.Input("Input").front();
     auto Filter = op_desc.Input("Filter").front();
     auto Out = op_desc.Output("Output").front();

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -38,7 +38,6 @@ class ConvOpLite : public OpLite {
 
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {
-    delete op_param_;
     op_param_ = static_cast<ConvParam*>(&param_);
 
     auto X = op_desc.Input("Input").front();

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -38,7 +38,7 @@ class ConvOpLite : public OpLite {
 
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {
-    op_param_ = dynamic_cast<ConvParam*>(&param_);
+    op_param_ = static_cast<ConvParam*>(&param_);
 
     auto X = op_desc.Input("Input").front();
     auto Filter = op_desc.Input("Filter").front();

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -38,6 +38,7 @@ class ConvOpLite : public OpLite {
 
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {
+    delete op_param_;
     op_param_ = static_cast<ConvParam*>(&param_);
 
     auto X = op_desc.Input("Input").front();

--- a/lite/operators/elementwise_ops.cc
+++ b/lite/operators/elementwise_ops.cc
@@ -87,6 +87,7 @@ bool ElementwiseOp::InferShapeImpl() const {
 }
 
 bool ElementwiseOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
+  delete op_param_;
   op_param_ = static_cast<ElementwiseParam*>(&param_);
 
   auto X_name = opdesc.Input("X").front();

--- a/lite/operators/elementwise_ops.cc
+++ b/lite/operators/elementwise_ops.cc
@@ -87,7 +87,6 @@ bool ElementwiseOp::InferShapeImpl() const {
 }
 
 bool ElementwiseOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
-  delete op_param_;
   op_param_ = static_cast<ElementwiseParam*>(&param_);
 
   auto X_name = opdesc.Input("X").front();

--- a/lite/operators/elementwise_ops.cc
+++ b/lite/operators/elementwise_ops.cc
@@ -87,7 +87,7 @@ bool ElementwiseOp::InferShapeImpl() const {
 }
 
 bool ElementwiseOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
-  op_param_ = dynamic_cast<ElementwiseParam*>(&param_);
+  op_param_ = static_cast<ElementwiseParam*>(&param_);
 
   auto X_name = opdesc.Input("X").front();
   auto Y_name = opdesc.Input("Y").front();

--- a/lite/operators/elementwise_ops.cc
+++ b/lite/operators/elementwise_ops.cc
@@ -87,7 +87,7 @@ bool ElementwiseOp::InferShapeImpl() const {
 }
 
 bool ElementwiseOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
-  op_param_.reset(dynamic_cast<ElementwiseParam*>(&param_));
+  op_param_ = dynamic_cast<ElementwiseParam*>(&param_);
 
   auto X_name = opdesc.Input("X").front();
   auto Y_name = opdesc.Input("Y").front();

--- a/lite/operators/elementwise_ops.cc
+++ b/lite/operators/elementwise_ops.cc
@@ -87,6 +87,8 @@ bool ElementwiseOp::InferShapeImpl() const {
 }
 
 bool ElementwiseOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
+  op_param_.reset(dynamic_cast<ElementwiseParam*>(&param_));
+
   auto X_name = opdesc.Input("X").front();
   auto Y_name = opdesc.Input("Y").front();
   auto Out_name = opdesc.Output("Out").front();

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -69,7 +69,6 @@ bool FcOpLite::InferShapeImpl() const {
 }
 
 bool FcOpLite::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
-  delete op_param_;
   op_param_ = static_cast<FcParam*>(&param_);
 
   auto input = op_desc.Input("Input").front();

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -49,8 +49,6 @@ bool FcOpLite::CheckShape() const {
 }
 
 bool FcOpLite::InferShapeImpl() const {
-  op_param_.reset(dynamic_cast<FcParam*>(&param_));
-
   const auto& input_dims = param_.input->dims();
   const auto& w_dims = param_.w->dims();
   int in_num_col_dims = param_.in_num_col_dims;
@@ -71,6 +69,8 @@ bool FcOpLite::InferShapeImpl() const {
 }
 
 bool FcOpLite::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
+  op_param_ = dynamic_cast<FcParam*>(&param_);
+
   auto input = op_desc.Input("Input").front();
   auto W = op_desc.Input("W").front();
   auto out = op_desc.Output("Out").front();

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -69,7 +69,7 @@ bool FcOpLite::InferShapeImpl() const {
 }
 
 bool FcOpLite::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
-  op_param_ = dynamic_cast<FcParam*>(&param_);
+  op_param_ = static_cast<FcParam*>(&param_);
 
   auto input = op_desc.Input("Input").front();
   auto W = op_desc.Input("W").front();

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -49,6 +49,8 @@ bool FcOpLite::CheckShape() const {
 }
 
 bool FcOpLite::InferShapeImpl() const {
+  op_param_.reset(dynamic_cast<FcParam*>(&param_));
+
   const auto& input_dims = param_.input->dims();
   const auto& w_dims = param_.w->dims();
   int in_num_col_dims = param_.in_num_col_dims;

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -69,6 +69,7 @@ bool FcOpLite::InferShapeImpl() const {
 }
 
 bool FcOpLite::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
+  delete op_param_;
   op_param_ = static_cast<FcParam*>(&param_);
 
   auto input = op_desc.Input("Input").front();

--- a/lite/operators/mul_op.h
+++ b/lite/operators/mul_op.h
@@ -38,6 +38,7 @@ class MulOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
+    delete op_param_;
     op_param_ = static_cast<MulParam *>(&param_);
 
     CHECK(!op_desc.Input("X").empty());

--- a/lite/operators/mul_op.h
+++ b/lite/operators/mul_op.h
@@ -38,7 +38,7 @@ class MulOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
-    op_param_.reset(dynamic_cast<MulParam *>(&param_));
+    op_param_ = dynamic_cast<MulParam *>(&param_);
 
     CHECK(!op_desc.Input("X").empty());
     CHECK(!op_desc.Input("Y").empty());

--- a/lite/operators/mul_op.h
+++ b/lite/operators/mul_op.h
@@ -38,7 +38,7 @@ class MulOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
-    op_param_ = dynamic_cast<MulParam *>(&param_);
+    op_param_ = static_cast<MulParam *>(&param_);
 
     CHECK(!op_desc.Input("X").empty());
     CHECK(!op_desc.Input("Y").empty());

--- a/lite/operators/mul_op.h
+++ b/lite/operators/mul_op.h
@@ -38,7 +38,6 @@ class MulOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
-    delete op_param_;
     op_param_ = static_cast<MulParam *>(&param_);
 
     CHECK(!op_desc.Input("X").empty());

--- a/lite/operators/mul_op.h
+++ b/lite/operators/mul_op.h
@@ -38,6 +38,8 @@ class MulOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
+    op_param_.reset(dynamic_cast<MulParam *>(&param_));
+
     CHECK(!op_desc.Input("X").empty());
     CHECK(!op_desc.Input("Y").empty());
     CHECK(!op_desc.Output("Out").empty());
@@ -56,7 +58,6 @@ class MulOpLite : public OpLite {
     param_.output = var->GetMutable<Tensor>();
     param_.x_num_col_dims = op_desc.GetAttr<int>("x_num_col_dims");
     param_.y_num_col_dims = op_desc.GetAttr<int>("y_num_col_dims");
-
     return true;
   }
 

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -35,6 +35,7 @@ namespace operators {
 
 struct ParamBase {
  public:
+  virtual ~ParamBase() {}
   virtual const std::vector<const Tensor*>* input_tensor_ptrs() {
     return nullptr;
   }

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -35,8 +35,10 @@ namespace operators {
 
 struct ParamBase {
  public:
-  const std::vector<Tensor*>* input_tensor_ptrs() const { return nullptr; }
-  std::vector<Tensor*>* output_tensor_ptrs() { return nullptr; }
+  virtual const std::vector<const Tensor*>* input_tensor_ptrs() {
+    return nullptr;
+  }
+  virtual std::vector<Tensor*>* output_tensor_ptrs() { return nullptr; }
 
  protected:
   std::shared_ptr<std::vector<const Tensor*>> input_tensor_ptrs_cache_{nullptr};
@@ -108,15 +110,15 @@ struct FcParam : ParamBase {
   WITH_INT8_CONFIG
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({input}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -160,15 +162,15 @@ struct MulParam : ParamBase {
   WITH_INT8_CONFIG
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x, y}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -243,15 +245,15 @@ struct ScaleParam : ParamBase {
   bool bias_after_scale{true};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -265,15 +267,15 @@ struct SoftmaxParam : ParamBase {
   int axis{-1};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -292,15 +294,15 @@ struct ReshapeParam : ParamBase {
   bool inplace{false};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -314,8 +316,8 @@ struct ConcatParam : ParamBase {
   int axis{0};
   lite::Tensor* axis_tensor{};
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       std::vector<const Tensor*> vec;
       for (auto in : x) {
         vec.push_back(in);
@@ -325,8 +327,8 @@ struct ConcatParam : ParamBase {
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -406,15 +408,15 @@ struct ConvParam : ParamBase {
 
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -440,15 +442,15 @@ struct BatchNormParam : ParamBase {
   DataLayoutType data_layout{DATALAYOUT(kNCHW)};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({y}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -479,15 +481,15 @@ struct PoolParam : ParamBase {
   WITH_INT8_CONFIG
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -518,15 +520,15 @@ struct SplitParam : ParamBase {
   std::vector<int> sections;
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -544,15 +546,15 @@ struct TransposeParam : ParamBase {
   std::string data_format{"AnyLayout"};
   ///////////////////////////////////////////////////////////////////////////////////
   //  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -571,15 +573,15 @@ struct ElementwiseParam : ParamBase {
   float y_input_scale{1.0};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X, Y}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -884,15 +886,15 @@ struct SequenceSoftmaxParam : ParamBase {
   lite::Tensor* Out{};
   ///////////////////////////////////////////////////////////////////////////////////
   //  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -1135,15 +1137,15 @@ struct SliceParam : ParamBase {
   lite::Tensor* EndsTensor{nullptr};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -1197,15 +1199,15 @@ struct SqueezeParam : ParamBase {
   std::vector<int> axes{};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -1221,15 +1223,15 @@ struct UnsqueezeParam : ParamBase {
   std::vector<const lite::Tensor*> axes_tensor_vct{};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
     }
     return output_tensor_ptrs_cache_.get();
@@ -1253,15 +1255,15 @@ struct MatMulParam : ParamBase {
   float alpha{1.0f};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() {
-    if (UNLIKELY(input_tensor_ptrs_cache_)) {
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X, Y}));
     }
     return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
-  const std::vector<Tensor*>* output_tensor_ptrs() {
-    if (UNLIKELY(output_tensor_ptrs_cache_)) {
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
     }
     return output_tensor_ptrs_cache_.get();

--- a/lite/operators/softmax_op.cc
+++ b/lite/operators/softmax_op.cc
@@ -38,7 +38,7 @@ bool SoftmaxOp::InferShapeImpl() const {
 }
 
 bool SoftmaxOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  op_param_.reset(dynamic_cast<SoftmaxParam *>(&param_));
+  op_param_ = dynamic_cast<SoftmaxParam *>(&param_);
 
   param_.x = const_cast<lite::Tensor *>(
       &scope->FindVar(opdesc.Input("X").front())->Get<lite::Tensor>());

--- a/lite/operators/softmax_op.cc
+++ b/lite/operators/softmax_op.cc
@@ -38,7 +38,6 @@ bool SoftmaxOp::InferShapeImpl() const {
 }
 
 bool SoftmaxOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  delete op_param_;
   op_param_ = static_cast<SoftmaxParam *>(&param_);
 
   param_.x = const_cast<lite::Tensor *>(

--- a/lite/operators/softmax_op.cc
+++ b/lite/operators/softmax_op.cc
@@ -38,6 +38,7 @@ bool SoftmaxOp::InferShapeImpl() const {
 }
 
 bool SoftmaxOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
+  delete op_param_;
   op_param_ = static_cast<SoftmaxParam *>(&param_);
 
   param_.x = const_cast<lite::Tensor *>(

--- a/lite/operators/softmax_op.cc
+++ b/lite/operators/softmax_op.cc
@@ -38,6 +38,8 @@ bool SoftmaxOp::InferShapeImpl() const {
 }
 
 bool SoftmaxOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
+  op_param_.reset(dynamic_cast<SoftmaxParam *>(&param_));
+
   param_.x = const_cast<lite::Tensor *>(
       &scope->FindVar(opdesc.Input("X").front())->Get<lite::Tensor>());
   param_.output =

--- a/lite/operators/softmax_op.cc
+++ b/lite/operators/softmax_op.cc
@@ -38,7 +38,7 @@ bool SoftmaxOp::InferShapeImpl() const {
 }
 
 bool SoftmaxOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  op_param_ = dynamic_cast<SoftmaxParam *>(&param_);
+  op_param_ = static_cast<SoftmaxParam *>(&param_);
 
   param_.x = const_cast<lite::Tensor *>(
       &scope->FindVar(opdesc.Input("X").front())->Get<lite::Tensor>());


### PR DESCRIPTION
【问题描述】：`InferShapeImpl`没有实现`SmartInferShape`中对`infershape`耗时的降低
【定位问题】： `op_lite`基类中param_ 变量，与op子类继承实现中 param_实际是两个分开的实现，而非期望中同意变量，op_lite->InferShape 中指向了 `ParamBase:: `方法而非 op中param实例中的实现

【本PR修改】：将op_lite中定义的`param_`修改为`shared_ptr`类型，在`operator->AttachImpl`中，使其指向现有& param_ 地址

【效果对比】：
修改前：mv45.nb 模型运行一次所有infershape操作总时长（连续10次）：
![image](https://user-images.githubusercontent.com/45189361/79676558-eec67c00-8219-11ea-96de-9e1c8b412d46.png)

对比： SmartInferShape实现中InferShape总时长（连续10次）
![image](https://user-images.githubusercontent.com/45189361/79676581-13225880-821a-11ea-8a40-70f7c91a7adc.png)


本PR修改效果：(比SmartInferShape 慢约0.005ms；比修改前加速明显，符合infershape总耗时 0.1ms以内期望)
![image](https://user-images.githubusercontent.com/45189361/79676594-2f25fa00-821a-11ea-9ebd-1b430e5ca179.png)


【下一步修改 todo】：将`operator`实例中`param_`参数定义去除，直接复用op_lite基类中定义的op_param


