### PR TITLE
[CI][Opt]Check the usability of opt in CI project

### DIFF
--- a/lite/tests/math/conv_compute_test.cc
+++ b/lite/tests/math/conv_compute_test.cc
@@ -237,18 +237,18 @@ void test_conv_fp32(const std::vector<DDim>& input_dims,
         double gops = 2.0 * dim_out.production() * dim_in[1] * weight_dim[2] *
                       weight_dim[3] / param.groups;
         VLOG(4) << "conv fp32: input shape: " << dim_in << ", output shape"
-                  << dim_out << ",running time, avg: " << t0.LapTimes().Avg()
-                  << ", min time: " << t0.LapTimes().Min()
-                  << ", total GOPS: " << 1e-9 * gops
-                  << " GOPS, avg GOPs: " << 1e-6 * gops / t0.LapTimes().Avg()
-                  << " GOPs, max GOPs: " << 1e-6 * gops / t0.LapTimes().Min();
+                << dim_out << ",running time, avg: " << t0.LapTimes().Avg()
+                << ", min time: " << t0.LapTimes().Min()
+                << ", total GOPS: " << 1e-9 * gops
+                << " GOPS, avg GOPs: " << 1e-6 * gops / t0.LapTimes().Avg()
+                << " GOPs, max GOPs: " << 1e-6 * gops / t0.LapTimes().Min();
 
         if (FLAGS_check_result) {
           double max_ratio = 0;
           double max_diff = 0;
           tensor_cmp_host(tout_basic, *param.output, max_ratio, max_diff);
           VLOG(4) << "compare result, max diff: " << max_diff
-                    << ", max ratio: " << max_ratio;
+                  << ", max ratio: " << max_ratio;
           if (std::abs(max_ratio) > 1e-3f) {
             if (max_diff > 5e-4f) {
               LOG(WARNING) << "basic result";
@@ -275,14 +275,14 @@ void test_conv_fp32(const std::vector<DDim>& input_dims,
           }
         }
         VLOG(4) << "test fp32 conv: input: " << dim_in
-                  << ", output: " << dim_out << ", weight dim: " << weight_dim
-                  << ", pad: " << pads[0] << ", " << pads[1] << ", " << pads[2]
-                  << ", " << pads[3] << ", stride: " << strides[0] << ", "
-                  << strides[1] << ", dila_: " << dilas[0] << ", " << dilas[1]
-                  << ", group: " << group
-                  << ", bias: " << (flag_bias ? "true" : "false")
-                  << ", act: " << flag_act << ", threads: " << th
-                  << ", power_mode: " << cls << " successed!!\n";
+                << ", output: " << dim_out << ", weight dim: " << weight_dim
+                << ", pad: " << pads[0] << ", " << pads[1] << ", " << pads[2]
+                << ", " << pads[3] << ", stride: " << strides[0] << ", "
+                << strides[1] << ", dila_: " << dilas[0] << ", " << dilas[1]
+                << ", group: " << group
+                << ", bias: " << (flag_bias ? "true" : "false")
+                << ", act: " << flag_act << ", threads: " << th
+                << ", power_mode: " << cls << " successed!!\n";
       }
     }
   }

--- a/lite/tests/math/conv_compute_test.cc
+++ b/lite/tests/math/conv_compute_test.cc
@@ -236,23 +236,21 @@ void test_conv_fp32(const std::vector<DDim>& input_dims,
 
         double gops = 2.0 * dim_out.production() * dim_in[1] * weight_dim[2] *
                       weight_dim[3] / param.groups;
+        VLOG(4) << "conv fp32: input shape: " << dim_in << ", output shape"
+                  << dim_out << ",running time, avg: " << t0.LapTimes().Avg()
+                  << ", min time: " << t0.LapTimes().Min()
+                  << ", total GOPS: " << 1e-9 * gops
+                  << " GOPS, avg GOPs: " << 1e-6 * gops / t0.LapTimes().Avg()
+                  << " GOPs, max GOPs: " << 1e-6 * gops / t0.LapTimes().Min();
+
         if (FLAGS_check_result) {
           double max_ratio = 0;
           double max_diff = 0;
           tensor_cmp_host(tout_basic, *param.output, max_ratio, max_diff);
           VLOG(4) << "compare result, max diff: " << max_diff
-                  << ", max ratio: " << max_ratio;
+                    << ", max ratio: " << max_ratio;
           if (std::abs(max_ratio) > 1e-3f) {
             if (max_diff > 5e-4f) {
-              LOG(WARNING) << "conv fp32: input shape: " << dim_in
-                           << ", output shape" << dim_out
-                           << ",running time, avg: " << t0.LapTimes().Avg()
-                           << ", min time: " << t0.LapTimes().Min()
-                           << ", total GOPS: " << 1e-9 * gops
-                           << " GOPS, avg GOPs: "
-                           << 1e-6 * gops / t0.LapTimes().Avg()
-                           << " GOPs, max GOPs: "
-                           << 1e-6 * gops / t0.LapTimes().Min();
               LOG(WARNING) << "basic result";
               print_tensor(tout_basic);
               LOG(WARNING) << "lite result";
@@ -277,14 +275,14 @@ void test_conv_fp32(const std::vector<DDim>& input_dims,
           }
         }
         VLOG(4) << "test fp32 conv: input: " << dim_in
-                << ", output: " << dim_out << ", weight dim: " << weight_dim
-                << ", pad: " << pads[0] << ", " << pads[1] << ", " << pads[2]
-                << ", " << pads[3] << ", stride: " << strides[0] << ", "
-                << strides[1] << ", dila_: " << dilas[0] << ", " << dilas[1]
-                << ", group: " << group
-                << ", bias: " << (flag_bias ? "true" : "false")
-                << ", act: " << flag_act << ", threads: " << th
-                << ", power_mode: " << cls << " successed!!\n";
+                  << ", output: " << dim_out << ", weight dim: " << weight_dim
+                  << ", pad: " << pads[0] << ", " << pads[1] << ", " << pads[2]
+                  << ", " << pads[3] << ", stride: " << strides[0] << ", "
+                  << strides[1] << ", dila_: " << dilas[0] << ", " << dilas[1]
+                  << ", group: " << group
+                  << ", bias: " << (flag_bias ? "true" : "false")
+                  << ", act: " << flag_act << ", threads: " << th
+                  << ", power_mode: " << cls << " successed!!\n";
       }
     }
   }

--- a/lite/tests/math/conv_compute_test.cc
+++ b/lite/tests/math/conv_compute_test.cc
@@ -236,21 +236,23 @@ void test_conv_fp32(const std::vector<DDim>& input_dims,
 
         double gops = 2.0 * dim_out.production() * dim_in[1] * weight_dim[2] *
                       weight_dim[3] / param.groups;
-        LOG(INFO) << "conv fp32: input shape: " << dim_in << ", output shape"
-                  << dim_out << ",running time, avg: " << t0.LapTimes().Avg()
-                  << ", min time: " << t0.LapTimes().Min()
-                  << ", total GOPS: " << 1e-9 * gops
-                  << " GOPS, avg GOPs: " << 1e-6 * gops / t0.LapTimes().Avg()
-                  << " GOPs, max GOPs: " << 1e-6 * gops / t0.LapTimes().Min();
-
         if (FLAGS_check_result) {
           double max_ratio = 0;
           double max_diff = 0;
           tensor_cmp_host(tout_basic, *param.output, max_ratio, max_diff);
-          LOG(INFO) << "compare result, max diff: " << max_diff
-                    << ", max ratio: " << max_ratio;
+          VLOG(4) << "compare result, max diff: " << max_diff
+                  << ", max ratio: " << max_ratio;
           if (std::abs(max_ratio) > 1e-3f) {
             if (max_diff > 5e-4f) {
+              LOG(WARNING) << "conv fp32: input shape: " << dim_in
+                           << ", output shape" << dim_out
+                           << ",running time, avg: " << t0.LapTimes().Avg()
+                           << ", min time: " << t0.LapTimes().Min()
+                           << ", total GOPS: " << 1e-9 * gops
+                           << " GOPS, avg GOPs: "
+                           << 1e-6 * gops / t0.LapTimes().Avg()
+                           << " GOPs, max GOPs: "
+                           << 1e-6 * gops / t0.LapTimes().Min();
               LOG(WARNING) << "basic result";
               print_tensor(tout_basic);
               LOG(WARNING) << "lite result";
@@ -274,15 +276,15 @@ void test_conv_fp32(const std::vector<DDim>& input_dims,
             }
           }
         }
-        LOG(INFO) << "test fp32 conv: input: " << dim_in
-                  << ", output: " << dim_out << ", weight dim: " << weight_dim
-                  << ", pad: " << pads[0] << ", " << pads[1] << ", " << pads[2]
-                  << ", " << pads[3] << ", stride: " << strides[0] << ", "
-                  << strides[1] << ", dila_: " << dilas[0] << ", " << dilas[1]
-                  << ", group: " << group
-                  << ", bias: " << (flag_bias ? "true" : "false")
-                  << ", act: " << flag_act << ", threads: " << th
-                  << ", power_mode: " << cls << " successed!!\n";
+        VLOG(4) << "test fp32 conv: input: " << dim_in
+                << ", output: " << dim_out << ", weight dim: " << weight_dim
+                << ", pad: " << pads[0] << ", " << pads[1] << ", " << pads[2]
+                << ", " << pads[3] << ", stride: " << strides[0] << ", "
+                << strides[1] << ", dila_: " << dilas[0] << ", " << dilas[1]
+                << ", group: " << group
+                << ", bias: " << (flag_bias ? "true" : "false")
+                << ", act: " << flag_act << ", threads: " << th
+                << ", power_mode: " << cls << " successed!!\n";
       }
     }
   }

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -564,8 +564,18 @@ function test_arm_model {
 function test_model_optimize_tool_compile {
     cd $workspace
     cd build
+    # Compile opt tool
     cmake .. -DWITH_LITE=ON -DLITE_ON_MODEL_OPTIMIZE_TOOL=ON -DWITH_TESTING=OFF -DLITE_BUILD_EXTRA=ON
     make opt -j$NUM_CORES_FOR_COMPILE
+    # Check whether opt can transform quantized mobilenetv1 successfully.
+    cd lite/api && chmod +x ./opt
+    wget --no-check-certificate https://paddlelite-data.bj.bcebos.com/doc_models/MobileNetV1_quant.tar.gz
+    tar zxf MobileNetV1_quant.tar.gz
+    ./opt --model_dir=./MobileNetV1_quant --valid_targets=arm --optimize_out=quant_mobilenetv1
+    if [ ! -f quant_mobilenetv1.nb ]; then
+       echo -e "Error! Resulted opt can not tramsform MobileNetV1_quant successfully!"
+       exit 1
+    fi
 }
 
 function _test_paddle_code_generator {


### PR DESCRIPTION
**Issue1**:
 CI task `PR_CI_Paddle-Lite-mobile-Android` will consume almost 1 hour and the resulted log file is almost 1G .
**Reason**:
unit test of conv op has print too much log 
**modification of current PR**
unit test conv op will not print log info until error has occurred. 
**Effect**
CI time : 53 min 
Resulted log file: 37.81M 



**Issue2**:
 CI task `PR_CI_Paddle-Lite-mobile-Server` will check if current opt can optimize quantized model
