### PR TITLE
[DOC] Fix iOS compiling docs

### DIFF
--- a/docs/user_guides/Compile/iOS.md
+++ b/docs/user_guides/Compile/iOS.md
@@ -61,7 +61,7 @@ inference_lite_lib.ios64.armv8                iOS预测库和头文件
 - 裁剪预测库方法（只编译模型中的kernel&OP，降低预测库体积）:
 
 ```shell
-./lite/tools/build_android.sh --with_strip=ON --opt_model_dir=YourOptimizedModelDir
+./lite/tools/build_ios.sh --with_strip=ON --opt_model_dir=YourOptimizedModelDir
 ```
 ```shell
 --with_strip: (OFF|ON);   是否根据输入模型裁剪预测库，默认为OFF


### PR DESCRIPTION
**Issue**
There is a written error in  the doc of `iOS compiling`
![image](https://user-images.githubusercontent.com/45189361/85968649-37f43280-b9f8-11ea-8ee6-40449b9ec622.png)

**Effect of Current PR**
Fix this error
