### PR TITLE
[X86][Demo][MAC] Fix the issue that python demo and cxx_demo failed on MAC env

### DIFF
--- a/lite/core/mir/fusion/fc_fuse_pass.cc
+++ b/lite/core/mir/fusion/fc_fuse_pass.cc
@@ -38,7 +38,7 @@ void FcFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 
 REGISTER_MIR_PASS(lite_fc_fuse_pass, paddle::lite::mir::FcFusePass)
     .BindTargets({TARGET(kAny)})
-    .ExcludeTargets({TARGET(kXPU)})
+    .ExcludeTargets({TARGET(kXPU), TARGET(kX86)})
     .ExcludeTargets({TARGET(kBM)})
     .ExcludeTargets({TARGET(kCUDA)})
     .BindKernel("fc");

--- a/lite/demo/cxx/x86_mobilenetv1_full_demo/CMakeLists.txt
+++ b/lite/demo/cxx/x86_mobilenetv1_full_demo/CMakeLists.txt
@@ -17,5 +17,5 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 # 4.add executable output
 add_executable(${TARGET} ${TARGET}.cc)
 target_link_libraries(${TARGET} -lpaddle_full_api_shared)
-target_link_libraries(${TARGET} -lmklml_intel)
+target_link_libraries(${TARGET} -liomp5)
 target_link_libraries(${TARGET} -ldl)

--- a/lite/demo/cxx/x86_mobilenetv1_light_demo/CMakeLists.txt
+++ b/lite/demo/cxx/x86_mobilenetv1_light_demo/CMakeLists.txt
@@ -17,5 +17,5 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 # 4.add executable output
 add_executable(${TARGET} ${TARGET}.cc)
 target_link_libraries(${TARGET} -lpaddle_light_api_shared)
-target_link_libraries(${TARGET} -lmklml_intel)
+target_link_libraries(${TARGET} -liomp5)
 target_link_libraries(${TARGET} -ldl)


### PR DESCRIPTION
【问题描述】Paddle-Lite 在2.6版本支持MAC编译，测试时发现编译出的C++ demo和python demo无法正常运行
C++ demo问题： lib路径问题，本PR已经修复
python demo问题： MAC上编译Paddle-Lite不支持openmp编译，但当前x86平台的FC kernel无 非openmp的实现，本PR关闭x86平台的FC_fusion_pass，待补充了x86平台非openmp实现的FC后再打开本Pass