### PR TITLE
[Compiling][BUG FIX] Fix the issue that full_publish is not supported  on build_android.sh

### DIFF
--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -176,7 +176,7 @@ function make_full_publish_so {
 
   prepare_thirdparty
 
-  build_directory=$workspace/build.lite.android.$ARCH.$ARM_LANG
+  build_directory=$workspace/build.lite.android.$ARCH.$TOOLCHAIN
 
   if [ -d $build_directory ]
   then
@@ -202,7 +202,7 @@ function make_full_publish_so {
       -DNPU_DDK_ROOT=$HUAWEI_KIRIN_NPU_SDK_ROOT \
       -DLITE_WITH_OPENCL=$WITH_OPENCL \
       -DARM_TARGET_ARCH_ABI=$ARCH \
-      -DARM_TARGET_LANG=$ARM_LANG \
+      -DARM_TARGET_LANG=$TOOLCHAIN \
       -DLITE_WITH_TRAIN=$WITH_TRAIN \
       -DANDROID_STL_TYPE=$ANDROID_STL"
 


### PR DESCRIPTION
[Issue] Command below failed when compiling full_publish android library:
          `build_android.sh full_publish` 
[Effect of Current PR] Fix this issue , full publish compiling will be supported by build_android.sh after current PR is merged.