### PR TITLE
[compile] [cuda] update cuda compile.

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -347,6 +347,7 @@ function make_cuda {
             -DLITE_WITH_XTCL=$BUILD_XTCL \
             -DXPU_SDK_ROOT=$XPU_SDK_ROOT
  
+  make -j$NUM_PROC
   make publish_inference -j$NUM_PROC
   cd -
 }


### PR DESCRIPTION
cuda编译得到第三方库，其中third_party不符预期。

修改make_cuda编译脚本，先全量编译，准备好全部的第三方库后，再make publish_infernece，保证打包好所有第三方库