### PR TITLE
[Example] Enable profile option in tiny_publish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,8 @@ if (WITH_LITE AND LITE_WITH_LIGHT_WEIGHT_FRAMEWORK)
         include(external/gtest)     # download, build, install gtest
         include(ccache)             # set ccache for compilation
         include(external/protobuf)  # download, build, install protobuf
+    else()
+        include(external/gflags)    # download, build, install gflags
     endif()
 
     # for opencl

--- a/lite/core/CMakeLists.txt
+++ b/lite/core/CMakeLists.txt
@@ -140,6 +140,8 @@ if (NOT LITE_ON_TINY_PUBLISH)
   add_subdirectory(mir)
   add_subdirectory(profile)
   add_subdirectory(arena)
+else()
+  add_subdirectory(profile)
 endif()
 
 # for mobile, unnecessary to compile the following testings.

--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -123,6 +123,7 @@ function prepare_thirdparty {
 # 4.1 function of tiny_publish compiling
 # here we only compile light_api lib
 function make_tiny_publish_so {
+  prepare_thirdparty
   build_dir=$workspace/build.lite.android.$ARCH.$TOOLCHAIN
   if [ "${WITH_OPENCL}" == "ON" ]; then
       build_dir=${build_dir}.opencl
@@ -151,6 +152,7 @@ function make_tiny_publish_so {
       -DLITE_BUILD_TAILOR=$WITH_STRIP \
       -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \
       -DLITE_WITH_JAVA=$WITH_JAVA \
+      -DLITE_WITH_PROFILE=ON \
       -DLITE_WITH_CV=$WITH_CV \
       -DLITE_WITH_NPU=$WITH_HUAWEI_KIRIN_NPU \
       -DNPU_DDK_ROOT=$HUAWEI_KIRIN_NPU_SDK_ROOT \
@@ -196,7 +198,7 @@ function make_full_publish_so {
 
   local cmake_mutable_options="
       -DLITE_BUILD_EXTRA=$WITH_EXTRA \
-      -DLITE_WITH_LOG=$WITH_LOG \
+      -DLITE_WITH_LOG=ON \
       -DLITE_WITH_EXCEPTION=$WITH_EXCEPTION \
       -DLITE_BUILD_TAILOR=$WITH_STRIP \
       -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \


### PR DESCRIPTION
[Issue] LITE_WITH_PROFILE is not supported on tiny_publish, which is the default compiling method of build_android.sh
[Effect of Current PR]
Enable LITE_WITH_PROFILE option on tiny_publish
[Problems Remaining]
This will invite third-party library into tiny_publish, which will extend compiling time.