### PR TITLE
[Fix bug] Skip fusing conv and elementwise when the bias of elementwise has two output

### DIFF
--- a/lite/api/benchmark.cc
+++ b/lite/api/benchmark.cc
@@ -91,6 +91,8 @@ void OutputOptModel(const std::string& save_optimized_model_dir) {
   }
   std::vector<Place> vaild_places = {
       Place{TARGET(kARM), PRECISION(kFloat)},
+      Place{TARGET(kARM), PRECISION(kInt32)},
+      Place{TARGET(kARM), PRECISION(kInt64)},
   };
   config.set_valid_places(vaild_places);
   auto predictor = lite_api::CreatePaddlePredictor(config);

--- a/lite/core/mir/fusion/conv_elementwise_fuser.cc
+++ b/lite/core/mir/fusion/conv_elementwise_fuser.cc
@@ -30,7 +30,8 @@ void ConvElementwiseFuser::BuildPattern() {
   auto* bias = VarNode("bias")
                    ->assert_is_op_input("elementwise_add", "Y")
                    ->AsInput()
-                   ->assert_is_persistable_var();
+                   ->assert_is_persistable_var()
+                   ->assert_only_one_output();
 
   // create op nodes
   auto* conv2d = OpNode("conv2d", conv_type_)->assert_is_op(conv_type_);

--- a/lite/core/mir/pattern_matcher.cc
+++ b/lite/core/mir/pattern_matcher.cc
@@ -364,6 +364,11 @@ PMNode *PMNode::assert_is_op() {
   return this;
 }
 
+PMNode *PMNode::assert_only_one_output() {
+  asserts_.emplace_back([](const Node *x) { return x->outlinks.size() == 1; });
+  return this;
+}
+
 PMNode *PMNode::assert_is_op(const std::string &op_type) {
   asserts_.emplace_back([op_type](const Node *x) {
     if (x && x->IsStmt()) {

--- a/lite/core/mir/pattern_matcher.h
+++ b/lite/core/mir/pattern_matcher.h
@@ -127,6 +127,7 @@ struct PMNode {
   PMNode* assert_is_var();
   PMNode* assert_var_not_persistable();
   PMNode* assert_is_persistable_var();
+  PMNode* assert_only_one_output();
   PMNode* assert_is_op_output(const std::string& op_type);
   PMNode* assert_is_op_input(const std::string& op_type);
   PMNode* assert_is_op_input(const std::string& op_type,


### PR DESCRIPTION
对于conv_elementwise_add_fuse，如果elementwise_add的bias是多个op的输入，不应该对此进行fuse。因为fuse会将conv的bias加到elementwise_add的bias上，这个bias再作为conv的bias。此时这个bias如果作为其他op的输入，其数值就错误了。