### PR TITLE
[Memory] Reuse tensor memory in concat operator

### DIFF
--- a/lite/core/mir/memory_optimize_pass.cc
+++ b/lite/core/mir/memory_optimize_pass.cc
@@ -47,7 +47,6 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
                                             "merge_lod_tensor",
                                             "equal",
                                             "lod_reset",
-                                            "concat",
                                             "yolo_box",
                                             "subgraph",
                                             "feed",


### PR DESCRIPTION
【问题描述】
发现内存复用`memory_optimize_pass`实现中，剔除了`concat`及其周边`tensor` ，导致如果模型中有较多`concat` 算子时，运行时内存过大。
【本PR工作】
`opt` 优化模型时会将`concat` 算子内的`tensor`也进行内存复用
【效果】
![image](https://user-images.githubusercontent.com/45189361/92078698-48a69780-edf1-11ea-8b92-e39da280b04e.png)
