### PR TITLE
[BUG FIX][Compiling] Fix the issue that x86 lib can not compile successfully on MAC env

### DIFF
--- a/lite/kernels/x86/sequence_reshape_compute.h
+++ b/lite/kernels/x86/sequence_reshape_compute.h
@@ -81,7 +81,7 @@ class SequenceReshapeFloatCompute
     auto& param = *param_.get_mutable<operators::SequenceReshapeParam>();
     auto* in = param.x;
     auto* out = param.output;
-    auto out_data = out->mutable_data<T>();
+    auto out_data = out->template mutable_data<T>();
     for (int i = 0; i < out->dims().production(); i++) {
       out_data[i] = 0;
     }
@@ -109,9 +109,9 @@ class SequenceReshapeFloatCompute
       }
     }
     out->Resize(std::vector<int64_t>{in->numel() / out_width, out_width});
-    auto* dst_ptr = out->mutable_data<T>();
+    auto* dst_ptr = out->template mutable_data<T>();
     auto size = in->numel() * sizeof(T);
-    std::memcpy(dst_ptr, in->data<T>(), size);
+    std::memcpy(dst_ptr, in->template data<T>(), size);
   }
 
   virtual ~SequenceReshapeFloatCompute() = default;


### PR DESCRIPTION
【问题描述】 Paddle-Lite 在MAC 上执行x86 编译失败
【问题定位】 新提交代码中有有不符合cmake 3.15 代码风格检查的新片段
【本PR工作】修改对应代码段，使通过cmake 3.15 规范性要求，修改后在Mac 课正常编译x86平台预测库
```
out->mutable_data<T>();
```
-------> 修改为
```
out->template mutable_data<T>()
```