### PR TITLE
[APU] Fix the generation of the APU DLA model

### DIFF
--- a/lite/kernels/apu/subgraph_compute.cc
+++ b/lite/kernels/apu/subgraph_compute.cc
@@ -29,6 +29,10 @@ namespace kernels {
 namespace apu {
 
 bool SubgraphEngine::BuildDeviceProgram() {
+  if (!origin_program_) {
+    BuildOriginProgram();
+  }
+
   unsigned int version;
   Neuron_getVersion(&version);
   VLOG(3) << "Neuron Adapter version: " << version;
@@ -46,9 +50,6 @@ bool SubgraphEngine::BuildDeviceProgram() {
 
   // Convert all of ops and their input vars and weights and added into the APU
   // NIR graph
-  if (!origin_program_) {
-    BuildOriginProgram();
-  }
   const auto& bridges = subgraph::Registry::Instance();
   const auto& insts = origin_program_->instructions(kRootBlockIdx);
   for (auto& inst : insts) {


### PR DESCRIPTION
这个问题比较奇怪，只要将BuildOriginProgram()放在Neuron_xxx函数调用之后，APU DLA mode就会生成失败，可能是neuron_adapter.so的bug。