### PR TITLE
Add BF16 to framework.proto

### DIFF
--- a/lite/core/framework.proto
+++ b/lite/core/framework.proto
@@ -115,6 +115,7 @@ message VarType {
     SIZE_T = 19;
     UINT8 = 20;
     INT8 = 21;
+    BF16 = 22;
 
     // Other types that may need additional descriptions
     LOD_TENSOR = 7;


### PR DESCRIPTION
This PR adds **BF16** to `framework.proto` file.  
It is related to https://github.com/PaddlePaddle/Paddle/pull/25402 PR that also adds **BF16** to `framework.proto` to Paddle.

In Paddles PR there was a problem in building  Paddle with Paddle-Lite. It seems that the Paddle-Lite proto files have priority over the Paddle ones what cause that **BF16** is not visible. 

This is a tested workaround that resolves that problem that was  mentioned in this comment:
https://github.com/PaddlePaddle/Paddle/pull/25402#issuecomment-684514106