### PR TITLE
[Compile] [fluid-lite-subgraph] Fix fluid-lite compile error, because of not defined LITE_WITH_LOG.

### DIFF
--- a/lite/utils/cp_logging.h
+++ b/lite/utils/cp_logging.h
@@ -13,9 +13,19 @@
 // limitations under the License.
 
 #pragma once
+
+// Use internal log or glog, the priority is as follows:
+// 1. tiny_publish should use internally implemented logging.
+// 2. if LITE_WITH_LOG is turned off, internal logging is used.
+// 3. use glog in other cases.
+
 #if defined(LITE_WITH_LIGHT_WEIGHT_FRAMEWORK) || \
-    defined(LITE_ON_MODEL_OPTIMIZE_TOOL) || !defined(LITE_WITH_LOG)
+    defined(LITE_ON_MODEL_OPTIMIZE_TOOL)
 #include "lite/utils/logging.h"
-#else  // LITE_WITH_LIGHT_WEIGHT_FRAMEWORK
+#else
+#ifndef LITE_WITH_LOG
+#include "lite/utils/logging.h"
+#else
 #include <glog/logging.h>
-#endif  // LITE_WITH_LIGHT_WEIGHT_FRAMEWORK
+#endif
+#endif


### PR DESCRIPTION
【问题描述】
fluid-lite联编的时候，因为LITE_WITH_LOG是在paddle-lite内部的宏定义，对paddle来说不可见，认为该宏为空，编译时导致lite使用的内部实现的logging，而paddle fluid使用的则是glog，编译过程中报错。

【问题定位 && 解决】
1. 可在paddle的lite.cmake中添加add_defintions(LITE_WITH_LOG)，但是这样做不直观，可读性差。
2. 在lite的cp_logging.h中将!defined(LITE_WITH_LOG)改成ifndef LITE_WITH_LOG，这样联合编译时行为一致，paddle fluid和lite都使用了glog，依赖打平。

经过讨论选用方式2解决联编问题。