### PR TITLE
[x86][compiling] enable with_log in x86 compiling and add with_profile method in build.sh

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -22,6 +22,7 @@ OPTMODEL_DIR=""
 BUILD_TAILOR=OFF
 BUILD_CV=OFF
 WITH_LOG=ON
+WITH_PROFILE=OFF
 BUILD_NPU=OFF
 NPU_DDK_ROOT="$(pwd)/ai_ddk_lib/" # Download HiAI DDK from https://developer.huawei.com/consumer/cn/hiai/
 BUILD_XPU=OFF
@@ -218,6 +219,7 @@ function make_full_publish_so {
       -DLITE_WITH_JAVA=$BUILD_JAVA \
       -DLITE_WITH_PYTHON=$BUILD_PYTHON \
       -DLITE_WITH_LOG=$WITH_LOG \
+      -DLITE_WITH_PROFILE=${WITH_PROFILE} \
       -DANDROID_STL_TYPE=$android_stl \
       -DLITE_BUILD_EXTRA=$BUILD_EXTRA \
       -DLITE_WITH_CV=$BUILD_CV \
@@ -374,6 +376,8 @@ function make_x86 {
             -DWITH_GPU=OFF \
             -DLITE_WITH_PYTHON=${BUILD_PYTHON} \
             -DLITE_BUILD_EXTRA=ON \
+            -DWITH_LOG=${WITH_LOG} \
+            -DLITE_WITH_PROFILE=${WITH_PROFILE} \
             -DLITE_WITH_XPU=$BUILD_XPU \
             -DLITE_WITH_XTCL=$BUILD_XTCL \
             -DXPU_SDK_ROOT=$XPU_SDK_ROOT \
@@ -485,11 +489,15 @@ function main {
                 WITH_LOG="${i#*=}"
                 shift
                 ;;
+            --with_profile=*)
+                WITH_PROFILE="${i#*=}"
+                shift
+                ;;
             --build_npu=*)
                 BUILD_NPU="${i#*=}"
                 shift
                 ;;
-           --npu_ddk_root=*)
+            --npu_ddk_root=*)
                 NPU_DDK_ROOT="${i#*=}"
                 shift
                 ;;


### PR DESCRIPTION
(1)在build.sh脚本中添加 `--with_profile`选项，可以打开profile
(2)`./lite/tools/build.sh x86` 编译时可以识别`--with_log=OFF`选项，可以关闭log输出