### PR TITLE
[Framework][Internal] Add set_passes_internal inference for CxxConfig 

### DIFF
--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -35,7 +35,7 @@ namespace lite {
 void CxxPaddleApiImpl::Init(const lite_api::CxxConfig &config) {
   config_ = config;
   auto places = config.valid_places();
-  std::vector<std::string> passes{};
+  std::vector<std::string> passes = config.get_passes_internal();
 #ifdef LITE_WITH_CUDA
   // if kCUDA is included in valid places, it should be initialized first,
   // otherwise skip this step.

--- a/lite/api/opt_base.cc
+++ b/lite/api/opt_base.cc
@@ -40,6 +40,11 @@ void OptBase::SetModelType(std::string optimize_out_type) {
   }
 }
 
+void OptBase::SetPassesInternal(
+    const std::vector<std::string>& passes_internal) {
+  opt_config_.set_passes_internal(passes_internal);
+}
+
 void OptBase::SetValidPlaces(const std::string& valid_places) {
   valid_places_.clear();
   auto target_reprs = lite::Split(valid_places, ",");
@@ -110,11 +115,13 @@ void OptBase::Run() {
 void OptBase::RunOptimize(const std::string& model_dir_path,
                           const std::string& model_path,
                           const std::string& param_path,
+                          const std::string& model_type,
                           const std::string& valid_places,
                           const std::string& optimized_out_path) {
   SetModelDir(model_dir_path);
   SetModelFile(model_path);
   SetParamFile(param_path);
+  SetModelType(model_type);
   SetValidPlaces(valid_places);
   SetOptimizeOut(optimized_out_path);
   CheckIfModelSupported(false);

--- a/lite/api/opt_base.h
+++ b/lite/api/opt_base.h
@@ -51,12 +51,16 @@ class LITE_API OptBase {
   void SetOptimizeOut(const std::string &lite_out_name);
   void RecordModelInfo(bool record_strip_info = true);
   // set optimized_model type
-  void SetModelType(std::string model_type);
+  void SetModelType(std::string model_type = "naive_buffer");
+  // internal inference for developer, not recommanded.
+  // choose methods of model optimizing.
+  void SetPassesInternal(const std::vector<std::string> &passes_internal = {});
   // transform and save the optimized model
   void Run();
   void RunOptimize(const std::string &model_dir_path = "",
                    const std::string &model_path = "",
                    const std::string &param_path = "",
+                   const std::string &model_type = "",
                    const std::string &valid_places = "",
                    const std::string &optimized_out_path = "");
   // fuctions of printing info

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -137,6 +137,7 @@ class LITE_API CxxConfig : public ConfigBase {
   std::vector<Place> valid_places_;
   std::string model_file_;
   std::string param_file_;
+  std::vector<std::string> passes_internal_{};
   bool model_from_memory_{false};
 #ifdef LITE_WITH_X86
   int x86_math_library_math_threads_ = 1;
@@ -165,7 +166,16 @@ class LITE_API CxxConfig : public ConfigBase {
     param_file_ = std::string(param_buffer, param_buffer + param_buffer_size);
     model_from_memory_ = true;
   }
-
+  // internal inference to choose passes for model optimizing,
+  // it's designed for internal developer and not recommanded
+  // for comman users.
+  void set_passes_internal(
+      const std::vector<std::string>& passes_internal = {}) {
+    passes_internal_ = passes_internal;
+  }
+  const std::vector<std::string>& get_passes_internal() const {
+    return passes_internal_;
+  }
   const std::vector<Place>& valid_places() const { return valid_places_; }
   std::string model_file() const { return model_file_; }
   std::string param_file() const { return param_file_; }

--- a/lite/api/python/pybind/pybind.cc
+++ b/lite/api/python/pybind/pybind.cc
@@ -65,6 +65,7 @@ void BindLiteOpt(py::module *m) {
       .def("set_optimize_out", &OptBase::SetOptimizeOut)
       .def("set_model_type", &OptBase::SetModelType)
       .def("record_model_info", &OptBase::RecordModelInfo)
+      .def("set_passes_internal", &OptBase::SetPassesInternal)
       .def("run", &OptBase::Run)
       .def("run_optimize", &OptBase::RunOptimize)
       .def("help", &OptBase::PrintHelpInfo)
@@ -124,6 +125,7 @@ void BindLiteCxxConfig(py::module *m) {
       .def("param_file", &CxxConfig::param_file)
       .def("set_valid_places", &CxxConfig::set_valid_places)
       .def("set_model_buffer", &CxxConfig::set_model_buffer)
+      .def("set_passes_internal", &CxxConfig::set_passes_internal)
       .def("model_from_memory", &CxxConfig::model_from_memory);
 #ifdef LITE_WITH_ARM
   cxx_config.def("set_threads", &CxxConfig::set_threads)


### PR DESCRIPTION
cherry-pick自：#3614
【需求描述】 PaddleJs需要在调用opt时需要选择模型优化方法，即修改opt执行时使用的pass
【本PR工作】添加接口可以修改opt执行时运行的优化方法，即pass 。 现有pass可以在`lite/core/optimizer.cc`中查看 到
`opt_base::set_passes_internal `是内部开发接口，不对外开放文档，不推荐普通用户使用，不当使用容易照成运行时错误