### PR TITLE
[x86] Add `fusion_elementwise_activation` kernels for x86 backend

### DIFF
--- a/lite/kernels/x86/elementwise_compute.cc
+++ b/lite/kernels/x86/elementwise_compute.cc
@@ -25,6 +25,17 @@ REGISTER_LITE_KERNEL(elementwise_sub,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
     .Finalize();
 
+REGISTER_LITE_KERNEL(fusion_elementwise_sub_activation,
+                     kX86,
+                     kFloat,
+                     kNCHW,
+                     paddle::lite::kernels::x86::ElementwiseSubCompute<float>,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
+    .Finalize();
+
 REGISTER_LITE_KERNEL(elementwise_add,
                      kX86,
                      kFloat,
@@ -36,7 +47,29 @@ REGISTER_LITE_KERNEL(elementwise_add,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
     .Finalize();
 
+REGISTER_LITE_KERNEL(fusion_elementwise_add_activation,
+                     kX86,
+                     kFloat,
+                     kNCHW,
+                     paddle::lite::kernels::x86::ElementwiseAddCompute<float>,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
+    .Finalize();
+
 REGISTER_LITE_KERNEL(elementwise_mul,
+                     kX86,
+                     kFloat,
+                     kNCHW,
+                     paddle::lite::kernels::x86::ElementwiseMulCompute<float>,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(fusion_elementwise_mul_activation,
                      kX86,
                      kFloat,
                      kNCHW,


### PR DESCRIPTION
**Issue**
`fusion_elementwise_activation` kernels are not registered on x86 backends, causing that `lite_elementwise_activation_fuse_pass` can not operate on x86 backend. This pass is used for fusing `elementwise` kernel and its neighboring `activation`kernel to reduce time costing and data swapping. 
**Effect of Curren PR**
Register `fusion_elementwise_activation` kernel to enable `lite_elementwise_activation_fuse_pass` on x86 backend.