### PR TITLE
[BUG FIX] Fix the issue that paddle-lite python lib can not inference on mac env

### DIFF
--- a/lite/api/python/setup_mac.py.in
+++ b/lite/api/python/setup_mac.py.in
@@ -47,7 +47,7 @@ if '${WITH_MKL}' == 'ON':
     PACKAGE_DATA['paddlelite.libs'] += ['libmklml.dylib', 'libiomp5.dylib']
 
 # link lite.so to paddlelite.libs
-COMMAND = "install_name_tool -id \"@loader_path/libs/\" ${PADDLE_BINARY_DIR}\
+COMMAND = "install_name_tool -add_rpath \"@loader_path/libs/\" ${PADDLE_BINARY_DIR}\
 /inference_lite_lib/python/install/lite/lite.so"
 if os.system(COMMAND) != 0:
     raise Exception("patch third_party libs failed, command: %s" % COMMAND)


### PR DESCRIPTION
【问题描述】Paddle-Lite 在2.6版本发布支持python lib 
python lib测试过程发现，在mac上调用Paddle-Lite inference 执行预测，会提示找不到第三方库mklml。
【问题定位】打包过程中，需要修改`lite.so`的默认寻找库文件的路径，mac上使用`install_name_tool`实现
【本PR工作】
实现如下：
```
COMMAND = "install_name_tool -add_rpath \"@loader_path/libs/\" ${PADDLE_BINARY_DIR}\
/inference_lite_lib/python/install/lite/lite.so"	/inference_lite_lib/python/install/lite/lite.so"
```
经测试，可以正常执行预测，并可以自动定位第三方库mklml
