### PR TITLE
[Framwork][InferShape]Improve InferShape period

### DIFF
--- a/lite/core/op_lite.cc
+++ b/lite/core/op_lite.cc
@@ -36,25 +36,21 @@ bool OpLite::InferShapeWithCache() {
   // 1. Get vector of current input tensors
   auto *current_inputs = op_param_->input_tensor_ptrs();
   // 2. Get hash value of current inputs shape and lod
-  size_t new_hash = 0;
-  for (auto iter = current_inputs->begin(); iter != current_inputs->end();
-       iter++) {
-    // combined dims value into new_hash value.
-    auto &element_dims = (*iter)->dims();
-    for (size_t i = 0; i < element_dims.size(); i++) {
-      lite::CombineHash(static_cast<int64_t>(element_dims[i]), &new_hash);
-    }
-    // combine lod value into new_hash valud.
-    auto &emement_lods = (*iter)->lod();
-    for (auto lod_iter = emement_lods.begin(); lod_iter != emement_lods.end();
-         lod_iter++) {
-      for (size_t i = 0; i < lod_iter->size(); i++) {
-        lite::CombineHash(static_cast<int64_t>(lod_iter->at(i)), &new_hash);
+  bool use_cache = true;
+  if (last_input_shapes.size() == current_inputs->size()) {
+    for (int i = 0; i < current_inputs->size(); i++) {
+      if (last_input_shapes[i] != current_inputs->at(i)->dims() ||
+          last_input_lods[i] != current_inputs->at(i)->lod()) {
+        use_cache = false;
+        break;
       }
     }
+  } else {
+    use_cache = false;
   }
+
   // 3. infer shapes of output tensors
-  if (new_hash == io_shape_lod_hash_ && new_hash != 0) {
+  if (use_cache) {
     // if current hash value is consistent with io_shape_lod_hash_,
     // previous outputs shape and lod are reused.
     auto *current_outputs = op_param_->output_tensor_ptrs();
@@ -64,7 +60,6 @@ bool OpLite::InferShapeWithCache() {
     }
   } else {
     // otherwise, current hash value is changed, InferShapeImpl will apply.
-    io_shape_lod_hash_ = new_hash;
     this->InferShapeImpl();
     auto *current_outputs = op_param_->output_tensor_ptrs();
     last_output_shapes.clear();
@@ -72,6 +67,12 @@ bool OpLite::InferShapeWithCache() {
     for (size_t i = 0; i < current_outputs->size(); i++) {
       last_output_shapes.push_back(current_outputs->at(i)->dims());
       last_output_lods.push_back(current_outputs->at(i)->lod());
+    }
+    last_input_shapes.clear();
+    last_input_lods.clear();
+    for (size_t i = 0; i < current_inputs->size(); i++) {
+      last_input_shapes.push_back(current_inputs->at(i)->dims());
+      last_input_lods.push_back(current_inputs->at(i)->lod());
     }
   }
   return true;

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -172,9 +172,10 @@ class OpLite : public Registry {
   std::vector<Place> valid_places_;
   Place kernel_place_{TARGET(kHost), PRECISION(kFloat)};
   std::unique_ptr<OpInfo> op_info_;
+  std::vector<DDimLite> last_input_shapes{};
+  std::vector<std::vector<std::vector<uint64_t>>> last_input_lods{};
   std::vector<DDimLite> last_output_shapes{};
   std::vector<std::vector<std::vector<uint64_t>>> last_output_lods{};
-  size_t io_shape_lod_hash_{};
   mutable operators::ParamBase *op_param_{nullptr};
 
  private:

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -172,6 +172,9 @@ class OpLite : public Registry {
   std::vector<Place> valid_places_;
   Place kernel_place_{TARGET(kHost), PRECISION(kFloat)};
   std::unique_ptr<OpInfo> op_info_;
+  // todo: it's prefered to combine last_input_shapes and
+  // last_input_lods into a single hash value to decrease
+  // memory usage.
   std::vector<DDimLite> last_input_shapes{};
   std::vector<std::vector<std::vector<uint64_t>>> last_input_lods{};
   std::vector<DDimLite> last_output_shapes{};


### PR DESCRIPTION
【问题描述】：当前InferShape过程采用所有Shape&Lod信息的Hash值作为标记，判断是否是第一次InferShape。 业务方反应，当前InferShape采用的Hash算法存在Hash碰撞现象，即不同的Input算出相同的Hash值。
【尝试过的修改方法】：尝试改善Hash算法的实现方式：
-  1、改善增量Hash实现方法、与TensorFlow中的对应实现一致，业务方测试仍然存在Hash碰撞 #3573    
- 2、修改为系统Hash实现，在测试脚本中未出现Hash碰撞现象，但较严格的Hash实现导致计算耗时增加，间接增加InferShape&Op->Run的耗时，增量无法接受。 #3600 

【本PR工作】将用Hash 标记shape&Lod方法修改为直接存储Shape&Lod信息，进行前后数据比较。
优势：
- 不存在hash碰撞现象
- InferShape耗时降低：测试模型下 由 0.018ms降低至0.016ms
缺点：
- 每个op中保存了历史的Input shape&lod信息，增加内存占用，实现不够优雅，后续待改进（尽量使用Hash等标记方法实现）