### PR TITLE
[Compile] Accelerate compiling period by avoiding repetitive compiling 

### DIFF
--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -269,6 +269,7 @@ function main {
     if [ -z "$1" ]; then
         # compiling result contains light_api lib only, recommanded.
         make_tiny_publish_so $ARCH $TOOLCHAIN $ANDROID_STL
+        exit 0
     fi
 
     # Parse command line.
@@ -358,6 +359,7 @@ function main {
     done
     # compiling result contains light_api lib only, recommanded.
     make_tiny_publish_so
+    exit 0
 }
 
 main $@

--- a/lite/tools/build_ios.sh
+++ b/lite/tools/build_ios.sh
@@ -152,6 +152,7 @@ function main {
         esac
     done
     make_ios $ARCH
+    exit 0
 }
 
 main $@


### PR DESCRIPTION
[Issue] `build_android.sh` will compile twice when no input arguments are inputed
[Effect of Current PR] If no input is detected by `build_android.sh`, this script will exit after first compiling