### PR TITLE
[Core] Fix stack overflow in STL::ostream

### DIFF
--- a/lite/api/paddle_place.cc
+++ b/lite/api/paddle_place.cc
@@ -161,6 +161,7 @@ std::set<TargetType> ExpandValidTargets(TargetType target) {
                                                TARGET(kBM),
                                                TARGET(kMLU),
                                                TARGET(kAPU),
+                                               TARGET(kRKNPU),
                                                TARGET(kFPGA)});
   if (target == TARGET(kAny)) {
     return valid_set;

--- a/lite/core/op_registry.h
+++ b/lite/core/op_registry.h
@@ -261,6 +261,9 @@ class KernelRegistry final {
                                       PRECISION(kAny),
                                       DATALAYOUT(kAny)> *,  //
               KernelRegistryForTarget<TARGET(kRKNPU),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kNCHW)> *,  //
+              KernelRegistryForTarget<TARGET(kRKNPU),
                                       PRECISION(kFloat),
                                       DATALAYOUT(kNCHW)> *,  //
               KernelRegistryForTarget<TARGET(kRKNPU),

--- a/lite/utils/replace_stl/stream.cc
+++ b/lite/utils/replace_stl/stream.cc
@@ -40,9 +40,9 @@ void ostream::pad(const std::string& text) {
 #ifdef LITE_SHUTDOWN_LOG
 #define ADD_DATA_AS_STRING(data_, obj_)
 #else
-#define ADD_DATA_AS_STRING(data_, obj_)             \
-  std::string text = paddle::lite::to_string(obj_); \
-  pad(text);                                        \
+#define ADD_DATA_AS_STRING(data_, obj_)    \
+  std::string text = std::to_string(obj_); \
+  pad(text);                               \
   data_ = data_ + text;
 
 #endif


### PR DESCRIPTION
**问题**
当在tiny_publish模式下开启log(即--shutdown_log=OFF)时，链接libpaddle_light_api.so后的程序执行时会报"segmentation fault"的错误。

**原因**
以下代码会引发函数循环递归调用，导致栈溢出。

#define ADD_DATA_AS_STRING(data_, obj_)             \
  std::string text = paddle::lite::to_string(obj_); \
  pad(text);                                        \
  data_ = data_ + text;

template <>
ostream& ostream::operator<<(const int16_t& obj) {
  ADD_DATA_AS_STRING(data_, obj);
  return *this;
}
