### PR TITLE
[NPU] Disable scale_activation_fuse_pass which causes the wrong result in yolov3_mobilenetv3

### DIFF
--- a/lite/core/mir/fusion/scale_activation_fuse_pass.cc
+++ b/lite/core/mir/fusion/scale_activation_fuse_pass.cc
@@ -36,5 +36,9 @@ void ScaleActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 REGISTER_MIR_PASS(lite_scale_activation_fuse_pass,
                   paddle::lite::mir::ScaleActivationFusePass)
     .BindTargets({TARGET(kARM)})
-    .ExcludeTargets({TARGET(kNPU)})
+    .ExcludeTargets({TARGET(kNPU),
+                     TARGET(kXPU),
+                     TARGET(kRKNPU),
+                     TARGET(kAPU),
+                     TARGET(kHuaweiAscendNPU)})
     .BindKernel("scale");

--- a/lite/core/mir/fusion/scale_activation_fuse_pass.cc
+++ b/lite/core/mir/fusion/scale_activation_fuse_pass.cc
@@ -36,4 +36,5 @@ void ScaleActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 REGISTER_MIR_PASS(lite_scale_activation_fuse_pass,
                   paddle::lite::mir::ScaleActivationFusePass)
     .BindTargets({TARGET(kARM)})
+    .ExcludeTargets({TARGET(kNPU)})
     .BindKernel("scale");


### PR DESCRIPTION
由于NPU scale op bridge 没有考虑leaky_relu fusion的情况，导致NPU跑mobilenetv3存在结果错误的问题。