### PR TITLE
[LITE][BM] Fixed an error in build_bm.sh that would cause 'exit 1'. test=develop

### DIFF
--- a/lite/tools/build_bm.sh
+++ b/lite/tools/build_bm.sh
@@ -103,6 +103,9 @@ function main {
             --target_name=*)
                 TARGET_NAME="${i#*=}"
                 build_bm
+                shift
+                ;;
+            *)
                 # unknown option
                 print_usage
                 exit 1
@@ -110,5 +113,4 @@ function main {
         esac
     done
 }
-
 main $@


### PR DESCRIPTION
修复build_bm.sh中的代码中会返回 "exit 1" 的错误