### PR TITLE
[cherry-pick] Fix abnormal exit for opencl build

### DIFF
--- a/cmake/cross_compiling/postproject.cmake
+++ b/cmake/cross_compiling/postproject.cmake
@@ -71,6 +71,12 @@ if (LITE_ON_TINY_PUBLISH)
     check_linker_flag(-Wl,--gc-sections)
 endif()
 
+if(ARM_TARGET_LANG STREQUAL "clang")
+    # note(ysh329): fix slow compilation for arm cpu, 
+    #               and abnormal exit compilation for opencl due to lots of warning
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override -Wno-return-type")
+endif()
+
 if(LITE_WITH_OPENMP)
     find_package(OpenMP REQUIRED)
     if(OPENMP_FOUND OR OpenMP_CXX_FOUND)


### PR DESCRIPTION
* [LITE][COMPILE] Fix clang compile slow for arm cpu and abnormal exit for opencl. test=develop

* add note for compilation option. test=develop