### PR TITLE
[Framework][Op_regitry]reconstruct op_registry

### DIFF
--- a/docs/develop_guides/add_layout.md
+++ b/docs/develop_guides/add_layout.md
@@ -165,9 +165,7 @@ std::set<DataLayoutType> ExpandValidLayouts(DataLayoutType layout) {
 // 该文件第2处
 // 找到文件中的下面的函数
 KernelRegistry::KernelRegistry()
-    : registries_(static_cast<int>(TARGET(NUM)) *
-                  static_cast<int>(PRECISION(NUM)) *
-                  static_cast<int>(DATALAYOUT(NUM)))
+    : registries_() {
 
 // 在该函数中加入新增Layout的下面内容
   INIT_FOR(kOpenCL, kFP16, kNCHW);

--- a/lite/core/op_registry.cc
+++ b/lite/core/op_registry.cc
@@ -124,19 +124,16 @@ std::list<std::unique_ptr<KernelBase>> KernelRegistry::Create(
   return std::list<std::unique_ptr<KernelBase>>();
 }
 
-KernelRegistry::KernelRegistry()
-    : registries_(static_cast<int>(TARGET(NUM)) *
-                  static_cast<int>(PRECISION(NUM)) *
-                  static_cast<int>(DATALAYOUT(NUM))) {
-#define INIT_FOR(target__, precision__, layout__)                      \
-  registries_[KernelRegistry::GetKernelOffset<TARGET(target__),        \
-                                              PRECISION(precision__),  \
-                                              DATALAYOUT(layout__)>()] \
-      .set<KernelRegistryForTarget<TARGET(target__),                   \
-                                   PRECISION(precision__),             \
-                                   DATALAYOUT(layout__)> *>(           \
-          &KernelRegistryForTarget<TARGET(target__),                   \
-                                   PRECISION(precision__),             \
+KernelRegistry::KernelRegistry() : registries_() {
+#define INIT_FOR(target__, precision__, layout__)            \
+  registries_[std::make_tuple(TARGET(target__),              \
+                              PRECISION(precision__),        \
+                              DATALAYOUT(layout__))]         \
+      .set<KernelRegistryForTarget<TARGET(target__),         \
+                                   PRECISION(precision__),   \
+                                   DATALAYOUT(layout__)> *>( \
+          &KernelRegistryForTarget<TARGET(target__),         \
+                                   PRECISION(precision__),   \
                                    DATALAYOUT(layout__)>::Global());
   // Currently, just register 2 kernel targets.
   INIT_FOR(kCUDA, kFloat, kNCHW);

--- a/lite/core/op_registry.h
+++ b/lite/core/op_registry.h
@@ -364,18 +364,6 @@ class KernelRegistry final {
                                                 PrecisionType precision,
                                                 DataLayoutType layout);
 
-  // Get a kernel registry offset in all the registries.
-  template <TargetType Target, PrecisionType Precision, DataLayoutType Layout>
-  static int GetKernelOffset() {
-    CHECK_LT(static_cast<int>(Target), static_cast<int>(TARGET(NUM)));
-    CHECK_LT(static_cast<int>(Precision), static_cast<int>(PRECISION(NUM)));
-    CHECK_LT(static_cast<int>(Layout), static_cast<int>(DATALAYOUT(NUM)));
-    return static_cast<int>(Target) * static_cast<int>(PRECISION(NUM)) *
-               static_cast<int>(DATALAYOUT(NUM)) +                            //
-           static_cast<int>(Precision) * static_cast<int>(DATALAYOUT(NUM)) +  //
-           static_cast<int>(Layout);
-  }
-
   std::string DebugString() const {
 #ifndef LITE_ON_MODEL_OPTIMIZE_TOOL
     return "No more debug info";


### PR DESCRIPTION
[Issue] Current kernel registry framework can be improved to reduce library size
[Effect of Current PR]
The size of 
/build.lite.android.armv8.gcc/inference_lite_lib.android.armv8/cxx/lib/libpaddle_light_api_shared.so : 
Before reconstruction:  1819K
After reconstruction:  1783K
