### PR TITLE
fix constexpr definitions bug in class, test=develop

### DIFF
--- a/lite/model_parser/base/traits.h
+++ b/lite/model_parser/base/traits.h
@@ -119,22 +119,30 @@ class VectorView;
 template <typename T, typename U = Standard>
 struct OpDataTypeTrait;
 
-#define ATTR_TYPE_TRAIT_IMPL(T, type__)             \
-  template <typename U>                             \
-  struct OpDataTypeTrait<type__, U> {               \
-    typedef type__ ET;                              \
-    typedef type__ RT;                              \
-    static constexpr OpAttrType AT = OpAttrType::T; \
-    static constexpr const char* ATN = #T;          \
-  };
-#define ATTR_VECTOR_TYPE_TRAIT_IMPL(T, type__)      \
-  template <typename U>                             \
-  struct OpDataTypeTrait<std::vector<type__>, U> {  \
-    typedef type__ ET;                              \
-    typedef VectorView<type__, U> RT;               \
-    static constexpr OpAttrType AT = OpAttrType::T; \
-    static constexpr const char* ATN = #T;          \
-  };
+#define ATTR_TYPE_TRAIT_IMPL(T, type__)                \
+  template <typename U>                                \
+  struct OpDataTypeTrait<type__, U> {                  \
+    typedef type__ ET;                                 \
+    typedef type__ RT;                                 \
+    static constexpr OpAttrType AT{OpAttrType::T};     \
+    static constexpr const char* ATN{#T};              \
+  };                                                   \
+  template <typename U>                                \
+  constexpr OpAttrType OpDataTypeTrait<type__, U>::AT; \
+  template <typename U>                                \
+  constexpr const char* OpDataTypeTrait<type__, U>::ATN;
+#define ATTR_VECTOR_TYPE_TRAIT_IMPL(T, type__)                      \
+  template <typename U>                                             \
+  struct OpDataTypeTrait<std::vector<type__>, U> {                  \
+    typedef type__ ET;                                              \
+    typedef VectorView<type__, U> RT;                               \
+    static constexpr OpAttrType AT{OpAttrType::T};                  \
+    static constexpr const char* ATN{#T};                           \
+  };                                                                \
+  template <typename U>                                             \
+  constexpr OpAttrType OpDataTypeTrait<std::vector<type__>, U>::AT; \
+  template <typename U>                                             \
+  constexpr const char* OpDataTypeTrait<std::vector<type__>, U>::ATN;
 
 ATTR_TYPE_TRAIT_IMPL(BLOCK, int16_t);
 ATTR_TYPE_TRAIT_IMPL(INT, int32_t);


### PR DESCRIPTION
<img width="773" alt="3b5bc4e4b586b77da3c3d8ec24ae556f" src="https://user-images.githubusercontent.com/39303645/92596111-e14c8400-f2d7-11ea-9e45-3e58336cd816.png">

C++ 11 规定：当 `static constexpr` 出现在类内时，可用字面常量初始化声明；但必须在类外进行一次不带赋值的定义，否则在选择不同优化选项时，编译器可能找不到变量定义。此提交修复了这个问题。