### PR TITLE
[compiling][url] change `https:` into `http`

### DIFF
--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -45,7 +45,7 @@ else()
         # we changed the source code to adapt for windows compiling
         #         git diffs : (1) unsupported/Eigen/CXX11/src/Tensor/TensorBlockV2.h
         ######################################################################################################
-        URL             https://paddlelite-data.bj.bcebos.com/third_party_libs/eigen-git-mirror-master-9ab917e9db99f5907d086aa73d5f9103.zip
+        URL             http://paddlelite-data.bj.bcebos.com/third_party_libs/eigen-git-mirror-master-9ab917e9db99f5907d086aa73d5f9103.zip
         DOWNLOAD_DIR          ${EIGEN_SOURCECODE_DIR}
         DOWNLOAD_NO_PROGRESS  1
         PREFIX          ${EIGEN_SOURCE_DIR}


### PR DESCRIPTION
【问题描述】：第三方库eigen的下载地址以 `https:\\`开头，部分环境下无法解析
【本PR工作】：将eigen的下载地址改为以 `http:\\`开头，解决部分环境不能解析 `htpps:\\`问题