### PR TITLE
[Core] Support char* in the replace_stl::ostream

### DIFF
--- a/lite/utils/replace_stl/stream.cc
+++ b/lite/utils/replace_stl/stream.cc
@@ -54,6 +54,12 @@ ostream& ostream::operator<<(const char* obj) {
 }
 
 template <>
+ostream& ostream::operator<<(char* const& obj) {
+  data_ = data_ + std::string(obj);
+  return *this;
+}
+
+template <>
 ostream& ostream::operator<<(const char& obj) {
   data_ = data_ + obj;
   return *this;


### PR DESCRIPTION
replace_stl::ostream支持char*字符串的输出，否则编译测试程序时，会报找不到符号的错误。
例如：LOG(WARNING) << "Failed to open libneuron_adapter.so. " << dlerror(); 