### PR TITLE
[ARM] Add memset to weights in conv_winograd. test=develop

### DIFF
--- a/lite/kernels/arm/conv_winograd.cc
+++ b/lite/kernels/arm/conv_winograd.cc
@@ -78,6 +78,9 @@ void WinogradConv<PRECISION(kFloat), PRECISION(kFloat)>::ReInitWhenNeeded() {
   weights_.Resize({1, 1, 1, wino_iw * wino_iw * oc_pad * ic_pad});
   void* trans_tmp_ptr = malloc(sizeof(float) * wino_iw * wino_iw * oc * ic);
   auto weights_data_ = weights_.mutable_data<float>();
+  memset(reinterpret_cast<char*>(weights_data_),
+         0,
+         weights_.numel() * sizeof(float));
   if (!choose_small_) {
     lite::arm::math::weight_trans_c4_8x8(
         weights_data_, param.filter->data<float>(), ic, oc, trans_tmp_ptr);
@@ -251,6 +254,9 @@ void WinogradConv<PRECISION(kInt8), OutType>::ReInitWhenNeeded() {
   weights_.Resize({1, 1, 1, wino_iw * wino_iw * oc_pad * ic_pad});
   void* trans_tmp_ptr = malloc(sizeof(int16_t) * wino_iw * wino_iw * oc * ic);
   auto weights_data_ = weights_.mutable_data<int16_t>();
+  memset(reinterpret_cast<char*>(weights_data_),
+         0,
+         weights_.numel() * sizeof(int16_t));
   if (!choose_small_) {
   } else {
     lite::arm::math::weight_trans_c8_4x4_int8(


### PR DESCRIPTION
[背景] 在`conv-winograd.cc`中，在使用`weights_`前如果不对其初始化为零，部分模型（如VIS图像修复模型）计算结果会出现偶发性错误。错误原因为在执行 winograd conv 时，会读取到`weights_`中未被赋值的值（一般是个极大/极小或NAN），进而导致该层输出错误。
[解决方法] 在`conv-winograd.cc`中，当使用`weights_`时，提前初始化为零。已在VIS图像修复模型上验证通过。