### PR TITLE
[Compile] Enable profile option in tiny_publish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,8 +191,6 @@ if (WITH_LITE AND LITE_WITH_LIGHT_WEIGHT_FRAMEWORK)
         include(external/gtest)     # download, build, install gtest
         include(ccache)             # set ccache for compilation
         include(external/protobuf)  # download, build, install protobuf
-    else()
-        include(external/gflags)    # download, build, install gflags
     endif()
 
     # for opencl
@@ -200,7 +198,10 @@ if (WITH_LITE AND LITE_WITH_LIGHT_WEIGHT_FRAMEWORK)
         include(external/opencl-headers)
         include(external/opencl-clhpp)
     endif()
-
+    if (LITE_WITH_PROFILE)
+        include(external/gflags)
+        include(external/glog)
+    endif()
     include(generic)            # simplify cmake module
     include(configure)          # add paddle env configuration
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,8 @@ if (WITH_LITE AND LITE_WITH_LIGHT_WEIGHT_FRAMEWORK)
         include(external/gtest)     # download, build, install gtest
         include(ccache)             # set ccache for compilation
         include(external/protobuf)  # download, build, install protobuf
+    else()
+        include(external/gflags)    # download, build, install gflags
     endif()
 
     # for opencl

--- a/lite/core/CMakeLists.txt
+++ b/lite/core/CMakeLists.txt
@@ -140,6 +140,8 @@ if (NOT LITE_ON_TINY_PUBLISH)
   add_subdirectory(mir)
   add_subdirectory(profile)
   add_subdirectory(arena)
+else()
+  add_subdirectory(profile)
 endif()
 
 # for mobile, unnecessary to compile the following testings.

--- a/lite/core/profile/profiler.cc
+++ b/lite/core/profile/profiler.cc
@@ -126,15 +126,15 @@ std::string Profiler::Summary(Type type, bool concise, size_t w) {
   std::string title;
   // Title.
   if (concise) {
-    ss << "Timing cycle = " << units_.front().Timer(type)->LapTimes().Size()
-       << std::endl;
+    ss << "Timing cycle = " << units_.front().Timer(type)->LapTimes().Size();
+    ss << "\n";
     ss << "===== Concise " << TypeStr.find(type)->second
        << " Profiler Summary: " << name_ << ", Exclude " << w
-       << " warm-ups =====" << std::endl;
+       << " warm-ups =====\n";
   } else {
     ss << "===== Detailed " << TypeStr.find(type)->second
        << " Profiler Summary: " << name_ << ", Exclude " << w
-       << " warm-ups =====" << std::endl;
+       << " warm-ups =====\n";
   }
   ss << setw(20) << left << "OperatorType"
      << " " << setw(30) << left << "KerneAttr(Place)"
@@ -169,7 +169,7 @@ std::string Profiler::Summary(Type type, bool concise, size_t w) {
        << " " << setw(12) << left << "LocalWorkSize";
   }
 #endif
-  ss << std::endl;
+  ss << "\n";
 
   // Profile information.
   if (concise) {
@@ -248,7 +248,7 @@ std::string Profiler::Summary(Type type, bool concise, size_t w) {
          << item.second.cl_max
          << " " << left << fixed << setprecision(2) << cl_percent << "%   ";
 #endif
-      ss << std::endl;
+      ss << "\n";
       // clang-format on
     }
   } else {
@@ -310,7 +310,7 @@ std::string Profiler::Summary(Type type, bool concise, size_t w) {
          << unit.Character().global_work_size << " " << setw(12) << left
          << fixed << unit.Character().local_work_size;
 #endif
-      ss << std::endl;
+      ss << "\n";
     }
   }
   return ss.str();

--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -123,6 +123,7 @@ function prepare_thirdparty {
 # 4.1 function of tiny_publish compiling
 # here we only compile light_api lib
 function make_tiny_publish_so {
+  prepare_thirdparty
   build_dir=$workspace/build.lite.android.$ARCH.$TOOLCHAIN
   if [ "${WITH_OPENCL}" == "ON" ]; then
       build_dir=${build_dir}.opencl
@@ -151,6 +152,7 @@ function make_tiny_publish_so {
       -DLITE_BUILD_TAILOR=$WITH_STRIP \
       -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \
       -DLITE_WITH_JAVA=$WITH_JAVA \
+      -DLITE_WITH_PROFILE=ON \
       -DLITE_WITH_CV=$WITH_CV \
       -DLITE_WITH_NPU=$WITH_HUAWEI_KIRIN_NPU \
       -DNPU_DDK_ROOT=$HUAWEI_KIRIN_NPU_SDK_ROOT \
@@ -196,7 +198,7 @@ function make_full_publish_so {
 
   local cmake_mutable_options="
       -DLITE_BUILD_EXTRA=$WITH_EXTRA \
-      -DLITE_WITH_LOG=$WITH_LOG \
+      -DLITE_WITH_LOG=ON \
       -DLITE_WITH_EXCEPTION=$WITH_EXCEPTION \
       -DLITE_BUILD_TAILOR=$WITH_STRIP \
       -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \


### PR DESCRIPTION
[Issue] LITE_WITH_PROFILE is not supported on tiny_publish, which is the default compiling method of build_android.sh
[Effect of Current PR]
Enable LITE_WITH_PROFILE option on tiny_publish
[Problems Remaining]
This will invite third-party library into tiny_publish, which will extend compiling time.