### PR TITLE
Introduce option --optimize_out more clear

### DIFF
--- a/docs/user_guides/opt/opt_python.md
+++ b/docs/user_guides/opt/opt_python.md
@@ -67,7 +67,7 @@ paddle_lite_opt \
 | --model_file        | 待优化的PaddlePaddle模型（combined形式）的网络结构文件路径。 |
 | --param_file        | 待优化的PaddlePaddle模型（combined形式）的权重文件路径。 |
 | --optimize_out_type | 输出模型类型，目前支持两种类型：protobuf和naive_buffer，其中naive_buffer是一种更轻量级的序列化/反序列化实现。若您需要在mobile端执行模型预测，请将此选项设置为naive_buffer。默认为protobuf。 |
-| --optimize_out      | 优化模型的输出路径。                                         |
+| --optimize_out      | 优化模型的文件名字，默认为空，例如使用`--optimize_out=mobilenet_v1_opt`则会在执行命令的当前路径下生成`mobilenet_v1_opt.nb`输出路径。 |
 | --valid_targets     | 指定模型可执行的backend，默认为arm。目前可支持x86、arm、opencl、npu、xpu，可以同时指定多个backend(以空格分隔)，Model Optimize Tool将会自动选择最佳方式。如果需要支持华为NPU（Kirin 810/990 Soc搭载的达芬奇架构NPU），应当设置为npu, arm。 |
 | --record_tailoring_info | 当使用 [根据模型裁剪库文件](./library_tailoring.html) 功能时，则设置该选项为true，以记录优化后模型含有的kernel和OP信息，默认为false。 |
 


### PR DESCRIPTION
Users cannot specifiy the store directory of optimized model by `--optimize_out` option. This option can only set optimized model's name.