### PR TITLE
[BUGFIX][Hash] Improve the implementation of hash_combine

### DIFF
--- a/lite/api/paddle_place.cc
+++ b/lite/api/paddle_place.cc
@@ -24,9 +24,9 @@ namespace lite_api {
 size_t Place::hash() const {
   std::hash<int> h;
   size_t hash = h(static_cast<int>(target));
-  hash = lite::hash_combine(hash, static_cast<int>(precision));
-  hash = lite::hash_combine(hash, static_cast<int>(layout));
-  hash = lite::hash_combine(hash, static_cast<int>(device));
+  lite::CombineHash(static_cast<int64_t>(precision), &hash);
+  lite::CombineHash(static_cast<int64_t>(layout), &hash);
+  lite::CombineHash(static_cast<int64_t>(device), &hash);
   return hash;
 }
 

--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -42,16 +42,14 @@ bool OpLite::InferShapeWithCache() {
     // combined dims value into new_hash value.
     auto &element_dims = (*iter)->dims();
     for (size_t i = 0; i < element_dims.size(); i++) {
-      new_hash =
-          lite::hash_combine(new_hash, static_cast<int>(element_dims[i]));
+      lite::CombineHash(static_cast<int64_t>(element_dims[i]), &new_hash);
     }
     // combine lod value into new_hash valud.
     auto &emement_lods = (*iter)->lod();
     for (auto lod_iter = emement_lods.begin(); lod_iter != emement_lods.end();
          lod_iter++) {
       for (size_t i = 0; i < lod_iter->size(); i++) {
-        new_hash =
-            lite::hash_combine(new_hash, static_cast<int>(lod_iter->at(i)));
+        lite::CombineHash(static_cast<int64_t>(lod_iter->at(i)), &new_hash);
       }
     }
   }

--- a/lite/core/type_system.cc
+++ b/lite/core/type_system.cc
@@ -21,9 +21,9 @@ namespace lite {
 size_t ParamTypeRegistry::KernelIdTy::hash() const {
   std::hash<std::string> h;
   size_t hash = h(kernel_type);
-  hash = hash_combine(hash, place.hash());
-  hash = hash_combine(hash, std::hash<int>()(static_cast<int>(io)));
-  hash = hash_combine(hash, std::hash<std::string>()(arg_name));
+  lite::CombineHash(place.hash(), &hash);
+  lite::CombineHash(std::hash<int>()(static_cast<int>(io)), &hash);
+  lite::CombineHash(std::hash<std::string>()(arg_name), &hash);
   return hash;
 }
 
@@ -48,8 +48,7 @@ const Type *Type::GetTensorTy(TargetType target,
   // NOTE quite naive implementation here, but not performance sensitive.
   DataType::ID type_id = DataType::ID::Tensor;
 
-#define HASH_ONE(x) v = hash_combine(v, hasher(static_cast<int>(x)))
-
+#define HASH_ONE(x) CombineHash(hasher(static_cast<int>(x)), &v);
   std::hash<int> hasher;
   size_t v = hasher(static_cast<int>(type_id));
   HASH_ONE(target);
@@ -80,8 +79,7 @@ const Type *Type::GetTensorListTy(TargetType target,
   static std::map<size_t, const Type *> type_repo;
   DataType::ID type_id = DataType::ID::TensorList;
 
-#define HASH_ONE(x) v = hash_combine(v, hasher(static_cast<int>(x)))
-
+#define HASH_ONE(x) CombineHash(hasher(static_cast<int>(x)), &v);
   std::hash<int> hasher;
   size_t v = hasher(static_cast<int>(type_id));
   HASH_ONE(target);

--- a/lite/utils/hash.h
+++ b/lite/utils/hash.h
@@ -18,10 +18,11 @@
 namespace paddle {
 namespace lite {
 
+// A simplified implementation of boost::hash_combine.
 template <typename T>
-inline size_t hash_combine(size_t s, const T& v) {
+inline void CombineHash(const T& from, size_t* to) {
   std::hash<T> h;
-  return (s ^ h(v)) + 0x9e3779b9 + (s << 6) + (s >> 2);
+  *to ^= h(from) + 0x9e3779b9 + (*to << 6) + (*to >> 2);
 }
 
 }  // namespace lite


### PR DESCRIPTION
【问题描述】Paddle-Lite有`hash_combine`加密方法实现。 在`InferShape`函数调用`hash_combine`算法验证是否需要执行`InferShapeImpl`。业务反馈`hash_combine`出现“hash碰撞现象” （即不同的input得到相同的“hash”结果）

![image](https://user-images.githubusercontent.com/45189361/81305708-3cb00080-90b1-11ea-9ac1-4a3831dbfe29.png)


【问题定位】`hash_combine`实现可靠度低
【本PR工作】改进`hash_combine`实现，新实现采用旋转Hash简化实现`boost::hash_combine`
```
// A simplified implementation of boost::hash_combine.
template <typename T>
inline void CombineHash(const T& from, size_t* to) {
  std::hash<T> h;
  *to ^= h(from) + 0x9e3779b9 + (*to << 6) + (*to >> 2);
}
```
当前实现与`Tensor Flow`中的[`HashCombine`实现](https://github.com/tensorflow/tensorflow/blob/ab8e195d2e0978c21234a5632d4fabf47535eda1/tensorflow/core/grappler/graph_analyzer/hash_tools.h#L29)一致

【效果】修改后可以避免当前出现的hash碰撞现象。
计算量评估：两`hash_combine`实现计算量一致： 两次二进制数据移位（uint64)、三次加法（uint64+uint64)、一次按位异或（uint64^uint64)；新的实现方法void型，直接对指针操作，没有返回数据，少了一次内存拷贝
实验验证： `vector<uint64_t>(3000000)`内保存了3000000个uint64_t的连续数据，对vector所有数据执行hash_combine操作， 先执行100 0000 次作为warmup， 再执行 100 0000 次作为测试结果
(原有Hash_combine方法记为HashOld，新方法记为HashNew) ，多次测试平均结果如下(测试环境为PC Linux)：
```
CostTime of HashOld :6.3e-05 ms.
CostTime of HashNew :6e-05 ms.
```
综上可知，本次对Hash_combine函数的修改未降低运行性能