### PR TITLE
change the NotImpl macros, test=develop

### DIFF
--- a/lite/model_parser/base/block_desc.h
+++ b/lite/model_parser/base/block_desc.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include "lite/model_parser/base/traits.h"
 #include "lite/utils/cp_logging.h"
 
 namespace paddle {
@@ -47,30 +48,29 @@ class BlockDescReadAPI {
 
 class BlockDescWriteAPI {
  public:
-  virtual void SetIdx(int32_t idx) { NotImplemented(); }
-  virtual void SetParentIdx(int32_t idx) { NotImplemented(); }
-  virtual void ClearVars() { NotImplemented(); }
-  virtual void ClearOps() { NotImplemented(); }
-  virtual void SetForwardBlockIdx(int32_t idx) { NotImplemented(); }
+  virtual void SetIdx(int32_t idx) { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  virtual void SetParentIdx(int32_t idx) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void ClearVars() { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  virtual void ClearOps() { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  virtual void SetForwardBlockIdx(int32_t idx) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
 
   template <typename T>
   T* AddVar() {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
   template <typename T>
   T* AddOp() {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
   virtual ~BlockDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "BlockDescWriteAPI is not available in model read-only mode.";
-  }
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/base/op_desc.h
+++ b/lite/model_parser/base/op_desc.h
@@ -62,27 +62,24 @@ class OpDescReadAPI {
 
 class OpDescWriteAPI {
  public:
-  virtual void SetType(const std::string& type) { NotImplemented(); }
+  virtual void SetType(const std::string& type) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
   virtual void SetInput(const std::string& param,
                         const std::vector<std::string>& args) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
   }
   virtual void SetOutput(const std::string& param,
                          const std::vector<std::string>& args) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
   }
 
   template <typename T>
   void SetAttr(const std::string& name, const T& v) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
   }
 
   virtual ~OpDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "OpDescWriteAPI is not available in model read-only mode.";
-  }
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/base/param_desc.h
+++ b/lite/model_parser/base/param_desc.h
@@ -34,17 +34,20 @@ class ParamDescReadAPI {
 
 class ParamDescWriteAPI {
  public:
-  virtual void SetName(const std::string &name) { NotImplemented(); }
-  virtual void SetDim(const std::vector<int64_t> &dim) { NotImplemented(); }
-  virtual void SetDataType(VarDataType data_type) { NotImplemented(); }
-  virtual void SetData(const void *data, size_t byte_size) { NotImplemented(); }
+  virtual void SetName(const std::string &name) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetDim(const std::vector<int64_t> &dim) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetDataType(VarDataType data_type) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetData(const void *data, size_t byte_size) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
 
   virtual ~ParamDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "ParamDescWriteAPI is not available in model read-only mode.";
-  }
 };
 
 class CombinedParamsDescReadAPI {
@@ -57,16 +60,10 @@ class CombinedParamsDescReadAPI {
 class CombinedParamsDescWriteAPI {
  public:
   virtual ParamDescWriteAPI *AddParamDesc() {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
   virtual ~CombinedParamsDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "CombinedParamsDescWriteAPI is not available in model "
-                  "read-only mode.";
-  }
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/base/program_desc.h
+++ b/lite/model_parser/base/program_desc.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "lite/model_parser/base/traits.h"
 #include "lite/utils/cp_logging.h"
 
 namespace paddle {
@@ -36,22 +37,18 @@ class ProgramDescReadAPI {
 
 class ProgramDescWriteAPI {
  public:
-  virtual void ClearBlocks() { NotImplemented(); }
-  virtual void SetVersion(int64_t version) { NotImplemented(); }
+  virtual void ClearBlocks() { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  virtual void SetVersion(int64_t version) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
 
   template <typename T>
   T* AddBlock() {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
   virtual ~ProgramDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL)
-        << "ProgramDescWriteAPI is not available in model read-only mode.";
-  }
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/base/traits.h
+++ b/lite/model_parser/base/traits.h
@@ -19,6 +19,10 @@
 #include "lite/api/paddle_place.h"
 #include "lite/utils/cp_logging.h"
 
+#define LITE_MODEL_INTERFACE_NOT_IMPLEMENTED                \
+  LOG(FATAL) << "This additional interface is temporarily " \
+                "unavailable in flatbuffers read-only mode."
+
 namespace paddle {
 namespace lite {
 

--- a/lite/model_parser/base/var_desc.h
+++ b/lite/model_parser/base/var_desc.h
@@ -33,16 +33,19 @@ class VarDescReadAPI {
 
 class VarDescWriteAPI {
  public:
-  virtual void SetName(std::string name) { NotImplemented(); }
-  virtual void SetType(VarDataType type) { NotImplemented(); }
-  virtual void SetPersistable(bool persistable) { NotImplemented(); }
-  virtual void SetShape(const std::vector<int64_t>& dims) { NotImplemented(); }
-  virtual ~VarDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "VarDescWriteAPI is not available in model read-only mode.";
+  virtual void SetName(std::string name) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
   }
+  virtual void SetType(VarDataType type) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetPersistable(bool persistable) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetShape(const std::vector<int64_t>& dims) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual ~VarDescWriteAPI() = default;
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/flatbuffers/block_desc.h
+++ b/lite/model_parser/flatbuffers/block_desc.h
@@ -51,7 +51,7 @@ class BlockDescView : public BlockDescAPI {
 
   template <typename T>
   T* GetVar(int32_t idx) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
@@ -66,7 +66,7 @@ class BlockDescView : public BlockDescAPI {
 
   template <typename T>
   T* GetOp(int32_t idx) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
@@ -82,12 +82,6 @@ class BlockDescView : public BlockDescAPI {
   proto::BlockDesc const* desc_;  // not_own
   std::vector<VarDescView> vars_;
   std::vector<OpDescView> ops_;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "The additional interfaces of BlockDescView is temporarily "
-                  "unavailable in read-only mode.";
-  }
 };
 
 #ifdef LITE_WITH_FLATBUFFERS_DESC

--- a/lite/model_parser/flatbuffers/op_desc.h
+++ b/lite/model_parser/flatbuffers/op_desc.h
@@ -154,23 +154,19 @@ class OpDescView : public OpDescAPI {
   }
 
   const std::map<std::string, std::vector<std::string>>& inputs() const {
-    VLOG(8) << "[additional interfaces] OpDescView::inputs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return inputs_;
   }
   const std::map<std::string, std::vector<std::string>>& outputs() const {
-    VLOG(8) << "[additional interfaces] OpDescView::outputs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return outputs_;
   }
   std::map<std::string, std::vector<std::string>>* mutable_inputs() {
-    VLOG(8) << "[additional interfaces] OpDescView::mutable_inputs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return &inputs_;
   }
   std::map<std::string, std::vector<std::string>>* mutable_outputs() {
-    VLOG(8) << "[additional interfaces] OpDescView::mutable_outputs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return &outputs_;
   }
 
@@ -187,8 +183,7 @@ class OpDescView : public OpDescAPI {
   }
 
   std::vector<std::string> output_vars() const {
-    VLOG(8) << "[additional interfaces] OpDescView::output_vars()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return std::vector<std::string>();
   }
 
@@ -197,21 +192,15 @@ class OpDescView : public OpDescAPI {
   }
 
   const std::map<std::string, Any>& attrs() const {
-    VLOG(8) << "[additional interfaces] OpDescView::attrs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return attrs_;
   }
   const std::map<std::string, AttrType>& attr_types() const {
-    VLOG(8) << "[additional interfaces] OpDescView::attr_types()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return attr_types_;
   }
 
  private:
-  void NotImplemented() const {
-    LOG(FATAL) << "The additional interfaces of OpDescView is temporarily "
-                  "unavailable in read-only mode.";
-  }
   std::string type_;
   std::map<std::string, std::vector<std::string>> inputs_;
   std::map<std::string, std::vector<std::string>> outputs_;

--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -66,7 +66,7 @@ class ProgramDescView : public ProgramDescAPI {
 
   template <typename T>
   T* GetBlock(int32_t idx) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
@@ -91,10 +91,6 @@ class ProgramDescView : public ProgramDescAPI {
  private:
   ProgramDescView& operator=(const ProgramDescView&) = delete;
   ProgramDescView(const ProgramDescView&) = delete;
-  void NotImplemented() const {
-    LOG(FATAL) << "The additional interfaces of ProgramDescView is temporarily "
-                  "unavailable in read-only mode.";
-  }
 };
 
 #ifdef LITE_WITH_FLATBUFFERS_DESC

--- a/lite/model_parser/flatbuffers/var_desc.h
+++ b/lite/model_parser/flatbuffers/var_desc.h
@@ -67,14 +67,12 @@ class VarDescView : public VarDescAPI {
 
  public:
   VarDescView() = default;
-  void SetDataType(Type data_type) { NotImplemented(); }
-  void SetShape(const std::vector<int64_t>& dims) { NotImplemented(); }
+  void SetDataType(Type data_type) { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  void SetShape(const std::vector<int64_t>& dims) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
 
  private:
-  void NotImplemented() const {
-    LOG(FATAL) << "The additional interfaces of VarDescView is temporarily "
-                  "unavailable in read-only mode.";
-  }
   std::vector<int64_t> shape_;
 };
 


### PR DESCRIPTION
将未实现的提示从函数变为宏，以正确显示函数名和代码行号。