### PR TITLE
[LITE][OPENCL] Fix Places of CXX Config for OpenCL. test=develop

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -293,6 +293,7 @@ void Predictor::Build(const cpp::ProgramDesc &desc,
   // `inner_places` is used to optimize passes
   std::vector<Place> inner_places = valid_places;
   for (auto &valid_place : valid_places) {
+    if (valid_place.target == TARGET(kOpenCL)) continue;
     inner_places.emplace_back(
         Place(TARGET(kHost), valid_place.precision, valid_place.layout));
   }

--- a/lite/kernels/opencl/slice_image_compute_test.cc
+++ b/lite/kernels/opencl/slice_image_compute_test.cc
@@ -84,7 +84,7 @@ TEST(slice_image2d_fp16, compute) {
   }
 
   LOG(INFO) << "prepare input";
-  std::shared_ptr<CLImageConverterDefault> default_converter(
+  std::unique_ptr<CLImageConverterDefault> default_converter(
       new CLImageConverterDefault());
   DDim image_shape = default_converter->InitImageDimInfoWith(in_dim);
   LOG(INFO) << "image_shape = " << image_shape[0] << " " << image_shape[1];


### PR DESCRIPTION
修复CXX Config的Place错误问题。你看下面，之前的写法opencl有自己的layout和精度，这么for循环搞（见原代码），直接jj了（host就没有ImageDefault这种layout，导致后面选kernel出问题）：

```shell
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:301 Build] inner_places.size():10
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[0]:opencl/float16/ImageDefault
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[1]:opencl/float/NCHW
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[2]:opencl/any/ImageDefault
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[3]:opencl/any/NCHW
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[4]:arm/float/NCHW
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[5]:host/float16/ImageDefault
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[6]:host/float/NCHW
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[7]:host/any/ImageDefault
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[8]:host/any/NCHW
[I  4/22 17: 0:23.856 ...ai/code/lite-mnasnet/lite/api/cxx_api.cc:304 Build] inner_places[9]:host/float/NCHW
```

修改后，mobilenetv1的test可以正常跑到opencl。