### PR TITLE
[Example] Add unit test for tensor.cc

### DIFF
--- a/lite/core/CMakeLists.txt
+++ b/lite/core/CMakeLists.txt
@@ -141,6 +141,7 @@ if (NOT LITE_ON_TINY_PUBLISH)
   add_subdirectory(arena)
 endif()
 
+lite_cc_test(test_tensor SRCS tensor_test.cc DEPS tensor)
 # for mobile, unnecessary to compile the following testings.
 if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK)
     return()
@@ -152,7 +153,6 @@ endif()
 #         ${host_kernels}
 #         )
 
-lite_cc_test(test_tensor SRC tensor_test.cc DEPS tensor)
 lite_cc_test(test_scope SRCS scope_test.cc DEPS scope)
 lite_cc_test(test_kernel SRCS kernel_test.cc DEPS kernel target_wrapper any)
 lite_cc_test(test_op SRCS op_lite_test.cc DEPS op)

--- a/lite/core/CMakeLists.txt
+++ b/lite/core/CMakeLists.txt
@@ -152,6 +152,7 @@ endif()
 #         ${host_kernels}
 #         )
 
+lite_cc_test(test_tensor SRC tensor_test.cc DEPS tensor)
 lite_cc_test(test_scope SRCS scope_test.cc DEPS scope)
 lite_cc_test(test_kernel SRCS kernel_test.cc DEPS kernel target_wrapper any)
 lite_cc_test(test_op SRCS op_lite_test.cc DEPS op)

--- a/lite/core/tensor_test.cc
+++ b/lite/core/tensor_test.cc
@@ -21,22 +21,20 @@ namespace lite {
 bool TestDDimLite(const std::vector<int64_t>& data) {
   DDimLite dims(data);
   auto result = dims.data();
-  for(int i = 0; i< data.size(); i++) {
+  for (int i = 0; i < data.size(); i++) {
     ASSERT_EQ(result[i], data[i])
   }
   return true;
 }
 
 TEST(Tensor, DDimLite) {
-  
   DDimLite dims;
-  for(int64_t i = 0; i<1000; i++) {
-    for(int64_t j = 0; j < 1000; j++) {
+  for (int64_t i = 0; i < 1000; i++) {
+    for (int64_t j = 0; j < 1000; j++) {
       TestDDimLite(std::vector<int64_t>({i, j});
     }
   }
 }
-
 
 }  // namespace lite
 }  // namespace paddle

--- a/lite/core/tensor_test.cc
+++ b/lite/core/tensor_test.cc
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/tensor.h"
+#include <gtest/gtest.h>
+
+namespace paddle {
+namespace lite {
+
+bool TestDDimLite(const std::vector<int64_t>& data) {
+  DDimLite dims(data);
+  auto result = dims.data();
+  for(int i = 0; i< data.size(); i++) {
+    ASSERT_EQ(result[i], data[i])
+  }
+  return true;
+}
+
+TEST(Tensor, DDimLite) {
+  
+  DDimLite dims;
+  for(int64_t i = 0; i<1000; i++) {
+    for(int64_t j = 0; j < 1000; j++) {
+      TestDDimLite(std::vector<int64_t>({i, j});
+    }
+  }
+}
+
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/tensor_test.cc
+++ b/lite/core/tensor_test.cc
@@ -22,7 +22,7 @@ bool TestDDimLite(const std::vector<int64_t>& data) {
   DDimLite dims(data);
   auto result = dims.data();
   for (int i = 0; i < data.size(); i++) {
-    ASSERT_EQ(result[i], data[i])
+    EXPECT_NEAR(result[i], data[i], 1e-3);
   }
   return true;
 }
@@ -31,7 +31,7 @@ TEST(Tensor, DDimLite) {
   DDimLite dims;
   for (int64_t i = 0; i < 1000; i++) {
     for (int64_t j = 0; j < 1000; j++) {
-      TestDDimLite(std::vector<int64_t>({i, j});
+      TestDDimLite(std::vector<int64_t>({i, j}));
     }
   }
 }


### PR DESCRIPTION
An example of adding unit test for `lite/core/tensor.cc` to test the function of `DDimLite`
How to compile and use this unit test :

**Compile:**
```
  ./lite/tools/build.sh --arm_os=android --arm_abi=armv8 --arm_lang=gcc test
```
 (you can interrupt it after cmake and `cd build.lite.android.armv8.gcc && make test_tensor` to accerate this procedure)
Compiling result : `build.lite.android.armv8.gcc/lite/core/test_tensor`

**Test:**
(with mobilephone connected in developer mode)
```
  chmod +x test_tensor && adb push test_tensor /data/local/tmp
  adb shell `cd /data/local/tmp && ./test_tensor`
```