### PR TITLE
[BugFix][OpenCL] Fix concat image impl when axis is not 1. test=develop

### DIFF
--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -45,11 +45,6 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
 
     auto inputs = concat_param_->x;
     auto output_tensor_dims = concat_param_->output->dims();
-    auto* axis_tensor = concat_param_->axis_tensor;
-    if (axis_tensor != nullptr) {
-      // auto* axis_tensor_data = axis_tensor->data<int>(TARGET(kARM));
-      // axis = axis_tensor_data[0];
-    }
 
     if (inputs.size() == 2) {
       kernel_func_name_ = "concat2";
@@ -115,17 +110,12 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
     auto input0_tensor_dims = inputs[0]->dims();
     for (int i = 1; i < inputs.size(); i++) {
       auto dims = inputs[i]->dims();
-      if (input0_tensor_dims.size() != dims.size()) {
-        LOG(FATAL) << "All inputs must have the same axes.";
-        return;
-      }
+      CHECK(input0_tensor_dims.size() != dims.size())
+          << "All inputs must have the same axes!";
       for (int i = 0; i < dims.size(); i++) {
         if (i != axis_) {
-          if (input0_tensor_dims[i] != dims[i]) {
-            LOG(FATAL) << "All inputs must have the same shape,"
-                          "except at concat axis.";
-            return;
-          }
+          CHECK(input0_tensor_dims[i] != dims[i])
+              << "All inputs must have the same shape, except at concat axis!";
         }
       }
     }
@@ -153,29 +143,18 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
     VLOG(4) << "concat input shape:  ";
     for (size_t i = 0; i < inputs.size(); i++) {
       VLOG(4) << "inputs [" << i << "]"
-              << "[" << inputs[i]->dims().size() << "D]:"
-              << "   dims:" << inputs[i]->dims()[0] << " "
-              << inputs[i]->dims()[1] << " " << inputs[i]->dims()[2] << " "
-              << inputs[i]->dims()[3];
+              << "   dims:" << inputs[i]->dims();
     }
 
     VLOG(4) << "concat output shape:  ";
-    VLOG(4) << " out  dims:  "
-            << "[" << output_tensor_dims.size()
-            << "D]:" << output_tensor_dims[0] << " " << output_tensor_dims[1]
-            << " " << output_tensor_dims[2] << " " << output_tensor_dims[3];
+    VLOG(4) << " out  dims:  " << output_tensor_dims;
     VLOG(4) << "axis_: " << axis_;
     VLOG(4) << "flag_: " << flag_;
 
     VLOG(4) << TargetToStr(concat_param_->output->target());
-    VLOG(4) << "output_image_shape(w,h):" << output_image_shape["width"] << " "
+    VLOG(4) << "output_image_shape(w,h): " << output_image_shape["width"] << " "
             << output_image_shape["height"];
-    VLOG(4) << "output_tensor_dims[" << output_tensor_dims.size()
-            << "D]:" << output_tensor_dims[0] << " " << output_tensor_dims[1]
-            << " " << output_tensor_dims[2] << " " << output_tensor_dims[3]
-            << "output_tensor_dims[output_tensor_dims.size() - 1]"
-            << output_tensor_dims[output_tensor_dims.size() - 1];
-    VLOG(4) << "output_tensor_w: " << output_tensor_w << ", flag_: " << flag_;
+    VLOG(4) << "output_tensor_w: " << output_tensor_w;
     VLOG(4) << "width_:" << width_;
     VLOG(4) << "global_work_size: "
             << output_tensor_dims[output_tensor_dims.size() - 1] << "  "

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -39,6 +39,9 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
     auto& context = ctx_->As<OpenCLContext>();
     concat_param_ = param_.get_mutable<param_t>();
     axis_ = concat_param_->axis;
+    if (-1 == axis_) {
+      axis_ = concat_param_->x[0]->dims().size() - 1;
+    }
 
     auto inputs = concat_param_->x;
     auto output_tensor_dims = concat_param_->output->dims();
@@ -100,8 +103,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
           width_ = output_tensor_dims[0];  // n
           flag_ = 2;
           break;
-        case 3:
-        case -1:                           // width
+        case 3:                            // width
           width_ = output_tensor_dims[1];  // c
           flag_ = 3;
           break;
@@ -110,9 +112,6 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       }
     }
 
-    if (-1 == axis_) {
-      axis_ = concat_param_->output->dims().size() - 1;
-    }
     auto input0_tensor_dims = inputs[0]->dims();
     for (int i = 1; i < inputs.size(); i++) {
       auto dims = inputs[i]->dims();

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -38,9 +38,9 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
   void PrepareForRun() override {
     auto& context = ctx_->As<OpenCLContext>();
     concat_param_ = param_.get_mutable<param_t>();
+    axis_ = concat_param_->axis;
 
     auto inputs = concat_param_->x;
-    auto axis_ = concat_param_->axis;
     auto output_tensor_dims = concat_param_->output->dims();
     auto* axis_tensor = concat_param_->axis_tensor;
     if (axis_tensor != nullptr) {
@@ -433,6 +433,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
   }
 #endif
 
+ private:
   int axis_ = 1;
   int flag_ = 1;
   int width_ = 1;

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -110,11 +110,11 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
     auto input0_tensor_dims = inputs[0]->dims();
     for (int i = 1; i < inputs.size(); i++) {
       auto dims = inputs[i]->dims();
-      CHECK(input0_tensor_dims.size() != dims.size())
+      CHECK(input0_tensor_dims.size() == dims.size())
           << "All inputs must have the same axes!";
       for (int i = 0; i < dims.size(); i++) {
         if (i != axis_) {
-          CHECK(input0_tensor_dims[i] != dims[i])
+          CHECK(input0_tensor_dims[i] == dims[i])
               << "All inputs must have the same shape, except at concat axis!";
         }
       }

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -122,7 +122,8 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       for (int i = 0; i < dims.size(); i++) {
         if (i != axis_) {
           if (input0_tensor_dims[i] != dims[i]) {
-            LOG(FATAL) << "All inputs must have the same shape, except at concat axis.";
+            LOG(FATAL) << "All inputs must have the same shape,"
+                          "except at concat axis.";
             return;
           }
         }

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -110,18 +110,20 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       }
     }
 
+    if (-1 == axis_) {
+      axis_ = concat_param_->output->dims().size() - 1;
+    }
     auto input0_tensor_dims = inputs[0]->dims();
     for (int i = 1; i < inputs.size(); i++) {
       auto dims = inputs[i]->dims();
-      // auto flag = CHECK_EQ_OR_FALSE(input0_tensor_dims.size(), dims.size());
       if (input0_tensor_dims.size() != dims.size()) {
-        printf("input shape must be same \n");
+        LOG(FATAL) << "All inputs must have the same axes.";
         return;
       }
       for (int i = 0; i < dims.size(); i++) {
         if (i != axis_) {
           if (input0_tensor_dims[i] != dims[i]) {
-            printf("input shape must be same \n");
+            LOG(FATAL) << "All inputs must have the same shape, except at concat axis.";
             return;
           }
         }


### PR DESCRIPTION
【问题1】当 concat 的 axis 不为 1 时，opencl concat image 实现计算错误。
【原因】在成员函数`PrepareForRun`中定义了一个临时变量`axis_`（该临时变量与类的成员变量`axis_`重名），在`PrepareForRun`中对临时变量的赋值并不会传递到成员函数`Run`中，因此在`Run`中读取的`axis_`值恒为默认值。
【解决方法】删除成员函数`PrepareForRun`中对`axis_`的定义，改为直接对成员变量`axis_`赋值。

【问题2】当 concat 的 axis 为 -1 时，opencl concat image 实现计算错误且有内存越界现象。
【原因】当 axis==-1时，需要对其进行转换。
【解决方法】将 axis 置为 output 的最后一个 axis。

【其他】修改了输出debug信息时存在的内存越界访问。