### PR TITLE
fix undef replace stl pad of android armv8 static lib. test=develop

### DIFF
--- a/lite/utils/replace_stl/stream.cc
+++ b/lite/utils/replace_stl/stream.cc
@@ -23,6 +23,14 @@ namespace paddle {
 namespace lite {
 namespace replace_stl {
 
+#ifndef LITE_WITH_LOG
+#define ADD_DATA_AS_STRING(data_, obj_)
+#else
+#define ADD_DATA_AS_STRING(data_, obj_)    \
+  std::string text = std::to_string(obj_); \
+  pad(text);                               \
+  data_ = data_ + text;
+
 void ostream::pad(const std::string& text) {
   if (display_width_ > 0) {
     if (display_width_ < text.size()) {
@@ -36,15 +44,6 @@ void ostream::pad(const std::string& text) {
     }
   }
 }
-
-#ifndef LITE_WITH_LOG
-#define ADD_DATA_AS_STRING(data_, obj_)
-#else
-#define ADD_DATA_AS_STRING(data_, obj_)    \
-  std::string text = std::to_string(obj_); \
-  pad(text);                               \
-  data_ = data_ + text;
-
 #endif
 
 template <>

--- a/lite/utils/replace_stl/stream.h
+++ b/lite/utils/replace_stl/stream.h
@@ -57,7 +57,9 @@ class ostream {
   ostream& operator<<(const T* obj);
 
  private:
+#ifdef LITE_WITH_LOG
   void pad(const std::string& text);
+#endif
   std::string data_;
   int display_width_{-1};  // -1 refers to no setting
 };


### PR DESCRIPTION
fix undef replace stl pad of android armv8 static lib. test=develop

NDK版本兼容性问题，在android armv8下，在关掉LOG时候，编译android项目时，出现undef replace::stl的pad问题，但实际该方法不会被调用（因为log没开，这个方法不会用到）。

我这里的改动，只是把该方法放到宏里。