### PR TITLE
[BugFix][PASS] Handle layout cast when input place is <host, float, ImageDefault, 0>. test=develop

### DIFF
--- a/lite/core/mir/type_layout_cast_pass.cc
+++ b/lite/core/mir/type_layout_cast_pass.cc
@@ -83,7 +83,8 @@ void TypeLayoutTransformPass::ComplementInputs(SSAGraph* graph,
   // static_pick_kernel_pass
   // to this pass.
   auto* in_arg_type = const_cast<Type*>(in->AsArg().type);
-  if (in_arg_type->target() == TARGET(kARM) &&
+  if ((in_arg_type->target() == TARGET(kARM) ||
+       in_arg_type->target() == TARGET(kHost)) &&
       in_arg_type->layout() == DATALAYOUT(kImageDefault)) {
     return;
   }

--- a/lite/core/mir/type_layout_cast_pass.cc
+++ b/lite/core/mir/type_layout_cast_pass.cc
@@ -83,8 +83,7 @@ void TypeLayoutTransformPass::ComplementInputs(SSAGraph* graph,
   // static_pick_kernel_pass
   // to this pass.
   auto* in_arg_type = const_cast<Type*>(in->AsArg().type);
-  if ((in_arg_type->target() == TARGET(kARM) ||
-       in_arg_type->target() == TARGET(kHost)) &&
+  if (in_arg_type->target() == TARGET(kARM) &&
       in_arg_type->layout() == DATALAYOUT(kImageDefault)) {
     return;
   }

--- a/lite/kernels/host/CMakeLists.txt
+++ b/lite/kernels/host/CMakeLists.txt
@@ -25,6 +25,7 @@ add_kernel(conditional_block_compute_host Host extra SRCS conditional_block_comp
 add_kernel(activation_grad_compute_host Host train SRCS activation_grad_compute.cc DEPS ${lite_kernel_deps})
 add_kernel(pixel_shuffle_compute_host Host extra SRCS pixel_shuffle_compute.cc DEPS ${lite_kernel_deps})
 add_kernel(one_hot_compute_host Host extra SRCS one_hot_compute.cc DEPS ${lite_kernel_deps})
+add_kernel(layout_compute_host Host basic SRCS layout_compute.cc DEPS ${lite_kernel_deps})
 
 if(LITE_BUILD_EXTRA AND LITE_WITH_x86)
   lite_cc_test(test_where_index_compute_host SRCS where_index_compute.cc DEPS where_index_compute_host)

--- a/lite/kernels/host/layout_compute.cc
+++ b/lite/kernels/host/layout_compute.cc
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/host/layout_compute.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <>
+void ImageToNCHWCompute<PRECISION(kFloat)>::Run() {
+  LOG(INFO) << "image -> nchw on host";
+}
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+typedef paddle::lite::kernels::host::ImageToNCHWCompute<PRECISION(kFloat)>
+    Image_fp32;
+
+REGISTER_LITE_KERNEL(
+    layout_once, kHost, kFloat, kNCHW, Image_fp32, fp32_image2nchw)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kFloat),
+                                      DATALAYOUT(kImageDefault))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost),
+                                       PRECISION(kFloat),
+                                       DATALAYOUT(kNCHW))})
+    .Finalize();

--- a/lite/kernels/host/layout_compute.h
+++ b/lite/kernels/host/layout_compute.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <PrecisionType Ptype>
+class ImageToNCHWCompute : public KernelLite<TARGET(kHost), Ptype> {
+ public:
+  using param_t = operators::LayoutParam;
+  void Run() override;
+  virtual ~ImageToNCHWCompute() = default;
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle


### PR DESCRIPTION
问题：模型转换报错，/lite/core/mir/type_layout_cast_pass.cc:169 AddLayoutInst] Check failed: is_found: Can't find a layout kernel for layout op: Tensor<host,float,ImageDefault,0>:box_coder_0.tmp_0/target_trans->Tensor<host,float,NCHW,0>:multiclass_nms
当输入 tensor 的 place 是`<host, float, ImageDefault, 0>`时，说明数据已经在 host 端，无需再进行 layout的转换（ImageDefault -> NCHW）。

下图是当不加入该patch时，在 opt 模型转换环节会报错；加入该patch后，执行逻辑变为图中橙色线，可以正常进行模型转换，且预测结果正确。
![image](https://user-images.githubusercontent.com/24290792/91859771-69f66f00-ec9d-11ea-976b-7cdbab201468.png)

