### PR TITLE
[BACKEND][OPENCL] Delete redundant calling: InitializeDevice. test=develop

### DIFF
--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -75,6 +75,7 @@ class CLRuntime {
     //  2. dlsym_success must be true
 
     InitializeDevice();
+
     bool support_fp16 =
         static_cast<bool>(device_info_["CL_DEVICE_EXTENSIONS_FP16"]);
 #ifdef LITE_WITH_LOG

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -74,8 +74,6 @@ class CLRuntime {
     //  1. opencl_lib_found must be true
     //  2. dlsym_success must be true
 
-    InitializeDevice();
-
     bool support_fp16 =
         static_cast<bool>(device_info_["CL_DEVICE_EXTENSIONS_FP16"]);
 #ifdef LITE_WITH_LOG

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -74,7 +74,6 @@ class CLRuntime {
     //  1. opencl_lib_found must be true
     //  2. dlsym_success must be true
 
-    InitializeDevice();
     bool support_fp16 =
         static_cast<bool>(device_info_["CL_DEVICE_EXTENSIONS_FP16"]);
 #ifdef LITE_WITH_LOG


### PR DESCRIPTION
`InitializeDevice()`函数在 lite/core/program.cc 中的`RuntimeProgram::RuntimeProgram`函数中被调用了，在本patch处又被调用了，实际上只需要调用一次即可。