### PR TITLE
fix opt fatal errors, test=develop

### DIFF
--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -48,7 +48,7 @@ class ProgramDescView : public ProgramDescAPI {
 
   void InitProgramDesc() {
     desc_ = proto::GetProgramDesc(buf_.data());
-    blocks_.resize(BlocksSize());
+    blocks_.resize(desc_->blocks()->size());
     for (size_t idx = 0; idx < BlocksSize(); ++idx) {
       blocks_[idx] = BlockDescView(desc_->blocks()->Get(idx));
     }
@@ -59,7 +59,7 @@ class ProgramDescView : public ProgramDescAPI {
     Init(buf_);
   }
 
-  size_t BlocksSize() const override { return desc_->blocks()->size(); }
+  size_t BlocksSize() const override { return blocks_.size(); }
 
   template <typename T>
   T const* GetBlock(int32_t idx) const;

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -835,7 +835,6 @@ void LoadModelNaiveFromFile(const std::string &filename,
                             cpp::ProgramDesc *cpp_prog) {
   CHECK(cpp_prog);
   CHECK(scope);
-  cpp_prog->ClearBlocks();
   // ModelFile
   const std::string prog_path = filename;
 
@@ -923,7 +922,7 @@ void LoadModelFbsFromFile(const std::string &filename,
                           cpp::ProgramDesc *cpp_prog) {
   CHECK(cpp_prog);
   CHECK(scope);
-  cpp_prog->ClearBlocks();
+  CHECK_EQ(cpp_prog->BlocksSize(), 0);
   // Offset
   uint64_t offset = sizeof(uint16_t);
 

--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -189,7 +189,9 @@ class LogMessageFatal : public LogMessage {
 #ifndef LITE_ON_TINY_PUBLISH
     abort();
 #else
-    assert(false);
+    // If we decide whether the process exits according to the NDEBUG macro
+    // definition, assert() can be used here.
+    abort();
 #endif
 #endif
   }
@@ -250,7 +252,11 @@ class VoidifyFatal : public Voidify {
 #ifdef LITE_WITH_EXCEPTION
   ~VoidifyFatal() noexcept(false) { throw std::exception(); }
 #else
-  ~VoidifyFatal() { assert(false); }
+  ~VoidifyFatal() {
+    // If we decide whether the process exits according to the NDEBUG macro
+    // definition, assert() can be used here.
+    abort();
+  }
 #endif
 };
 


### PR DESCRIPTION
1、修复 FLATBUFFERS_VIEW = ON 时 OPT 尝试写入数据结构的问题；
2、修复 `LOG(FATAL)` 不能中止进程的问题。