### PR TITLE
[CI] Modify approval rules

### DIFF
--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -281,7 +281,9 @@ function test_server {
 function assert_api_spec_approvals() {
     /bin/bash ${LITE_ROOT}/lite/tools/check_api_approvals.sh check_modified_file_nums
     if [ "$?" != 0 ];then
-       exit 1
+       return 1
+    else
+       return 0
     fi
 }
 
@@ -290,12 +292,20 @@ function build_test_server {
     mkdir -p ./build
     cd ./build
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/third_party/install/mklml/lib"
+    # check approval
     assert_api_spec_approvals
+    approval_result = $?
+    # build on x86 backend
     cmake_x86_for_CI
     build
-
+    # test on x86 backend
     test_server
     test_model_optimize_tool_compile
+    # test approval result
+    if [ "$approval_result" != 0 ];then
+       echo "Error: Approval error occured."
+       exit 1
+    fi
 }
 
 # Build the code and run lite server tests. This is executed in the CI system.


### PR DESCRIPTION
参考： #3727
需求：
```
当前Paddle-Lite CI任务`PR_CI_Paddle-Lite-server (Paddle-Lite) `会同时检测修改文件数量
如果修改文件大于20个会报错（除非有特定人员approve并重新触发任务）
当前执行顺序是先 “检查修改文件个数”---- 通过后执行 server_test 任务
需要修改为 先执行 server_test 任务，通过后“检查修改文件个数”
```