### PR TITLE
[BUG FIX] fix the issue that opt can not convert quantized model

### DIFF
--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -157,8 +157,8 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
         if (type->IsTensor()) {
           auto tensor = scope->FindVar(out_name)->GetMutable<Tensor>();
           v->SetPersistable(tensor->persistable());
-          if (in_name != "feed" && in_name != "fetch") {
-            LOG(INFO) << "update var" << in_name;
+          if (out_name != "feed" && out_name != "fetch") {
+            LOG(INFO) << "update var" << out_name;
             v->SetShape(tensor->dims().data());
             switch (tensor->precision()) {
 #define SET_DATATYPE(precision__, data_type)                    \
@@ -177,174 +177,175 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
               default:
                 LOG(WARNING) << "unknown precision type";
             }
-          } else {
-            CHECK(false) << "unsupported var type";
-          }
-        }
-      }
-    }
-  }
-  void RuntimeProgram::Run() {
-#ifdef LITE_WITH_PRECISION_PROFILE
-    auto inst_precision_profiler = paddle::lite::profile::PrecisionProfiler();
-    std::string precision_profiler_summary =
-        inst_precision_profiler.GetSummaryHeader();
-#endif
-
-    for (auto& inst : instructions_) {
-#ifndef LITE_WITH_FPGA
-      if (inst.is_feed_fetch_op()) continue;
-#endif
-#ifdef LITE_WITH_CUDA
-      if (inst.need_sync()) {
-        inst.Sync();
-      }
-#endif
-      inst.Run();
-#ifdef LITE_WITH_PRECISION_PROFILE
-#ifndef LITE_WITH_FPGA
-      precision_profiler_summary +=
-          inst_precision_profiler.GetInstPrecision(&inst);
-#endif
-#endif  // LITE_WITH_PRECISION_PROFILE
-    }
-#ifdef LITE_WITH_PROFILE
-    LOG(INFO) << "\n" << profiler_.Summary(profile::Type::kDispatch, false, 0);
-#endif
-#ifdef LITE_WITH_PRECISION_PROFILE
-    LOG(INFO) << "\n" << precision_profiler_summary;
-#endif
-  }
-
-  void Program::Build(const cpp::ProgramDesc& prog) {
-    CHECK(ops_.empty()) << "Executor duplicate Build found";
-
-    // Create operators.
-    auto program = prog;
-    CHECK(program.BlocksSize());
-    auto& main_block = *program.GetBlock<cpp::BlockDesc>(0);
-    for (size_t i = 0; i < main_block.OpsSize(); ++i) {
-      auto& op_desc = *main_block.GetOp<cpp::OpDesc>(i);
-      auto op_type = op_desc.Type();
-      // if (op_type == "feed" || op_type == "fetch") continue;
-      VLOG(4) << "create Op [" << op_type << "]";
-      auto op = LiteOpRegistry::Global().Create(op_type);
-      CHECK(op) << "no Op found for " << op_type;
-      if (op_type == "while" || op_type == "conditional_block" ||
-          op_type == "subgraph") {
-        auto sub_block_idx = op_desc.GetAttr<int32_t>("sub_block");
-        CHECK(sub_block_idx >= 0 && sub_block_idx < program.BlocksSize())
-            << "Invalid attribute sub_block(" << sub_block_idx << ") for "
-            << op_type;
-        auto sub_block_desc =
-            const_cast<cpp::ProgramDesc&>(prog).GetBlock<cpp::BlockDesc>(
-                sub_block_idx);
-        CHECK(sub_block_desc);
-        if (op_type == "while") {
-          static_cast<operators::WhileOpLite*>(op.get())->SetSubBlock(
-              sub_block_desc);
-        } else if (op_type == "conditional_block") {
-          static_cast<operators::ConditionalBlockOpLite*>(op.get())
-              ->SetSubBlock(sub_block_desc);
-        } else if (op_type == "subgraph") {
-          static_cast<operators::SubgraphOp*>(op.get())->SetSubBlock(
-              sub_block_desc);
-        }
-      }
-      ops_.emplace_back(std::move(op));
-      ops_.back()->Attach(op_desc, exec_scope_);
-    }
-  }
-
-  void Program::PrepareWorkspace(const cpp::ProgramDesc& prog) {
-    CHECK(!exec_scope_) << "Duplicate PrepareWorkspace found";
-    exec_scope_ = &scope_->NewScope();
-    // Create Feed and Fetch var.
-    scope_->Var("feed")->GetMutable<std::vector<lite::Tensor>>();
-    scope_->Var("fetch")->GetMutable<std::vector<lite::Tensor>>();
-    tmp_vars_.push_back("feed");
-    tmp_vars_.push_back("fetch");
-
-    auto VarPrecision2KernlPrecision =
-        [](const lite::VarDescAPI::Type& type) -> PrecisionType {
-      switch (type) {
-        case lite::VarDescAPI::Type::FP32:
-          return PRECISION(kFloat);
-        case lite::VarDescAPI::Type::FP16:
-          return PRECISION(kFP16);
-        case lite::VarDescAPI::Type::INT8:
-          return PRECISION(kInt8);
-        case lite::VarDescAPI::Type::INT16:
-          return PRECISION(kInt16);
-        case lite::VarDescAPI::Type::INT32:
-          return PRECISION(kInt32);
-        case lite::VarDescAPI::Type::INT64:
-          return PRECISION(kInt64);
-        default:
-          // LOG(FATAL) << "not supported type: " << static_cast<int>(type);
-          return PRECISION(kUnk);
-      }
-    };
-
-    auto program = prog;
-    CHECK(program.BlocksSize());
-    for (size_t b = 0; b < program.BlocksSize(); ++b) {
-      auto& main_block = *program.GetBlock<cpp::BlockDesc>(b);
-      for (size_t i = 0; i < main_block.VarsSize(); ++i) {
-        auto& var_desc = *main_block.GetVar<cpp::VarDesc>(i);
-        if (!var_desc.Persistable()) {
-          if (var_desc.GetType() == lite::VarDescAPI::Type::LOD_TENSOR &&
-              VarPrecision2KernlPrecision(var_desc.GetDataType()) !=
-                  PRECISION(kUnk)) {
-            var_data_type_[var_desc.Name()] =
-                VarPrecision2KernlPrecision(var_desc.GetDataType());
-          }
-          tmp_vars_.push_back(var_desc.Name());
-          VLOG(4) << "var name: " << var_desc.Name() << " type is "
-                  << static_cast<int>(var_desc.GetType()) << " data type is "
-                  << static_cast<int>(var_desc.GetDataType());
-          exec_scope_->Var(var_desc.Name());
-          if (b > 0) {
-            VLOG(4) << "var: " << var_desc.Name();
           }
         } else {
-          if (var_desc.Name() == "feed" || var_desc.Name() == "fetch") continue;
-          weights_.push_back(var_desc.Name());
-          if (var_desc.Persistable()) scope_->Var(var_desc.Name());
+          CHECK(false) << "unsupported var type";
         }
       }
     }
   }
-
-  void Instruction::Run() {
-#ifdef LITE_WITH_PROFILE
-    CHECK(profiler_) << "Profiler pointer of kernel can not be nullptr. "
-                        "When LITE_WITH_PROFILE is defined, please set a "
-                        "Profiler for Instruction.";
-    profiler_->StartTiming(
-        profile::Type::kCreate, profile_id_, kernel_->mutable_context());
+}
+void RuntimeProgram::Run() {
+#ifdef LITE_WITH_PRECISION_PROFILE
+  auto inst_precision_profiler = paddle::lite::profile::PrecisionProfiler();
+  std::string precision_profiler_summary =
+      inst_precision_profiler.GetSummaryHeader();
 #endif
-    CHECK(op_) << "op null";
-    CHECK(kernel_) << "kernel null";
 
-    if (first_epoch_) {
-      first_epoch_ = false;
-      CHECK(op_->CheckShape());
+  for (auto& inst : instructions_) {
+#ifndef LITE_WITH_FPGA
+    if (inst.is_feed_fetch_op()) continue;
+#endif
+#ifdef LITE_WITH_CUDA
+    if (inst.need_sync()) {
+      inst.Sync();
     }
+#endif
+    inst.Run();
+#ifdef LITE_WITH_PRECISION_PROFILE
+#ifndef LITE_WITH_FPGA
+    precision_profiler_summary +=
+        inst_precision_profiler.GetInstPrecision(&inst);
+#endif
+#endif  // LITE_WITH_PRECISION_PROFILE
+  }
+#ifdef LITE_WITH_PROFILE
+  LOG(INFO) << "\n" << profiler_.Summary(profile::Type::kDispatch, false, 0);
+#endif
+#ifdef LITE_WITH_PRECISION_PROFILE
+  LOG(INFO) << "\n" << precision_profiler_summary;
+#endif
+}
 
-    if (op_->run_once() && has_run_) {
-      return;
+void Program::Build(const cpp::ProgramDesc& prog) {
+  CHECK(ops_.empty()) << "Executor duplicate Build found";
+
+  // Create operators.
+  auto program = prog;
+  CHECK(program.BlocksSize());
+  auto& main_block = *program.GetBlock<cpp::BlockDesc>(0);
+  for (size_t i = 0; i < main_block.OpsSize(); ++i) {
+    auto& op_desc = *main_block.GetOp<cpp::OpDesc>(i);
+    auto op_type = op_desc.Type();
+    // if (op_type == "feed" || op_type == "fetch") continue;
+    VLOG(4) << "create Op [" << op_type << "]";
+    auto op = LiteOpRegistry::Global().Create(op_type);
+    CHECK(op) << "no Op found for " << op_type;
+    if (op_type == "while" || op_type == "conditional_block" ||
+        op_type == "subgraph") {
+      auto sub_block_idx = op_desc.GetAttr<int32_t>("sub_block");
+      CHECK(sub_block_idx >= 0 && sub_block_idx < program.BlocksSize())
+          << "Invalid attribute sub_block(" << sub_block_idx << ") for "
+          << op_type;
+      auto sub_block_desc =
+          const_cast<cpp::ProgramDesc&>(prog).GetBlock<cpp::BlockDesc>(
+              sub_block_idx);
+      CHECK(sub_block_desc);
+      if (op_type == "while") {
+        static_cast<operators::WhileOpLite*>(op.get())->SetSubBlock(
+            sub_block_desc);
+      } else if (op_type == "conditional_block") {
+        static_cast<operators::ConditionalBlockOpLite*>(op.get())->SetSubBlock(
+            sub_block_desc);
+      } else if (op_type == "subgraph") {
+        static_cast<operators::SubgraphOp*>(op.get())->SetSubBlock(
+            sub_block_desc);
+      }
     }
+    ops_.emplace_back(std::move(op));
+    ops_.back()->Attach(op_desc, exec_scope_);
+  }
+}
 
-    op_->InferShape();
-    kernel_->Launch();
-    has_run_ = true;
+void Program::PrepareWorkspace(const cpp::ProgramDesc& prog) {
+  CHECK(!exec_scope_) << "Duplicate PrepareWorkspace found";
+  exec_scope_ = &scope_->NewScope();
+  // Create Feed and Fetch var.
+  scope_->Var("feed")->GetMutable<std::vector<lite::Tensor>>();
+  scope_->Var("fetch")->GetMutable<std::vector<lite::Tensor>>();
+  tmp_vars_.push_back("feed");
+  tmp_vars_.push_back("fetch");
+
+  auto VarPrecision2KernlPrecision =
+      [](const lite::VarDescAPI::Type& type) -> PrecisionType {
+    switch (type) {
+      case lite::VarDescAPI::Type::FP32:
+        return PRECISION(kFloat);
+      case lite::VarDescAPI::Type::FP16:
+        return PRECISION(kFP16);
+      case lite::VarDescAPI::Type::INT8:
+        return PRECISION(kInt8);
+      case lite::VarDescAPI::Type::INT16:
+        return PRECISION(kInt16);
+      case lite::VarDescAPI::Type::INT32:
+        return PRECISION(kInt32);
+      case lite::VarDescAPI::Type::INT64:
+        return PRECISION(kInt64);
+      default:
+        // LOG(FATAL) << "not supported type: " << static_cast<int>(type);
+        return PRECISION(kUnk);
+    }
+  };
+
+  auto program = prog;
+  CHECK(program.BlocksSize());
+  for (size_t b = 0; b < program.BlocksSize(); ++b) {
+    auto& main_block = *program.GetBlock<cpp::BlockDesc>(b);
+    for (size_t i = 0; i < main_block.VarsSize(); ++i) {
+      auto& var_desc = *main_block.GetVar<cpp::VarDesc>(i);
+      if (!var_desc.Persistable()) {
+        if (var_desc.GetType() == lite::VarDescAPI::Type::LOD_TENSOR &&
+            VarPrecision2KernlPrecision(var_desc.GetDataType()) !=
+                PRECISION(kUnk)) {
+          var_data_type_[var_desc.Name()] =
+              VarPrecision2KernlPrecision(var_desc.GetDataType());
+        }
+        tmp_vars_.push_back(var_desc.Name());
+        VLOG(4) << "var name: " << var_desc.Name() << " type is "
+                << static_cast<int>(var_desc.GetType()) << " data type is "
+                << static_cast<int>(var_desc.GetDataType());
+        exec_scope_->Var(var_desc.Name());
+        if (b > 0) {
+          VLOG(4) << "var: " << var_desc.Name();
+        }
+      } else {
+        if (var_desc.Name() == "feed" || var_desc.Name() == "fetch") continue;
+        weights_.push_back(var_desc.Name());
+        if (var_desc.Persistable()) scope_->Var(var_desc.Name());
+      }
+    }
+  }
+}
+
+void Instruction::Run() {
+#ifdef LITE_WITH_PROFILE
+  CHECK(profiler_) << "Profiler pointer of kernel can not be nullptr. "
+                      "When LITE_WITH_PROFILE is defined, please set a "
+                      "Profiler for Instruction.";
+  profiler_->StartTiming(
+      profile::Type::kCreate, profile_id_, kernel_->mutable_context());
+#endif
+  CHECK(op_) << "op null";
+  CHECK(kernel_) << "kernel null";
+
+  if (first_epoch_) {
+    first_epoch_ = false;
+    CHECK(op_->CheckShape());
   }
 
-  STL::ostream& operator<<(STL::ostream& os, const Instruction& other) {
-    os << other.kernel_->summary() << "\t(" << other.kernel_->doc() << ")";
-    return os;
+  if (op_->run_once() && has_run_) {
+    return;
   }
+
+  op_->InferShape();
+  kernel_->Launch();
+  has_run_ = true;
+}
+
+STL::ostream& operator<<(STL::ostream& os, const Instruction& other) {
+  os << other.kernel_->summary() << "\t(" << other.kernel_->doc() << ")";
+  return os;
+}
 
 }  // namespace lite
 }  // namespace paddle

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -73,7 +73,7 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
   std::unordered_map<std::string, cpp::VarDesc> origin_var_maps;
   auto& main_block = *desc->GetBlock<cpp::BlockDesc>(0);
   auto var_size = main_block.VarsSize();
-  for (size_t i = 0; i < var_size; i++) {
+  for (int i = 0; i < var_size; i++) {
     auto v = main_block.GetVar<cpp::VarDesc>(i);
     auto name = v->Name();
     origin_var_maps.emplace(name, *v);
@@ -86,16 +86,8 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
     auto* scope = op->scope();
     auto in_names = op->op_info()->input_names();
     auto out_names = op->op_info()->output_names();
-
-    std::vector<std::string> var_names;
-    var_names.insert(var_names.end(), in_names.begin(), in_names.end());
-    var_names.insert(var_names.end(), out_names.begin(), out_names.end());
-    std::sort(var_names.begin(), var_names.end());
-    var_names.erase(std::unique(var_names.begin(), var_names.end()),
-                    var_names.end());
-
-    for (auto& var_name : var_names) {
-      auto it = origin_var_maps.find(var_name);
+    for (auto& in_name : in_names) {
+      auto it = origin_var_maps.find(in_name);
       if (it != origin_var_maps.end()) {
         auto* v = main_block.AddVar<cpp::VarDesc>();
         v->SetName((it->second).Name());
@@ -108,30 +100,33 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
       } else {
         // New created vars must be LOD_TENSOR
         auto* v = main_block.AddVar<cpp::VarDesc>();
-        v->SetName(var_name);
+        v->SetName(in_name);
         v->SetType(cpp::VarDesc::Type::LOD_TENSOR);
         std::string in_arg_name;
-        op->op_info()->GetInputArgname(var_name, &in_arg_name);
+        op->op_info()->GetInputArgname(in_name, &in_arg_name);
         auto type = kernel->GetInputDeclType(in_arg_name);
         if (type->IsTensor()) {
-          auto tensor = scope->FindVar(var_name)->GetMutable<Tensor>();
+          auto tensor = scope->FindVar(in_name)->GetMutable<Tensor>();
           v->SetPersistable(tensor->persistable());
-          if ((it->second).Name() != "feed" && (it->second).Name() != "fetch") {
+          if (in_name != "feed" && in_name != "fetch") {
+            LOG(INFO) << "update var" << in_name;
             v->SetShape(tensor->dims().data());
             switch (tensor->precision()) {
-#define SET_DATATYPE(precision__, data_type) \
-  case PrecisionType::precision__:           \
-    v->SetDataType(data_type);               \
+#define SET_DATATYPE(precision__, data_type)                    \
+  case PrecisionType::precision__:                              \
+    v->SetDataType(data_type);                                  \
+    LOG(INFO) << "update var" << (it->second).Name() << "done"; \
     break
-
+              SET_DATATYPE(kBool, VarDescAPI::VarDataType::BOOL);
               SET_DATATYPE(kFloat, VarDescAPI::VarDataType::FP32);
+              SET_DATATYPE(kFP16, VarDescAPI::VarDataType::FP16);
               SET_DATATYPE(kInt8, VarDescAPI::VarDataType::INT8);
               SET_DATATYPE(kInt16, VarDescAPI::VarDataType::INT16);
               SET_DATATYPE(kInt32, VarDescAPI::VarDataType::INT32);
               SET_DATATYPE(kInt64, VarDescAPI::VarDataType::INT64);
 #undef SET_DATATYPE
               default:
-                LOG(FATAL) << "unknown precision type";
+                LOG(WARNING) << "unknown precision type";
             }
           }
         } else {
@@ -139,170 +134,217 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
         }
       }
     }
-  }
-}
 
-void RuntimeProgram::Run() {
-#ifdef LITE_WITH_PRECISION_PROFILE
-  auto inst_precision_profiler = paddle::lite::profile::PrecisionProfiler();
-  std::string precision_profiler_summary =
-      inst_precision_profiler.GetSummaryHeader();
-#endif
-
-  for (auto& inst : instructions_) {
-#ifndef LITE_WITH_FPGA
-    if (inst.is_feed_fetch_op()) continue;
-#endif
-#ifdef LITE_WITH_CUDA
-    if (inst.need_sync()) {
-      inst.Sync();
-    }
-#endif
-    inst.Run();
-#ifdef LITE_WITH_PRECISION_PROFILE
-#ifndef LITE_WITH_FPGA
-    precision_profiler_summary +=
-        inst_precision_profiler.GetInstPrecision(&inst);
-#endif
-#endif  // LITE_WITH_PRECISION_PROFILE
-  }
-#ifdef LITE_WITH_PROFILE
-  LOG(INFO) << "\n" << profiler_.Summary(profile::Type::kDispatch, false, 0);
-#endif
-#ifdef LITE_WITH_PRECISION_PROFILE
-  LOG(INFO) << "\n" << precision_profiler_summary;
-#endif
-}
-
-void Program::Build(const cpp::ProgramDesc& prog) {
-  CHECK(ops_.empty()) << "Executor duplicate Build found";
-
-  // Create operators.
-  auto program = prog;
-  CHECK(program.BlocksSize());
-  auto& main_block = *program.GetBlock<cpp::BlockDesc>(0);
-  for (size_t i = 0; i < main_block.OpsSize(); ++i) {
-    auto& op_desc = *main_block.GetOp<cpp::OpDesc>(i);
-    auto op_type = op_desc.Type();
-    // if (op_type == "feed" || op_type == "fetch") continue;
-    VLOG(4) << "create Op [" << op_type << "]";
-    auto op = LiteOpRegistry::Global().Create(op_type);
-    CHECK(op) << "no Op found for " << op_type;
-    if (op_type == "while" || op_type == "conditional_block" ||
-        op_type == "subgraph") {
-      auto sub_block_idx = op_desc.GetAttr<int32_t>("sub_block");
-      CHECK(sub_block_idx >= 0 && sub_block_idx < program.BlocksSize())
-          << "Invalid attribute sub_block(" << sub_block_idx << ") for "
-          << op_type;
-      auto sub_block_desc =
-          const_cast<cpp::ProgramDesc&>(prog).GetBlock<cpp::BlockDesc>(
-              sub_block_idx);
-      CHECK(sub_block_desc);
-      if (op_type == "while") {
-        static_cast<operators::WhileOpLite*>(op.get())->SetSubBlock(
-            sub_block_desc);
-      } else if (op_type == "conditional_block") {
-        static_cast<operators::ConditionalBlockOpLite*>(op.get())->SetSubBlock(
-            sub_block_desc);
-      } else if (op_type == "subgraph") {
-        static_cast<operators::SubgraphOp*>(op.get())->SetSubBlock(
-            sub_block_desc);
-      }
-    }
-    ops_.emplace_back(std::move(op));
-    ops_.back()->Attach(op_desc, exec_scope_);
-  }
-}
-
-void Program::PrepareWorkspace(const cpp::ProgramDesc& prog) {
-  CHECK(!exec_scope_) << "Duplicate PrepareWorkspace found";
-  exec_scope_ = &scope_->NewScope();
-  // Create Feed and Fetch var.
-  scope_->Var("feed")->GetMutable<std::vector<lite::Tensor>>();
-  scope_->Var("fetch")->GetMutable<std::vector<lite::Tensor>>();
-  tmp_vars_.push_back("feed");
-  tmp_vars_.push_back("fetch");
-
-  auto VarPrecision2KernlPrecision =
-      [](const lite::VarDescAPI::Type& type) -> PrecisionType {
-    switch (type) {
-      case lite::VarDescAPI::Type::FP32:
-        return PRECISION(kFloat);
-      case lite::VarDescAPI::Type::FP16:
-        return PRECISION(kFP16);
-      case lite::VarDescAPI::Type::INT8:
-        return PRECISION(kInt8);
-      case lite::VarDescAPI::Type::INT16:
-        return PRECISION(kInt16);
-      case lite::VarDescAPI::Type::INT32:
-        return PRECISION(kInt32);
-      case lite::VarDescAPI::Type::INT64:
-        return PRECISION(kInt64);
-      default:
-        // LOG(FATAL) << "not supported type: " << static_cast<int>(type);
-        return PRECISION(kUnk);
-    }
-  };
-
-  auto program = prog;
-  CHECK(program.BlocksSize());
-  for (size_t b = 0; b < program.BlocksSize(); ++b) {
-    auto& main_block = *program.GetBlock<cpp::BlockDesc>(b);
-    for (size_t i = 0; i < main_block.VarsSize(); ++i) {
-      auto& var_desc = *main_block.GetVar<cpp::VarDesc>(i);
-      if (!var_desc.Persistable()) {
-        if (var_desc.GetType() == lite::VarDescAPI::Type::LOD_TENSOR &&
-            VarPrecision2KernlPrecision(var_desc.GetDataType()) !=
-                PRECISION(kUnk)) {
-          var_data_type_[var_desc.Name()] =
-              VarPrecision2KernlPrecision(var_desc.GetDataType());
-        }
-        tmp_vars_.push_back(var_desc.Name());
-        VLOG(4) << "var name: " << var_desc.Name() << " type is "
-                << static_cast<int>(var_desc.GetType()) << " data type is "
-                << static_cast<int>(var_desc.GetDataType());
-        exec_scope_->Var(var_desc.Name());
-        if (b > 0) {
-          VLOG(4) << "var: " << var_desc.Name();
+    for (auto& out_name : out_names) {
+      auto it = origin_var_maps.find(out_name);
+      if (it != origin_var_maps.end()) {
+        auto* v = main_block.AddVar<cpp::VarDesc>();
+        v->SetName((it->second).Name());
+        v->SetType((it->second).GetType());
+        v->SetPersistable((it->second).Persistable());
+        if ((it->second).Name() != "feed" && (it->second).Name() != "fetch") {
+          v->SetShape((it->second).GetShape());
+          v->SetDataType((it->second).GetDataType());
         }
       } else {
-        if (var_desc.Name() == "feed" || var_desc.Name() == "fetch") continue;
-        weights_.push_back(var_desc.Name());
-        if (var_desc.Persistable()) scope_->Var(var_desc.Name());
+        // New created vars must be LOD_TENSOR
+        auto* v = main_block.AddVar<cpp::VarDesc>();
+        v->SetName(out_name);
+        v->SetType(cpp::VarDesc::Type::LOD_TENSOR);
+        std::string out_arg_name;
+        op->op_info()->GetOutputArgname(out_name, &out_arg_name);
+        auto type = kernel->GetOutputDeclType(out_arg_name);
+        if (type->IsTensor()) {
+          auto tensor = scope->FindVar(out_name)->GetMutable<Tensor>();
+          v->SetPersistable(tensor->persistable());
+          if (in_name != "feed" && in_name != "fetch") {
+            LOG(INFO) << "update var" << in_name;
+            v->SetShape(tensor->dims().data());
+            switch (tensor->precision()) {
+#define SET_DATATYPE(precision__, data_type)                    \
+  case PrecisionType::precision__:                              \
+    v->SetDataType(data_type);                                  \
+    LOG(INFO) << "update var" << (it->second).Name() << "done"; \
+    break
+              SET_DATATYPE(kBool, VarDescAPI::VarDataType::BOOL);
+              SET_DATATYPE(kFloat, VarDescAPI::VarDataType::FP32);
+              SET_DATATYPE(kFP16, VarDescAPI::VarDataType::FP16);
+              SET_DATATYPE(kInt8, VarDescAPI::VarDataType::INT8);
+              SET_DATATYPE(kInt16, VarDescAPI::VarDataType::INT16);
+              SET_DATATYPE(kInt32, VarDescAPI::VarDataType::INT32);
+              SET_DATATYPE(kInt64, VarDescAPI::VarDataType::INT64);
+#undef SET_DATATYPE
+              default:
+                LOG(WARNING) << "unknown precision type";
+            }
+          } else {
+            CHECK(false) << "unsupported var type";
+          }
+        }
       }
     }
   }
-}
-
-void Instruction::Run() {
-#ifdef LITE_WITH_PROFILE
-  CHECK(profiler_) << "Profiler pointer of kernel can not be nullptr. "
-                      "When LITE_WITH_PROFILE is defined, please set a "
-                      "Profiler for Instruction.";
-  profiler_->StartTiming(
-      profile::Type::kCreate, profile_id_, kernel_->mutable_context());
+  void RuntimeProgram::Run() {
+#ifdef LITE_WITH_PRECISION_PROFILE
+    auto inst_precision_profiler = paddle::lite::profile::PrecisionProfiler();
+    std::string precision_profiler_summary =
+        inst_precision_profiler.GetSummaryHeader();
 #endif
-  CHECK(op_) << "op null";
-  CHECK(kernel_) << "kernel null";
 
-  if (first_epoch_) {
-    first_epoch_ = false;
-    CHECK(op_->CheckShape());
+    for (auto& inst : instructions_) {
+#ifndef LITE_WITH_FPGA
+      if (inst.is_feed_fetch_op()) continue;
+#endif
+#ifdef LITE_WITH_CUDA
+      if (inst.need_sync()) {
+        inst.Sync();
+      }
+#endif
+      inst.Run();
+#ifdef LITE_WITH_PRECISION_PROFILE
+#ifndef LITE_WITH_FPGA
+      precision_profiler_summary +=
+          inst_precision_profiler.GetInstPrecision(&inst);
+#endif
+#endif  // LITE_WITH_PRECISION_PROFILE
+    }
+#ifdef LITE_WITH_PROFILE
+    LOG(INFO) << "\n" << profiler_.Summary(profile::Type::kDispatch, false, 0);
+#endif
+#ifdef LITE_WITH_PRECISION_PROFILE
+    LOG(INFO) << "\n" << precision_profiler_summary;
+#endif
   }
 
-  if (op_->run_once() && has_run_) {
-    return;
+  void Program::Build(const cpp::ProgramDesc& prog) {
+    CHECK(ops_.empty()) << "Executor duplicate Build found";
+
+    // Create operators.
+    auto program = prog;
+    CHECK(program.BlocksSize());
+    auto& main_block = *program.GetBlock<cpp::BlockDesc>(0);
+    for (size_t i = 0; i < main_block.OpsSize(); ++i) {
+      auto& op_desc = *main_block.GetOp<cpp::OpDesc>(i);
+      auto op_type = op_desc.Type();
+      // if (op_type == "feed" || op_type == "fetch") continue;
+      VLOG(4) << "create Op [" << op_type << "]";
+      auto op = LiteOpRegistry::Global().Create(op_type);
+      CHECK(op) << "no Op found for " << op_type;
+      if (op_type == "while" || op_type == "conditional_block" ||
+          op_type == "subgraph") {
+        auto sub_block_idx = op_desc.GetAttr<int32_t>("sub_block");
+        CHECK(sub_block_idx >= 0 && sub_block_idx < program.BlocksSize())
+            << "Invalid attribute sub_block(" << sub_block_idx << ") for "
+            << op_type;
+        auto sub_block_desc =
+            const_cast<cpp::ProgramDesc&>(prog).GetBlock<cpp::BlockDesc>(
+                sub_block_idx);
+        CHECK(sub_block_desc);
+        if (op_type == "while") {
+          static_cast<operators::WhileOpLite*>(op.get())->SetSubBlock(
+              sub_block_desc);
+        } else if (op_type == "conditional_block") {
+          static_cast<operators::ConditionalBlockOpLite*>(op.get())
+              ->SetSubBlock(sub_block_desc);
+        } else if (op_type == "subgraph") {
+          static_cast<operators::SubgraphOp*>(op.get())->SetSubBlock(
+              sub_block_desc);
+        }
+      }
+      ops_.emplace_back(std::move(op));
+      ops_.back()->Attach(op_desc, exec_scope_);
+    }
   }
 
-  op_->InferShape();
-  kernel_->Launch();
-  has_run_ = true;
-}
+  void Program::PrepareWorkspace(const cpp::ProgramDesc& prog) {
+    CHECK(!exec_scope_) << "Duplicate PrepareWorkspace found";
+    exec_scope_ = &scope_->NewScope();
+    // Create Feed and Fetch var.
+    scope_->Var("feed")->GetMutable<std::vector<lite::Tensor>>();
+    scope_->Var("fetch")->GetMutable<std::vector<lite::Tensor>>();
+    tmp_vars_.push_back("feed");
+    tmp_vars_.push_back("fetch");
 
-STL::ostream& operator<<(STL::ostream& os, const Instruction& other) {
-  os << other.kernel_->summary() << "\t(" << other.kernel_->doc() << ")";
-  return os;
-}
+    auto VarPrecision2KernlPrecision =
+        [](const lite::VarDescAPI::Type& type) -> PrecisionType {
+      switch (type) {
+        case lite::VarDescAPI::Type::FP32:
+          return PRECISION(kFloat);
+        case lite::VarDescAPI::Type::FP16:
+          return PRECISION(kFP16);
+        case lite::VarDescAPI::Type::INT8:
+          return PRECISION(kInt8);
+        case lite::VarDescAPI::Type::INT16:
+          return PRECISION(kInt16);
+        case lite::VarDescAPI::Type::INT32:
+          return PRECISION(kInt32);
+        case lite::VarDescAPI::Type::INT64:
+          return PRECISION(kInt64);
+        default:
+          // LOG(FATAL) << "not supported type: " << static_cast<int>(type);
+          return PRECISION(kUnk);
+      }
+    };
+
+    auto program = prog;
+    CHECK(program.BlocksSize());
+    for (size_t b = 0; b < program.BlocksSize(); ++b) {
+      auto& main_block = *program.GetBlock<cpp::BlockDesc>(b);
+      for (size_t i = 0; i < main_block.VarsSize(); ++i) {
+        auto& var_desc = *main_block.GetVar<cpp::VarDesc>(i);
+        if (!var_desc.Persistable()) {
+          if (var_desc.GetType() == lite::VarDescAPI::Type::LOD_TENSOR &&
+              VarPrecision2KernlPrecision(var_desc.GetDataType()) !=
+                  PRECISION(kUnk)) {
+            var_data_type_[var_desc.Name()] =
+                VarPrecision2KernlPrecision(var_desc.GetDataType());
+          }
+          tmp_vars_.push_back(var_desc.Name());
+          VLOG(4) << "var name: " << var_desc.Name() << " type is "
+                  << static_cast<int>(var_desc.GetType()) << " data type is "
+                  << static_cast<int>(var_desc.GetDataType());
+          exec_scope_->Var(var_desc.Name());
+          if (b > 0) {
+            VLOG(4) << "var: " << var_desc.Name();
+          }
+        } else {
+          if (var_desc.Name() == "feed" || var_desc.Name() == "fetch") continue;
+          weights_.push_back(var_desc.Name());
+          if (var_desc.Persistable()) scope_->Var(var_desc.Name());
+        }
+      }
+    }
+  }
+
+  void Instruction::Run() {
+#ifdef LITE_WITH_PROFILE
+    CHECK(profiler_) << "Profiler pointer of kernel can not be nullptr. "
+                        "When LITE_WITH_PROFILE is defined, please set a "
+                        "Profiler for Instruction.";
+    profiler_->StartTiming(
+        profile::Type::kCreate, profile_id_, kernel_->mutable_context());
+#endif
+    CHECK(op_) << "op null";
+    CHECK(kernel_) << "kernel null";
+
+    if (first_epoch_) {
+      first_epoch_ = false;
+      CHECK(op_->CheckShape());
+    }
+
+    if (op_->run_once() && has_run_) {
+      return;
+    }
+
+    op_->InferShape();
+    kernel_->Launch();
+    has_run_ = true;
+  }
+
+  STL::ostream& operator<<(STL::ostream& os, const Instruction& other) {
+    os << other.kernel_->summary() << "\t(" << other.kernel_->doc() << ")";
+    return os;
+  }
 
 }  // namespace lite
 }  // namespace paddle

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -86,6 +86,10 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
     auto* scope = op->scope();
     auto in_names = op->op_info()->input_names();
     auto out_names = op->op_info()->output_names();
+    in_names.insert(in_names.end(), out_names.begin(), out_names.end());
+    std::sort(in_names.begin(), in_names.end());
+    in_names.erase(std::unique(in_names.begin(), in_names.end()),
+                   in_names.end());
     for (auto& in_name : in_names) {
       auto it = origin_var_maps.find(in_name);
       if (it != origin_var_maps.end()) {
@@ -103,13 +107,17 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
         v->SetName(in_name);
         v->SetType(cpp::VarDesc::Type::LOD_TENSOR);
         std::string in_arg_name;
-        op->op_info()->GetInputArgname(in_name, &in_arg_name);
-        auto type = kernel->GetInputDeclType(in_arg_name);
+        const Type* type;
+        if (op->op_info()->GetInputArgname(in_name, &in_arg_name)) {
+          type = kernel->GetInputDeclType(in_arg_name);
+        } else {
+          op->op_info()->GetOutputArgname(in_name, &in_arg_name);
+          type = kernel->GetOutputDeclType(in_arg_name);
+        }
         if (type->IsTensor()) {
           auto tensor = scope->FindVar(in_name)->GetMutable<Tensor>();
           v->SetPersistable(tensor->persistable());
           if (in_name != "feed" && in_name != "fetch") {
-            LOG(INFO) << "update var" << in_name;
             v->SetShape(tensor->dims().data());
             switch (tensor->precision()) {
 #define SET_DATATYPE(precision__, data_type)                    \
@@ -126,56 +134,7 @@ void RuntimeProgram::UpdateVarsOfProgram(cpp::ProgramDesc* desc) {
               SET_DATATYPE(kInt64, VarDescAPI::VarDataType::INT64);
 #undef SET_DATATYPE
               default:
-                LOG(WARNING) << "unknown precision type";
-            }
-          }
-        } else {
-          CHECK(false) << "unsupported var type";
-        }
-      }
-    }
-
-    for (auto& out_name : out_names) {
-      auto it = origin_var_maps.find(out_name);
-      if (it != origin_var_maps.end()) {
-        auto* v = main_block.AddVar<cpp::VarDesc>();
-        v->SetName((it->second).Name());
-        v->SetType((it->second).GetType());
-        v->SetPersistable((it->second).Persistable());
-        if ((it->second).Name() != "feed" && (it->second).Name() != "fetch") {
-          v->SetShape((it->second).GetShape());
-          v->SetDataType((it->second).GetDataType());
-        }
-      } else {
-        // New created vars must be LOD_TENSOR
-        auto* v = main_block.AddVar<cpp::VarDesc>();
-        v->SetName(out_name);
-        v->SetType(cpp::VarDesc::Type::LOD_TENSOR);
-        std::string out_arg_name;
-        op->op_info()->GetOutputArgname(out_name, &out_arg_name);
-        auto type = kernel->GetOutputDeclType(out_arg_name);
-        if (type->IsTensor()) {
-          auto tensor = scope->FindVar(out_name)->GetMutable<Tensor>();
-          v->SetPersistable(tensor->persistable());
-          if (out_name != "feed" && out_name != "fetch") {
-            LOG(INFO) << "update var" << out_name;
-            v->SetShape(tensor->dims().data());
-            switch (tensor->precision()) {
-#define SET_DATATYPE(precision__, data_type)                    \
-  case PrecisionType::precision__:                              \
-    v->SetDataType(data_type);                                  \
-    LOG(INFO) << "update var" << (it->second).Name() << "done"; \
-    break
-              SET_DATATYPE(kBool, VarDescAPI::VarDataType::BOOL);
-              SET_DATATYPE(kFloat, VarDescAPI::VarDataType::FP32);
-              SET_DATATYPE(kFP16, VarDescAPI::VarDataType::FP16);
-              SET_DATATYPE(kInt8, VarDescAPI::VarDataType::INT8);
-              SET_DATATYPE(kInt16, VarDescAPI::VarDataType::INT16);
-              SET_DATATYPE(kInt32, VarDescAPI::VarDataType::INT32);
-              SET_DATATYPE(kInt64, VarDescAPI::VarDataType::INT64);
-#undef SET_DATATYPE
-              default:
-                LOG(WARNING) << "unknown precision type";
+                VLOG(4) << "warning! unknown precision type";
             }
           }
         } else {


### PR DESCRIPTION
【问题描述】Paddle-Lite v2.6.0编译出的opt出现转化量化模型失败问题
【问题定位】为了实现paddle.js可以调用Paddle-Lite接口。2.6.0版本，对Paddle-Lite模型格式进行部分修改，使之与Fluid中的模型格式更加对齐。 相关修改合入后，opt工具转化量化模型出现问题。
【本PR工作】修复2.6.0 opt工具不能转化量化模型问题，修复后可以正常转化量化模型