### PR TITLE
fix python lib feed op not found, test=develop

### DIFF
--- a/lite/api/python/pybind/CMakeLists.txt
+++ b/lite/api/python/pybind/CMakeLists.txt
@@ -9,6 +9,7 @@ if(WIN32)
    target_link_libraries(lite_pybind ${os_dependency_modules})
 else()
    lite_cc_library(lite_pybind SHARED SRCS pybind.cc DEPS ${PYBIND_DEPS})
+   target_sources(lite_pybind PUBLIC ${__lite_cc_files})
 endif(WIN32)
 
 if (LITE_ON_TINY_PUBLISH)


### PR DESCRIPTION
Python demo of "mobilenetv1_full_api.py" and "mobilenetv1_light_api.py" will throw error of feed op not found.