### PR TITLE
[Framework]Update Malloc implementation to reduce memory usage of Tensor

### DIFF
--- a/lite/backends/arm/math/prior_box.cc
+++ b/lite/backends/arm/math/prior_box.cc
@@ -21,7 +21,7 @@ namespace lite {
 namespace arm {
 namespace math {
 
-const int MALLOC_ALIGN = 64;
+const int MALLOC_ALIGN = 16;
 
 void* fast_malloc(size_t size) {
   size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;

--- a/lite/backends/host/target_wrapper.cc
+++ b/lite/backends/host/target_wrapper.cc
@@ -19,7 +19,7 @@
 namespace paddle {
 namespace lite {
 
-const int MALLOC_ALIGN = 64;
+const int MALLOC_ALIGN = 16;
 
 void* TargetWrapper<TARGET(kHost)>::Malloc(size_t size) {
   size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;

--- a/lite/tests/kernels/prior_box_compute_test.cc
+++ b/lite/tests/kernels/prior_box_compute_test.cc
@@ -21,7 +21,7 @@
 namespace paddle {
 namespace lite {
 
-const int MALLOC_ALIGN = 64;
+const int MALLOC_ALIGN = 16;
 
 void* fast_malloc(size_t size) {
   size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;


### PR DESCRIPTION
【Issue】Current `Tensor` struct will consume almost 120% physical space  as referenced to the inside data size.
``` C++
// Experiment: Create 100 Tensors of 8K byte，800K memory usage in theory. 
// But corresponding malloc procedure will consume 1000K actually.
std::vector<Tensor*> test_tensors;
test_tensors.resize(100);
for(int i = 0; i < 100; i++) {
  test_tensors[i] = new Tensor();
  test_tensors[i]->Resize({2048});
  auto tensor_data = test_tensors[i]->mutable_data<float>();
  for(int j = 0; j < 2048; j++) {
   tensor_data[j] = 1;
  }
}
```
【Reason】
The implementation of Malloc in Paddle-Lite has assign `MALLOC_ALIGN` to be 64. The `MALLOC_ALIGN` in Anakin is 16 and will result in a reduce in Tensor memory usage.
```C++
TargetWrapper<TARGET(kHost)>::Malloc(size_t size)
```
【Effect of Current PR】
Change `MALLOC_ALIGN` in `TargetWrapper<TARGET(kHost)>::Malloc(size_t size)` from 64 to 16.
Experiment result: The memory consumed by 98 tensors has reduced from 1060KB to 800KB