### PR TITLE
[windows][compiling]add the untar.py for compiling the library on windows 

### DIFF
--- a/lite/tools/build.bat
+++ b/lite/tools/build.bat
@@ -2,7 +2,7 @@
 setlocal
 setlocal enabledelayedexpansion
 
-set source_path=%~dp0
+set source_path=%~dp0\\..\\..\\
 rem  global variables
 set BUILD_EXTRA=OFF
 set BUILD_JAVA=ON
@@ -92,16 +92,16 @@ goto:eof
         ) else (
                echo "The directory of third_party exists, the third-party-05b862.tar.gz exists."
                call:rm_rebuild_dir "%workspace%\third-party"
-               !python_path! %workspace%\untar.py %source_path%\third-party-05b862.tar.gz %workspace%
+               !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-05b862.tar.gz %workspace%
         )
     ) else (
         if NOT EXIST "%workspace%\third-party-05b862.tar.gz" (
             echo "The directory of third_party not exists, the third-party-05b862.tar.gz not exists."
             call:download_third_party
-            !python_path! %workspace%\untar.py %source_path%\third-party-05b862.tar.gz %workspace%
+            !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-05b862.tar.gz %workspace%
         ) else (
             echo "The directory of third_party not exists, the third-party-05b862.tar.gz exists."
-               !python_path! %workspace%\untar.py %source_path%\third-party-05b862.tar.gz %workspace%
+               !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-05b862.tar.gz %workspace%
         )
 
     )

--- a/lite/tools/untar.py
+++ b/lite/tools/untar.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tarfile, os
+import sys
+
+
+def untar(fname, dirs):
+    """
+    extract the tar.gz file
+    :param fname: the name of tar.gz file
+    :param dirs: the path of decompressed file 
+    :return: bool
+    """
+    try:
+        t = tarfile.open(name=fname, mode='r:gz')
+        t.extractall(path=dirs)
+        return True
+    except Exception as e:
+        print(e)
+        return False
+
+
+untar(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
1. add the untar.py for compiling the library on windows 
2. remove the build.bat to lite/tools/build.bat