### PR TITLE
[Core] Adjust the file path of subgraph_bridge_registry and subgraph_engine_base

### DIFF
--- a/lite/core/CMakeLists.txt
+++ b/lite/core/CMakeLists.txt
@@ -142,6 +142,15 @@ if (NOT LITE_ON_TINY_PUBLISH)
   add_subdirectory(arena)
 endif()
 
+if(LITE_WITH_NPU OR LITE_WITH_XTCL OR LITE_WITH_BM OR LITE_WITH_RKNPU OR LITE_WITH_MLU OR LITE_WITH_APU OR LITE_WITH_HUAWEI_ASCEND_NPU)
+    lite_cc_library(subgraph_bridge_registry
+      SRCS subgraph_bridge_registry.cc
+      DEPS op)
+   lite_cc_library(subgraph_engine_base
+      SRCS subgraph_engine_base.cc
+      DEPS tensor op scope program)
+endif()
+
 # for mobile, unnecessary to compile the following testings.
 if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK)
     return()

--- a/lite/core/subgraph_bridge_registry.cc
+++ b/lite/core/subgraph_bridge_registry.cc
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include <utility>
 
 namespace paddle {
 namespace lite {
 namespace subgraph {
 
-Registry& Registry::Instance() {
-  static Registry x;
+SubgraphBridgeRegistry& SubgraphBridgeRegistry::Instance() {
+  static SubgraphBridgeRegistry x;
   return x;
 }
 
-void Registry::Insert(const std::string& op_type,
-                      const TargetType& target,
-                      const cvt_func_type& cvt_func_name) {
+void SubgraphBridgeRegistry::Insert(const std::string& op_type,
+                                    const TargetType& target,
+                                    const cvt_func_type& cvt_func_name) {
   int key = static_cast<int>(target);
   auto it = map_.find(key);
   if (it == map_.end()) {
@@ -35,14 +35,14 @@ void Registry::Insert(const std::string& op_type,
   map_.at(key).insert(std::make_pair(op_type, cvt_func_name));
 }
 
-const cvt_func_type& Registry::Select(const std::string& op_type,
-                                      const TargetType& target) const {
+const cvt_func_type& SubgraphBridgeRegistry::Select(
+    const std::string& op_type, const TargetType& target) const {
   int key = static_cast<int>(target);
   return map_.at(key).at(op_type);
 }
 
-bool Registry::Exists(const std::string& op_type,
-                      const TargetType& target) const {
+bool SubgraphBridgeRegistry::Exists(const std::string& op_type,
+                                    const TargetType& target) const {
   int key = static_cast<int>(target);
   bool found = map_.find(key) != map_.end();
   if (found) {

--- a/lite/core/subgraph_bridge_registry.h
+++ b/lite/core/subgraph_bridge_registry.h
@@ -36,9 +36,9 @@ inline bool CHECK_REBUILD_WHEN_SHAPE_CHANGED(int status) {
 using cvt_func_type =
     std::function<int(void* ctx, OpLite* op, KernelBase* kernel)>;
 using cvt_map_type = std::map<int, std::map<std::string, cvt_func_type>>;
-class Registry {
+class SubgraphBridgeRegistry {
  public:
-  static Registry& Instance();
+  static SubgraphBridgeRegistry& Instance();
 
   void Insert(const std::string& op_type,
               const TargetType& target,
@@ -46,11 +46,11 @@ class Registry {
   const cvt_func_type& Select(const std::string& op_type,
                               const TargetType& target) const;
   bool Exists(const std::string& op_type, const TargetType& target) const;
-  Registry() = default;
+  SubgraphBridgeRegistry() = default;
 
  private:
   cvt_map_type map_;
-  DISALLOW_COPY_AND_ASSIGN(Registry);
+  DISALLOW_COPY_AND_ASSIGN(SubgraphBridgeRegistry);
 };
 
 }  // namespace subgraph
@@ -69,7 +69,7 @@ class Registry {
       "REGISTER_SUBGRAPH_BRIDGE must be called in global namespace only " \
       "once!");                                                           \
   int __reg_subgraph_bridge_##op_type__##_##target__##_Insert() {         \
-    paddle::lite::subgraph::Registry::Instance().Insert(                  \
+    paddle::lite::subgraph::SubgraphBridgeRegistry::Instance().Insert(    \
         #op_type__, TARGET(target__), cvt_func_name);                     \
     return 0;                                                             \
   }

--- a/lite/core/subgraph_engine_base.h
+++ b/lite/core/subgraph_engine_base.h
@@ -26,20 +26,21 @@ namespace paddle {
 namespace lite {
 namespace subgraph {
 
-class Engine {
+class SubgraphEngineBase {
  public:
-  Engine(KernelContext *ctx,
-         int block_idx,
-         const std::shared_ptr<const cpp::ProgramDesc> &program_desc,
-         Scope *exec_scope,
-         const std::vector<std::string> &input_names,
-         const std::vector<std::string> &output_names);
-  virtual ~Engine() = default;
+  SubgraphEngineBase(
+      KernelContext *ctx,
+      int block_idx,
+      const std::shared_ptr<const cpp::ProgramDesc> &program_desc,
+      Scope *exec_scope,
+      const std::vector<std::string> &input_names,
+      const std::vector<std::string> &output_names);
+  virtual ~SubgraphEngineBase() = default;
 
   virtual bool Run();
 
  private:
-  Engine(const Engine &) = delete;
+  SubgraphEngineBase(const SubgraphEngineBase &) = delete;
 
  protected:
   virtual bool PrepareWorkspaceForOriginProgram();

--- a/lite/kernels/apu/CMakeLists.txt
+++ b/lite/kernels/apu/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory(bridges)
 
-add_kernel(subgraph_compute_apu APU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_apu neuron_adapter subgraph_bridge_engine ${apu_subgraph_bridges})
+add_kernel(subgraph_compute_apu APU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_apu neuron_adapter subgraph_engine_base ${apu_subgraph_bridges})

--- a/lite/kernels/apu/bridges/act_op.cc
+++ b/lite/kernels/apu/bridges/act_op.cc
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
+#include "lite/kernels/apu/bridges/graph.h"
 #include "lite/kernels/apu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/apu/bridges/conv_op.cc
+++ b/lite/kernels/apu/bridges/conv_op.cc
@@ -15,9 +15,9 @@
 #include "lite/operators/conv_op.h"
 #include <iostream>
 #include <vector>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/apu/bridges/graph.h"
 #include "lite/kernels/apu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/apu/bridges/elementwise_ops.cc
+++ b/lite/kernels/apu/bridges/elementwise_ops.cc
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/apu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/kernels/apu/bridges/utility.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/apu/bridges/fc_op.cc
+++ b/lite/kernels/apu/bridges/fc_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/apu/bridges/graph.h"
 #include "lite/kernels/apu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/apu/bridges/pool_op.cc
+++ b/lite/kernels/apu/bridges/pool_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "lite/operators/pool_op.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/apu/bridges/graph.h"
 #include "lite/kernels/apu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/apu/bridges/softmax_op.cc
+++ b/lite/kernels/apu/bridges/softmax_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/apu/bridges/graph.h"
 #include "lite/kernels/apu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/apu/subgraph_compute.cc
+++ b/lite/kernels/apu/subgraph_compute.cc
@@ -50,7 +50,7 @@ bool SubgraphEngine::BuildDeviceProgram() {
 
   // Convert all of ops and their input vars and weights and added into the APU
   // NIR graph
-  const auto& bridges = subgraph::Registry::Instance();
+  const auto& bridges = subgraph::SubgraphBridgeRegistry::Instance();
   const auto& insts = origin_program_->instructions(kRootBlockIdx);
   for (auto& inst : insts) {
     auto op = const_cast<OpLite*>(inst.op());

--- a/lite/kernels/apu/subgraph_compute.h
+++ b/lite/kernels/apu/subgraph_compute.h
@@ -19,15 +19,15 @@
 #include <vector>
 #include "NeuronAdapter.h"
 #include "lite/core/kernel.h"
-#include "lite/kernels/npu/bridges/engine.h"
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
+#include "lite/core/subgraph_engine_base.h"
 
 namespace paddle {
 namespace lite {
 namespace kernels {
 namespace apu {
 
-class SubgraphEngine : public subgraph::Engine {
+class SubgraphEngine : public subgraph::SubgraphEngineBase {
  public:
   SubgraphEngine(KernelContext *ctx,
                  int block_idx,
@@ -35,12 +35,12 @@ class SubgraphEngine : public subgraph::Engine {
                  Scope *exec_scope,
                  const std::vector<std::string> &input_names,
                  const std::vector<std::string> &output_names)
-      : subgraph::Engine(ctx,
-                         block_idx,
-                         program_desc,
-                         exec_scope,
-                         input_names,
-                         output_names) {}
+      : subgraph::SubgraphEngineBase(ctx,
+                                     block_idx,
+                                     program_desc,
+                                     exec_scope,
+                                     input_names,
+                                     output_names) {}
 
   ~SubgraphEngine();
 

--- a/lite/kernels/bm/CMakeLists.txt
+++ b/lite/kernels/bm/CMakeLists.txt
@@ -3,4 +3,4 @@ if(NOT LITE_WITH_BM)
 endif()
 
 add_subdirectory(bridges)
-add_kernel(subgraph_compute_bm BM basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} ${bm_subgraph_bridges})
+add_kernel(subgraph_compute_bm BM basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} subgraph_engine_base ${bm_subgraph_bridges})

--- a/lite/kernels/bm/bridges/CMakeLists.txt
+++ b/lite/kernels/bm/bridges/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 lite_cc_library(subgraph_bridge_utility_bm SRCS utility.cc DEPS)
 lite_cc_library(subgraph_bridge_graph_bm SRCS graph.cc DEPS subgraph_bridge_utility_bm)
 
-set(bm_subgraph_bridge_deps subgraph_bridge_registry subgraph_bridge_engine subgraph_bridge_utility_bm subgraph_bridge_graph_bm)
+set(bm_subgraph_bridge_deps subgraph_bridge_registry subgraph_bridge_utility_bm subgraph_bridge_graph_bm)
 
 lite_cc_library(subgraph_bridge_act_op_bm SRCS act_op.cc DEPS ${bm_subgraph_bridge_deps})
 lite_cc_library(subgraph_bridge_conv_op_bm SRCS conv_op.cc DEPS ${bm_subgraph_bridge_deps})
@@ -40,7 +40,6 @@ lite_cc_library(subgraph_bridge_swish_op_bm SRCS swish_op.cc DEPS ${bm_subgraph_
 
 set(bm_subgraph_bridges
         subgraph_bridge_registry
-        subgraph_bridge_engine
         subgraph_bridge_graph_bm
         subgraph_bridge_act_op_bm
         subgraph_bridge_conv_op_bm

--- a/lite/kernels/bm/bridges/act_op.cc
+++ b/lite/kernels/bm/bridges/act_op.cc
@@ -15,8 +15,8 @@
 #include <bmcompiler_if.h>
 #include <bmcompiler_if_lite.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/assign_value_op.cc
+++ b/lite/kernels/bm/bridges/assign_value_op.cc
@@ -15,9 +15,9 @@
 #include <bmcompiler_defs.h>
 #include <bmcompiler_if.h>
 #include <bmcompiler_if_lite.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/batch_norm_op.cc
+++ b/lite/kernels/bm/bridges/batch_norm_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_if.h>
 #include <math.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/box_coder_op.cc
+++ b/lite/kernels/bm/bridges/box_coder_op.cc
@@ -16,9 +16,9 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/cast_op.cc
+++ b/lite/kernels/bm/bridges/cast_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_defs.h>
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/concat_op.cc
+++ b/lite/kernels/bm/bridges/concat_op.cc
@@ -11,10 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/conv_op.cc
+++ b/lite/kernels/bm/bridges/conv_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/conv_transpose_op.cc
+++ b/lite/kernels/bm/bridges/conv_transpose_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/density_prior_box_op.cc
+++ b/lite/kernels/bm/bridges/density_prior_box_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_if.h>
 #include <math.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/dropout_op.cc
+++ b/lite/kernels/bm/bridges/dropout_op.cc
@@ -11,11 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <bmcompiler_if.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/elementwise_ops.cc
+++ b/lite/kernels/bm/bridges/elementwise_ops.cc
@@ -11,13 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <bmcompiler_defs.h>
 #include <bmcompiler_if.h>
 #include <bmcompiler_if_lite.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/fill_constant_op.cc
+++ b/lite/kernels/bm/bridges/fill_constant_op.cc
@@ -15,9 +15,9 @@
 #include <bmcompiler_defs.h>
 #include <bmcompiler_if.h>
 #include <bmcompiler_if_lite.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/interpolate_op.cc
+++ b/lite/kernels/bm/bridges/interpolate_op.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/matmul_op.cc
+++ b/lite/kernels/bm/bridges/matmul_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_if.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/mul_op.cc
+++ b/lite/kernels/bm/bridges/mul_op.cc
@@ -11,10 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/multiclass_nms_op.cc
+++ b/lite/kernels/bm/bridges/multiclass_nms_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_if.h>
 #include <user_bmcpu_common.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/norm_op.cc
+++ b/lite/kernels/bm/bridges/norm_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/pool_op.cc
+++ b/lite/kernels/bm/bridges/pool_op.cc
@@ -11,13 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <bmcompiler_defs.h>
 #include <bmcompiler_if.h>
 #include <bmcompiler_if_lite.h>
 #include <user_bmcpu_common.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/prior_box_op.cc
+++ b/lite/kernels/bm/bridges/prior_box_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/reduce_full_op.cc
+++ b/lite/kernels/bm/bridges/reduce_full_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_if.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/reshape_op.cc
+++ b/lite/kernels/bm/bridges/reshape_op.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/scale_op.cc
+++ b/lite/kernels/bm/bridges/scale_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_if.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/shape_op.cc
+++ b/lite/kernels/bm/bridges/shape_op.cc
@@ -15,9 +15,9 @@
 #include <bmcompiler_defs.h>
 #include <bmcompiler_if.h>
 #include <bmcompiler_if_lite.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/slice_op.cc
+++ b/lite/kernels/bm/bridges/slice_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_if.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/softmax_op.cc
+++ b/lite/kernels/bm/bridges/softmax_op.cc
@@ -11,10 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/split_op.cc
+++ b/lite/kernels/bm/bridges/split_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_if.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/squeeze_op.cc
+++ b/lite/kernels/bm/bridges/squeeze_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_if.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/swish_op.cc
+++ b/lite/kernels/bm/bridges/swish_op.cc
@@ -11,11 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <bmcompiler_if.h>
 #include <bmcompiler_op_code.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/transpose_op.cc
+++ b/lite/kernels/bm/bridges/transpose_op.cc
@@ -14,9 +14,9 @@
 
 #include <bmcompiler_defs.h>
 #include <bmcompiler_if.h>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/bridges/yolo_box_op.cc
+++ b/lite/kernels/bm/bridges/yolo_box_op.cc
@@ -17,9 +17,9 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/bm/bridges/graph.h"
 #include "lite/kernels/bm/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/bm/subgraph_compute.cc
+++ b/lite/kernels/bm/subgraph_compute.cc
@@ -31,7 +31,7 @@ namespace bm {
 bool SubgraphEngine::BuildDeviceProgram() {
   int status = 0;
   subgraph::bm::Graph graph;
-  const auto& bridges = subgraph::Registry::Instance();
+  const auto& bridges = subgraph::SubgraphBridgeRegistry::Instance();
   graph.CreateCompilerHandle();
   auto& ctx = this->ctx_->template As<BMContext>();
   for (size_t i = 0; i < input_names_.size(); i++) {

--- a/lite/kernels/bm/subgraph_compute.h
+++ b/lite/kernels/bm/subgraph_compute.h
@@ -23,16 +23,16 @@
 #include "lite/core/kernel.h"
 #include "lite/core/op_registry.h"
 #include "lite/core/program.h"
+#include "lite/core/subgraph_bridge_registry.h"
+#include "lite/core/subgraph_engine_base.h"
 #include "lite/core/types.h"
-#include "lite/kernels/npu/bridges/engine.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {
 namespace kernels {
 namespace bm {
 
-class SubgraphEngine : public subgraph::Engine {
+class SubgraphEngine : public subgraph::SubgraphEngineBase {
  public:
   SubgraphEngine(KernelContext *ctx,
                  int block_idx,
@@ -40,12 +40,12 @@ class SubgraphEngine : public subgraph::Engine {
                  Scope *exec_scope,
                  const std::vector<std::string> &input_names,
                  const std::vector<std::string> &output_names)
-      : subgraph::Engine(ctx,
-                         block_idx,
-                         program_desc,
-                         exec_scope,
-                         input_names,
-                         output_names) {}
+      : subgraph::SubgraphEngineBase(ctx,
+                                     block_idx,
+                                     program_desc,
+                                     exec_scope,
+                                     input_names,
+                                     output_names) {}
 
  protected:
   bool BuildDeviceProgram() override;

--- a/lite/kernels/huawei_ascend_npu/CMakeLists.txt
+++ b/lite/kernels/huawei_ascend_npu/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory(bridges)
 
-add_kernel(subgraph_compute_huawei_ascend_npu HUAWEI_ASCEND_NPU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_huawei_ascend_npu subgraph_bridge_engine ${huawei_ascend_npu_subgraph_bridges})
+add_kernel(subgraph_compute_huawei_ascend_npu HUAWEI_ASCEND_NPU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_huawei_ascend_npu subgraph_engine_base ${huawei_ascend_npu_subgraph_bridges})

--- a/lite/kernels/huawei_ascend_npu/bridges/CMakeLists.txt
+++ b/lite/kernels/huawei_ascend_npu/bridges/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 lite_cc_library(subgraph_bridge_utility_huawei_ascend_npu SRCS utility.cc DEPS)
 lite_cc_library(subgraph_bridge_graph_huawei_ascend_npu SRCS graph.cc DEPS subgraph_bridge_utility_huawei_ascend_npu)
 
-set(huawei_ascend_npu_subgraph_bridge_deps subgraph_bridge_registry subgraph_bridge_engine subgraph_bridge_utility_huawei_ascend_npu subgraph_bridge_graph_huawei_ascend_npu)
+set(huawei_ascend_npu_subgraph_bridge_deps subgraph_bridge_registry subgraph_bridge_utility_huawei_ascend_npu subgraph_bridge_graph_huawei_ascend_npu)
 
 lite_cc_library(subgraph_bridge_act_op_huawei_ascend_npu SRCS act_op.cc DEPS ${huawei_ascend_npu_subgraph_bridge_deps})
 lite_cc_library(subgraph_bridge_conv_op_huawei_ascend_npu SRCS conv_op.cc DEPS ${huawei_ascend_npu_subgraph_bridge_deps})
@@ -29,7 +29,6 @@ lite_cc_library(subgraph_bridge_gather_op_huawei_ascend_npu SRCS gather_op.cc DE
 
 set(huawei_ascend_npu_subgraph_bridges
         subgraph_bridge_registry
-        subgraph_bridge_engine
         subgraph_bridge_graph_huawei_ascend_npu
         subgraph_bridge_act_op_huawei_ascend_npu
         subgraph_bridge_conv_op_huawei_ascend_npu

--- a/lite/kernels/huawei_ascend_npu/bridges/act_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/act_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/batch_norm_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/batch_norm_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/cast_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/cast_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/concat_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/concat_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/conv_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/conv_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "lite/operators/conv_op.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/dropout_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/dropout_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/elementwise_ops.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/elementwise_ops.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/fc_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/fc_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/flatten_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/flatten_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/gather_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/gather_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/interpolate_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/interpolate_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // #include "lite/operators/interpolate_op.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/layer_norm_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/layer_norm_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/matmul_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/matmul_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/pool_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/pool_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "lite/operators/pool_op.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/reshape_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/reshape_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "lite/operators/reshape_op.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/scale_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/scale_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/slice_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/slice_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/softmax_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/softmax_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/bridges/transpose_op.cc
+++ b/lite/kernels/huawei_ascend_npu/bridges/transpose_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/graph.h"
 #include "lite/kernels/huawei_ascend_npu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/huawei_ascend_npu/subgraph_compute.cc
+++ b/lite/kernels/huawei_ascend_npu/subgraph_compute.cc
@@ -119,7 +119,7 @@ bool DeviceProgram::BuildGraphAndCacheToFile(
   // then added them into the IR graph
   int status = 0;
   subgraph::huawei_ascend_npu::Graph graph;
-  const auto& bridges = subgraph::Registry::Instance();
+  const auto& bridges = subgraph::SubgraphBridgeRegistry::Instance();
   CHECK(origin_program)
       << "[HUAWEI_ASCEND_NPU] The origin program is not initialized!";
   CHECK_GT(origin_program->instructions(kRootBlockIdx).size(), 0)

--- a/lite/kernels/huawei_ascend_npu/subgraph_compute.h
+++ b/lite/kernels/huawei_ascend_npu/subgraph_compute.h
@@ -21,8 +21,8 @@
 #include "graph/tensor.h"
 #include "lite/backends/huawei_ascend_npu/device.h"
 #include "lite/core/kernel.h"
-#include "lite/kernels/npu/bridges/engine.h"
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
+#include "lite/core/subgraph_engine_base.h"
 
 namespace paddle {
 namespace lite {
@@ -76,7 +76,7 @@ class DeviceProgram {
   std::vector<TensorDesc> device_odims_{};
 };
 
-class SubgraphEngine : public subgraph::Engine {
+class SubgraphEngine : public subgraph::SubgraphEngineBase {
  public:
   SubgraphEngine(KernelContext* ctx,
                  int block_idx,
@@ -84,12 +84,12 @@ class SubgraphEngine : public subgraph::Engine {
                  Scope* exec_scope,
                  const std::vector<std::string>& input_names,
                  const std::vector<std::string>& output_names)
-      : subgraph::Engine(ctx,
-                         block_idx,
-                         program_desc,
-                         exec_scope,
-                         input_names,
-                         output_names) {}
+      : subgraph::SubgraphEngineBase(ctx,
+                                     block_idx,
+                                     program_desc,
+                                     exec_scope,
+                                     input_names,
+                                     output_names) {}
 
  protected:
   bool PrepareWorkspaceForDeviceProgram() override;

--- a/lite/kernels/mlu/CMakeLists.txt
+++ b/lite/kernels/mlu/CMakeLists.txt
@@ -3,7 +3,7 @@ if(NOT LITE_WITH_MLU)
 endif()
 
 add_subdirectory(bridges)
-add_kernel(subgraph_compute_mlu MLU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} ${mlu_subgraph_bridges})
+add_kernel(subgraph_compute_mlu MLU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} subgraph_engine_base ${mlu_subgraph_bridges})
 add_kernel(io_copy_compute_mlu MLU basic SRCS io_copy_compute.cc DEPS ${lite_kernel_deps} ${target_wrapper_mlu})
 add_kernel(calib_compute_mlu MLU basic SRCS calib_compute.cc DEPS ${lite_kernel_deps})
 # depend on transpose function in backend/x86/math/math_function

--- a/lite/kernels/mlu/bridges/CMakeLists.txt
+++ b/lite/kernels/mlu/bridges/CMakeLists.txt
@@ -6,7 +6,7 @@ lite_cc_library(subgraph_bridge_utility_mlu SRCS utility.cc DEPS ${mlu_builder_l
 lite_cc_library(subgraph_bridge_tensor_mlu SRCS tensor.cc DEPS ${mlu_builder_libs} subgraph_bridge_utility_mlu)
 lite_cc_library(subgraph_bridge_graph_mlu SRCS graph.cc DEPS subgraph_bridge_utility_mlu subgraph_bridge_tensor_mlu)
 
-set(mlu_subgraph_bridge_deps subgraph_bridge_registry subgraph_bridge_engine subgraph_bridge_utility_mlu subgraph_bridge_graph_mlu)
+set(mlu_subgraph_bridge_deps subgraph_bridge_registry subgraph_bridge_utility_mlu subgraph_bridge_graph_mlu)
 
 lite_cc_library(subgraph_bridge_act_op_mlu SRCS act_op.cc DEPS ${mlu_subgraph_bridge_deps})
 lite_cc_library(subgraph_bridge_batch_norm_op_mlu SRCS batch_norm_op.cc DEPS ${mlu_subgraph_bridge_deps})

--- a/lite/kernels/mlu/bridges/act_op.cc
+++ b/lite/kernels/mlu/bridges/act_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/act_op_test.cc
+++ b/lite/kernels/mlu/bridges/act_op_test.cc
@@ -18,8 +18,8 @@
 
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/operators/activation_ops.h"
 
 namespace paddle {

--- a/lite/kernels/mlu/bridges/argmax_op.cc
+++ b/lite/kernels/mlu/bridges/argmax_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/argmax_op_test.cc
+++ b/lite/kernels/mlu/bridges/argmax_op_test.cc
@@ -20,9 +20,9 @@
 #include <iostream>
 
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 namespace paddle {
 namespace lite {
 namespace subgraph {

--- a/lite/kernels/mlu/bridges/batch_norm_op.cc
+++ b/lite/kernels/mlu/bridges/batch_norm_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/batch_norm_op_test.cc
+++ b/lite/kernels/mlu/bridges/batch_norm_op_test.cc
@@ -15,8 +15,8 @@
 #include "lite/operators/batch_norm_op.h"
 #include <gtest/gtest.h>
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/cast_op.cc
+++ b/lite/kernels/mlu/bridges/cast_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/cast_op_test.cc
+++ b/lite/kernels/mlu/bridges/cast_op_test.cc
@@ -16,9 +16,9 @@
 #include <gtest/gtest.h>
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/concat_op.cc
+++ b/lite/kernels/mlu/bridges/concat_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/concat_op_test.cc
+++ b/lite/kernels/mlu/bridges/concat_op_test.cc
@@ -17,8 +17,8 @@
 #include <random>
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/conv_op.cc
+++ b/lite/kernels/mlu/bridges/conv_op.cc
@@ -16,9 +16,9 @@
 
 #include <algorithm>
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/conv_op_test.cc
+++ b/lite/kernels/mlu/bridges/conv_op_test.cc
@@ -20,8 +20,8 @@
 
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/dropout_op.cc
+++ b/lite/kernels/mlu/bridges/dropout_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/dropout_op_test.cc
+++ b/lite/kernels/mlu/bridges/dropout_op_test.cc
@@ -16,8 +16,8 @@
 #include <gtest/gtest.h>
 #include <random>
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/elementwise_ops.cc
+++ b/lite/kernels/mlu/bridges/elementwise_ops.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/elementwise_ops_test.cc
+++ b/lite/kernels/mlu/bridges/elementwise_ops_test.cc
@@ -16,8 +16,8 @@
 #include <gtest/gtest.h>
 #include <random>
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/fc_op.cc
+++ b/lite/kernels/mlu/bridges/fc_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/fc_op_test.cc
+++ b/lite/kernels/mlu/bridges/fc_op_test.cc
@@ -16,8 +16,8 @@
 #include <gtest/gtest.h>
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/flatten_op.cc
+++ b/lite/kernels/mlu/bridges/flatten_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/flatten_op_test.cc
+++ b/lite/kernels/mlu/bridges/flatten_op_test.cc
@@ -19,8 +19,8 @@
 #include <random>
 
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/gather_op.cc
+++ b/lite/kernels/mlu/bridges/gather_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/gather_op_test.cc
+++ b/lite/kernels/mlu/bridges/gather_op_test.cc
@@ -16,9 +16,9 @@
 #include <gtest/gtest.h>
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/interpolate_op.cc
+++ b/lite/kernels/mlu/bridges/interpolate_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/interpolate_op_test.cc
+++ b/lite/kernels/mlu/bridges/interpolate_op_test.cc
@@ -18,9 +18,9 @@
 #include "lite/core/device_info.h"
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/layout_op.cc
+++ b/lite/kernels/mlu/bridges/layout_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/layout_op_test.cc
+++ b/lite/kernels/mlu/bridges/layout_op_test.cc
@@ -16,9 +16,9 @@
 #include <gtest/gtest.h>
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/lrn_op.cc
+++ b/lite/kernels/mlu/bridges/lrn_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/lrn_op_test.cc
+++ b/lite/kernels/mlu/bridges/lrn_op_test.cc
@@ -21,8 +21,8 @@
 
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/norm_op.cc
+++ b/lite/kernels/mlu/bridges/norm_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/norm_op_test.cc
+++ b/lite/kernels/mlu/bridges/norm_op_test.cc
@@ -20,9 +20,9 @@
 #include <iostream>
 
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 namespace paddle {
 namespace lite {
 namespace subgraph {

--- a/lite/kernels/mlu/bridges/pool_op.cc
+++ b/lite/kernels/mlu/bridges/pool_op.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "lite/operators/pool_op.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/pool_op_test.cc
+++ b/lite/kernels/mlu/bridges/pool_op_test.cc
@@ -16,8 +16,8 @@
 #include <gtest/gtest.h>
 #include <random>
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/reshape_op.cc
+++ b/lite/kernels/mlu/bridges/reshape_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/reshape_op_test.cc
+++ b/lite/kernels/mlu/bridges/reshape_op_test.cc
@@ -19,8 +19,8 @@
 #include <random>
 
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/scale_op.cc
+++ b/lite/kernels/mlu/bridges/scale_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/scale_op_test.cc
+++ b/lite/kernels/mlu/bridges/scale_op_test.cc
@@ -16,8 +16,8 @@
 #include <gtest/gtest.h>
 #include <random>
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/slice_op.cc
+++ b/lite/kernels/mlu/bridges/slice_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/slice_op_test.cc
+++ b/lite/kernels/mlu/bridges/slice_op_test.cc
@@ -18,8 +18,8 @@
 #include <vector>
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/softmax_op.cc
+++ b/lite/kernels/mlu/bridges/softmax_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/softmax_op_test.cc
+++ b/lite/kernels/mlu/bridges/softmax_op_test.cc
@@ -15,8 +15,8 @@
 #include "lite/operators/softmax_op.h"
 #include <gtest/gtest.h>
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/split_op.cc
+++ b/lite/kernels/mlu/bridges/split_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/split_op_test.cc
+++ b/lite/kernels/mlu/bridges/split_op_test.cc
@@ -16,9 +16,9 @@
 #include <gtest/gtest.h>
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/squeeze_op.cc
+++ b/lite/kernels/mlu/bridges/squeeze_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/squeeze_op_test.cc
+++ b/lite/kernels/mlu/bridges/squeeze_op_test.cc
@@ -18,8 +18,8 @@
 #include <utility>
 #include <vector>
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/test_helper.cc
+++ b/lite/kernels/mlu/bridges/test_helper.cc
@@ -16,9 +16,10 @@
 #include <utility>
 #include "lite/core/device_info.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/utility.h"
 #include "lite/kernels/mlu/subgraph_compute.h"
-#include "lite/kernels/npu/bridges/registry.h"
+
 namespace paddle {
 namespace lite {
 namespace subgraph {

--- a/lite/kernels/mlu/bridges/transpose_op.cc
+++ b/lite/kernels/mlu/bridges/transpose_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/utility.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/bridges/transpose_op_test.cc
+++ b/lite/kernels/mlu/bridges/transpose_op_test.cc
@@ -15,8 +15,8 @@
 #include "lite/operators/transpose_op.h"
 #include <gtest/gtest.h>
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/mlu/bridges/test_helper.h"
-#include "lite/kernels/npu/bridges/registry.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/mlu/subgraph_compute.h
+++ b/lite/kernels/mlu/subgraph_compute.h
@@ -24,13 +24,13 @@
 #include "lite/core/kernel.h"
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
+#include "lite/core/subgraph_engine_base.h"
 #include "lite/core/tensor.h"
 #include "lite/core/type_system.h"
 #include "lite/core/types.h"
 #include "lite/kernels/mlu/bridges/graph.h"
 #include "lite/kernels/mlu/bridges/tensor.h"
-#include "lite/kernels/npu/bridges/engine.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/utils/env.h"
 
 namespace paddle {
@@ -39,7 +39,7 @@ namespace kernels {
 namespace mlu {
 
 template <PrecisionType Precision>
-class SubgraphEngine : public subgraph::Engine {
+class SubgraphEngine : public subgraph::SubgraphEngineBase {
  public:
   SubgraphEngine(KernelContext* ctx,
                  int block_idx,
@@ -48,12 +48,12 @@ class SubgraphEngine : public subgraph::Engine {
                  const std::vector<std::string>& input_names,
                  const std::vector<std::string>& output_names,
                  paddle::lite_api::PrecisionType type)
-      : subgraph::Engine(ctx,
-                         block_idx,
-                         program_desc,
-                         exec_scope,
-                         input_names,
-                         output_names),
+      : subgraph::SubgraphEngineBase(ctx,
+                                     block_idx,
+                                     program_desc,
+                                     exec_scope,
+                                     input_names,
+                                     output_names),
         fp_type_(type) {
     VLOG(4) << "[MLU] PADDLE_LITE_MLU_SAVE_OFFLINE_MODEL is "
             << GetBoolFromEnv("PADDLE_LITE_MLU_SAVE_OFFLINE_MODEL");
@@ -166,7 +166,7 @@ class SubgraphEngine : public subgraph::Engine {
     }
     LOG(INFO) << "START TO CONVERT ";
     // Convert all of ops and its weights and added into the MLU IR graph
-    const auto& bridges = subgraph::Registry::Instance();
+    const auto& bridges = subgraph::SubgraphBridgeRegistry::Instance();
     const auto& insts = origin_program_->instructions(kRootBlockIdx);
     for (auto& inst : insts) {
       auto op = inst.op();

--- a/lite/kernels/npu/CMakeLists.txt
+++ b/lite/kernels/npu/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory(bridges)
 
-add_kernel(subgraph_compute_npu NPU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_npu subgraph_bridge_engine ${npu_subgraph_bridges})
+add_kernel(subgraph_compute_npu NPU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_npu subgraph_engine_base ${npu_subgraph_bridges})

--- a/lite/kernels/npu/bridges/CMakeLists.txt
+++ b/lite/kernels/npu/bridges/CMakeLists.txt
@@ -1,14 +1,3 @@
-if(NOT LITE_WITH_NPU AND NOT LITE_WITH_XTCL AND NOT LITE_WITH_BM AND NOT LITE_WITH_RKNPU AND NOT LITE_WITH_MLU AND NOT LITE_WITH_APU AND NOT LITE_WITH_HUAWEI_ASCEND_NPU)
-  return()
-endif()
-
-lite_cc_library(subgraph_bridge_registry
-    SRCS registry.cc
-    DEPS op)
-lite_cc_library(subgraph_bridge_engine
-    SRCS engine.cc
-    DEPS tensor op scope program)
-
 if(NOT LITE_WITH_NPU)
   return()
 endif()

--- a/lite/kernels/npu/bridges/act_op.cc
+++ b/lite/kernels/npu/bridges/act_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/argmax_op.cc
+++ b/lite/kernels/npu/bridges/argmax_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/batch_norm_op.cc
+++ b/lite/kernels/npu/bridges/batch_norm_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/compare_op.cc
+++ b/lite/kernels/npu/bridges/compare_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/concat_op.cc
+++ b/lite/kernels/npu/bridges/concat_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/conv_op.cc
+++ b/lite/kernels/npu/bridges/conv_op.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "lite/operators/conv_op.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/conv_transpose_op.cc
+++ b/lite/kernels/npu/bridges/conv_transpose_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 #include "lite/operators/conv_op.h"
 

--- a/lite/kernels/npu/bridges/dropout_op.cc
+++ b/lite/kernels/npu/bridges/dropout_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/elementwise_ops.cc
+++ b/lite/kernels/npu/bridges/elementwise_ops.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/expand_op.cc
+++ b/lite/kernels/npu/bridges/expand_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/fc_op.cc
+++ b/lite/kernels/npu/bridges/fc_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/fill_constant_batch_size_like_op.cc
+++ b/lite/kernels/npu/bridges/fill_constant_batch_size_like_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/fill_constant_op.cc
+++ b/lite/kernels/npu/bridges/fill_constant_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/gather_op.cc
+++ b/lite/kernels/npu/bridges/gather_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/increment_op.cc
+++ b/lite/kernels/npu/bridges/increment_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/instance_norm_op.cc
+++ b/lite/kernels/npu/bridges/instance_norm_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/interpolate_op.cc
+++ b/lite/kernels/npu/bridges/interpolate_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/layer_norm_op.cc
+++ b/lite/kernels/npu/bridges/layer_norm_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/lookup_table_op.cc
+++ b/lite/kernels/npu/bridges/lookup_table_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/matmul_op.cc
+++ b/lite/kernels/npu/bridges/matmul_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/mul_op.cc
+++ b/lite/kernels/npu/bridges/mul_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/pad2d_op.cc
+++ b/lite/kernels/npu/bridges/pad2d_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/pool_op.cc
+++ b/lite/kernels/npu/bridges/pool_op.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "lite/operators/pool_op.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/reduce_mean_op.cc
+++ b/lite/kernels/npu/bridges/reduce_mean_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/reshape_op.cc
+++ b/lite/kernels/npu/bridges/reshape_op.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "lite/operators/reshape_op.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/scale_op.cc
+++ b/lite/kernels/npu/bridges/scale_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/shape_op.cc
+++ b/lite/kernels/npu/bridges/shape_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/shuffle_channel_op.cc
+++ b/lite/kernels/npu/bridges/shuffle_channel_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/softmax_op.cc
+++ b/lite/kernels/npu/bridges/softmax_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/split_op.cc
+++ b/lite/kernels/npu/bridges/split_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/topk_op.cc
+++ b/lite/kernels/npu/bridges/topk_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/transpose_op.cc
+++ b/lite/kernels/npu/bridges/transpose_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/bridges/unsqueeze_op.cc
+++ b/lite/kernels/npu/bridges/unsqueeze_op.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/npu/bridges/graph.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "lite/kernels/npu/bridges/utility.h"
 
 namespace paddle {

--- a/lite/kernels/npu/subgraph_compute.cc
+++ b/lite/kernels/npu/subgraph_compute.cc
@@ -129,7 +129,7 @@ bool DeviceProgram::BuildGraphAndCacheToFile(
   // then added them into the HiAI IR graph
   int status = 0;
   subgraph::npu::Graph graph;
-  const auto& bridges = subgraph::Registry::Instance();
+  const auto& bridges = subgraph::SubgraphBridgeRegistry::Instance();
   CHECK(origin_program) << "[NPU] The origin program is not initialized!";
   CHECK_GT(origin_program->instructions(kRootBlockIdx).size(), 0)
       << "[NPU] No instructions found in the origin program!";

--- a/lite/kernels/npu/subgraph_compute.h
+++ b/lite/kernels/npu/subgraph_compute.h
@@ -20,8 +20,8 @@
 #include <vector>
 #include "HiAiModelManagerService.h"
 #include "lite/core/kernel.h"
-#include "lite/kernels/npu/bridges/engine.h"
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
+#include "lite/core/subgraph_engine_base.h"
 
 namespace paddle {
 namespace lite {
@@ -67,7 +67,7 @@ class DeviceProgram {
   std::vector<hiai::TensorDimension> device_odims_{};
 };
 
-class SubgraphEngine : public subgraph::Engine {
+class SubgraphEngine : public subgraph::SubgraphEngineBase {
  public:
   SubgraphEngine(KernelContext* ctx,
                  int block_idx,
@@ -75,12 +75,12 @@ class SubgraphEngine : public subgraph::Engine {
                  Scope* exec_scope,
                  const std::vector<std::string>& input_names,
                  const std::vector<std::string>& output_names)
-      : subgraph::Engine(ctx,
-                         block_idx,
-                         program_desc,
-                         exec_scope,
-                         input_names,
-                         output_names) {}
+      : subgraph::SubgraphEngineBase(ctx,
+                                     block_idx,
+                                     program_desc,
+                                     exec_scope,
+                                     input_names,
+                                     output_names) {}
 
  protected:
   bool PrepareWorkspaceForDeviceProgram() override;

--- a/lite/kernels/rknpu/CMakeLists.txt
+++ b/lite/kernels/rknpu/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(bridges)
-add_kernel(subgraph_compute_rknpu RKNPU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_rknpu ${rknpu_subgraph_bridges})
+
+add_kernel(subgraph_compute_rknpu RKNPU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_rknpu subgraph_engine_base ${rknpu_subgraph_bridges})

--- a/lite/kernels/rknpu/bridges/CMakeLists.txt
+++ b/lite/kernels/rknpu/bridges/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 lite_cc_library(subgraph_bridge_utility_rknpu SRCS utility.cc DEPS ${rknpu_builder_libs} tensor)
 lite_cc_library(subgraph_bridge_graph_rknpu SRCS graph.cc DEPS subgraph_bridge_utility_rknpu)
 
-set(rknpu_subgraph_bridge_deps subgraph_bridge_registry subgraph_bridge_engine subgraph_bridge_utility_rknpu subgraph_bridge_graph_rknpu)
+set(rknpu_subgraph_bridge_deps subgraph_bridge_registry subgraph_bridge_utility_rknpu subgraph_bridge_graph_rknpu)
 
 lite_cc_library(subgraph_bridge_conv_op_rknpu SRCS conv_op.cc DEPS ${rknpu_subgraph_bridge_deps})
 lite_cc_library(subgraph_bridge_act_op_rknpu SRCS act_op.cc DEPS ${rknpu_subgraph_bridge_deps})

--- a/lite/kernels/rknpu/bridges/act_op.cc
+++ b/lite/kernels/rknpu/bridges/act_op.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/rknpu/bridges/graph.h"
-// #include "lite/kernels/npu/bridges/utility.h"
+#include "lite/kernels/rknpu/bridges/utility.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/kernels/rknpu/bridges/batch_norm_op.cc
+++ b/lite/kernels/rknpu/bridges/batch_norm_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/rknpu/bridges/graph.h"
 #include "lite/kernels/rknpu/bridges/utility.h"
 

--- a/lite/kernels/rknpu/bridges/concat_op.cc
+++ b/lite/kernels/rknpu/bridges/concat_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/rknpu/bridges/graph.h"
 #include "lite/kernels/rknpu/bridges/utility.h"
 

--- a/lite/kernels/rknpu/bridges/conv_op.cc
+++ b/lite/kernels/rknpu/bridges/conv_op.cc
@@ -14,7 +14,7 @@
 
 #include "lite/operators/conv_op.h"
 #include <algorithm>
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/rknpu/bridges/graph.h"
 #include "lite/kernels/rknpu/bridges/utility.h"
 

--- a/lite/kernels/rknpu/bridges/elementwise_ops.cc
+++ b/lite/kernels/rknpu/bridges/elementwise_ops.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/rknpu/bridges/graph.h"
 #include "lite/kernels/rknpu/bridges/utility.h"
 

--- a/lite/kernels/rknpu/bridges/fc_op.cc
+++ b/lite/kernels/rknpu/bridges/fc_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/rknpu/bridges/graph.h"
 #include "lite/kernels/rknpu/bridges/utility.h"
 

--- a/lite/kernels/rknpu/bridges/pool_op.cc
+++ b/lite/kernels/rknpu/bridges/pool_op.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "lite/operators/pool_op.h"
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/rknpu/bridges/graph.h"
 #include "lite/kernels/rknpu/bridges/utility.h"
 

--- a/lite/kernels/rknpu/bridges/softmax_op.cc
+++ b/lite/kernels/rknpu/bridges/softmax_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/rknpu/bridges/graph.h"
 #include "lite/kernels/rknpu/bridges/utility.h"
 

--- a/lite/kernels/rknpu/subgraph_compute.cc
+++ b/lite/kernels/rknpu/subgraph_compute.cc
@@ -34,7 +34,7 @@ bool SubgraphEngine::BuildDeviceProgram() {
   // Convert all of ops and their input vars and weights and added into the NPU
   // RKNPU IR graph
   subgraph::rknpu::Graph graph;
-  const auto& bridges = subgraph::Registry::Instance();
+  const auto& bridges = subgraph::SubgraphBridgeRegistry::Instance();
   if (!origin_program_) {
     BuildOriginProgram();
   }

--- a/lite/kernels/rknpu/subgraph_compute.h
+++ b/lite/kernels/rknpu/subgraph_compute.h
@@ -20,9 +20,9 @@
 #include "lite/core/kernel.h"
 #include "lite/core/op_registry.h"
 #include "lite/core/program.h"
+#include "lite/core/subgraph_bridge_registry.h"
+#include "lite/core/subgraph_engine_base.h"
 #include "lite/core/types.h"
-#include "lite/kernels/npu/bridges/engine.h"
-#include "lite/kernels/npu/bridges/registry.h"
 #include "rknpu/rknpu_pub.h"
 
 namespace paddle {
@@ -30,7 +30,7 @@ namespace lite {
 namespace kernels {
 namespace rknpu {
 
-class SubgraphEngine : public subgraph::Engine {
+class SubgraphEngine : public subgraph::SubgraphEngineBase {
  public:
   SubgraphEngine(KernelContext *ctx,
                  int block_idx,
@@ -38,12 +38,12 @@ class SubgraphEngine : public subgraph::Engine {
                  Scope *exec_scope,
                  const std::vector<std::string> &input_names,
                  const std::vector<std::string> &output_names)
-      : subgraph::Engine(ctx,
-                         block_idx,
-                         program_desc,
-                         exec_scope,
-                         input_names,
-                         output_names) {}
+      : subgraph::SubgraphEngineBase(ctx,
+                                     block_idx,
+                                     program_desc,
+                                     exec_scope,
+                                     input_names,
+                                     output_names) {}
 
  protected:
   bool BuildDeviceProgram() override;

--- a/lite/kernels/xpu/CMakeLists.txt
+++ b/lite/kernels/xpu/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 if(LITE_WITH_XTCL)
   add_subdirectory(bridges)
-  add_kernel(subgraph_compute_xpu XPU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_xpu subgraph_bridge_engine ${xpu_subgraph_bridges})
+  add_kernel(subgraph_compute_xpu XPU basic SRCS subgraph_compute.cc DEPS ${lite_kernel_deps} device_xpu subgraph_engine_base ${xpu_subgraph_bridges})
 else()
   # basic
   add_kernel(conv_compute_xpu XPU basic SRCS conv_compute.cc DEPS ${lite_kernel_deps})

--- a/lite/kernels/xpu/bridges/act_op.cc
+++ b/lite/kernels/xpu/bridges/act_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/batch_norm_op.cc
+++ b/lite/kernels/xpu/bridges/batch_norm_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/cast_op.cc
+++ b/lite/kernels/xpu/bridges/cast_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/conv_op.cc
+++ b/lite/kernels/xpu/bridges/conv_op.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "lite/operators/conv_op.h"
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/dropout_op.cc
+++ b/lite/kernels/xpu/bridges/dropout_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/elementwise_ops.cc
+++ b/lite/kernels/xpu/bridges/elementwise_ops.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/gather_op.cc
+++ b/lite/kernels/xpu/bridges/gather_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/layer_norm_op.cc
+++ b/lite/kernels/xpu/bridges/layer_norm_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/lookup_table_op.cc
+++ b/lite/kernels/xpu/bridges/lookup_table_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/matmul_op.cc
+++ b/lite/kernels/xpu/bridges/matmul_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/mul_op.cc
+++ b/lite/kernels/xpu/bridges/mul_op.cc
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
-
 namespace paddle {
 namespace lite {
 namespace subgraph {

--- a/lite/kernels/xpu/bridges/mul_op.cc
+++ b/lite/kernels/xpu/bridges/mul_op.cc
@@ -15,6 +15,7 @@
 #include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
+
 namespace paddle {
 namespace lite {
 namespace subgraph {

--- a/lite/kernels/xpu/bridges/pool_op.cc
+++ b/lite/kernels/xpu/bridges/pool_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/reshape_op.cc
+++ b/lite/kernels/xpu/bridges/reshape_op.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "lite/operators/reshape_op.h"
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/scale_op.cc
+++ b/lite/kernels/xpu/bridges/scale_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/slice_op.cc
+++ b/lite/kernels/xpu/bridges/slice_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/softmax_op.cc
+++ b/lite/kernels/xpu/bridges/softmax_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/stack_op.cc
+++ b/lite/kernels/xpu/bridges/stack_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/transpose_op.cc
+++ b/lite/kernels/xpu/bridges/transpose_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/bridges/yolo_box_op.cc
+++ b/lite/kernels/xpu/bridges/yolo_box_op.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
 #include "lite/kernels/xpu/bridges/graph.h"
 #include "lite/kernels/xpu/bridges/utility.h"
 

--- a/lite/kernels/xpu/subgraph_compute.cc
+++ b/lite/kernels/xpu/subgraph_compute.cc
@@ -36,7 +36,7 @@ bool SubgraphEngine::BuildDeviceProgram() {
   // Convert all of ops and their input vars and weights and added into the XPU
   // IR graph
   subgraph::xpu::Graph graph;
-  const auto& bridges = subgraph::Registry::Instance();
+  const auto& bridges = subgraph::SubgraphBridgeRegistry::Instance();
   const auto& insts = origin_program_->instructions(kRootBlockIdx);
   for (auto& inst : insts) {
     auto op = const_cast<OpLite*>(inst.op());

--- a/lite/kernels/xpu/subgraph_compute.h
+++ b/lite/kernels/xpu/subgraph_compute.h
@@ -19,15 +19,15 @@
 #include <vector>
 #include "lite/backends/xpu/xpu_header_sitter.h"
 #include "lite/core/kernel.h"
-#include "lite/kernels/npu/bridges/engine.h"
-#include "lite/kernels/npu/bridges/registry.h"
+#include "lite/core/subgraph_bridge_registry.h"
+#include "lite/core/subgraph_engine_base.h"
 
 namespace paddle {
 namespace lite {
 namespace kernels {
 namespace xpu {
 
-class SubgraphEngine : public subgraph::Engine {
+class SubgraphEngine : public subgraph::SubgraphEngineBase {
  public:
   SubgraphEngine(KernelContext *ctx,
                  int block_idx,
@@ -35,12 +35,12 @@ class SubgraphEngine : public subgraph::Engine {
                  Scope *exec_scope,
                  const std::vector<std::string> &input_names,
                  const std::vector<std::string> &output_names)
-      : subgraph::Engine(ctx,
-                         block_idx,
-                         program_desc,
-                         exec_scope,
-                         input_names,
-                         output_names) {}
+      : subgraph::SubgraphEngineBase(ctx,
+                                     block_idx,
+                                     program_desc,
+                                     exec_scope,
+                                     input_names,
+                                     output_names) {}
 
  protected:
   bool BuildDeviceProgram() override;


### PR DESCRIPTION
由于subgraph的registry和engine为NPU、XPU、RKNPU、APU、MLU、BM和HuaweiAscendNPU的公用模块，因此，将其从/lite/kernels/npu/bridges目录调整到/lite/core，同时对引用它们的文件做了适应性修改。主要修改如下：
1.  lite/kernels/npu/bridges/registry.h/cc -> lite/core/subgraph_bridge_registry.h/cc
2. lite/kernels/npu/bridges/engine.h/cc -> lite/core/subgraph_engine_base.h/cc
3.  paddle::lite::subgraph::Registry -> paddle::lite::subgraph::SubgraphBridgeRegistry
4. paddle::lite::subgraph::Engine -> paddle::lite::subgraph::SubgraphEngineBase