### PR TITLE
[x86][CodeStyle] Remove glog and gflag from x86 base kernel implementaion code

### DIFF
--- a/lite/backends/x86/CMakeLists.txt
+++ b/lite/backends/x86/CMakeLists.txt
@@ -8,7 +8,7 @@ lite_cc_library(target_wrapper_x86 SRCS target_wrapper.cc)
 if (LITE_ON_MODEL_OPTIMIZE_TOOL)
     return()
 endif(LITE_ON_MODEL_OPTIMIZE_TOOL)
-lite_cc_library(dynamic_loader SRCS dynamic_loader.cc DEPS glog gflags)
+lite_cc_library(dynamic_loader SRCS dynamic_loader.cc)
 lite_cc_library(dynload_mklml SRCS mklml.cc DEPS dynamic_loader mklml)
 lite_cc_library(x86_cpu_info SRCS cpu_info.cc)
 

--- a/lite/backends/x86/cpu_info.cc
+++ b/lite/backends/x86/cpu_info.cc
@@ -29,8 +29,8 @@
 #include <unistd.h>
 #endif  // _WIN32
 
-#include <gflags/gflags.h>
 #include <algorithm>
+#include "lite/utils/cp_logging.h"
 
 #include "lite/utils/env.h"
 

--- a/lite/backends/x86/dynamic_loader.cc
+++ b/lite/backends/x86/dynamic_loader.cc
@@ -17,8 +17,6 @@ limitations under the License. */
 #include <mutex>  // NOLINT
 #include <string>
 
-#include "gflags/gflags.h"
-#include "glog/logging.h"
 #include "lite/backends/x86/cupti_lib_path.h"
 #include "lite/backends/x86/port.h"
 #include "lite/backends/x86/warpctc_lib_path.h"

--- a/lite/backends/x86/jit/gen/act.h
+++ b/lite/backends/x86/jit/gen/act.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <string>
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/backends/x86/jit/gen/blas.h
+++ b/lite/backends/x86/jit/gen/blas.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <string>
-#include "glog/logging.h"
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 #include "lite/utils/string.h"
 
 namespace paddle {

--- a/lite/backends/x86/jit/gen/embseqpool.h
+++ b/lite/backends/x86/jit/gen/embseqpool.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <string>
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 #include "lite/utils/paddle_enforce.h"
 
 namespace paddle {

--- a/lite/backends/x86/jit/gen/gru.h
+++ b/lite/backends/x86/jit/gen/gru.h
@@ -15,9 +15,9 @@
 #pragma once
 
 #include <string>
-#include "glog/logging.h"
 #include "lite/backends/x86/jit/gen/act.h"
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/backends/x86/jit/gen/hopv.h
+++ b/lite/backends/x86/jit/gen/hopv.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <string>
-#include "glog/logging.h"
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/backends/x86/jit/gen/lstm.h
+++ b/lite/backends/x86/jit/gen/lstm.h
@@ -15,9 +15,9 @@
 #pragma once
 
 #include <string>
-#include "glog/logging.h"
 #include "lite/backends/x86/jit/gen/act.h"
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/backends/x86/jit/gen/matmul.h
+++ b/lite/backends/x86/jit/gen/matmul.h
@@ -17,8 +17,8 @@
 #include <stdlib.h>  // for malloc and free
 #include <string>
 #include <vector>
-#include "glog/logging.h"
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 #include "lite/utils/paddle_enforce.h"
 
 namespace paddle {

--- a/lite/backends/x86/jit/gen/seqpool.h
+++ b/lite/backends/x86/jit/gen/seqpool.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <string>
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 #include "lite/utils/paddle_enforce.h"
 
 namespace paddle {

--- a/lite/backends/x86/jit/gen/sgd.h
+++ b/lite/backends/x86/jit/gen/sgd.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <string>
-#include "glog/logging.h"
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/backends/x86/jit/gen/vbroadcast.h
+++ b/lite/backends/x86/jit/gen/vbroadcast.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <string>
-#include "glog/logging.h"
 #include "lite/backends/x86/jit/gen/jitcode.h"
+#include "lite/utils/cp_logging.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/backends/x86/jit/refer/refer.h
+++ b/lite/backends/x86/jit/refer/refer.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <cmath>
 #include <cstring>
 #include <limits>
@@ -22,6 +21,7 @@
 #include "lite/backends/x86/jit/helper.h"
 #include "lite/backends/x86/jit/kernel_base.h"
 #include "lite/backends/x86/jit/macro.h"
+#include "lite/utils/cp_logging.h"
 #include "lite/utils/paddle_enforce.h"
 
 namespace paddle {

--- a/lite/backends/x86/port.h
+++ b/lite/backends/x86/port.h
@@ -22,7 +22,7 @@
 #include <string>
 
 #define GLOG_NO_ABBREVIATED_SEVERITIES  // msvc conflict logging with windows.h
-#include "glog/logging.h"
+#include "lite/utils/cp_logging.h"
 
 #if !defined(_WIN32)
 #include <dlfcn.h>     //  dladdr

--- a/lite/kernels/x86/elementwise_op_function.h
+++ b/lite/kernels/x86/elementwise_op_function.h
@@ -14,16 +14,15 @@ limitations under the License. */
 
 #pragma once
 
-#include <glog/logging.h>
 #include <algorithm>
 #include <iterator>
 #include <vector>
-#include "lite/fluid/eigen.h"
-#include "lite/fluid/transform.h"
-#include "lite/utils/paddle_enforce.h"
-
 #include "lite/backends/x86/math/math_function.h"
+#include "lite/fluid/eigen.h"
 #include "lite/fluid/for_range.h"
+#include "lite/fluid/transform.h"
+#include "lite/utils/cp_logging.h"
+#include "lite/utils/paddle_enforce.h"
 #include "lite/utils/variant.h"
 
 namespace paddle {


### PR DESCRIPTION
将x86 kernel实现中直接引用 `glog`头文件的部分，修改为引用`cp_logging`，`cp_logging`可以根据`with_log`选项预测库是否依赖`glog`