### PR TITLE
[Framework]Update opt and model topology

### DIFF
--- a/lite/api/cxx_api_test.cc
+++ b/lite/api/cxx_api_test.cc
@@ -131,7 +131,8 @@ TEST(CXXApi, save_model) {
   predictor.Build(FLAGS_model_dir, "", "", valid_places);
 
   LOG(INFO) << "Save optimized model to " << FLAGS_optimized_model;
-  predictor.SaveModel(FLAGS_optimized_model);
+  predictor.SaveModel(FLAGS_optimized_model,
+                      lite_api::LiteModelType::kProtobuf);
   predictor.SaveModel(FLAGS_optimized_model + ".naive",
                       lite_api::LiteModelType::kNaiveBuffer);
 }

--- a/lite/model_parser/flatbuffers/io.cc
+++ b/lite/model_parser/flatbuffers/io.cc
@@ -55,11 +55,10 @@ std::vector<char> LoadFile(const std::string& path,
   return buf;
 }
 
-void SaveFile(const std::string& path, const void* src, size_t byte_size) {
-  CHECK(src);
+void SaveFile(const std::string& path, const std::vector<char>& cache) {
   FILE* file = fopen(path.c_str(), "wb");
   CHECK(file);
-  CHECK(fwrite(src, sizeof(char), byte_size, file) == byte_size);
+  CHECK(fwrite(cache.data(), sizeof(char), cache.size(), file) == cache.size());
   fclose(file);
 }
 

--- a/lite/model_parser/flatbuffers/io.cc
+++ b/lite/model_parser/flatbuffers/io.cc
@@ -23,18 +23,6 @@ namespace paddle {
 namespace lite {
 namespace fbs {
 
-std::vector<char> LoadFile(const std::string& path) {
-  FILE* file = fopen(path.c_str(), "rb");
-  CHECK(file);
-  fseek(file, 0, SEEK_END);
-  uint64_t length = ftell(file);
-  rewind(file);
-  std::vector<char> buf(length);
-  CHECK_EQ(fread(buf.data(), 1, length, file), length);
-  fclose(file);
-  return buf;
-}
-
 std::vector<char> LoadFile(const std::string& path,
                            const size_t& offset,
                            const size_t& size) {

--- a/lite/model_parser/flatbuffers/io.cc
+++ b/lite/model_parser/flatbuffers/io.cc
@@ -35,6 +35,26 @@ std::vector<char> LoadFile(const std::string& path) {
   return buf;
 }
 
+std::vector<char> LoadFile(const std::string& path,
+                           const size_t& offset,
+                           const size_t& size) {
+  // open file in readonly mode
+  FILE* file = fopen(path.c_str(), "rb");
+  CHECK(file) << "Unable to open file: " << path;
+  // move fstream pointer backward for offset
+  uint64_t length = size;
+  if (size == 0) {
+    fseek(file, 0L, SEEK_END);
+    length = ftell(file) - offset;
+  }
+  fseek(file, offset, SEEK_SET);
+  // read data of `length` into buf
+  std::vector<char> buf(length);
+  CHECK_EQ(fread(buf.data(), 1, length, file), length);
+  fclose(file);
+  return buf;
+}
+
 void SaveFile(const std::string& path, const void* src, size_t byte_size) {
   CHECK(src);
   FILE* file = fopen(path.c_str(), "wb");

--- a/lite/model_parser/flatbuffers/io.h
+++ b/lite/model_parser/flatbuffers/io.h
@@ -30,7 +30,7 @@ std::vector<char> LoadFile(const std::string& path);
 std::vector<char> LoadFile(const std::string& path,
                            const size_t& offset,
                            const size_t& size = 0);
-void SaveFile(const std::string& path, const void* src, size_t byte_size);
+void SaveFile(const std::string& path, const std::vector<char>& cache);
 
 void SetScopeWithCombinedParams(lite::Scope* scope,
                                 const CombinedParamsDescReadAPI& params);

--- a/lite/model_parser/flatbuffers/io.h
+++ b/lite/model_parser/flatbuffers/io.h
@@ -26,9 +26,8 @@ namespace paddle {
 namespace lite {
 namespace fbs {
 
-std::vector<char> LoadFile(const std::string& path);
 std::vector<char> LoadFile(const std::string& path,
-                           const size_t& offset,
+                           const size_t& offset = 0,
                            const size_t& size = 0);
 void SaveFile(const std::string& path, const std::vector<char>& cache);
 

--- a/lite/model_parser/flatbuffers/io.h
+++ b/lite/model_parser/flatbuffers/io.h
@@ -27,6 +27,9 @@ namespace lite {
 namespace fbs {
 
 std::vector<char> LoadFile(const std::string& path);
+std::vector<char> LoadFile(const std::string& path,
+                           const size_t& offset,
+                           const size_t& size = 0);
 void SaveFile(const std::string& path, const void* src, size_t byte_size);
 
 void SetScopeWithCombinedParams(lite::Scope* scope,

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -592,10 +592,10 @@ void SaveModelNaive(const std::string &model_file,
 
   fbs::ProgramDesc fbs_prog;
   TransformProgramDescCppToAny(cpp_prog, &fbs_prog);
-  uint64_t topology_size = fbs_prog.buf_size();
+  uint64_t topology_size = (fbs_prog.data()).size();
   AppendToFile(prog_path, &topology_size, sizeof(uint64_t));
   /* 1. Save model to model.fbs */
-  AppendToFile(prog_path, fbs_prog.data(), topology_size);
+  AppendToFile(prog_path, (fbs_prog.data()).data(), topology_size);
   VLOG(4) << "save topology_size:" << topology_size;
 
   /* 2. Get param names from cpp::ProgramDesc */
@@ -613,8 +613,8 @@ void SaveModelNaive(const std::string &model_file,
   /* 3. Save combined params to params.fbs */
   fbs::CombinedParamsDesc params_prog;
   fbs::SetCombinedParamsWithScope(exec_scope, unique_var_names, &params_prog);
-  AppendToFile(prog_path, params_prog.data(), params_prog.buf_size());
-  VLOG(4) << "save params_size:" << params_prog.buf_size();
+  AppendToFile(
+      prog_path, (params_prog.data()).data(), (params_prog.data()).size());
 
   LOG(INFO) << "Save naive buffer model in '" << prog_path << " successfully";
 }

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -550,6 +550,17 @@ void SaveCombinedParamsNaive(const std::string &path,
 // Save model: meta_version = 1
 // Flatbuffer model + params
 ////////////////////////////////////////////////////////////////////////////////////
+// Create a new file and write data into it.
+void WriteToFile(const std::string &filename,
+                 const void *src,
+                 size_t byte_size) {
+  CHECK(src);
+  FILE *file = fopen(filename.c_str(), "wb");
+  CHECK(file);
+  CHECK(fwrite(src, sizeof(char), byte_size, file) == byte_size);
+  fclose(file);
+}
+// Append data into an existed file.
 void AppendToFile(const std::string &filename,
                   const void *src,
                   size_t byte_size) {
@@ -571,7 +582,7 @@ void SaveModelNaive(const std::string &model_file,
   const std::string prog_path = model_file + ".nb";
   // Save meta_version(uint16) into file
   uint16_t meta_version = 1;
-  fbs::SaveFile(prog_path, &meta_version, sizeof(uint16_t));
+  WriteToFile(prog_path, &meta_version, sizeof(uint16_t));
 
   // Save lite_version(char[16]) into file
   const int paddle_version_length = 16 * sizeof(char);

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -606,7 +606,7 @@ void SaveModelNaive(const std::string &model_file,
 
   LOG(INFO) << "Save naive buffer model in '" << prog_path << " successfully";
 }
-
+#endif  // LITE_ON_TINY_PUBLISH
 template <typename T>
 void SetTensorDataNaive(T *out, size_t size, const std::vector<T> &src) {
   CHECK(out);

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -23,12 +23,12 @@
 #include "lite/core/variable.h"
 #include "lite/core/version.h"
 #include "lite/model_parser/base/apis.h"
+#include "lite/model_parser/flatbuffers/io.h"
 #include "lite/model_parser/naive_buffer/combined_params_desc.h"
 #include "lite/model_parser/naive_buffer/param_desc.h"
 #include "lite/model_parser/naive_buffer/program_desc.h"
 #include "lite/model_parser/naive_buffer/var_desc.h"
 #ifndef LITE_ON_TINY_PUBLISH
-#include "lite/model_parser/flatbuffers/io.h"
 #include "lite/model_parser/pb/program_desc.h"
 #include "lite/model_parser/pb/var_desc.h"
 #endif

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -1057,12 +1057,12 @@ void LoadModelNaiveV1FromMemory(const std::string &model_buffer,
   std::vector<char> prog_data(prog_size);
   memcpy(prog_data.data(), model_buffer.c_str() + offset, prog_size);
 #ifdef LITE_ON_FLATBUFFERS_DESC_VIEW
-  cpp_prog->Init(fbs::LoadFile(prog_path));
+  cpp_prog->Init(prog_data);
 #elif LITE_ON_TINY_PUBLISH
   LOG(FATAL) << "Since no data structure of Flatbuffers has been constructed, "
                 "the model cannot be loaded.";
 #else
-  fbs::ProgramDesc program(fbs::LoadFile(prog_path));
+  fbs::ProgramDesc program(prog_data);
   TransformProgramDescAnyToCpp(program, cpp_prog);
 #endif
   offset = offset + prog_size;

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -856,7 +856,7 @@ void LoadModelNaiveFromFile(const std::string &filename,
       LoadModelFbsFromFile(filename, scope, cpp_prog);
       break;
     default:
-      LOG(ERROR) << "Error, this model file is not supported.";
+      LOG(FATAL) << "Error, this model file is not supported.";
       break;
   }
 }
@@ -960,13 +960,10 @@ void LoadModelFbsFromFile(const std::string &filename,
 #endif
   offset = offset + topo_size;
 
-  /* 2. Save scope with params.fbs */
+  /* 2. Load scope from params.fbs */
   fbs::CombinedParamsDescView params(fbs::LoadFile(filename, offset));
   fbs::SetScopeWithCombinedParams(scope, params);
 
-  auto data = fbs::LoadFile(filename, offset);
-  LOG(INFO) << "Params data:" << int(data[0]) << ","
-            << int(data[data.size() - 1]);
   VLOG(4) << "Load naive buffer model in '" << filename << "' successfully";
 }
 
@@ -1003,7 +1000,7 @@ void LoadModelNaiveFromMemory(const std::string &model_buffer,
       LoadModelNaiveV1FromMemory(model_buffer, scope, cpp_prog);
       break;
     default:
-      LOG(ERROR) << "Error: Unsupported model type.";
+      LOG(FATAL) << "Error: Unsupported model type.";
       break;
   }
 }

--- a/lite/model_parser/model_parser.h
+++ b/lite/model_parser/model_parser.h
@@ -35,6 +35,16 @@ namespace lite {
 std::unique_ptr<framework::proto::ProgramDesc> LoadProgram(
     const std::string& path, bool program_from_memory = false);
 
+template <typename T>
+void ReadModelDataFromFile(T* data,
+                           const std::string& prog_path,
+                           uint64_t* offset,
+                           const uint64_t& size);
+
+void AppendToFile(const std::string& filename,
+                  const void* src,
+                  size_t byte_size);
+
 // Read a single file containing all the parameters.
 void LoadParams(const std::string& path);
 
@@ -86,12 +96,7 @@ void SaveCombinedParamsNaive(const std::string& path,
 
 void SaveModelNaive(const std::string& model_dir,
                     const Scope& exec_scope,
-                    const cpp::ProgramDesc& cpp_prog,
-                    bool combined = true);
-
-void SaveModelFbs(const std::string& model_dir,
-                  const Scope& exec_scope,
-                  const cpp::ProgramDesc& cpp_prog);
+                    const cpp::ProgramDesc& cpp_prog);
 
 void LoadModelFbsFromFile(const std::string& filename,
                           Scope* scope,
@@ -108,6 +113,9 @@ void LoadModelNaive(const std::string& model_dir,
                     lite::Scope* scope,
                     cpp::ProgramDesc* prog,
                     bool combined = true);
+void LoadModelNaiveV0FromFile(const std::string& filename,
+                              Scope* scope,
+                              cpp::ProgramDesc* cpp_prog);
 void LoadModelNaiveFromFile(const std::string& filename,
                             lite::Scope* scope,
                             cpp::ProgramDesc* prog);
@@ -118,6 +126,15 @@ void LoadModelNaiveFromMemory(const std::string& model_buffer,
 void LoadModelNaiveFromMemory(const std::string& model_buffer,
                               lite::Scope* scope,
                               cpp::ProgramDesc* cpp_prog);
+void LoadModelNaiveV1FromMemory(const std::string& model_buffer,
+                                Scope* scope,
+                                cpp::ProgramDesc* cpp_prog);
 
+void LoadModelFbsFromMemory(const std::string& model_buffer,
+                            lite::Scope* scope,
+                            cpp::ProgramDesc* cpp_prog);
+void LoadModelNaiveV0FromMemory(const std::string& model_buffer,
+                                Scope* scope,
+                                cpp::ProgramDesc* cpp_prog);
 }  // namespace lite
 }  // namespace paddle

--- a/lite/model_parser/model_parser.h
+++ b/lite/model_parser/model_parser.h
@@ -101,11 +101,10 @@ void SaveModelNaive(const std::string& model_dir,
 void SaveModelFbs(const std::string& model_dir,
                   const Scope& exec_scope,
                   const cpp::ProgramDesc& cpp_prog);
-
+#endif  // LITE_ON_TINY_PUBLISH
 void LoadModelFbsFromFile(const std::string& filename,
                           Scope* scope,
                           cpp::ProgramDesc* cpp_prog);
->>>>>>> origin
 
 void LoadParamNaive(const std::string& path,
                     lite::Scope* scope,

--- a/lite/model_parser/model_parser.h
+++ b/lite/model_parser/model_parser.h
@@ -98,9 +98,6 @@ void SaveModelNaive(const std::string& model_dir,
                     const Scope& exec_scope,
                     const cpp::ProgramDesc& cpp_prog);
 
-void LoadModelFbsFromFile(const std::string& filename,
-                          Scope* scope,
-                          cpp::ProgramDesc* cpp_prog);
 #endif  // LITE_ON_TINY_PUBLISH
 
 void LoadParamNaive(const std::string& path,
@@ -113,6 +110,9 @@ void LoadModelNaive(const std::string& model_dir,
                     lite::Scope* scope,
                     cpp::ProgramDesc* prog,
                     bool combined = true);
+void LoadModelFbsFromFile(const std::string& filename,
+                          Scope* scope,
+                          cpp::ProgramDesc* cpp_prog);
 void LoadModelNaiveV0FromFile(const std::string& filename,
                               Scope* scope,
                               cpp::ProgramDesc* cpp_prog);

--- a/lite/model_parser/model_parser_test.cc
+++ b/lite/model_parser/model_parser_test.cc
@@ -21,7 +21,6 @@ DEFINE_string(model_dir, "", "");
 
 namespace paddle {
 namespace lite {
-
 TEST(ModelParser, LoadProgram) {
   CHECK(!FLAGS_model_dir.empty());
   auto program = LoadProgram(FLAGS_model_dir + "/__model__");
@@ -117,7 +116,7 @@ TEST(ModelParser, SaveModelNaive) {
   cpp::ProgramDesc prog;
   Scope scope;
   LoadModelPb(FLAGS_model_dir, "", "", &scope, &prog);
-  const std::string save_pb_model_path = FLAGS_model_dir + ".saved.naive";
+  const std::string save_pb_model_path = FLAGS_model_dir + ".saved";
   SaveModelNaive(save_pb_model_path, scope, prog);
 }
 
@@ -126,7 +125,7 @@ TEST(ModelParser, LoadModelNaiveFromFile) {
   cpp::ProgramDesc prog;
   Scope scope;
 
-  auto model_path = std::string(FLAGS_model_dir) + ".saved.naive.nb";
+  auto model_path = std::string(FLAGS_model_dir) + ".saved.nb";
   LoadModelNaiveFromFile(model_path, &scope, &prog);
 }
 
@@ -135,7 +134,7 @@ TEST(ModelParser, LoadModelNaiveFromMemory) {
   cpp::ProgramDesc prog;
   Scope scope;
 
-  auto model_path = std::string(FLAGS_model_dir) + ".saved.naive.nb";
+  auto model_path = std::string(FLAGS_model_dir) + ".saved.nb";
   std::string model_buffer = lite::ReadFile(model_path);
   LoadModelNaiveFromMemory(model_buffer, &scope, &prog);
 }


### PR DESCRIPTION
【背景描述】
Paddle-Lite 模型中的拓扑部分已(`__model__`）被修改为`flatbuffer`格式，该修改可有效降低模型体积和加载速度。模型转化(OPT)和加载相关逻辑需要更新。
【本PR工作】
1. opt工具将转化后的模型保存为新的`flatbuffer`格式，新的模型格式存储为`meta_version=1`
2. 预测库可以同时加载两种格式的模型，通过`meta_version` 判断加载方法。`meta_version=0`：老的加载方法，`meta_version=1`: 新的加载方法