### PR TITLE
Update get op func in cxx_api.

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -28,13 +28,7 @@ namespace paddle {
 namespace lite {
 
 std::vector<std::string> GetAllOps() {
-  const std::map<std::string, std::string> &op2path =
-      OpKernelInfoCollector::Global().GetOp2PathDict();
-  std::vector<std::string> res;
-  for (const auto &op : op2path) {
-    res.push_back(op.first);
-  }
-  return res;
+  return OpLiteFactory::Global().GetAllOps();
 }
 
 void Predictor::SaveModel(const std::string &dir,

--- a/lite/core/op_registry.h
+++ b/lite/core/op_registry.h
@@ -97,6 +97,14 @@ class OpLiteFactory {
     return ss.str();
   }
 
+  std::vector<std::string> GetAllOps() const {
+    std::vector<std::string> res;
+    for (const auto& op : op_registry_) {
+      res.push_back(op.first);
+    }
+    return res;
+  }
+
  protected:
   std::map<std::string, std::function<std::shared_ptr<OpLite>()>> op_registry_;
 };


### PR DESCRIPTION
旧版的cxx_api中提供的GetAllOps函数依赖OpKernelInfoCollector类，间接依赖了paddle_use_ops和paddle_use_kernels头文件，使用不便。

注册机制依赖于静态变量，GetAllOps可以从OpFactory中取出所有注册的op，这种方式不依赖于paddle_use_ops头文件。