### PR TITLE
[BUG FIX][PYTHON] fix the issue that python lib can not compile properly

### DIFF
--- a/lite/api/python/setup.py.in
+++ b/lite/api/python/setup.py.in
@@ -50,7 +50,7 @@ if '${WITH_MKL}' == 'ON':
 # link lite.so to paddlelite.libs
 if os.name != 'nt':
     COMMAND = "patchelf --set-rpath '$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}\
-    /inference_lite_lib/python/install/lite/lite.so"
+/inference_lite_lib/python/install/lite/lite.so"
     if os.system(COMMAND) != 0:
         raise Exception("patch third_party libs failed, command: %s" % COMMAND)
 


### PR DESCRIPTION
【问题描述】Linux环境下编译 Paddle-Lite 打开 --build_python=ON 时编译错误
【问题定位】  `setup.py` 文件语法错误，来源 #3403 
【本PR工作】修复`setup.py` ，Linux编译 `--build_python=ON` 正常