### PR TITLE
[Bug] Fix compile multithread error. 

### DIFF
--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -244,7 +244,6 @@ if (LITE_WITH_X86)
     add_dependencies(publish_inference_x86_cxx_lib test_model_bin)
 
     add_custom_target(publish_inference_x86_cxx_demos ${TARGET}
-           COMMAND rm -rf "${INFER_LITE_PUBLISH_ROOT}/demo/cxx"
            COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/demo/cxx"
            COMMAND cp -r "${CMAKE_SOURCE_DIR}/lite/demo/cxx/x86_mobilenetv1_light_demo" "${INFER_LITE_PUBLISH_ROOT}/demo/cxx/mobilenetv1_light"
            COMMAND cp -r "${CMAKE_SOURCE_DIR}/lite/demo/cxx/x86_mobilenetv1_full_demo" "${INFER_LITE_PUBLISH_ROOT}/demo/cxx/mobilenetv1_full"


### PR DESCRIPTION
多线程编译时，x86和cuda的demo target  `publish_inference_x86_cxx_demos`  `publish_inference_cuda_cxx_demos` 可能出现竞争导致编译随机出错。
