### PR TITLE
[Framework]Dynamic memory malloc to reduce memory usage

### DIFF
--- a/lite/backends/host/target_wrapper.cc
+++ b/lite/backends/host/target_wrapper.cc
@@ -30,7 +30,6 @@ void* TargetWrapper<TARGET(kHost)>::Malloc(size_t size) {
   void* r = reinterpret_cast<void*>(reinterpret_cast<size_t>(p + offset) &
                                     (~(MALLOC_ALIGN - 1)));
   static_cast<void**>(r)[-1] = p;
-  memset(r, 0, size);
   return r;
 }
 void TargetWrapper<TARGET(kHost)>::Free(void* ptr) {

--- a/lite/kernels/opencl/nearest_interp_image_compute_test.cc
+++ b/lite/kernels/opencl/nearest_interp_image_compute_test.cc
@@ -155,7 +155,7 @@ TEST(nearest_interp_image2d, compute) {
               auto *x_data = x.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
               auto *y_data = y.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
               auto *y_data_ref = y_ref.mutable_data<float>(TARGET(kARM));
-              memset(reinterpret_cast<char*>(y_data_ref), y_ref.numel(), 0);
+              memset(reinterpret_cast<char *>(y_data_ref), y_ref.numel(), 0);
               auto *mapped_x = static_cast<float *>(TargetWrapperCL::Map(
                   x_data, 0, sizeof(float) * x_dim.production()));
               auto *mapped_y = static_cast<float *>(TargetWrapperCL::Map(

--- a/lite/kernels/opencl/nearest_interp_image_compute_test.cc
+++ b/lite/kernels/opencl/nearest_interp_image_compute_test.cc
@@ -155,7 +155,7 @@ TEST(nearest_interp_image2d, compute) {
               auto *x_data = x.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
               auto *y_data = y.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
               auto *y_data_ref = y_ref.mutable_data<float>(TARGET(kARM));
-              memset(reinterpret_cast<char *>(y_data_ref), y_ref.numel(), 0);
+              memset(reinterpret_cast<char *>(y_data_ref), 0, y_ref.numel());
               auto *mapped_x = static_cast<float *>(TargetWrapperCL::Map(
                   x_data, 0, sizeof(float) * x_dim.production()));
               auto *mapped_y = static_cast<float *>(TargetWrapperCL::Map(

--- a/lite/kernels/opencl/nearest_interp_image_compute_test.cc
+++ b/lite/kernels/opencl/nearest_interp_image_compute_test.cc
@@ -155,6 +155,7 @@ TEST(nearest_interp_image2d, compute) {
               auto *x_data = x.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
               auto *y_data = y.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
               auto *y_data_ref = y_ref.mutable_data<float>(TARGET(kARM));
+              memset(reinterpret_cast<char*>(y_data_ref), y_ref.numel(), 0);
               auto *mapped_x = static_cast<float *>(TargetWrapperCL::Map(
                   x_data, 0, sizeof(float) * x_dim.production()));
               auto *mapped_y = static_cast<float *>(TargetWrapperCL::Map(

--- a/lite/tests/math/gemm_int8_compute_test.cc
+++ b/lite/tests/math/gemm_int8_compute_test.cc
@@ -120,6 +120,8 @@ bool test_gemm_int8(bool tra,
   auto dc_fp32 = tc_fp32.mutable_data<float>();
   auto dc_basic_int8 = tc_basic_int8.mutable_data<int8_t>();
   auto dc_basic_fp32 = tc_basic_fp32.mutable_data<float>();
+  // set intial input to be 0
+  memset((char*)dc_basic_fp32, 0, tc_basic_fp32.numel() * sizeof(float));
   auto dbias = tbias.mutable_data<float>();
 
   if (FLAGS_check_result) {

--- a/lite/tests/math/gemm_int8_compute_test.cc
+++ b/lite/tests/math/gemm_int8_compute_test.cc
@@ -121,7 +121,9 @@ bool test_gemm_int8(bool tra,
   auto dc_basic_int8 = tc_basic_int8.mutable_data<int8_t>();
   auto dc_basic_fp32 = tc_basic_fp32.mutable_data<float>();
   // set intial input to be 0
-  memset((char*)dc_basic_fp32, 0, tc_basic_fp32.numel() * sizeof(float));
+  memset(reinterpret_cast<char*>(dc_basic_fp32),
+         0,
+         tc_basic_fp32.numel() * sizeof(float));
   auto dbias = tbias.mutable_data<float>();
 
   if (FLAGS_check_result) {

--- a/lite/tests/math/gemv_int8_compute_test.cc
+++ b/lite/tests/math/gemv_int8_compute_test.cc
@@ -108,6 +108,10 @@ bool test_gemv_int8(bool tra,
   auto dc_basic_int8 = tc_basic_int8.mutable_data<int8_t>();
   auto dc_basic_fp32 = tc_basic_fp32.mutable_data<float>();
   auto dbias = tbias.mutable_data<float>();
+  // set intial input to be 0
+  memset(reinterpret_cast<char*>(dc_basic_fp32),
+         0,
+         tc_basic_fp32.numel() * sizeof(float));
 
   paddle::lite_api::ActivationType act =
       paddle::lite_api::ActivationType::kIndentity;

--- a/lite/tests/math/sgemm_c4_compute_test.cc
+++ b/lite/tests/math/sgemm_c4_compute_test.cc
@@ -92,6 +92,7 @@ bool test_sgemm_c4(
   auto db_c4 = tb_c4.mutable_data<float>();
   auto dc_basic = tc_basic.mutable_data<float>();
   auto dbias = tbias.mutable_data<float>();
+  memset(reinterpret_cast<char*>(dc_basic), 0, tc_basic.numel());
 
   // trans A, B to c4
   basic_trans_mat_to_c4(da, da_c4, k, m, k, true);

--- a/lite/tests/math/sgemv_compute_test.cc
+++ b/lite/tests/math/sgemv_compute_test.cc
@@ -84,6 +84,7 @@ bool test_sgemv(bool tra,
   auto db = tb.mutable_data<float>();
   auto dc = tc.mutable_data<float>();
   auto dc_basic = tc_basic.mutable_data<float>();
+  memset(reinterpret_cast<char*>(dc_basic), 0, tc_basic.numel());
   auto dbias = tbias.mutable_data<float>();
   paddle::lite_api::ActivationType act =
       paddle::lite_api::ActivationType::kIndentity;


### PR DESCRIPTION
[Issue] Malloc<host> will `memset` the malloced space automatically, which has caused that once `mutable_data` is called both virtual and physical memory will be occupied. 
After removing `memset` from `Malloc<host>` implementation, only virtual space will be created when `tensor->mutable_data` is applied, and the corresponding physical memory space will not be allocated until corresponding data is inputed.
[Effect of Current PR]
500KB memory  usage has been reduced (7MB in total ) on v45 model in our experiment on Android mobile