### PR TITLE
[CI][Test Coverage] Fix security hardening

### DIFF
--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -289,6 +289,17 @@ function build_test_server {
     test_model_optimize_tool_compile
 }
 
+# Build the code and run lite server tests. This is executed in the CI system.
+function build_test_coverage {
+    mkdir -p ./build
+    cd ./build
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/third_party/install/mklml/lib"
+    cmake_x86_for_CI
+    build
+
+    test_server
+}
+
 # The CUDA version of CI is cuda_10.1.243_418.87.00_linux.
 # The cuDNN version is cudnn-10.1-linux-x64-v7.5.0.56.
 function build_test_cuda_server {
@@ -1136,7 +1147,7 @@ function main {
                 shift
                 ;;
             build_check_coverage)
-                build_test_server
+                build_test_coverage
                 check_coverage
                 shift
                 ;;

--- a/tools/coverage/gcda_clean.py
+++ b/tools/coverage/gcda_clean.py
@@ -10,8 +10,7 @@ import sys
 
 from github import Github
 
-token = os.getenv('GITHUB_API_TOKEN', 'e51cb020919a6eef689257966e8fb6477981788a')
-
+token = os.getenv('GITHUB_API_TOKEN')
 
 def get_pull(pull_id):
     """

--- a/tools/coverage/paddle_lite_coverage.sh
+++ b/tools/coverage/paddle_lite_coverage.sh
@@ -1,4 +1,6 @@
-et -xe
+#!/bin/bash
+# The git version of CI is 2.7.4. This script is not compatible with git version 1.7.1.
+set -xe
 
 PADDLE_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../../" && pwd )"
 
@@ -26,7 +28,6 @@ function gen_full_html_report() {
         '/Paddle-Lite/lite/kernels/*' \
         '/Paddle-Lite/lite/model_parser/*' \
         '/Paddle-Lite/lite/opreators/*' \
-        '/Paddle-Lite/lite/tests/*' \
         '/Paddle-Lite/lite/tools/*' \
         '/Paddle-Lite/lite/utils/*' \
         -o coverage-full.tmp \
@@ -35,7 +36,21 @@ function gen_full_html_report() {
     mv -f coverage-full.tmp coverage-full.info
 
     lcov --remove coverage-full.info \
-        '/Paddle-Lite/lite/demo*' \
+        '/Paddle-Lite/lite/tests/*' \
+        '/Paddle-Lite/lite/demo/*' \
+        '/Paddle-Lite/lite/fluid/*_test*' \
+        '/Paddle-Lite/lite/model_parser/*_test*' \
+        '/Paddle-Lite/lite/kernels/*/*test*' \
+        '/Paddle-Lite/lite/kernels/*/bridges/*test*' \
+        '/Paddle-Lite/lite/utils/*_test*' \
+        '/Paddle-Lite/lite/api/*test*' \
+        '/Paddle-Lite/lite/core/*_test*' \
+        '/Paddle-Lite/lite/core/*/*test*' \
+        '/Paddle-Lite/lite/core/mir/*/*_test*' \
+        '/Paddle-Lite/lite/core/mir/*_test*' \
+        '/Paddle-Lite/lite/backends/x86/*/*test*' \
+        '/Paddle-Lite/lite/backends/opencl/*test*' \
+        '/Paddle-Lite/lite/operators/*test*' \
         -o coverage-full.tmp \
         --rc lcov_branch_coverage=0
 
@@ -48,7 +63,7 @@ gen_full_html_report || true
 function gen_diff_html_report() {
     if [ "${GIT_PR_ID}" != "" ]; then
         COVERAGE_DIFF_PATTERN="`python ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
-
+        sleep 5
         python ${PADDLE_ROOT}/tools/coverage/pull_request.py diff ${GIT_PR_ID} > git-diff.out
     fi
 
@@ -57,6 +72,7 @@ function gen_diff_html_report() {
         -o coverage-diff.info \
         --rc lcov_branch_coverage=0
     
+    sleep 5 
     python ${PADDLE_ROOT}/tools/coverage/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp
 
     mv -f coverage-diff.tmp coverage-diff.info

--- a/tools/coverage/pull_request.py
+++ b/tools/coverage/pull_request.py
@@ -11,8 +11,7 @@ import os
 
 from github import Github
 
-token = os.getenv('GITHUB_API_TOKEN', 'e51cb020919a6eef689257966e8fb6477981788a')
-
+token = os.getenv('GITHUB_API_TOKEN')
 
 def get_pull(pull_id):
     """


### PR DESCRIPTION
[Effect of Current PR] Equip current CI with test coverage checking (Support x86 platform only). You can apply `Test Coverage Checking` by  inputing command below:
`./lite/tools/ci_build.sh build_test_coverage `