### PR TITLE
[bug fix] fix the issue that paddle-lite can not compile on Centos

### DIFF
--- a/lite/kernels/host/compare_compute.cc
+++ b/lite/kernels/host/compare_compute.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "lite/kernels/host/compare_compute.h"
+#include <math.h>
 #include <vector>
 
 namespace paddle {


### PR DESCRIPTION
【问题描述】： Paddle-Lite 在CentOs编译失败
报错信息：
```
lite/kernels/host/compare_compute.cc 
     undefined defination of fabs();
```
【定位问题】#3197
【本PR工作】【解决方法】
`lite/kernels/host/compare_compute.cc ` 补充头文件引用 `#include <math.h>`