### PR TITLE
[doc] Fix docs of build_android.sh

### DIFF
--- a/docs/user_guides/Compile/Android.md
+++ b/docs/user_guides/Compile/Android.md
@@ -65,7 +65,7 @@ inference_lite_lib.android.armv8/
 ```shell
 --arch: (armv8|armv7)        arm版本，默认为armv8
 --toolchain: (gcc|clang)     编译器类型，默认为gcc
---android_stl: (c++_static|c++_shared|gnu_static|gnu_shared)   NDK stl库链接方法，默认为静态链接c++_static
+--android_stl: (c++_static|c++_shared|gnustl_static)   NDK stl库链接方法，默认为静态链接c++_static
 --with_java: (OFF|ON)        是否编译Java预测库, 默认为 ON
 --with_cv: (OFF|ON)          是否编译CV相关预处理库, 默认为 OFF
 --with_log: (OFF|ON)         是否输出日志信息, 默认为 ON

--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -233,7 +233,7 @@ function print_usage {
     echo -e "|  optional argument:                                                                                                                  |"
     echo -e "|     --arch: (armv8|armv7), default is armv8                                                                                          |"
     echo -e "|     --toolchain: (gcc|clang), defalut is gcc                                                                                         |"
-    echo -e "|     --android_stl: (c++_static|c++_shared|gnu_static|gnu_shared), default is c++_static                                              |"
+    echo -e "|     --android_stl: (c++_static|c++_shared|gnustl_static), default is c++_static                                                      |"
     echo -e "|     --with_java: (OFF|ON); controls whether to publish java api lib, default is ON                                                   |"
     echo -e "|     --with_cv: (OFF|ON); controls whether to compile cv functions into lib, default is OFF                                           |"
     echo -e "|     --with_log: (OFF|ON); controls whether to print log information, default is ON                                                   |"


### PR DESCRIPTION
问题描述： build_android.sh脚本文档有误，本PR修复文档
正确数据：
`--android_stl: (c++_static|c++_shared|gnustl_static)`
本PR修改：
`gnu_static` ---> `gnustl_static`
`gnu_shared`不支持