### PR TITLE
[LITE][OPENCL] remove unused event & opt clang android log warning te…

### DIFF
--- a/lite/kernels/opencl/io_copy_buffer_compute_test.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute_test.cc
@@ -65,9 +65,7 @@ TEST(io_copy, compute) {
 
   h2d_kernel->Launch();
   auto* event_key = d_y.data<float, cl::Buffer>();
-  std::shared_ptr<cl::Event> event(new cl::Event);
   d2h_kernel->Launch();
-
   auto* h_y_data = h_y.data<float>();
 
   for (int i = 0; i < 3 * 9 * 28 * 28; i++) {

--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -36,11 +36,11 @@
 // Android log macors
 #define ANDROID_LOG_TAG "Paddle-Lite"
 #define ANDROID_LOG_I(msg) \
-  __android_log_print(ANDROID_LOG_INFO, ANDROID_LOG_TAG, msg)
+  __android_log_print(ANDROID_LOG_INFO, ANDROID_LOG_TAG, "%s", msg)
 #define ANDROID_LOG_W(msg) \
-  __android_log_print(ANDROID_LOG_WARN, ANDROID_LOG_TAG, msg)
+  __android_log_print(ANDROID_LOG_WARN, ANDROID_LOG_TAG, "%s", msg)
 #define ANDROID_LOG_F(msg) \
-  __android_log_print(ANDROID_LOG_FATAL, ANDROID_LOG_TAG, msg)
+  __android_log_print(ANDROID_LOG_FATAL, ANDROID_LOG_TAG, "%s", msg)
 #endif
 
 // NOLINTFILE()


### PR DESCRIPTION
1. fix clang android log warning.
2. remove an unused event.
