### PR TITLE
[Compiling][BUG FIX] Fix the issue of iOS compiling failure

### DIFF
--- a/lite/tools/build_ios.sh
+++ b/lite/tools/build_ios.sh
@@ -67,6 +67,7 @@ function make_ios {
             -DLITE_WITH_OPENMP=OFF \
             -DWITH_ARM_DOTPROD=OFF \
             -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=ON \
+            -DLITE_WITH_X86=OFF \
             -DLITE_WITH_LOG=$WITH_LOG \
             -DLITE_BUILD_TAILOR=$WITH_STRIP \
             -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \


### PR DESCRIPTION
【问题描述】Paddle-Lite使用 build_ios.sh 编译iOS失败
【问题定位】LITE_WITH_X86编译选项默认设置为ON，编译iOS预测库时使用LITE_WITH_X86默认值，编译失败
【本PR工作】修复编译失败问题