### PR TITLE
[BUG FIX] Race condition in KeyCounter::IncCounter() in case multi threads call CreatePaddlePredictor() simultaneously

### DIFF
--- a/lite/core/mir/pattern_matcher.h
+++ b/lite/core/mir/pattern_matcher.h
@@ -19,6 +19,7 @@
 #endif
 
 #include <memory>
+#include <mutex>  // NOLINT
 #include <numeric>
 #include <string>
 #include <unordered_map>
@@ -350,9 +351,13 @@ struct KeyCounter {
     return x;
   }
 
-  int IncCounter(const std::string& key) { return dic_[key]++; }
+  int IncCounter(const std::string& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dic_[key]++;
+  }
 
  private:
+  std::mutex mutex_;
   std::unordered_map<std::string, size_t> dic_;
 };
 


### PR DESCRIPTION
多个线程同时初始化Predictor时在global static变量上存在竞态条件
![image](https://user-images.githubusercontent.com/2132839/81821270-41b6f900-9564-11ea-88b7-2ef35462147e.png)
![image](https://user-images.githubusercontent.com/2132839/81821307-4aa7ca80-9564-11ea-8e9d-1b16b883db2e.png)
![image](https://user-images.githubusercontent.com/2132839/81821348-53989c00-9564-11ea-835e-0cc064144a19.png)
