### PR TITLE
[Framework][InferShape]Improve the implementation of hash computation

### DIFF
--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -41,11 +41,12 @@ bool OpLite::InferShapeWithCache() {
        iter++) {
     // combined dims value into new_hash value.
     auto cur_dim = (*iter)->dims();
-    hash_str.append((char *)(&(cur_dim[0])), sizeof(int64_t) * cur_dim.size());
+    hash_str.append(reinterpret_cast(char *)(&(cur_dim[0])),
+                    sizeof(int64_t) * cur_dim.size());
     auto &emement_lods = (*iter)->lod();
     for (auto lod_iter = emement_lods.begin(); lod_iter != emement_lods.end();
          lod_iter++) {
-      hash_str.append((char *)(&(lod_iter[0])),
+      hash_str.append(reinterpret_cast(char *)(&(lod_iter[0])),
                       sizeof(int64_t) * lod_iter->size());
       hash_str.append(1, 0);
     }

--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -41,13 +41,13 @@ bool OpLite::InferShapeWithCache() {
        iter++) {
     // combined dims value into new_hash value.
     auto cur_dim = (*iter)->dims();
-    hash_str.append(reinterpret_cast(char *)(&(cur_dim[0])),
+    hash_str.append(reinterpret_cast<char *>(&(cur_dim[0])),
                     sizeof(int64_t) * cur_dim.size());
     auto &emement_lods = (*iter)->lod();
-    for (auto lod_iter = emement_lods.begin(); lod_iter != emement_lods.end();
-         lod_iter++) {
-      hash_str.append(reinterpret_cast(char *)(&(lod_iter[0])),
-                      sizeof(int64_t) * lod_iter->size());
+    for (size_t i = 0; i < emement_lods.size(); i++) {
+      auto lod_iter = emement_lods[i];
+      hash_str.append(reinterpret_cast<char *>(&lod_iter[0]),
+                      sizeof(int64_t) * lod_iter.size());
       hash_str.append(1, 0);
     }
     hash_str.append(1, 0);


### PR DESCRIPTION
【问题描述】之前使用的增量Hash算法存在哈希碰撞现象，本PR修改为系统哈希实现
方案一采用增量hash： (与TensorFlow中相同实现的`HashCombination`方法，经测试，存在Hash仍然存在Hash碰撞现象，测试脚本如下：

![image](https://user-images.githubusercontent.com/45189361/81563519-ef8da080-93c8-11ea-8274-74d505659334.png)

【本PR工作】将之前的增量Hash方法修改为系统Hash方法，即将所有的input_shapes & input_lods 中的内存区域 append 到字符串中，每组数据之间以 0 间隔，拼接出的string再采用std::Hash 系统方法计算Hash值。
经测试，本Hash方法在以上测试中不存在Hash碰撞现象。较为可靠。     
【本PR缺点】Hash计算时间教方法一的增量Hash有提高，针对我们的测试模型InferShape时长从 0.02ms 增加到0.03ms ，主要耗时位于string::append (0.025ms) 而非std::Hash。采用std::string::reserve提前为string 分配500的内存空间，string::append耗时降低不明显，耗时增量无法接受，暂且搁置本方案


