### PR TITLE
[API] Refine tensor api.

### DIFF
--- a/docs/api_reference/cxx_api_doc.md
+++ b/docs/api_reference/cxx_api_doc.md
@@ -846,6 +846,43 @@ for (int i = 0; i < ShapeProduction(input_tensor->shape()); ++i) {
 返回类型：`T*`
 
 
+### `ShareExternalData(data, memory_size, target)`
+
+设置Tensor共享用户数据指针。注意：请保证数据指针在预测过程中处于有效状态。
+
+示例：
+
+```c++
+lite_api::CxxConfig config
+config.set_model_dir(FLAGS_model_dir);
+config.set_valid_places({
+  Place{TARGET(kX86), PRECISION(kFloat)},
+  Place{TARGET(kARM), PRECISION(kFloat)},
+});
+auto predictor = lite_api::CreatePaddlePredictor(config);
+auto inputs = predictor->GetInputNames();
+auto outputs = predictor->GetOutputNames();
+
+std::vector<float> external_data(100 * 100, 0);
+auto input_tensor = predictor->GetInputByName(inputs[0]);
+input_tensor->Resize(std::vector<int64_t>({100, 100}));
+size_t memory_size = external_data.size() * sizeof(float);
+
+input_tensor->ShareExternalData(static_cast<void*>(external_data.data()),
+                                memory_size,
+                                config.valid_places()[0].target);
+predictor->Run();
+```
+
+参数：
+
+- `data(void*)` - 外部数据指针，请确保在预测过程中数据处于有效状态
+- `memory_size(size_t)` - 外部数据所占字节大小
+- `target(TargetType)` - 目标设备硬件类型，即数据所处设备类型
+
+返回：`None`
+
+返回类型：`void`
 
 ### `SetLoD(lod)`
 
@@ -872,3 +909,42 @@ for (int i = 0; i < ShapeProduction(input_tensor->shape()); ++i) {
 返回：`Tensor`的LoD信息
 
 返回类型：`std::vector<std::vector<uint64_t>>`
+
+
+### `precision()`
+
+获取Tensor的精度信息
+
+参数：
+
+- `None`
+
+返回：`Tensor`的precision信息
+
+返回类型：`PrecisionType`
+
+
+### `SetPrecision(precision)`
+
+设置Tensor的精度信息
+
+参数：
+
+- `precision(PrecisionType)` - Tensor的precision信息
+
+返回：`None`
+
+返回类型：`void`
+
+
+### `target()`
+
+获取Tensor的数据所处设备信息
+
+参数：
+
+- `None`
+
+返回：`Tensor`的target信息
+
+返回类型：`TargetType`

--- a/docs/api_reference/cxx_api_doc.md
+++ b/docs/api_reference/cxx_api_doc.md
@@ -846,7 +846,7 @@ for (int i = 0; i < ShapeProduction(input_tensor->shape()); ++i) {
 返回类型：`T*`
 
 
-### `ShareExternalData(data, memory_size, target)`
+### `ShareExternalMemory(data, memory_size, target)`
 
 设置Tensor共享用户数据指针。注意：请保证数据指针在预测过程中处于有效状态。
 
@@ -868,9 +868,9 @@ auto input_tensor = predictor->GetInputByName(inputs[0]);
 input_tensor->Resize(std::vector<int64_t>({100, 100}));
 size_t memory_size = external_data.size() * sizeof(float);
 
-input_tensor->ShareExternalData(static_cast<void*>(external_data.data()),
-                                memory_size,
-                                config.valid_places()[0].target);
+input_tensor->ShareExternalMemory(static_cast<void*>(external_data.data()),
+                                  memory_size,
+                                  config.valid_places()[0].target);
 predictor->Run();
 ```
 

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -83,6 +83,14 @@ const T *Tensor::data() const {
   return ctensor(raw_tensor_)->data<T>();
 }
 
+void Tensor::ShareExternalData(void *data,
+                               size_t memory_size,
+                               TargetType target) {
+  auto buf =
+      std::make_shared<lite::Buffer>(lite::Buffer(data, target, memory_size));
+  tensor(raw_tensor_)->ResetBuffer(buf, memory_size);
+}
+
 template <typename T>
 T *Tensor::mutable_data(TargetType type) const {
   return tensor(raw_tensor_)->mutable_data<T>(type);
@@ -93,6 +101,7 @@ template const int8_t *Tensor::data<int8_t>() const;
 template const uint8_t *Tensor::data<uint8_t>() const;
 template const int64_t *Tensor::data<int64_t>() const;
 template const int32_t *Tensor::data<int32_t>() const;
+template const void *Tensor::data<void>() const;
 
 template int *Tensor::mutable_data(TargetType type) const;
 template float *Tensor::mutable_data(TargetType type) const;
@@ -197,6 +206,10 @@ PrecisionType Tensor::precision() const {
     CHECK(false) << "This tensor was not initialized.";
   }
   return precision;
+}
+
+void Tensor::SetPrecision(PrecisionType precision) {
+  tensor(raw_tensor_)->set_precision(precision);
 }
 
 lod_t Tensor::lod() const { return ctensor(raw_tensor_)->lod(); }

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -83,9 +83,9 @@ const T *Tensor::data() const {
   return ctensor(raw_tensor_)->data<T>();
 }
 
-void Tensor::ShareExternalData(void *data,
-                               size_t memory_size,
-                               TargetType target) {
+void Tensor::ShareExternalMemory(void *data,
+                                 size_t memory_size,
+                                 TargetType target) {
   auto buf =
       std::make_shared<lite::Buffer>(lite::Buffer(data, target, memory_size));
   tensor(raw_tensor_)->ResetBuffer(buf, memory_size);

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -49,6 +49,10 @@ struct LITE_API Tensor {
   template <typename T>
   T* mutable_data(TargetType type = TargetType::kHost) const;
 
+  // Share external data. Note: ensure that the data pointer is in a valid state
+  // during the prediction process.
+  void ShareExternalData(void* data, size_t memory_size, TargetType target);
+
   template <typename T, TargetType type = TargetType::kHost>
   void CopyFromCpu(const T* data);
 
@@ -58,6 +62,7 @@ struct LITE_API Tensor {
   shape_t shape() const;
   TargetType target() const;
   PrecisionType precision() const;
+  void SetPrecision(PrecisionType precision);
 
   // LoD of the tensor
   lod_t lod() const;
@@ -153,7 +158,7 @@ class LITE_API ConfigBase {
   }
   // set Device ID
   void set_device_id(int device_id) { device_id_ = device_id; }
-  const int get_device_id() const { return device_id_; }
+  int get_device_id() const { return device_id_; }
 };
 
 /// CxxConfig is the config for the Full feature predictor.

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -49,9 +49,10 @@ struct LITE_API Tensor {
   template <typename T>
   T* mutable_data(TargetType type = TargetType::kHost) const;
 
-  // Share external data. Note: ensure that the data pointer is in a valid state
+  // Share external memory. Note: ensure that the data pointer is in a valid
+  // state
   // during the prediction process.
-  void ShareExternalData(void* data, size_t memory_size, TargetType target);
+  void ShareExternalMemory(void* data, size_t memory_size, TargetType target);
 
   template <typename T, TargetType type = TargetType::kHost>
   void CopyFromCpu(const T* data);

--- a/lite/api/paddle_api_test.cc
+++ b/lite/api/paddle_api_test.cc
@@ -89,9 +89,9 @@ TEST(CxxApi, share_external_data) {
   auto input_tensor = predictor->GetInputByName(inputs[0]);
   input_tensor->Resize(std::vector<int64_t>({100, 100}));
   size_t memory_size = 100 * 100 * sizeof(float);
-  input_tensor->ShareExternalData(static_cast<void*>(external_data.data()),
-                                  memory_size,
-                                  config.valid_places()[0].target);
+  input_tensor->ShareExternalMemory(static_cast<void*>(external_data.data()),
+                                    memory_size,
+                                    config.valid_places()[0].target);
 
   predictor->Run();
 


### PR DESCRIPTION
新增 tensor api. lite子图中，支持zero_copy，需要在tensor中增加ShareExternalData方法

- add SetPrecision
- add ShareExternalData

![image](https://user-images.githubusercontent.com/26377421/92075487-2c076100-edeb-11ea-920e-eb27ac1ea58a.png)