### PR TITLE
[Framework]Remove program_desc after model is loaded

### DIFF
--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -33,7 +33,7 @@ void LightPredictor::Build(const std::string& lite_model_file,
   DequantizeWeight();
   BuildRuntimeProgram(program_desc_);
   PrepareFeedFetch();
-  cpp_program_desc_.reset();
+  program_desc_.reset();
 }
 
 void LightPredictor::Build(const std::string& model_dir,

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -33,6 +33,7 @@ void LightPredictor::Build(const std::string& lite_model_file,
   DequantizeWeight();
   BuildRuntimeProgram(program_desc_);
   PrepareFeedFetch();
+  cpp_program_desc_->reset();
 }
 
 void LightPredictor::Build(const std::string& model_dir,

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -33,7 +33,7 @@ void LightPredictor::Build(const std::string& lite_model_file,
   DequantizeWeight();
   BuildRuntimeProgram(program_desc_);
   PrepareFeedFetch();
-  cpp_program_desc_->reset();
+  cpp_program_desc_.reset();
 }
 
 void LightPredictor::Build(const std::string& model_dir,


### PR DESCRIPTION
【Issue】 ProgramDesc will not be used again after model is loaded, but  currently a copy of programDesc in LightPredictor will not be released, which is a waste of memory usage.
【Effect of Current PR】
Remove ProgramDesc data after RuntimeProgram has been built.
【Experiment】
v45 model, 1.1 M. We record the memory usage in `Predictor->Run()`
Effect: A reduce of 200K in memory usage