### PR TITLE
[CI] Fix the issue that android CI project consumes too much time and will result in a huge log file

### DIFF
--- a/lite/tests/math/conv_compute_test.cc
+++ b/lite/tests/math/conv_compute_test.cc
@@ -236,21 +236,23 @@ void test_conv_fp32(const std::vector<DDim>& input_dims,
 
         double gops = 2.0 * dim_out.production() * dim_in[1] * weight_dim[2] *
                       weight_dim[3] / param.groups;
-        LOG(INFO) << "conv fp32: input shape: " << dim_in << ", output shape"
-                  << dim_out << ",running time, avg: " << t0.LapTimes().Avg()
-                  << ", min time: " << t0.LapTimes().Min()
-                  << ", total GOPS: " << 1e-9 * gops
-                  << " GOPS, avg GOPs: " << 1e-6 * gops / t0.LapTimes().Avg()
-                  << " GOPs, max GOPs: " << 1e-6 * gops / t0.LapTimes().Min();
-
         if (FLAGS_check_result) {
           double max_ratio = 0;
           double max_diff = 0;
           tensor_cmp_host(tout_basic, *param.output, max_ratio, max_diff);
-          LOG(INFO) << "compare result, max diff: " << max_diff
-                    << ", max ratio: " << max_ratio;
+          VLOG(4) << "compare result, max diff: " << max_diff
+                  << ", max ratio: " << max_ratio;
           if (std::abs(max_ratio) > 1e-3f) {
             if (max_diff > 5e-4f) {
+              LOG(WARNING) << "conv fp32: input shape: " << dim_in
+                           << ", output shape" << dim_out
+                           << ",running time, avg: " << t0.LapTimes().Avg()
+                           << ", min time: " << t0.LapTimes().Min()
+                           << ", total GOPS: " << 1e-9 * gops
+                           << " GOPS, avg GOPs: "
+                           << 1e-6 * gops / t0.LapTimes().Avg()
+                           << " GOPs, max GOPs: "
+                           << 1e-6 * gops / t0.LapTimes().Min();
               LOG(WARNING) << "basic result";
               print_tensor(tout_basic);
               LOG(WARNING) << "lite result";
@@ -274,15 +276,15 @@ void test_conv_fp32(const std::vector<DDim>& input_dims,
             }
           }
         }
-        LOG(INFO) << "test fp32 conv: input: " << dim_in
-                  << ", output: " << dim_out << ", weight dim: " << weight_dim
-                  << ", pad: " << pads[0] << ", " << pads[1] << ", " << pads[2]
-                  << ", " << pads[3] << ", stride: " << strides[0] << ", "
-                  << strides[1] << ", dila_: " << dilas[0] << ", " << dilas[1]
-                  << ", group: " << group
-                  << ", bias: " << (flag_bias ? "true" : "false")
-                  << ", act: " << flag_act << ", threads: " << th
-                  << ", power_mode: " << cls << " successed!!\n";
+        VLOG(4) << "test fp32 conv: input: " << dim_in
+                << ", output: " << dim_out << ", weight dim: " << weight_dim
+                << ", pad: " << pads[0] << ", " << pads[1] << ", " << pads[2]
+                << ", " << pads[3] << ", stride: " << strides[0] << ", "
+                << strides[1] << ", dila_: " << dilas[0] << ", " << dilas[1]
+                << ", group: " << group
+                << ", bias: " << (flag_bias ? "true" : "false")
+                << ", act: " << flag_act << ", threads: " << th
+                << ", power_mode: " << cls << " successed!!\n";
       }
     }
   }


### PR DESCRIPTION
**Issue**:
 CI task `PR_CI_Paddle-Lite-mobile-Android` will consume almost 1 hour and the resulted log file is almost 1G .
**Reason**:
unit test of conv op has print too much log 
**modification of current PR**
unit test conv op will not print log info until error has occurred. 
**Effect**
CI time : 53 min 
Resulted log file: 37.81M 