### PR TITLE
 [Framework]Update Malloc implementation to accelerate  #3959

### DIFF
--- a/lite/backends/arm/math/prior_box.cc
+++ b/lite/backends/arm/math/prior_box.cc
@@ -21,7 +21,7 @@ namespace lite {
 namespace arm {
 namespace math {
 
-const int MALLOC_ALIGN = 16;
+const int MALLOC_ALIGN = 64;
 
 void* fast_malloc(size_t size) {
   size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;

--- a/lite/backends/host/target_wrapper.cc
+++ b/lite/backends/host/target_wrapper.cc
@@ -19,7 +19,7 @@
 namespace paddle {
 namespace lite {
 
-const int MALLOC_ALIGN = 16;
+const int MALLOC_ALIGN = 64;
 
 void* TargetWrapper<TARGET(kHost)>::Malloc(size_t size) {
   size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;

--- a/lite/tests/kernels/prior_box_compute_test.cc
+++ b/lite/tests/kernels/prior_box_compute_test.cc
@@ -21,7 +21,7 @@
 namespace paddle {
 namespace lite {
 
-const int MALLOC_ALIGN = 16;
+const int MALLOC_ALIGN = 64;
 
 void* fast_malloc(size_t size) {
   size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;


### PR DESCRIPTION
#3959  对内存对齐方式进行修改，从64字节对齐修改为16字节对齐，会降低运行时内存占用。
但是后期测试该修改会降低模型在ARMv8运行时速度、参照竞品 ncnn 在ARMv8上也是采用64字节对齐。 
测试结果反应在ARMv8平台，ALIGN=16到ALIGN=64内存增量较低；而对于特定模型有20%的运行耗时降低，故本PR将对齐方式修改回64字节对齐