### PR TITLE
[Fusion Pass][BUG FIX] Not fuse two scale in the same time

### DIFF
--- a/lite/core/mir/elimination/identity_scale_eliminate_pass.cc
+++ b/lite/core/mir/elimination/identity_scale_eliminate_pass.cc
@@ -26,7 +26,9 @@ class Eliminator : public FuseBase {
  public:
   void BuildPattern() override {
     // the previous op's output need updat
-    auto* pre_op = OpNode("preop")->assert_is_not_op_type("conditional_block");
+    auto* pre_op = OpNode("preop")
+                       ->assert_is_not_op_type("conditional_block")
+                       ->assert_is_not_op_type("scale");
     // TODO(Superjomn) check has only one output
     auto* x = VarNode("x")->assert_is_op_input("scale", "X");
     auto* scale_op = OpNode("scale", "scale")


### PR DESCRIPTION
Not fuse two scale in the same time

对连在一起的两个scale同时fuse，会导致连接的op错误。