### PR TITLE
[Framework]Remove `op_callstack` attribute from model file

### DIFF
--- a/lite/model_parser/compatible_pb.cc
+++ b/lite/model_parser/compatible_pb.cc
@@ -155,8 +155,12 @@ void OpAttrsAnyToCpp(const OpDescType &any_desc, cpp::OpDesc *cpp_desc) {
   };
 
   for (const auto &attr_name : any_desc.AttrNames()) {
-    auto type = any_desc.GetAttrType(attr_name);
-    set_attr(attr_name, type);
+    // note: since `op_callstack` attribute has no effect on inference process,
+    // we will not load it into op_desc.
+    if (attr_name != "op_callstack") {
+      auto type = any_desc.GetAttrType(attr_name);
+      set_attr(attr_name, type);
+    }
   }
 }
 


### PR DESCRIPTION
【Issue】 `__model__` file of Paddle-Lite‘s consumes too much space.
![image](https://user-images.githubusercontent.com/45189361/89247279-963bb300-d63f-11ea-94f4-620dfa86b585.png)

```
model v45:
Anakin __model__ part : 20K
Paddle-Lite __model__: 200K
```
【Effect of Current PR】
Abandon `op_callstack` attribute from `__model__`, as this attribute contains too much debug info which has no effect on inference process.
【Experiment】
```
v45.nb:
     Before: 899K 
     After: 641k
Size of __model__ module will be reduced by 1/3
```