### PR TITLE
fix the demo of opt saved can't work on windows

### DIFF
--- a/docs/demo_guides/python_demo.md
+++ b/docs/demo_guides/python_demo.md
@@ -27,12 +27,19 @@ tar zxf mobilenet_v1.tar.gz
   - 非combined形式：模型文件夹model_dir下存在一个模型文件和多个参数文件时，传入模型文件夹路径，模型文件名默认为__model__。
 
   ```shell
-  paddle_lite_opt --model_dir=./mobilenet_v1  --valid_targets=mobilenet_v1_opt --valid_targets=x86
+  paddle_lite_opt --model_dir=./mobilenet_v1  \
+                  --optimize_out=mobilenet_v1_opt \
+                  --optimize_out_type=naive_buffer \
+                  --valid_targets=x86
   ```
   - combined形式：模型文件夹model_dir下只有一个模型文件__model__和一个参数文件__params__时，传入模型文件和参数文件路径
 
   ```shell
-  paddle_lite_opt --model_file=./mobilenet_v1/__model__ --param_file=./mobilenet_v1/__params__  --valid_targets=mobilenet_v1_opt --valid_targets=x86
+  paddle_lite_opt --model_file=./mobilenet_v1/__model__ \
+                  --param_file=./mobilenet_v1/__params__  \
+                  --optimize_out=mobilenet_v1_opt \
+                  --optimize_out_type=naive_buffer \
+                  --valid_targets=x86
   ```
 
 - windows环境

--- a/docs/demo_guides/x86.md
+++ b/docs/demo_guides/x86.md
@@ -209,9 +209,9 @@ git checkout release/v2.6.0
 ```
 2、 源码编译(需要按照提示输入对应的参数)
 
-```bash
+```dos
 cd Paddle-Lite
-lite/tools/build_windows.bat 
+lite\tools\build_windows.bat 
 ```
 
 ### 编译结果说明
@@ -269,8 +269,8 @@ build.bat
 cd build 
 ```
 编译结果为当前目录下的 `Release\mobilenet_full_api.exe `
-``` bash
+``` dos
 # 2、执行预测
-Release\\mobilenet_full_api.exe mobilenet_v1
+Release\mobilenet_full_api.exe mobilenet_v1
 ```
 下载并解压模型[`mobilenet_v1`](http://paddle-inference-dist.bj.bcebos.com/mobilenet_v1.tar.gz)到`build`目录，执行以上命令进行预测。

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -323,7 +323,7 @@ void SaveCombinedParamsPb(const std::string &path,
   std::sort(paramlist.begin(), paramlist.end());
 
   // Load vars
-  std::ofstream file(path);
+  std::ofstream file(path, std::ios::binary);
   CHECK(file.is_open());
   for (size_t i = 0; i < paramlist.size(); ++i) {
     SerializeTensor(file, exec_scope, paramlist[i]);

--- a/lite/utils/io.h
+++ b/lite/utils/io.h
@@ -38,10 +38,17 @@ static bool IsFileExists(const std::string& path) {
 // ARM mobile not support mkdir in C++
 static void MkDirRecur(const std::string& path) {
 #ifndef LITE_WITH_ARM
+
+#ifdef _WIN32
+  if (system(string_format("md %s", path.c_str()).c_str()) != 0) {
+    LOG(ERROR) << "Cann't mkdir " << path;
+  }
+#else
   if (system(string_format("mkdir -p %s", path.c_str()).c_str()) != 0) {
     LOG(ERROR) << "Cann't mkdir " << path;
   }
-#else  // On ARM
+#endif  // _WIN32
+#else   // On ARM
   CHECK_NE(mkdir(path.c_str(), S_IRWXU), -1) << "Cann't mkdir " << path;
 #endif
 }


### PR DESCRIPTION
1. 修复 windows 使用opt工具保存的protobuf模型无法被正常使用的bug
修复前，加载pb模型时出现如下错误：
![image](https://user-images.githubusercontent.com/35439432/82634224-d211cf80-9c2f-11ea-9bfb-1f803ce6df0a.png)
修复后，加载pb模型时能够正常运行：
![image](https://user-images.githubusercontent.com/35439432/82634251-e05feb80-9c2f-11ea-9699-5ad1dfdfb759.png)

2. 修复windows 使用opt工具保存protobuf模型时创建-p目录的问题

3. 文档修复

![image](https://user-images.githubusercontent.com/35439432/82664447-53835500-9c64-11ea-81fd-465ffd489b4d.png)

