### PR TITLE
[BUG FIX] Fix the issue that Android static library can not  be linked  properly

### DIFF
--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -327,7 +327,6 @@ if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
                 add_dependencies(publish_inference tiny_publish_cxx_lib)
                 if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
                     add_custom_command(TARGET tiny_publish_cxx_lib POST_BUILD
-                                COMMAND ${CMAKE_STRIP} "-s" ${INFER_LITE_PUBLISH_ROOT}/cxx/lib/libpaddle_api_light_bundled.a
                                 COMMAND ${CMAKE_STRIP} "-s" ${INFER_LITE_PUBLISH_ROOT}/cxx/lib/libpaddle_light_api_shared.so)
                 endif()
             endif()


### PR DESCRIPTION
[Issue] Static library in v2.6.0 Android compiling result is verified unusable. When we tried to link `libpaddle_api_light_bundled.a`, 
error message listed below will appear:
```
could not read symbols: Archive has no index;
```
[Reason] After compiling, we stripped `libpaddle_api_light_bundled.a` to decrease its size, which is proved reason of this error, because some necessary symbols are striped. 

[Works of this Pull Request] We discarded striping of this static library, since the size of static library will not be added into the app's size directly, this modification has little impact on resulted app size.
After merging this PR, static library is tested to be usable.