### PR TITLE
[CUDA] [KERNEL] Fix graphics memory leak problem in dnn models.

### DIFF
--- a/lite/backends/cuda/math/batched_gemm.cc
+++ b/lite/backends/cuda/math/batched_gemm.cc
@@ -33,6 +33,9 @@ bool BatchedGemm<float, float>::init(const bool trans_a,
   }
   cu_trans_a_ = trans_a ? CUBLAS_OP_T : CUBLAS_OP_N;
   cu_trans_b_ = trans_b ? CUBLAS_OP_T : CUBLAS_OP_N;
+  if (A_ != nullptr) {
+    cudaFree(A_);
+  }
   cudaMalloc(reinterpret_cast<void **>(&A_),
              3 * max_batch_size * sizeof(float *));
   return true;

--- a/lite/kernels/cuda/search_aligned_mat_mul_compute.h
+++ b/lite/kernels/cuda/search_aligned_mat_mul_compute.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <limits>
 #include <memory>
 #include "lite/backends/cuda/math/batched_gemm.h"
 #include "lite/core/context.h"
@@ -32,6 +33,7 @@ class SearchAlignedMatMulCompute
 
   void PrepareForRun() override {
     batched_gemm_impl_.reset(new lite::cuda::math::BatchedGemm<float, float>);
+    last_seq_num_ = std::numeric_limits<int>::min();
   }
 
   void Run() override {
@@ -75,8 +77,11 @@ class SearchAlignedMatMulCompute
       A_[seq + seq_num * 2] = out_data + seq * out_stride;
     }
 
-    CHECK(
-        batched_gemm_impl_->init(x_transpose, y_transpose, seq_num, &cuda_ctx));
+    if (seq_num != last_seq_num_) {
+      CHECK(batched_gemm_impl_->init(
+          x_transpose, y_transpose, seq_num, &cuda_ctx));
+      last_seq_num_ = seq_num;
+    }
     batched_gemm_impl_->run(
         alpha, 0.0f, const_cast<const float**>(A_), M, N, K, seq_num);
   }
@@ -86,6 +91,7 @@ class SearchAlignedMatMulCompute
  private:
   std::unique_ptr<lite::cuda::math::BatchedGemm<float, float>>
       batched_gemm_impl_;
+  int last_seq_num_;
 };
 
 }  // namespace cuda


### PR DESCRIPTION
【问题描述】
dnn系列模型在长时间运行过程中发现，显存逐渐上升，存在显存泄露问题

【问题定位】
定位到search_aligned_mat_mul kernel，由于输入的seq_num长度会发生变化，需要多次调用BatchedGemm::init函数，在该函数中存在显存分配问题

【解决问题】
1. search_aligned_mat_mul kernel中添加缓存，记录上一次的seq_num，如果发生变化，再调用BatchedGemm::init函数
2. BatchedGemm::init函数中判断显存是否已经分配，如分配则需要先释放该显存区域

【验证】
在content-dnn， crmm等模型上验证，显存内存均保持稳定