### PR TITLE
[FC] Transpose FC weight according to whether GEMM is used

### DIFF
--- a/lite/core/mir/fusion/fc_fuser.cc
+++ b/lite/core/mir/fusion/fc_fuser.cc
@@ -113,11 +113,22 @@ void TransFcWeights(Tensor* weight,
       break;
     default:
       LOG(FATAL) << "Unsupported input precision type";
+      break;
   }
 
   if (!flag_gemm_) {
     Tensor tmp_tensor;
-    fc_trans_weights<PRECISION(kInt8)>(*weight, &tmp_tensor);
+    switch (input->precision()) {
+      case PRECISION(kFloat):
+        fc_trans_weights<PRECISION(kFloat)>(*weight, &tmp_tensor);
+        break;
+      case PRECISION(kInt8):
+        fc_trans_weights<PRECISION(kInt8)>(*weight, &tmp_tensor);
+        break;
+      default:
+        LOG(FATAL) << "Unsupported input precision type";
+        break;
+    }
     weight->CopyDataFrom(tmp_tensor);
   }
 }

--- a/lite/core/mir/fusion/fc_fuser.cc
+++ b/lite/core/mir/fusion/fc_fuser.cc
@@ -20,7 +20,7 @@ namespace paddle {
 namespace lite {
 namespace mir {
 namespace fusion {
-
+#ifdef LITE_WITH_ARM
 template <typename Dtype>
 void naive_transpose(const Dtype* din, Dtype* dout, int m, int n) {
   int k = 0;
@@ -131,6 +131,7 @@ void TransFcWeights(Tensor* weight,
     weight->CopyDataFrom(tmp_tensor);
   }
 }
+#endif
 
 void FcFuser::BuildPattern() {
   // create nodes.
@@ -216,6 +217,7 @@ cpp::OpDesc FcFuser::GenOpDesc(const key2nodes_t& matched) {
     op_desc.SetInputScale(matched.at("W")->arg()->name, y_scale_vct);
   }
 
+#ifdef LITE_WITH_ARM
   ///////////////////////////////////////////////////////////////////////////////
   // Judge if GEMM is used in FC.
   ///////////////////////////////////////////////////////////////////////////////
@@ -236,7 +238,7 @@ cpp::OpDesc FcFuser::GenOpDesc(const key2nodes_t& matched) {
                 .production();
   auto weight_scale = op_desc.GetInputScale(matched.at("W")->arg()->name);
   TransFcWeights(weight, input, output, bias, m_, weight_scale);
-
+#endif
   return op_desc;
 }
 

--- a/lite/core/mir/fusion/fc_fuser.cc
+++ b/lite/core/mir/fusion/fc_fuser.cc
@@ -15,7 +15,6 @@
 #include "lite/core/mir/fusion/fc_fuser.h"
 #include <memory>
 #include <vector>
-//#include "lite/kernels/arm/fc_compute.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/core/mir/fusion/fc_fuser.h
+++ b/lite/core/mir/fusion/fc_fuser.h
@@ -17,7 +17,6 @@
 #include <memory>
 #include <string>
 #include "lite/core/mir/pattern_matcher_high_api.h"
-
 namespace paddle {
 namespace lite {
 namespace mir {

--- a/lite/kernels/arm/fc_compute.cc
+++ b/lite/kernels/arm/fc_compute.cc
@@ -88,7 +88,7 @@ void FcCompute<PRECISION(kFloat), PRECISION(kFloat)>::Run() {
 
   auto i_data = param.input->data<float>();
   auto o_data = param.output->mutable_data<float>();
-  auto w_data = flag_gemm_ ? param.w->data<float>() : weights_.data<float>();
+  auto w_data = param.w->data<float>();
   const float* b_data = param.bias ? param.bias->data<float>() : nullptr;
   if (flag_trans_bias_) {
     b_data = bias_.data<float>();
@@ -149,8 +149,7 @@ void FcCompute<PRECISION(kInt8), PRECISION(kFloat)>::Run() {
 
   auto i_data = param.input->data<int8_t>();
   auto o_data = param.output->mutable_data<float>();
-  auto w_data =
-      flag_trans_weights_ ? weights_.data<int8_t>() : param.w->data<int8_t>();
+  auto w_data = param.w->data<int8_t>();
   const float* b_data = param.bias ? param.bias->data<float>() : nullptr;
   if (flag_trans_bias_) {
     b_data = bias_.data<float>();
@@ -208,8 +207,7 @@ void FcCompute<PRECISION(kInt8), PRECISION(kInt8)>::Run() {
 
   auto i_data = param.input->data<int8_t>();
   auto o_data = param.output->mutable_data<int8_t>();
-  auto w_data =
-      flag_trans_weights_ ? weights_.data<int8_t>() : param.w->data<int8_t>();
+  auto w_data = param.w->data<int8_t>();
   const float* b_data = param.bias ? param.bias->data<float>() : nullptr;
   if (flag_trans_bias_) {
     b_data = bias_.data<float>();

--- a/lite/kernels/arm/fc_compute.h
+++ b/lite/kernels/arm/fc_compute.h
@@ -104,10 +104,6 @@ class FcCompute : public KernelLite<TARGET(kARM), PType> {
     CHECK_EQ(k_, static_cast<int>(w_dims[0]));
     flag_gemm_ = check_fc_use_gemm<PType, OutType>(
         m_, param.weight_scale, param.bias != nullptr);
-    if (!flag_trans_weights_ && !flag_gemm_) {
-      flag_trans_weights_ = true;
-      fc_trans_weights<PType>(*param.w, &weights_);
-    }
   }
 
   virtual void PrepareForRun();
@@ -117,9 +113,7 @@ class FcCompute : public KernelLite<TARGET(kARM), PType> {
 
  private:
   DDim last_shape_;
-  Tensor weights_;
   Tensor bias_;
-  bool flag_trans_weights_{false};
   bool flag_trans_bias_{false};
   bool flag_gemm_{true};
   int m_;

--- a/lite/kernels/arm/fc_compute.h
+++ b/lite/kernels/arm/fc_compute.h
@@ -24,41 +24,6 @@ namespace lite {
 namespace kernels {
 namespace arm {
 
-template <typename Dtype>
-void naive_transpose(const Dtype* din, Dtype* dout, int m, int n) {
-  int k = 0;
-  for (int i = 0; i < n; ++i) {
-    for (int j = 0; j < m; ++j) {
-      dout[k++] = din[j * n + i];
-    }
-  }
-}
-
-template <PrecisionType PType>
-void fc_trans_weights(const Tensor& tin, Tensor* tout);
-
-template <>
-void fc_trans_weights<PRECISION(kFloat)>(const Tensor& tin, Tensor* tout) {
-  CHECK_EQ(tin.dims().size(), 2) << "fc weights size must = 2";
-  int m = tin.dims()[0];
-  int n = tin.dims()[1];
-  tout->Resize({n, m});
-  auto ptr_in = tin.data<float>();
-  auto ptr_out = tout->mutable_data<float>();
-  naive_transpose(ptr_in, ptr_out, m, n);
-}
-
-template <>
-void fc_trans_weights<PRECISION(kInt8)>(const Tensor& tin, Tensor* tout) {
-  CHECK_EQ(tin.dims().size(), 2) << "fc weights size must = 2";
-  int m = tin.dims()[0];
-  int n = tin.dims()[1];
-  tout->Resize({n, m});
-  auto ptr_in = tin.data<int8_t>();
-  auto ptr_out = tout->mutable_data<int8_t>();
-  naive_transpose(ptr_in, ptr_out, m, n);
-}
-
 template <PrecisionType PType, PrecisionType OutType>
 bool check_fc_use_gemm(int m, const std::vector<float>& scale, bool has_bias) {
   return m > 1;


### PR DESCRIPTION
【Issue】
Fc arm kernel will acquire a space to restore transposed weight when internal m_ is positive integer, which resulted in an  growth in memory usage.
【Effect of Current PR】
Update the original wight of FC by the transposed weight to avoid allocating a new memory space.
```
Experiment: 
input model: v45   size 1.8M (weights of FC is 1M)
After merging this pull request: 1M memory usage will be reduced 
```