### PR TITLE
set max llc_size, test=develop

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -242,8 +242,11 @@ std::shared_ptr<PaddlePredictor> CreatePaddlePredictor(const ConfigT &) {
   return std::shared_ptr<PaddlePredictor>();
 }
 
-ConfigBase::ConfigBase(PowerMode mode, int threads) {
+ConfigBase::ConfigBase(PowerMode mode, int threads, int max_llc_size) {
 #ifdef LITE_WITH_ARM
+  if (max_llc_size > 0) {
+    lite::DeviceInfo::Global().SetMaxllcSize(max_llc_size);
+  }
   lite::DeviceInfo::Init();
   lite::DeviceInfo::Global().SetRunMode(mode, threads);
   mode_ = lite::DeviceInfo::Global().mode();

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -137,7 +137,10 @@ class LITE_API ConfigBase {
   int device_id_{0};
 
  public:
-  explicit ConfigBase(PowerMode mode = LITE_POWER_NO_BIND, int threads = 1);
+  explicit ConfigBase(PowerMode mode = LITE_POWER_NO_BIND,
+                      int threads = 1,
+                      int max_llc_size = 0);
+
   // set Model_dir
   void set_model_dir(const std::string& x) { model_dir_ = x; }
   const std::string& model_dir() const { return model_dir_; }
@@ -271,6 +274,10 @@ class LITE_API MobileConfig : public ConfigBase {
   std::string param_buffer_;
 
  public:
+  explicit MobileConfig(PowerMode mode = LITE_POWER_NO_BIND,
+                        int threads = 1,
+                        int max_llc_size = 0)
+      : ConfigBase(mode, threads, max_llc_size) {}
   // set model data in combined format, `set_model_from_file` refers to loading
   // model from file, set_model_from_buffer refers to loading model from memory
   // buffer

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -65,11 +65,23 @@ class DeviceInfo {
   int l1_cache_size() const { return L1_cache_[active_ids_[0]]; }
   int l2_cache_size() const { return L2_cache_[active_ids_[0]]; }
   int l3_cache_size() const { return L3_cache_[active_ids_[0]]; }
+  void SetMaxllcSize(int size) {
+    if (size > 0) {
+      max_llc_size_ = size;
+    }
+  }
+
   int llc_size() const {
     auto size = L3_cache_[active_ids_[0]] > 0 ? L3_cache_[active_ids_[0]]
                                               : L2_cache_[active_ids_[0]];
-    return size > 0 ? size : 512 * 1024;
+    size = size > 0 ? size : 512 * 1024;
+    if (max_llc_size_ != 0) {
+      size = size < max_llc_size_ ? size : max_llc_size_;
+    }
+    printf("llc_size: %d\n", size);
+    return size;
   }
+
   bool has_dot() const { return dot_[active_ids_[0]]; }
   bool has_fp16() const { return fp16_[active_ids_[0]]; }
 
@@ -81,6 +93,7 @@ class DeviceInfo {
 
  private:
   int core_num_;
+  int max_llc_size_ = 0;
   std::vector<int> max_freqs_;
   std::vector<int> min_freqs_;
   std::string dev_name_;


### PR DESCRIPTION
At the beginning of the Paddle-Lite Configuration, some memory is allocated for the `sgemm` calculation. The memory size depends on the L3 cache size of the machine. When it comes to a Mate20 phone, the memory reaches 4 MB.

This Pull Request added a parameter in the ConfigBase Class, which makes it possible to limit the allocated memory size. We have tested the limited memory from 1MB to 4MB and no speed decrease is found in our application.

Any discussion about this design is very welcomed.