### PR TITLE
[Compile][iOS&Android] Update of build_android.sh and build_ios.sh

### DIFF
--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -4,7 +4,7 @@ set +x
 # 1. global variables, you can change them according to your requirements
 #####################################################################################################
 # armv7 or armv8, default armv8.
-ARM_ABI=armv8
+ARCH=armv8
 # c++_static or c++_shared, default c++_static.
 ANDROID_STL=c++_static
 # gcc or clang, default gcc.
@@ -121,7 +121,7 @@ function prepare_thirdparty {
 # 4.1 function of tiny_publish compiling
 # here we only compile light_api lib
 function make_tiny_publish_so {
-  build_dir=$workspace/build.lite.android.$ARM_ABI.$TOOLCHAIN
+  build_dir=$workspace/build.lite.android.$ARCH.$TOOLCHAIN
   if [ "${WITH_OPENCL}" == "ON" ]; then
       build_dir=${build_dir}.opencl
   fi
@@ -152,7 +152,7 @@ function make_tiny_publish_so {
       -DLITE_WITH_NPU=$WITH_HUAWEI_KIRIN_NPU \
       -DNPU_DDK_ROOT=$HUAWEI_KIRIN_NPU_SDK_ROOT \
       -DLITE_WITH_OPENCL=$WITH_OPENCL \
-      -DARM_TARGET_ARCH_ABI=$ARM_ABI \
+      -DARM_TARGET_ARCH_ABI=$ARCH \
       -DARM_TARGET_LANG=$TOOLCHAIN \
       -DANDROID_STL_TYPE=$ANDROID_STL"
 
@@ -176,7 +176,7 @@ function make_full_publish_so {
 
   prepare_thirdparty
 
-  build_directory=$workspace/build.lite.android.$ARM_ABI.$ARM_LANG
+  build_directory=$workspace/build.lite.android.$ARCH.$ARM_LANG
 
   if [ -d $build_directory ]
   then
@@ -201,7 +201,7 @@ function make_full_publish_so {
       -DLITE_WITH_NPU=$WITH_HUAWEI_KIRIN_NPU \
       -DNPU_DDK_ROOT=$HUAWEI_KIRIN_NPU_SDK_ROOT \
       -DLITE_WITH_OPENCL=$WITH_OPENCL \
-      -DARM_TARGET_ARCH_ABI=$ARM_ABI \
+      -DARM_TARGET_ARCH_ABI=$ARCH \
       -DARM_TARGET_LANG=$ARM_LANG \
       -DLITE_WITH_TRAIN=$WITH_TRAIN \
       -DANDROID_STL_TYPE=$ANDROID_STL"
@@ -231,12 +231,12 @@ function print_usage {
     echo -e "|     ./lite/tools/build_android.sh help                                                                                               |"
     echo -e "|                                                                                                                                      |"
     echo -e "|  optional argument:                                                                                                                  |"
-    echo -e "|     --arm_abi: (armv8|armv7), default is armv8                                                                                       |"
+    echo -e "|     --arch: (armv8|armv7), default is armv8                                                                                          |"
     echo -e "|     --toolchain: (gcc|clang), defalut is gcc                                                                                         |"
     echo -e "|     --android_stl: (c++_static|c++_shared|gnu_static|gnu_shared), default is c++_static                                              |"
     echo -e "|     --with_java: (OFF|ON); controls whether to publish java api lib, default is ON                                                   |"
     echo -e "|     --with_cv: (OFF|ON); controls whether to compile cv functions into lib, default is OFF                                           |"
-    echo -e "|     --with_log: (OFF|ON); controls whether to print log information, default is ON                                                |"
+    echo -e "|     --with_log: (OFF|ON); controls whether to print log information, default is ON                                                   |"
     echo -e "|     --with_extra: (OFF|ON); controls whether to publish extra operators and kernels for (sequence-related model such as OCR or NLP)  |"
     echo -e "|                                                                                                                                      |"
     echo -e "|  arguments of striping lib according to input model:(armv8, gcc, c++_static)                                                         |"
@@ -268,15 +268,15 @@ function print_usage {
 function main {
     if [ -z "$1" ]; then
         # compiling result contains light_api lib only, recommanded.
-        make_tiny_publish_so $ARM_ABI $TOOLCHAIN $ANDROID_STL
+        make_tiny_publish_so $ARCH $TOOLCHAIN $ANDROID_STL
     fi
 
     # Parse command line.
     for i in "$@"; do
         case $i in
             # armv7 or armv8, default armv8
-            --arm_abi=*)
-                ARM_ABI="${i#*=}"
+            --arch=*)
+                ARCH="${i#*=}"
                 shift
                 ;;
             # gcc or clang, default gcc

--- a/lite/tools/build_ios.sh
+++ b/lite/tools/build_ios.sh
@@ -5,7 +5,7 @@ set +x
 # 1. global variables, you can change them according to your requirements
 #####################################################################################################
 # armv7 or armv8, default armv8.
-ARM_ABI=armv8
+ARCH=armv8
 # ON or OFF, default OFF.
 WITH_EXTRA=OFF
 # controls whether to compile cv functions into lib, default is OFF.
@@ -36,24 +36,24 @@ fi
 # 3. compiling functions
 ####################################################################################################
 function make_ios {
-    local abi=$1
+    local arch=$1
 
-    if [ ${abi} == "armv8" ]; then
+    if [ ${arch} == "armv8" ]; then
         local os=ios64
-    elif [ ${abi} == "armv7" ]; then
+    elif [ ${arch} == "armv7" ]; then
         local os=ios
     else
-        echo -e "Error: unsupported arm_abi: ${abi} \t --arm_abi: armv8|armv7"
+        echo -e "Error: unsupported arch: ${arch} \t --arch: armv8|armv7"
         exit 1
     fi
 
-    build_dir=$workspace/build.ios.${os}.${abi}
+    build_dir=$workspace/build.ios.${os}.${arch}
     if [ -d $build_dir ]
     then
         rm -rf $build_dir
     fi
     echo "building ios target into $build_dir"
-    echo "target abi: $abi"
+    echo "target arch: $arch"
     mkdir -p ${build_dir}
     cd ${build_dir}
     GEN_CODE_PATH_PREFIX=lite/gen_code
@@ -71,7 +71,7 @@ function make_ios {
             -DLITE_WITH_LOG=$WITH_LOG \
             -DLITE_BUILD_TAILOR=$WITH_STRIP \
             -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \
-            -DARM_TARGET_ARCH_ABI=$abi \
+            -DARM_TARGET_ARCH_ABI=$arch \
             -DLITE_BUILD_EXTRA=$WITH_EXTRA \
             -DLITE_WITH_CV=$WITH_CV \
             -DARM_TARGET_OS=$os
@@ -88,14 +88,14 @@ function print_usage {
     echo -e "|  compile iOS armv8 library:                                                                                                          |"
     echo -e "|     ./lite/tools/build_ios.sh                                                                                                        |"
     echo -e "|  compile iOS armv7 library:                                                                                                          |"
-    echo -e "|     ./lite/tools/build_ios.sh  --arm_abi=armv7                                                                                       |"
+    echo -e "|     ./lite/tools/build_ios.sh  --arch=armv7                                                                                          |"
     echo -e "|  print help information:                                                                                                             |"
     echo -e "|     ./lite/tools/build_ios.sh help                                                                                                   |"
     echo -e "|                                                                                                                                      |"
     echo -e "|  optional argument:                                                                                                                  |"
-    echo -e "|     --arm_abi: (armv8|armv7), default is armv8                                                                                       |"
+    echo -e "|     --arch: (armv8|armv7), default is armv8                                                                                          |"
     echo -e "|     --with_cv: (OFF|ON); controls whether to compile cv functions into lib, default is OFF                                           |"
-    echo -e "|     --with_log: (OFF|ON); controls whether to print log information, default is ON                                                |"
+    echo -e "|     --with_log: (OFF|ON); controls whether to print log information, default is ON                                                   |"
     echo -e "|     --with_extra: (OFF|ON); controls whether to publish extra operators and kernels for (sequence-related model such as OCR or NLP)  |"
     echo -e "|                                                                                                                                      |"
     echo -e "|  arguments of striping lib according to input model:(armv8, gcc, c++_static)                                                         |"
@@ -109,16 +109,15 @@ function print_usage {
 
 function main {
     if [ -z "$1" ]; then
-        make_ios $ARM_ABI
+        make_ios $ARCH
         exit -1
     fi
 
     # Parse command line.
     for i in "$@"; do
         case $i in
-            --arm_abi=*)
-                ARM_ABI="${i#*=}"
-                make_ios $ARM_ABI
+            --arch=*)
+                ARCH="${i#*=}"
                 shift
                 ;;
             --with_extra=*)
@@ -152,7 +151,7 @@ function main {
                 ;;
         esac
     done
-    make_ios $ARM_ABI
+    make_ios $ARCH
 }
 
 main $@

--- a/lite/tools/build_ios.sh
+++ b/lite/tools/build_ios.sh
@@ -67,6 +67,7 @@ function make_ios {
             -DLITE_WITH_OPENMP=OFF \
             -DWITH_ARM_DOTPROD=OFF \
             -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=ON \
+            -DLITE_WITH_X86=OFF \
             -DLITE_WITH_LOG=$WITH_LOG \
             -DLITE_BUILD_TAILOR=$WITH_STRIP \
             -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \


### PR DESCRIPTION
cherry-pick 自：
 #3562  ： [Compiling][BUG FIX] Fix the issue of iOS compiling failure
【问题描述】Paddle-Lite使用 build_ios.sh 编译iOS失败
【问题定位】LITE_WITH_X86编译选项默认设置为ON，编译iOS预测库时使用LITE_WITH_X86默认值，编译失败
【本PR工作】修复编译失败问题

  #3563   ：[Compiling]Update build_android.sh and build_ios.sh 
【本PR工作】将`build_android.sh`脚本中的`arm_abi`编译选项修改为`arch`编译选项，更加符合其真实意义