### PR TITLE
fix save interfaces of flatbuffers, test=develop

### DIFF
--- a/lite/model_parser/flatbuffers/io.cc
+++ b/lite/model_parser/flatbuffers/io.cc
@@ -35,11 +35,10 @@ std::vector<char> LoadFile(const std::string& path) {
   return buf;
 }
 
-void SaveFile(const std::string& path, const void* src, size_t byte_size) {
-  CHECK(src);
+void SaveFile(const std::string& path, const std::vector<char>& cache) {
   FILE* file = fopen(path.c_str(), "wb");
   CHECK(file);
-  CHECK(fwrite(src, sizeof(char), byte_size, file) == byte_size);
+  CHECK(fwrite(cache.data(), sizeof(char), cache.size(), file) == cache.size());
   fclose(file);
 }
 

--- a/lite/model_parser/flatbuffers/io.h
+++ b/lite/model_parser/flatbuffers/io.h
@@ -27,7 +27,7 @@ namespace lite {
 namespace fbs {
 
 std::vector<char> LoadFile(const std::string& path);
-void SaveFile(const std::string& path, const void* src, size_t byte_size);
+void SaveFile(const std::string& path, const std::vector<char>& cache);
 
 void SetScopeWithCombinedParams(lite::Scope* scope,
                                 const CombinedParamsDescReadAPI& params);

--- a/lite/model_parser/flatbuffers/io_test.cc
+++ b/lite/model_parser/flatbuffers/io_test.cc
@@ -74,13 +74,8 @@ TEST(CombinedParamsDesc, Scope) {
   };
   check_params(combined_param);
 
-  /* --------- Cache scope ---------- */
-  std::vector<char> cache;
-  cache.resize(combined_param.buf_size());
-  std::memcpy(cache.data(), combined_param.data(), combined_param.buf_size());
-
   /* --------- View scope ---------- */
-  check_params(CombinedParamsDescView(std::move(cache)));
+  check_params(CombinedParamsDescView(combined_param.data()));
 }
 #endif  // LITE_WITH_FLATBUFFERS_DESC
 

--- a/lite/model_parser/flatbuffers/param_desc.h
+++ b/lite/model_parser/flatbuffers/param_desc.h
@@ -186,14 +186,12 @@ class CombinedParamsDesc : public CombinedParamsDescAPI {
     return params_[params_.size() - 1].get();
   }
 
-  const void* data() {
+  std::vector<char> data() {
     SyncBuffer();
-    return buf_.data();
-  }
-
-  size_t buf_size() {
-    SyncBuffer();
-    return buf_.size();
+    std::vector<char> cache;
+    cache.resize(buf_.size());
+    std::memcpy(cache.data(), buf_.data(), buf_.size());
+    return cache;
   }
 
  private:

--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -137,14 +137,12 @@ class ProgramDesc : public ProgramDescAPI {
     desc_.version->version = version_in;
   }
 
-  const void* data() {
+  std::vector<char> data() {
     SyncBuffer();
-    return buf_.data();
-  }
-
-  size_t buf_size() {
-    SyncBuffer();
-    return buf_.size();
+    std::vector<char> cache;
+    cache.resize(buf_.size());
+    std::memcpy(cache.data(), buf_.data(), buf_.size());
+    return cache;
   }
 
  private:

--- a/lite/model_parser/flatbuffers/test_helper.h
+++ b/lite/model_parser/flatbuffers/test_helper.h
@@ -73,10 +73,7 @@ inline std::vector<char> GenerateProgramCache() {
   op_b1.SetAttr<bool>("Attr1", true);
 
   /* --------- Cache Program ---------- */
-  std::vector<char> cache;
-  cache.resize(program.buf_size());
-  std::memcpy(cache.data(), program.data(), program.buf_size());
-  return cache;
+  return program.data();
 }
 
 inline void CheckProgramCache(ProgramDesc* program) {

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -603,7 +603,7 @@ void SaveModelFbs(const std::string &model_dir,
   const std::string prog_path = model_dir + "/model.fbs";
   fbs::ProgramDesc fbs_prog;
   TransformProgramDescCppToAny(cpp_prog, &fbs_prog);
-  fbs::SaveFile(prog_path, fbs_prog.data(), fbs_prog.buf_size());
+  fbs::SaveFile(prog_path, fbs_prog.data());
 
   /* 2. Get param names from cpp::ProgramDesc */
   auto &main_block_desc = *cpp_prog.GetBlock<cpp::BlockDesc>(0);
@@ -621,7 +621,7 @@ void SaveModelFbs(const std::string &model_dir,
   const std::string params_path = model_dir + "/params.fbs";
   fbs::CombinedParamsDesc params_prog;
   fbs::SetCombinedParamsWithScope(exec_scope, unique_var_names, &params_prog);
-  fbs::SaveFile(params_path, params_prog.data(), params_prog.buf_size());
+  fbs::SaveFile(params_path, params_prog.data());
 }
 #endif  // LITE_ON_TINY_PUBLISH
 


### PR DESCRIPTION
修复 `fbs::Desc::data()` 和 `fbs::Desc::buf_size()` 返回值可能和调用方式有关，导致随机出错的 bug。