### PR TITLE
[LITE][COMPILE] Fix clang compile slow for arm cpu and abnormal exit for opencl. test=develop

### DIFF
--- a/cmake/cross_compiling/postproject.cmake
+++ b/cmake/cross_compiling/postproject.cmake
@@ -72,6 +72,8 @@ if (LITE_ON_TINY_PUBLISH)
 endif()
 
 if(ARM_TARGET_LANG STREQUAL "clang")
+    # note(ysh329): fix slow compilation for arm cpu, 
+    #               and abnormal exit compilation for opencl due to lots of warning
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override -Wno-return-type")
 endif()
 

--- a/cmake/cross_compiling/postproject.cmake
+++ b/cmake/cross_compiling/postproject.cmake
@@ -71,6 +71,10 @@ if (LITE_ON_TINY_PUBLISH)
     check_linker_flag(-Wl,--gc-sections)
 endif()
 
+if(LITE_WITH_OPENCL AND (ARM_TARGET_LANG STREQUAL "clang"))
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override -Wno-return-type")
+endif()
+
 if(LITE_WITH_OPENMP)
     find_package(OpenMP REQUIRED)
     if(OPENMP_FOUND OR OpenMP_CXX_FOUND)

--- a/cmake/cross_compiling/postproject.cmake
+++ b/cmake/cross_compiling/postproject.cmake
@@ -71,7 +71,7 @@ if (LITE_ON_TINY_PUBLISH)
     check_linker_flag(-Wl,--gc-sections)
 endif()
 
-if(LITE_WITH_OPENCL AND (ARM_TARGET_LANG STREQUAL "clang"))
+if(ARM_TARGET_LANG STREQUAL "clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override -Wno-return-type")
 endif()
 


### PR DESCRIPTION
Fix clang compile slow for arm cpu and abnormal exit for opencl. test=develop

通过二分commit查找定位出，引入arm cpu编译缓慢，以及android opencl编译过程爆出大量log并跳出开发机的问题，是pr：https://github.com/PaddlePaddle/Paddle-Lite/pull/3699/files

该pr没有修改cmake但是对kernel注册做了修改，导致编译过程产生大量没有return type&没有override的warning的警告log。

本pr是这两种没有return type&没有override的warning改为不报warning。