### PR TITLE
[LITE][PROFILE] Fix profiler summary

### DIFF
--- a/docs/develop_guides/add_operation.md
+++ b/docs/develop_guides/add_operation.md
@@ -27,6 +27,28 @@
         bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
         void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
         std::string DebugString() const override { return "argmax"; }
+
+    #ifdef LITE_WITH_PROFILE
+        void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
+            auto input_dims = param_.X->dims();
+            auto output_dims = param_.Out->dims();
+            ch->input_shape = ch->DimToStr(input_dims);
+            ch->output_shape = ch->DimToStr(output_dims);
+            ch->remark = "axis" + std::to_string(param_.Axis);
+
+            auto axis = param_.Axis;
+            if (axis < 0) {
+                axis += input_dims.size();
+            }
+            int max_num = 1;
+            for (int64_t i = axis + 1; i < input_dims.size(); i++)
+                max_num *= input_dims[i];
+            float gops = 1.0f;
+            for (int i = 1; i <= max_num; i++) gops *= i;
+            ch->macs = gops * output_dims.production();
+        }
+    #endif
+
     private:
         mutable ArgmaxParam param_;
     };

--- a/lite/core/profile/profiler.h
+++ b/lite/core/profile/profiler.h
@@ -78,6 +78,13 @@ struct OpCharacter {
     }
     return dim_str;
   }
+
+  std::string str() {
+    std::string str{""};
+    str += kernel_name + "/" + kernel_func_name + "/" + remark + "/" +
+           input_shape + "/" + filter_shape + "/" + output_shape;
+    return str;
+  }
 };
 
 class StatisUnit final {
@@ -102,8 +109,10 @@ class Profiler final {
   void StopTiming(Type type, const int index, KernelContext* ctx);
   std::string Summary(Type type, bool concise = true, size_t warm_up = 10);
   int GetKernelFuncCalledTimes(const std::string& op_type,
+                               const std::string& kernel_attr,
                                const std::string& kernel_func_name);
   float GetKernelFuncSummaryGOPs(const std::string& op_type,
+                                 const std::string& kernel_attr,
                                  const std::string& kernel_func_name);
   OpCharacter* GetOpCharacter(const size_t index);
 


### PR DESCRIPTION
# 状态：求review

## 主要内容

修改Profiler汇总信息summary，之前显示错误，会重复显示，原因是op_comp的实现针对新版的profiler没针对性适配优化。

注：开启性能Profiler的方式是根目录下`CMakeLists.txt`设置`LITE_WITH_RPOFILE`为ON。

## mobilenetv1 profiler信息如下

## 单次profiler信息

```shell
===== Detailed Dispatch Profiler Summary: N/A, Exclude 1 warm-ups =====
OperatorType         KerneAttr(Place)               KernelFuncName           Remark                     InDim           FilterDim       OutDim          Avg(ms) Min(ms) Max(ms) Last(ms) Avg(%)  GOPs    GOPS    clAvg(ms) clMin(ms) clMax(ms) clAvg(%)
conv2d               arm/float/NCHW                 conv_3x3s2_direct_fp32   3x3p1s2g1d1BiasRelu        1x3x224x224     32x3x3x3        1x32x112x112    1.613   1.570   1.750   1.582   2.62%    0.022   13.44   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s1g32d1BiasRelu       1x32x112x112    32x1x3x3        1x32x112x112    0.662   0.645   0.728   0.652   1.08%    0.007   10.92   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x32x112x112    64x32x1x1       1x64x112x112    2.895   2.793   3.763   2.805   4.71%    0.051   17.75   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s2g64d1BiasRelu       1x64x112x112    64x1x3x3        1x64x56x56      0.710   0.683   0.867   0.683   1.16%    0.004   5.09    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x64x56x56      128x64x1x1      1x128x56x56     2.648   2.600   2.847   2.613   4.31%    0.051   19.40   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s1g128d1BiasRelu      1x128x56x56     128x1x3x3       1x128x56x56     0.639   0.608   0.797   0.632   1.04%    0.007   11.31   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x128x56x56     128x128x1x1     1x128x56x56     5.141   5.048   5.273   5.261   8.37%    0.103   19.99   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s2g128d1BiasRelu      1x128x56x56     128x1x3x3       1x128x28x28     0.275   0.251   0.306   0.271   0.45%    0.002   6.57    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x128x28x28     256x128x1x1     1x256x28x28     2.566   2.520   2.708   2.531   4.18%    0.051   20.02   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s1g256d1BiasRelu      1x256x28x28     256x1x3x3       1x256x28x28     0.289   0.283   0.303   0.286   0.47%    0.004   12.50   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x256x28x28     256x256x1x1     1x256x28x28     4.957   4.879   5.089   4.983   8.07%    0.103   20.73   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s2g256d1BiasRelu      1x256x28x28     256x1x3x3       1x256x14x14     0.152   0.145   0.164   0.150   0.25%    0.001   5.95    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x256x14x14     512x256x1x1     1x512x14x14     2.604   2.569   2.733   2.571   4.24%    0.051   19.73   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s1g512d1BiasRelu      1x512x14x14     512x1x3x3       1x512x14x14     0.201   0.198   0.209   0.200   0.33%    0.002   9.00    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x512x14x14     512x512x1x1     1x512x14x14     5.070   5.001   5.176   5.159   8.25%    0.103   20.27   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s1g512d1BiasRelu      1x512x14x14     512x1x3x3       1x512x14x14     0.204   0.199   0.243   0.203   0.33%    0.002   8.83    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x512x14x14     512x512x1x1     1x512x14x14     5.066   4.997   5.187   5.018   8.24%    0.103   20.29   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s1g512d1BiasRelu      1x512x14x14     512x1x3x3       1x512x14x14     0.204   0.199   0.250   0.200   0.33%    0.002   8.85    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x512x14x14     512x512x1x1     1x512x14x14     5.081   5.015   5.192   5.084   8.27%    0.103   20.23   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s1g512d1BiasRelu      1x512x14x14     512x1x3x3       1x512x14x14     0.202   0.199   0.213   0.203   0.33%    0.002   8.93    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x512x14x14     512x512x1x1     1x512x14x14     5.070   5.014   5.174   5.025   8.25%    0.103   20.27   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s1g512d1BiasRelu      1x512x14x14     512x1x3x3       1x512x14x14     0.202   0.199   0.216   0.200   0.33%    0.002   8.94    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x512x14x14     512x512x1x1     1x512x14x14     5.055   5.000   5.137   5.137   8.23%    0.103   20.33   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s2g512d1BiasRelu      1x512x14x14     512x1x3x3       1x512x7x7       0.094   0.091   0.108   0.094   0.15%    0.000   4.80    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x512x7x7       1024x512x1x1    1x1024x7x7      3.061   3.005   3.202   3.030   4.98%    0.051   16.79   0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3x3p1s1g1024d1BiasRelu     1x1024x7x7      1024x1x3x3      1x1024x7x7      0.129   0.127   0.132   0.130   0.21%    0.001   7.02    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1BiasRelu        1x1024x7x7      1024x1024x1x1   1x1024x7x7      5.984   5.891   6.100   5.961   9.74%    0.103   17.17   0.000     0.000     0.000     0.00%
pool2d               arm/float/NCHW                 NotImpl                  globalavg                  1x1024x7x7      N/A             1x1024x1x1      0.029   0.027   0.031   0.030   0.05%    0.000   1.71    0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv1x1s1_gemm           1x1p0s1g1d1Biasunk         1x1024x1x1      1000x1024x1x1   1x1000x1x1      0.635   0.623   0.703   0.629   1.03%    0.002   3.22    0.000     0.000     0.000     0.00%
softmax              arm/float/NCHW                 NotImpl                  axis1                      1x1000x1x1      N/A             1x1000x1x1      0.015   0.014   0.018   0.015   0.02%    0.000   0.39    0.000     0.000     0.000     0.00%
```

## 汇总profiler信息

```shell
Timing cycle = 20
===== Concise Create Profiler Summary: N/A, Exclude 10 warm-ups =====
OperatorType         KerneAttr(Place)               KernelFuncName           Avg(ms) Min(ms) Max(ms) Avg(%)  GOPs    CalledTimes clAvg(ms) clMin(ms) clMax(ms) clAvg(%)
conv2d               arm/float/NCHW                 conv1x1s1_gemm           0.059   0.047   0.075   49.58%    1.081   14          0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_3x3s2_direct_fp32   0.006   0.005   0.007   4.71%    0.022   1           0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  0.045   0.030   0.065   37.90%    0.035   13          0.000     0.000     0.000     0.00%
pool2d               arm/float/NCHW                 NotImpl                  0.005   0.004   0.007   4.62%    0.000   1           0.000     0.000     0.000     0.00%
softmax              arm/float/NCHW                 NotImpl                  0.004   0.003   0.005   3.19%    0.000   1           0.000     0.000     0.000     0.00%

[I  5/28 16:46:31.293 ...lite-armv8/lite/core/profile/profiler.cc:194 Summary] conv2d:arm/float/NCHW/conv_3x3s2_direct_fp32/3x3p1s2g1d1BiasRelu/1x3x224x224/32x3x3x3/1x32x112x112
[I  5/28 16:46:31.293 ...lite-armv8/lite/core/profile/profiler.cc:194 Summary] conv2d:arm/float/NCHW/conv_depthwise_3x3_fp32/3x3p1s1g32d1BiasRelu/1x32x112x112/32x1x3x3/1x32x112x112
[I  5/28 16:46:31.293 ...lite-armv8/lite/core/profile/profiler.cc:194 Summary] conv2d:arm/float/NCHW/conv1x1s1_gemm/1x1p0s1g1d1BiasRelu/1x32x112x112/64x32x1x1/1x64x112x112
[I  5/28 16:46:31.293 ...lite-armv8/lite/core/profile/profiler.cc:194 Summary] pool2d:arm/float/NCHW/NotImpl/globalavg/1x1024x7x7/N/A/1x1024x1x1
[I  5/28 16:46:31.293 ...lite-armv8/lite/core/profile/profiler.cc:194 Summary] softmax:arm/float/NCHW/NotImpl/axis1/1x1000x1x1/N/A/1x1000x1x1
[I  5/28 16:46:31.293 ...lite-armv8/lite/core/profile/profiler.cc:199 Summary] summary.size():5
[I  5/28 16:46:31.293 ...lite-armv8/lite/core/profile/profiler.cc:95 GetKernelFuncCalledTimes] units_.size:30
[I  5/28 16:46:31.293 ...lite-armv8/lite/core/profile/profiler.cc:95 GetKernelFuncCalledTimes] units_.size:30
[I  5/28 16:46:31.293 ...lite-armv8/lite/core/profile/profiler.cc:95 GetKernelFuncCalledTimes] units_.size:30
[I  5/28 16:46:31.294 ...lite-armv8/lite/core/profile/profiler.cc:95 GetKernelFuncCalledTimes] units_.size:30
[I  5/28 16:46:31.294 ...lite-armv8/lite/core/profile/profiler.cc:95 GetKernelFuncCalledTimes] units_.size:30
[I  5/28 16:46:31.293 ...huai/code/lite-armv8/lite/core/program.h:180 ~RuntimeProgram]
Timing cycle = 20
===== Concise Dispatch Profiler Summary: N/A, Exclude 10 warm-ups =====
OperatorType         KerneAttr(Place)               KernelFuncName           Avg(ms) Min(ms) Max(ms) Avg(%)  GOPs    CalledTimes clAvg(ms) clMin(ms) clMax(ms) clAvg(%)
conv2d               arm/float/NCHW                 conv1x1s1_gemm           55.765  54.991  57.311  90.84%    1.081   14          0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_3x3s2_direct_fp32   1.607   1.573   1.750   2.62%    0.022   1           0.000     0.000     0.000     0.00%
conv2d               arm/float/NCHW                 conv_depthwise_3x3_fp32  3.971   3.852   4.366   6.47%    0.035   13          0.000     0.000     0.000     0.00%
pool2d               arm/float/NCHW                 NotImpl                  0.029   0.027   0.031   0.05%    0.000   1           0.000     0.000     0.000     0.00%
softmax              arm/float/NCHW                 NotImpl                  0.015   0.014   0.017   0.02%    0.000   1           0.000     0.000     0.000     0.00%
```