### PR TITLE
[cherry-pick] [BUG FIX] Fix the issue that paddle-lite python lib can not inference on mac env

### DIFF
--- a/lite/api/python/setup_mac.py.in
+++ b/lite/api/python/setup_mac.py.in
@@ -47,7 +47,7 @@ if '${WITH_MKL}' == 'ON':
     PACKAGE_DATA['paddlelite.libs'] += ['libmklml.dylib', 'libiomp5.dylib']
 
 # link lite.so to paddlelite.libs
-COMMAND = "install_name_tool -id \"@loader_path/libs/\" ${PADDLE_BINARY_DIR}\
+COMMAND = "install_name_tool -add_rpath \"@loader_path/libs/\" ${PADDLE_BINARY_DIR}\
 /inference_lite_lib/python/install/lite/lite.so"
 if os.system(COMMAND) != 0:
     raise Exception("patch third_party libs failed, command: %s" % COMMAND)


### PR DESCRIPTION
cherry-pick 自： #3681