### PR TITLE
[Framework] Update InferShape period

### DIFF
--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -384,14 +384,14 @@ struct ActivationParam : ParamBase {
   // get a vector of input tensors
   const std::vector<const Tensor*>* input_tensor_ptrs() override {
     if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_ = new std::vector<const Tensor*>({X});
+      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
     }
     return input_tensor_ptrs_cache_;
   }
   // get a vector of output tensors
   std::vector<Tensor*>* output_tensor_ptrs() override {
     if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_ = new std::vector<lite::Tensor*>({Out});
+      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
     }
     return output_tensor_ptrs_cache_;
   }

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -83,6 +83,21 @@ struct CalibParam : ParamBase {
   const lite::Tensor* input{};
   lite::Tensor* output{};
   float scale;
+  ///////////////////////////////////////////////////////////////////////////////////
+  // get a vector of input tensors
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
+      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({input}));
+    }
+    return input_tensor_ptrs_cache_.get();
+  }
+  // get a vector of output tensors
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
+      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
+    }
+    return output_tensor_ptrs_cache_.get();
+  }
 };
 
 struct SubgraphParam : ParamBase {
@@ -364,6 +379,22 @@ struct ActivationParam : ParamBase {
   float relu_threshold{1.0f};
   // elu
   float Elu_alpha{1.0f};
+
+  ///////////////////////////////////////////////////////////////////////////////////
+  // get a vector of input tensors
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
+      input_tensor_ptrs_cache_ = new std::vector<const Tensor*>({X});
+    }
+    return input_tensor_ptrs_cache_;
+  }
+  // get a vector of output tensors
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
+      output_tensor_ptrs_cache_ = new std::vector<lite::Tensor*>({Out});
+    }
+    return output_tensor_ptrs_cache_;
+  }
 };
 
 struct ActivationGradParam : ParamBase {
@@ -800,6 +831,23 @@ struct BoxCoderParam : ParamBase {
   bool box_normalized{true};
   int axis{0};
   std::vector<float> variance{};
+  ///////////////////////////////////////////////////////////////////////////////////
+  // get a vector of input tensors
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
+      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>(
+          {prior_box, prior_box_var, target_box}));
+    }
+    return input_tensor_ptrs_cache_.get();
+  }
+  // get a vector of output tensors
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
+      output_tensor_ptrs_cache_.reset(
+          new std::vector<lite::Tensor*>({proposals}));
+    }
+    return output_tensor_ptrs_cache_.get();
+  }
 };
 
 /// ----------------------- multiclass_nms operators ----------------------
@@ -839,6 +887,23 @@ struct PriorBoxParam : ParamBase {
   // priortype: prior_min, prior_max, prior_com
   std::vector<std::string> order;
   bool min_max_aspect_ratios_order{false};
+  ///////////////////////////////////////////////////////////////////////////////////
+  // get a vector of input tensors
+  const std::vector<const Tensor*>* input_tensor_ptrs() override {
+    if (!input_tensor_ptrs_cache_) {
+      input_tensor_ptrs_cache_.reset(
+          new std::vector<const Tensor*>({input, image}));
+    }
+    return input_tensor_ptrs_cache_.get();
+  }
+  // get a vector of output tensors
+  std::vector<Tensor*>* output_tensor_ptrs() override {
+    if (!output_tensor_ptrs_cache_) {
+      output_tensor_ptrs_cache_.reset(
+          new std::vector<lite::Tensor*>({boxes, variances}));
+    }
+    return output_tensor_ptrs_cache_.get();
+  }
 };
 
 struct DensityPriorBoxParam : public PriorBoxParam {

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -386,14 +386,14 @@ struct ActivationParam : ParamBase {
     if (!input_tensor_ptrs_cache_) {
       input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
     }
-    return input_tensor_ptrs_cache_;
+    return input_tensor_ptrs_cache_.get();
   }
   // get a vector of output tensors
   std::vector<Tensor*>* output_tensor_ptrs() override {
     if (!output_tensor_ptrs_cache_) {
       output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
     }
-    return output_tensor_ptrs_cache_;
+    return output_tensor_ptrs_cache_.get();
   }
 };
 


### PR DESCRIPTION
【背景】InferShapeWithCache方法实现需要要求该Op的param已经实现`input_tensor_ptrs_cache_ `方法
扫描业务模型后发现有些OP没有实现该方法，不能实现InferShapeWithCache加速
【本PR工作】为5个Op注册`input_tensor_ptrs_cache_ `方法，使其可以适用`InferShapeWithCache`