### PR TITLE
[LITE][BM] Fixed dependency path issues for compiling third-party libraries

### DIFF
--- a/lite/backends/bm/CMakeLists.txt
+++ b/lite/backends/bm/CMakeLists.txt
@@ -2,4 +2,8 @@ if (NOT LITE_WITH_BM)
     return()
 endif()
 
-lite_cc_library(target_wrapper_bm SRCS target_wrapper.cc DEPS ${bm_runtime_libs})
+#lite_cc_library(target_wrapper_bm SRCS target_wrapper.cc DEPS ${bm_runtime_libs})
+
+add_library(target_wrapper_bm STATIC target_wrapper.cc)
+#target_link_libraries(target_wrapper_bm ${BM_SDK_ROOT}/lib/bmcompiler/libbmcompiler.so ${BM_SDK_ROOT}/lib/bmnn/pcie/libbmcpu.so ${BM_SDK_ROOT}/lib/bmnn/pcie/libbmlib.so ${BM_SDK_ROOT}/lib/bmnn/pcie/libbmrt.so)
+target_link_libraries(target_wrapper_bm -Wl,-rpath,${BM_SDK_ROOT}/lib/bmcompiler:${BM_SDK_ROOT}/lib/bmnn/pcie -L${BM_SDK_ROOT}/lib/bmcompiler -L${BM_SDK_ROOT}/lib/bmnn/pcie -lbmcompiler -lbmcpu -lbmlib -lbmrt)


### PR DESCRIPTION
[背景] 编译时会将BM第三方库的路径写入到lite生成的动态库ELF头中，移动lite的动态库或者第三方库，都会导致程序运行时找不到库。
[解决办法] 在BM的CMakeList.txt中使用：分别设置动态库链接时第三方库的路径，运行时搜索第三方库的路径。