### PR TITLE
[Bug fixes] Support ocr int8 model, test=develop

### DIFF
--- a/lite/api/benchmark.cc
+++ b/lite/api/benchmark.cc
@@ -30,6 +30,8 @@
 #include <string>
 #include <vector>
 #include "lite/api/paddle_api.h"
+#include "lite/api/paddle_use_kernels.h"
+#include "lite/api/paddle_use_ops.h"
 #include "lite/core/device_info.h"
 #include "lite/utils/cp_logging.h"
 #include "lite/utils/string.h"

--- a/lite/kernels/arm/fc_compute.h
+++ b/lite/kernels/arm/fc_compute.h
@@ -90,7 +90,7 @@ class FcCompute : public KernelLite<TARGET(kARM), PType> {
       return;
     }
     last_shape_ = x_dims;
-    auto w_dims = param.w->dims();
+    auto w_dims = param.w_dims;
     auto& ctx = this->ctx_->template As<ARMContext>();
 
     CHECK_GE(x_dims.size(), 2UL);
@@ -99,9 +99,7 @@ class FcCompute : public KernelLite<TARGET(kARM), PType> {
 
     m_ = x_dims.Slice(0, param.in_num_col_dims).production();
     k_ = x_dims.Slice(param.in_num_col_dims, x_dims.size()).production();
-    CHECK_EQ(k_, w_dims[0]);
     n_ = w_dims[1];
-    CHECK_EQ(k_, static_cast<int>(w_dims[0]));
     flag_gemm_ = check_fc_use_gemm<PType, OutType>(
         m_, param.weight_scale, param.bias != nullptr);
     if (flag_trans_weights_ == flag_gemm_) {


### PR DESCRIPTION
Use the origin weight dims in fc kernel.