### PR TITLE
[Doc] Remove the full publish from MTK APU doc

### DIFF
--- a/docs/demo_guides/mediatek_apu.md
+++ b/docs/demo_guides/mediatek_apu.md
@@ -160,7 +160,6 @@ $ tar -xvf apu_ddk.tar.gz
 ```
 - 编译full_publish and tiny_publish for MT8168-P2V1 Tablet
 ```shell
-$ ./lite/tools/build.sh --arm_os=android --arm_abi=armv8 --arm_lang=gcc --android_stl=c++_shared --build_extra=ON --with_log=ON --build_apu=ON --apu_ddk_root=./apu_ddk full_publish
 $ ./lite/tools/build.sh --arm_os=android --arm_abi=armv8 --arm_lang=gcc --android_stl=c++_shared --build_extra=ON --with_log=ON --build_apu=ON --apu_ddk_root=./apu_ddk tiny_publish
 ```
 - 将编译生成的build.lite.android.armv8.gcc/inference_lite_lib.android.armv8.apu/cxx/include替换PaddleLite-android-demo/libs/PaddleLite/arm64-v8a/include目录；


### PR DESCRIPTION
full_publish生成的libpaddle_light_api_shared.so由于没有隐藏protobuf符号，导致和android系统的libui使用的protobuf版本冲突，该问题普遍存在于其它非APU的android target，现暂时将full publish的编译从文档中删除，只支持tiny publish的编译生成的libpaddle_light_api_shared.so。