### PR TITLE
[LITE][XPU] 1. Add CloneFrom() method in SSAGraph for recovery from failed pattern match; 2. Fix BindKernel in xpu fusion passes;

### DIFF
--- a/lite/core/mir/fusion/__xpu__embedding_with_eltwise_add_fuse_pass.cc
+++ b/lite/core/mir/fusion/__xpu__embedding_with_eltwise_add_fuse_pass.cc
@@ -163,4 +163,4 @@ class XPUEmbeddingWithEltwiseAddFusePass : public ProgramPass {
 REGISTER_MIR_PASS(__xpu__embedding_with_eltwise_add_fuse_pass,
                   paddle::lite::mir::XPUEmbeddingWithEltwiseAddFusePass)
     .BindTargets({TARGET(kXPU)})
-    .BindKernel("lookup_table");
+    .BindKernel("__xpu__embedding_with_eltwise_add");

--- a/lite/core/mir/fusion/__xpu__fc_fuse_pass.cc
+++ b/lite/core/mir/fusion/__xpu__fc_fuse_pass.cc
@@ -144,4 +144,4 @@ class XPUFcFusePass : public ProgramPass {
 
 REGISTER_MIR_PASS(__xpu__fc_fuse_pass, paddle::lite::mir::XPUFcFusePass)
     .BindTargets({TARGET(kXPU)})
-    .BindKernel("fc");
+    .BindKernel("__xpu__fc");

--- a/lite/core/mir/fusion/__xpu__multi_encoder_fuse_pass.cc
+++ b/lite/core/mir/fusion/__xpu__multi_encoder_fuse_pass.cc
@@ -672,4 +672,4 @@ class XPUMultiEncoderFusePass : public ProgramPass {
 REGISTER_MIR_PASS(__xpu__multi_encoder_fuse_pass,
                   paddle::lite::mir::XPUMultiEncoderFusePass)
     .BindTargets({TARGET(kXPU)})
-    .BindKernel("matmul");
+    .BindKernel("__xpu__multi_encoder");

--- a/lite/core/mir/pattern_matcher_high_api.h
+++ b/lite/core/mir/pattern_matcher_high_api.h
@@ -32,7 +32,8 @@ class FuseBase {
 
   virtual ~FuseBase() = default;
 
-  void operator()(SSAGraph* graph) {
+  // Returns number of matched subgraphs
+  size_t operator()(SSAGraph* graph) {
     BuildPattern();
     PerformPatternMatcher(graph);
 
@@ -41,6 +42,7 @@ class FuseBase {
     }
 
     DeleteInterNodes(graph);
+    return key2nodes_.size();
   }
 
   // Build a PMPattern using PMNode.

--- a/lite/core/mir/ssa_graph.h
+++ b/lite/core/mir/ssa_graph.h
@@ -44,6 +44,9 @@ class SSAGraph : GraphBase {
              int block_idx = kRootBlockIdx);
   void RemoveNode(const mir::Node *node);
 
+  // Clone from another SSAGraph, all mir::Node(s) are duplicated.
+  void CloneFrom(const SSAGraph &from);
+
   std::vector<mir::Node *> StmtTopologicalOrder();
 
   std::vector<mir::Node *> NodeTopologicalOrder();

--- a/lite/core/mir/xpu_pattern_matcher_high_api.h
+++ b/lite/core/mir/xpu_pattern_matcher_high_api.h
@@ -31,7 +31,8 @@ class XPUFuseBase {
 
   virtual ~XPUFuseBase() = default;
 
-  void operator()(SSAGraph* graph) {
+  // Returns number of matched subgraphs
+  size_t operator()(SSAGraph* graph) {
     BuildPattern();
     PerformPatternMatcher(graph);
 
@@ -40,6 +41,7 @@ class XPUFuseBase {
     }
 
     DeleteInterNodes(graph);
+    return key2nodes_.size();
   }
 
   // Build a PMPattern using PMNode.


### PR DESCRIPTION
1. SSAGraph类增加CloneFrom()方法，用于从失败的匹配中恢复（SSAGraph已被部分修改）；
2. 一些xpu fussion pass中的BindKernel撰写有误；