### PR TITLE
[API][OPENCL] add opencl tune api for user. test=develop

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -244,6 +244,18 @@ ConfigBase::ConfigBase(PowerMode mode, int threads) {
 #endif
 }
 
+void ConfigBase::set_opencl_tune(bool enable_tune) {
+#ifdef LITE_WITH_OPENCL
+  if (paddle::lite_api::IsOpenCLBackendValid()) {
+    enable_opencl_tune_ = enable_tune;
+    paddle::lite::CLRuntime::Global()->set_auto_tune(enable_opencl_tune_);
+#ifdef LITE_WITH_OPENCL
+    LOG(INFO) << "auto_tune:" << paddle::lite::CLRuntime::Global()->auto_tune();
+#endif
+  }
+#endif
+}
+
 void ConfigBase::set_power_mode(paddle::lite_api::PowerMode mode) {
 #ifdef LITE_WITH_ARM
   lite::DeviceInfo::Global().SetRunMode(mode, threads_);

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -124,6 +124,8 @@ class LITE_API ConfigBase {
   std::string model_dir_;
   int threads_{1};
   PowerMode mode_{LITE_POWER_NO_BIND};
+  // gpu
+  bool enable_opencl_tune_{false};
   // to save subgraph model for npu/xpu/...
   std::string subgraph_model_cache_dir_{""};
   int device_id_{0};
@@ -139,6 +141,9 @@ class LITE_API ConfigBase {
   // set Power_mode
   void set_power_mode(PowerMode mode);
   PowerMode power_mode() const { return mode_; }
+  // set GPU opencl tune
+  void set_opencl_tune(bool enable_tune);
+  bool opencl_tune() const { return enable_opencl_tune_; }
   // set subgraph_model_dir
   void set_subgraph_model_cache_dir(std::string subgraph_model_cache_dir) {
     subgraph_model_cache_dir_ = subgraph_model_cache_dir;

--- a/lite/backends/opencl/cl_context.h
+++ b/lite/backends/opencl/cl_context.h
@@ -65,9 +65,11 @@ class CLContext {
   cl::NDRange LocalWorkSizeTune(cl::NDRange global_work_size,
                                 size_t max_work_size,
                                 int divitor = 2);
+
   cl::NDRange LocalWorkSizeTuneReverse(cl::NDRange global_work_size,
                                        size_t max_work_size,
                                        int divitor = 2);
+
   bool IsArmMali();
   //  cl::NDRange LocalWorkSizeConv1x1(cl::NDRange global_work_size,
   //                                   size_t max_work_size);

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -91,6 +91,10 @@ class CLRuntime {
     return is_device_avaliable_for_opencl_;
   }
 
+  void set_auto_tune(bool enable_tune) { auto_tune_ = enable_tune; }
+
+  bool auto_tune() { return auto_tune_; }
+
   bool Init();
 
   cl::Platform& platform();
@@ -195,6 +199,8 @@ class CLRuntime {
   bool is_cl_runtime_initialized_{false};
 
   bool is_platform_device_init_success_{false};
+
+  bool auto_tune_{false};
 };
 
 }  // namespace lite

--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -92,6 +92,7 @@ void RunModel(std::string model_dir,
   if (is_opencl_backend_valid) {
     // give opencl nb model dir
     config.set_model_from_file(model_dir);
+    config.set_opencl_tune(false); // default is false
   } else {
     std::cout << "Unsupport opencl nb model." << std::endl;
     exit(1);

--- a/lite/kernels/opencl/conv_image_compute.h
+++ b/lite/kernels/opencl/conv_image_compute.h
@@ -152,7 +152,7 @@ class ConvImageCompute : public KernelLite<TARGET(kOpenCL),
   cl::NDRange local_work_size_ = cl::NDRange{
       static_cast<size_t>(1), static_cast<size_t>(1), static_cast<size_t>(1)};
   bool use_lws_{true};
-  bool use_tune_{true};
+  bool use_tune_{false};
 };
 
 }  // namespace opencl


### PR DESCRIPTION
# 状态：等待review

## 主要内容

1. `Config`新增API `set_opencl_tune`，可以让用户是否选择打开或关闭auto tune。虽然性能更好，但第一次跑会tune花较长时间；
2. demo中增加如何使用的代码，前提是gpu；
3. 默认关闭。因为第一次跑会tune花较长时间。

PS：对于比较弱的机器，还有只跑一次推理的场景，就可能不太适合开。所以交给用户选择，后续关于高通的kernel tune策略还需要进一步分析。