### PR TITLE
[BUG FIX] Fix the issue that ios compiling failed

### DIFF
--- a/lite/api/python/pybind/CMakeLists.txt
+++ b/lite/api/python/pybind/CMakeLists.txt
@@ -21,7 +21,6 @@ else()
    add_custom_command(OUTPUT ${LINK_MAP_FILE} COMMAND ...)
    set_target_properties(lite_pybind PROPERTIES LINK_FLAGS ${LINK_FLAGS})
    add_dependencies(lite_pybind custom_linker_map)
-endif(APPLE)
 endif(WIN32)
 
 if (LITE_ON_TINY_PUBLISH)


### PR DESCRIPTION
【问题描述】： Paddle-Lite develop分支编译Python预测库失败，问题定位为`lite/api/python/pybind/CMakeLists.txt`中有一处括号没有关闭。  （release/v2.6.0没有该问题）
【本PR工作】：修复该编译问题