### PR TITLE
[Framework][ModelType] Add Shape&Precision information into optimized model

### DIFF
--- a/lite/model_parser/compatible_pb.cc
+++ b/lite/model_parser/compatible_pb.cc
@@ -30,13 +30,17 @@ namespace paddle {
 namespace lite {
 
 /// For VarDesc transfrom
-#define TRANS_VAR_ANY_WITH_CPP_IMPL(T)                           \
-  template <>                                                    \
-  void TransformVarDescCppToAny<T>(const cpp::VarDesc &cpp_desc, \
-                                   T *any_desc) {                \
-    any_desc->SetName(cpp_desc.Name());                          \
-    any_desc->SetType(cpp_desc.GetType());                       \
-    any_desc->SetPersistable(cpp_desc.Persistable());            \
+#define TRANS_VAR_ANY_WITH_CPP_IMPL(T)                             \
+  template <>                                                      \
+  void TransformVarDescCppToAny<T>(const cpp::VarDesc &cpp_desc,   \
+                                   T *any_desc) {                  \
+    any_desc->SetName(cpp_desc.Name());                            \
+    any_desc->SetType(cpp_desc.GetType());                         \
+    any_desc->SetPersistable(cpp_desc.Persistable());              \
+    if (cpp_desc.Name() != "feed" && cpp_desc.Name() != "fetch") { \
+      any_desc->SetShape(cpp_desc.GetShape());                     \
+      any_desc->SetDataType(cpp_desc.GetDataType());               \
+    }                                                              \
   }
 
 #ifndef LITE_ON_TINY_PUBLISH
@@ -47,6 +51,9 @@ void TransformVarDescAnyToCpp<pb::VarDesc>(const pb::VarDesc &any_desc,
   cpp_desc->SetType(any_desc.GetType());
   cpp_desc->SetPersistable(any_desc.Persistable());
   cpp_desc->SetDataType(any_desc.GetDataType());
+  if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
+    cpp_desc->SetShape(any_desc.GetShape());
+  }
 }
 #endif
 
@@ -56,6 +63,10 @@ void TransformVarDescAnyToCpp<naive_buffer::VarDesc>(
   cpp_desc->SetName(any_desc.Name());
   cpp_desc->SetType(any_desc.GetType());
   cpp_desc->SetPersistable(any_desc.Persistable());
+  cpp_desc->SetDataType(any_desc.GetDataType());
+  if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
+    cpp_desc->SetShape(any_desc.GetShape());
+  }
 }
 
 /// For OpDesc transform

--- a/lite/model_parser/compatible_pb.cc
+++ b/lite/model_parser/compatible_pb.cc
@@ -63,10 +63,14 @@ void TransformVarDescAnyToCpp<naive_buffer::VarDesc>(
   cpp_desc->SetName(any_desc.Name());
   cpp_desc->SetType(any_desc.GetType());
   cpp_desc->SetPersistable(any_desc.Persistable());
-  if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
-    cpp_desc->SetDataType(any_desc.GetDataType());
-    cpp_desc->SetShape(any_desc.GetShape());
-  }
+  // todo : SetDataType function is commented out temporarily
+  // because of Compatibility issues. The Compatibility issue
+  // should be fixed later and the code below should be applied
+  // later. @DannyIsFunny
+  /*  if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
+      cpp_desc->SetDataType(any_desc.GetDataType());
+      cpp_desc->SetShape(any_desc.GetShape());
+    }*/
 }
 
 /// For OpDesc transform

--- a/lite/model_parser/compatible_pb.cc
+++ b/lite/model_parser/compatible_pb.cc
@@ -50,8 +50,8 @@ void TransformVarDescAnyToCpp<pb::VarDesc>(const pb::VarDesc &any_desc,
   cpp_desc->SetName(any_desc.Name());
   cpp_desc->SetType(any_desc.GetType());
   cpp_desc->SetPersistable(any_desc.Persistable());
-  cpp_desc->SetDataType(any_desc.GetDataType());
   if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
+    cpp_desc->SetDataType(any_desc.GetDataType());
     cpp_desc->SetShape(any_desc.GetShape());
   }
 }
@@ -63,8 +63,8 @@ void TransformVarDescAnyToCpp<naive_buffer::VarDesc>(
   cpp_desc->SetName(any_desc.Name());
   cpp_desc->SetType(any_desc.GetType());
   cpp_desc->SetPersistable(any_desc.Persistable());
-  cpp_desc->SetDataType(any_desc.GetDataType());
   if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
+    cpp_desc->SetDataType(any_desc.GetDataType());
     cpp_desc->SetShape(any_desc.GetShape());
   }
 }

--- a/lite/model_parser/compatible_pb_test.cc
+++ b/lite/model_parser/compatible_pb_test.cc
@@ -36,6 +36,8 @@ void SetVarDesc(VarDescType* desc) {
   desc->SetName("X");
   desc->SetPersistable(true);
   desc->SetType(VarDescAPI::Type::LOD_TENSOR);
+  desc->SetShape({1, 3, 224, 224});
+  desc->SetDataType(VarDescAPI::VarDataType::FP32);
 }
 
 template <typename VarDescType>
@@ -43,6 +45,8 @@ void SetVarDesc1(VarDescType* desc) {
   desc->SetName("Y");
   desc->SetPersistable(false);
   desc->SetType(VarDescAPI::Type::SELECTED_ROWS);
+  desc->SetShape({1, 3, 224, 224});
+  desc->SetDataType(VarDescAPI::VarDataType::FP32);
 }
 
 template <typename VarDescType>

--- a/lite/model_parser/cpp/var_desc.h
+++ b/lite/model_parser/cpp/var_desc.h
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <string>
+#include <vector>
 #include "lite/model_parser/desc_apis.h"
 
 namespace paddle {
@@ -46,11 +47,16 @@ class VarDesc : public VarDescAPI {
 
   void SetDataType(Type data_type) { data_type_ = data_type; }
 
+  void SetShape(const std::vector<int64_t> &dims) { shape_ = dims; }
+
+  std::vector<int64_t> GetShape() const { return shape_; }
+
  private:
   std::string name_;
   Type type_;
   Type data_type_;
   bool persistable_;
+  std::vector<int64_t> shape_;
 };
 
 }  // namespace cpp

--- a/lite/model_parser/desc_apis.h
+++ b/lite/model_parser/desc_apis.h
@@ -76,6 +76,10 @@ class VarDescAPI {
   virtual bool Persistable() const = 0;
   // Set var to be persistable or not
   virtual void SetPersistable(bool persistable) = 0;
+  // Get var's shape
+  virtual std::vector<int64_t> GetShape() const = 0;
+  // Set var's shape
+  virtual void SetShape(const std::vector<int64_t>& dims) = 0;
 };
 
 /*

--- a/lite/model_parser/naive_buffer/proto/framework.nb.h
+++ b/lite/model_parser/naive_buffer/proto/framework.nb.h
@@ -159,6 +159,7 @@ class VarDesc : public StructBuilder {
     NewStr("name");
     New<VarType>("type");
     NewBool("persistable", false);
+    New<TensorDesc>("tensor_desc");
   }
 };
 

--- a/lite/model_parser/naive_buffer/proto/framework.nb.h
+++ b/lite/model_parser/naive_buffer/proto/framework.nb.h
@@ -159,7 +159,6 @@ class VarDesc : public StructBuilder {
     NewStr("name");
     New<VarType>("type");
     NewBool("persistable", false);
-    New<TensorDesc>("tensor_desc");
   }
 };
 

--- a/lite/model_parser/naive_buffer/var_desc.cc
+++ b/lite/model_parser/naive_buffer/var_desc.cc
@@ -131,6 +131,48 @@ proto::VarType* VarDesc::GetMutableVarType() {
   return builder;
 }
 
+void VarDesc::SetDataType(VarDescAPI::VarDataType data_type) {
+  using data_type_builder_t = EnumBuilder<proto::VarDataType>;
+  auto data_type_builder =
+      desc_->GetMutableField<proto::TensorDesc>("tensor_desc")
+          ->GetMutableField<data_type_builder_t>("data_type");
+#define SET_DATA_TYPE_CASE_ITEM(type__)                 \
+  case VarDescAPI::VarDataType::type__:                 \
+    data_type_builder->set(proto::VarDataType::type__); \
+    break
+
+  switch (data_type) {
+    // Only support primary data type now.
+    SET_DATA_TYPE_CASE_ITEM(UINT8);
+    SET_DATA_TYPE_CASE_ITEM(INT8);
+    SET_DATA_TYPE_CASE_ITEM(INT16);
+    SET_DATA_TYPE_CASE_ITEM(INT32);
+    SET_DATA_TYPE_CASE_ITEM(INT64);
+    SET_DATA_TYPE_CASE_ITEM(FP32);
+    SET_DATA_TYPE_CASE_ITEM(FP64);
+    default:
+      LOG(FATAL) << "Unknown var data type";
+  }
+#undef SET_DATA_TYPE_CASE_ITEM
+}
+// VarDescAPI::VarDataType VarDesc::GetDataType() const;
+
+// Get var's shape
+std::vector<int64_t> VarDesc::GetShape() const {
+  using data_type_builder_t = ListBuilder<Int64Builder>;
+  auto out_builder = desc_->GetField<proto::TensorDesc>("tensor_desc")
+                         .GetField<data_type_builder_t>("dims");
+  return RepeatedToVector<int64_t, Int64Builder>(out_builder);
+}
+// Set var's shape
+void VarDesc::SetShape(const std::vector<int64_t>& dims) {
+  using out_builder_type = ListBuilder<Int64Builder>;
+  auto out_builder = desc_->GetMutableField<proto::TensorDesc>("tensor_desc")
+                         ->GetMutableField<out_builder_type>("dims");
+  CHECK(out_builder);
+  VectorToRepeated<int64_t, Int64Builder>(dims, out_builder);
+}
+
 }  // namespace naive_buffer
 }  // namespace lite
 }  // namespace paddle

--- a/lite/model_parser/naive_buffer/var_desc.cc
+++ b/lite/model_parser/naive_buffer/var_desc.cc
@@ -131,29 +131,34 @@ proto::VarType* VarDesc::GetMutableVarType() {
   return builder;
 }
 
+// todo : SetDataType function is commented out temporarily
+// because of Compatibility issues. The Compatibility issue
+// should be fixed later and the code below should be applied
+// later. @DannyIsFunny
 void VarDesc::SetDataType(VarDescAPI::VarDataType data_type) {
-  using data_type_builder_t = EnumBuilder<proto::VarDataType>;
-  auto data_type_builder =
-      desc_->GetMutableField<proto::TensorDesc>("tensor_desc")
-          ->GetMutableField<data_type_builder_t>("data_type");
-#define SET_DATA_TYPE_CASE_ITEM(type__)                 \
-  case VarDescAPI::VarDataType::type__:                 \
-    data_type_builder->set(proto::VarDataType::type__); \
-    break
+  /*  using data_type_builder_t = EnumBuilder<proto::VarDataType>;
+    auto data_type_builder =
+        desc_->GetMutableField<proto::TensorDesc>("tensor_desc")
+            ->GetMutableField<data_type_builder_t>("data_type");
+  #define SET_DATA_TYPE_CASE_ITEM(type__)                 \
+    case VarDescAPI::VarDataType::type__:                 \
+      data_type_builder->set(proto::VarDataType::type__); \
+      break
 
-  switch (data_type) {
-    // Only support primary data type now.
-    SET_DATA_TYPE_CASE_ITEM(UINT8);
-    SET_DATA_TYPE_CASE_ITEM(INT8);
-    SET_DATA_TYPE_CASE_ITEM(INT16);
-    SET_DATA_TYPE_CASE_ITEM(INT32);
-    SET_DATA_TYPE_CASE_ITEM(INT64);
-    SET_DATA_TYPE_CASE_ITEM(FP32);
-    SET_DATA_TYPE_CASE_ITEM(FP64);
-    default:
-      LOG(FATAL) << "Unknown var data type";
-  }
-#undef SET_DATA_TYPE_CASE_ITEM
+    switch (data_type) {
+      // Only support primary data type now.
+      SET_DATA_TYPE_CASE_ITEM(UINT8);
+      SET_DATA_TYPE_CASE_ITEM(INT8);
+      SET_DATA_TYPE_CASE_ITEM(INT16);
+      SET_DATA_TYPE_CASE_ITEM(INT32);
+      SET_DATA_TYPE_CASE_ITEM(INT64);
+      SET_DATA_TYPE_CASE_ITEM(FP32);
+      SET_DATA_TYPE_CASE_ITEM(FP64);
+      default:
+        LOG(FATAL) << "Unknown var data type";
+    }
+  #undef SET_DATA_TYPE_CASE_ITEM
+  */
 }
 
 // Get var's shape
@@ -163,13 +168,18 @@ std::vector<int64_t> VarDesc::GetShape() const {
                          .GetField<data_type_builder_t>("dims");
   return RepeatedToVector<int64_t, Int64Builder>(out_builder);
 }
+
 // Set var's shape
+// todo : SetDataType function is commented out temporarily
+// because of Compatibility issues. The Compatibility issue
+// should be fixed later and the code below should be applied
+// later. @DannyIsFunny
 void VarDesc::SetShape(const std::vector<int64_t>& dims) {
-  using out_builder_type = ListBuilder<Int64Builder>;
-  auto out_builder = desc_->GetMutableField<proto::TensorDesc>("tensor_desc")
-                         ->GetMutableField<out_builder_type>("dims");
-  CHECK(out_builder);
-  VectorToRepeated<int64_t, Int64Builder>(dims, out_builder);
+  /*  using out_builder_type = ListBuilder<Int64Builder>;
+    auto out_builder = desc_->GetMutableField<proto::TensorDesc>("tensor_desc")
+                           ->GetMutableField<out_builder_type>("dims");
+    CHECK(out_builder);
+    VectorToRepeated<int64_t, Int64Builder>(dims, out_builder);*/
 }
 
 }  // namespace naive_buffer

--- a/lite/model_parser/naive_buffer/var_desc.cc
+++ b/lite/model_parser/naive_buffer/var_desc.cc
@@ -155,7 +155,6 @@ void VarDesc::SetDataType(VarDescAPI::VarDataType data_type) {
   }
 #undef SET_DATA_TYPE_CASE_ITEM
 }
-// VarDescAPI::VarDataType VarDesc::GetDataType() const;
 
 // Get var's shape
 std::vector<int64_t> VarDesc::GetShape() const {

--- a/lite/model_parser/naive_buffer/var_desc.h
+++ b/lite/model_parser/naive_buffer/var_desc.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include "lite/model_parser/desc_apis.h"
+#include "lite/model_parser/naive_buffer/naive_buffer_wrapper_helper.h"
 #include "lite/model_parser/naive_buffer/proto/framework.nb.h"
 
 namespace paddle {
@@ -51,7 +52,13 @@ class VarDesc : public VarDescAPI {
 
   void SetPersistable(bool persistable) override;
 
+  void SetDataType(VarDescAPI::VarDataType data_type);
   VarDescAPI::VarDataType GetDataType() const;
+
+  // Get var's shape
+  std::vector<int64_t> GetShape() const;
+  // Set var's shape
+  void SetShape(const std::vector<int64_t> &dims);
 
  private:
   const proto::VarType &GetVarType() const;

--- a/lite/model_parser/pb/var_desc.cc
+++ b/lite/model_parser/pb/var_desc.cc
@@ -130,8 +130,27 @@ std::vector<std::vector<int64_t>> VarDesc::GetShapes() const {
   return res;
 }
 
-void VarDesc::SetDataType(proto::VarType::Type data_type) {
-  mutable_tensor_desc()->set_data_type(data_type);
+void VarDesc::SetDataType(VarDescAPI::VarDataType data_type) {
+#define SET_DATA_TYPE_CASE_ITEM(type__)                                      \
+  case VarDescAPI::Type::type__:                                             \
+    mutable_tensor_desc()->set_data_type(framework::proto::VarType::type__); \
+    break;
+
+  switch (data_type) {
+    SET_DATA_TYPE_CASE_ITEM(BOOL);
+    SET_DATA_TYPE_CASE_ITEM(SIZE_T);
+    SET_DATA_TYPE_CASE_ITEM(UINT8);
+    SET_DATA_TYPE_CASE_ITEM(INT8);
+    SET_DATA_TYPE_CASE_ITEM(INT16);
+    SET_DATA_TYPE_CASE_ITEM(INT32);
+    SET_DATA_TYPE_CASE_ITEM(INT64);
+    SET_DATA_TYPE_CASE_ITEM(FP16);
+    SET_DATA_TYPE_CASE_ITEM(FP32);
+    SET_DATA_TYPE_CASE_ITEM(FP64);
+    default:
+      LOG(FATAL) << "Unknown var type: " << static_cast<int>(data_type);
+  }
+#undef SET_DATA_TYPE_CASE_ITEM
 }
 
 void VarDesc::SetDataTypes(

--- a/lite/model_parser/pb/var_desc.h
+++ b/lite/model_parser/pb/var_desc.h
@@ -84,7 +84,7 @@ class VarDesc : public VarDescAPI {
 
   std::vector<std::vector<int64_t>> GetShapes() const;
 
-  void SetDataType(framework::proto::VarType::Type data_type);
+  void SetDataType(VarDescAPI::VarDataType data_type);
 
   void SetDataTypes(
       const std::vector<framework::proto::VarType::Type> &multiple_data_type);


### PR DESCRIPTION
#3530 的修改版本
【修改说明】
因为 #3530 存在兼容性问题： #3530 修改模型格式后，无法加载之前版本的naive格式模型，需要使用最新版本的opt转化后才能运行， 针对模型的兼容性问题，已提交PR #3642 修复中（暂时未完成）。 本PR暂时先将naive_buffer部分的修改撤销，使opt 转化的protobuf 有shape&precision信息，满足paddlejs业务需求。opt转化的 naive_buffer模型仍然没有 shape&precision ，没有兼容性问题。---后续兼容性问题需要解决，使naive_buffer恢复 shape&precision信息。 @DannyIsFunny 

【问题描述】Paddle-Lite opt转化后的模型中，丢失了 变量的 数据类型 （precision）和shape信息
【本PR工作】
- 使 opt优化出的模型有 `precision`和`shape`信息
    - Naive_buffer & protobuf
- 发现问题： opt 转化后的模型会重复保存var_desc信息，导致转化后的model文件变大，本PR修复
以mobilenet_v1为例转化出的naive_buffer格式模型。
    - 本PR之前转化后的体积：        17407383 byte
    - 本PR修改后体积：17322487 byte
    - （体积减少约 0.08M）

【实现方法】
(1) cpp_desc、naive_buffer desc、pb desc 中都实现并对齐 Set&GetDataType() 、Set&GetShape方法
 - 修改前： cpp_desc、naive_buffer desc、pb desc  中均有部分实现并未对齐

(2) 修改naive_buffer中var_desc 定义，补充 `Tensor_desc成员`

【效果】
输出的pb模型与PaddlePaddle输出的模型的信息格式一致，naive_buffer格式的模型中不缺失 shape&precision 信息
【风险】
不向前兼容
合入后不能加载之前opt转化出的模型，会提示缺少shape&precision 信息