### PR TITLE
[Doc] Fix dead link in current doc

### DIFF
--- a/docs/api_reference/python_api/CxxPredictor.md
+++ b/docs/api_reference/python_api/CxxPredictor.md
@@ -10,7 +10,6 @@ class CxxPredictor
 
 ```python
 from paddlelite.lite import *
-from lite_core import *
 
 # 1. 设置CxxConfig
 config = CxxConfig()

--- a/docs/api_reference/python_api/Tensor.md
+++ b/docs/api_reference/python_api/Tensor.md
@@ -12,7 +12,6 @@ Tensor是Paddle-Lite的数据组织形式，用于对底层数据进行封装并
 
 ```python
 from paddlelite.lite import *
-from lite_core import *
 
 # 1. 设置CxxConfig
 config = CxxConfig()

--- a/docs/api_reference/python_api/TypePlace.md
+++ b/docs/api_reference/python_api/TypePlace.md
@@ -48,7 +48,7 @@ class Place{
 
 示例：
 ```python
-from lite_core import *
+from paddlelite.lite import *
 
 Place{TargetType(ARM), PrecisionType(FP32), DataLayoutType(NCHW)}
 ```

--- a/docs/user_guides/x2paddle.md
+++ b/docs/user_guides/x2paddle.md
@@ -2,29 +2,31 @@
 
 X2Paddle可以将caffe、tensorflow、onnx模型转换成Paddle支持的模型。
 
-[X2Paddle](https://github.com/PaddlePaddle/X2Paddle)支持将Caffe/TensorFlow模型转换为PaddlePaddle模型。目前X2Paddle支持的模型参考[x2paddle_model_zoo](https://github.com/PaddlePaddle/X2Paddle/blob/develop/x2paddle_model_zoo.md)。
+[X2Paddle](https://github.com/PaddlePaddle/X2Paddle)支持将Caffe/TensorFlow模型转换为PaddlePaddle模型。
+支持的模型可参考**X2Paddle模型测试库：**
+https://github.com/PaddlePaddle/X2Paddle/blob/develop/x2paddle_model_zoo.md
 
 
 ## 多框架支持
 
-|模型 | caffe | tensorflow | onnx | 
+|模型 | caffe | tensorflow | onnx |
 |---|---|---|---|
-|mobilenetv1 | Y | Y |  | 
-|mobilenetv2 | Y | Y | Y | 
-|resnet18 | Y | Y |  | 
-|resnet50 | Y | Y | Y | 
-|mnasnet | Y | Y |  | 
-|efficientnet | Y | Y | Y | 
-|squeezenetv1.1 | Y | Y | Y | 
-|shufflenet | Y | Y |  | 
-|mobilenet_ssd | Y | Y |  | 
-|mobilenet_yolov3 |  | Y |  | 
-|inceptionv4 |  |  |  | 
-|mtcnn | Y | Y |  | 
-|facedetection | Y |  |  | 
-|unet | Y | Y |  | 
-|ocr_attention |  |  |  | 
-|vgg16 |  |  |  | 
+|mobilenetv1 | Y | Y |  |
+|mobilenetv2 | Y | Y | Y |
+|resnet18 | Y | Y |  |
+|resnet50 | Y | Y | Y |
+|mnasnet | Y | Y |  |
+|efficientnet | Y | Y | Y |
+|squeezenetv1.1 | Y | Y | Y |
+|shufflenet | Y | Y |  |
+|mobilenet_ssd | Y | Y |  |
+|mobilenet_yolov3 |  | Y |  |
+|inceptionv4 |  |  |  |
+|mtcnn | Y | Y |  |
+|facedetection | Y |  |  |
+|unet | Y | Y |  |
+|ocr_attention |  |  |  |
+|vgg16 |  |  |  |
 
 
 ## 安装


### PR DESCRIPTION
问题描述： x2paddle文档中有死链
问题定位：当前文档使用Sphinx生成，生成过程会将链接中的md后缀去除，当前未找到良好解决方法
本PR工作：直接将后缀为md的链接写出来（而不是作为超链接）