### PR TITLE
[Compiling] Fix the issue that x86 compiling can not shutdown log

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -377,7 +377,7 @@ function make_x86 {
             -DWITH_GPU=OFF \
             -DLITE_WITH_PYTHON=${BUILD_PYTHON} \
             -DLITE_BUILD_EXTRA=ON \
-            -DWITH_LOG=${WITH_LOG} \
+            -DLITE_WITH_LOG=${WITH_LOG} \
             -DLITE_WITH_PROFILE=${WITH_PROFILE} \
             -DLITE_WITH_XPU=$BUILD_XPU \
             -DLITE_WITH_XTCL=$BUILD_XTCL \


### PR DESCRIPTION
【问题描述】x86编译无法关闭log， `with_log=OFF`无效
【问题定位】build.sh中书写错误，导致`with_log`未正确传入cmake编译选项
【本PR工作】修改该问题，编译x86时 ，`with_log=OFF`可以关闭log