### PR TITLE
[BUG FIX][X86 Demo] Fix the issue that x86 light_api_demo can not operate successfully

### DIFF
--- a/lite/demo/cxx/x86_mobilenetv1_light_demo/mobilenet_light_api.cc
+++ b/lite/demo/cxx/x86_mobilenetv1_light_demo/mobilenet_light_api.cc
@@ -24,10 +24,10 @@ int64_t ShapeProduction(const shape_t& shape) {
   return res;
 }
 
-void RunModel(std::string model_dir) {
+void RunModel(std::string model_name) {
   // 1. Create MobileConfig
   MobileConfig config;
-  config.set_model_dir(model_dir);
+  config.set_model_from_file(model_name);
   // 2. Create PaddlePredictor by CxxConfig
   std::shared_ptr<PaddlePredictor> predictor =
       CreatePaddlePredictor<MobileConfig>(config);


### PR DESCRIPTION
【问题描述】x86 light_api_demo无法正常运行
【问题定位】demo中使用了2.3版本之前的老接口，导致无法加载2.3之后版本的新格式的模型
【本PR工作】替换为新接口，测试light_api_demo正常运行