### PR TITLE
[BugFix][PASS] Fix segfault in remove tf redundant ops pass. test=develop

### DIFF
--- a/lite/core/mir/elimination/remove_tf_redundant_ops_pass.cc
+++ b/lite/core/mir/elimination/remove_tf_redundant_ops_pass.cc
@@ -184,6 +184,11 @@ void RemoveTFRedundantOpsPass::RemoveSqueeze2Reshape2Pattern(
       }
     }
 
+    if (nullptr == reshape2_out_node) {
+      VLOG(5) << "reshape2_out_node doesn't found, skip now";
+      return;
+    }
+
     // find next inst node of reshape2
     VLOG(5) << "reshape2_out_node->outlinks.size():"
             << reshape2_out_node->outlinks.size()


### PR DESCRIPTION
# 状态：等待review

## 主要内容

QA测试tensorFlow的VGG16模型在转换模型阶段出现在tf_remove_redundant_ops_pass有segfault情况，定位到是因为空指针导致，加入对空指针的判断。自测通过。