### PR TITLE
[Framework] Update flatbuffer and opt

### DIFF
--- a/lite/api/cxx_api_test.cc
+++ b/lite/api/cxx_api_test.cc
@@ -131,7 +131,8 @@ TEST(CXXApi, save_model) {
   predictor.Build(FLAGS_model_dir, "", "", valid_places);
 
   LOG(INFO) << "Save optimized model to " << FLAGS_optimized_model;
-  predictor.SaveModel(FLAGS_optimized_model);
+  predictor.SaveModel(FLAGS_optimized_model,
+                      lite_api::LiteModelType::kProtobuf);
   predictor.SaveModel(FLAGS_optimized_model + ".naive",
                       lite_api::LiteModelType::kNaiveBuffer);
 }

--- a/lite/core/mir/fusion/conv_conv_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_conv_fuse_pass.cc
@@ -30,7 +30,7 @@ void ConvConvFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   bool has_fp32 = false;
   bool has_int8 = false;
   for (auto& place : graph->valid_places()) {
-    if (place.target == TARGET(kARM)) {
+    if (place.target == TARGET(kARM) || place.target == TARGET(kHost)) {
       if (place.precision == PRECISION(kFloat)) {
         has_fp32 = true;
       }
@@ -38,6 +38,7 @@ void ConvConvFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
         has_int8 = true;
       }
     } else {
+      VLOG(5) << "place.target: " << static_cast<int>(place.target);
       return;
     }
   }
@@ -50,12 +51,12 @@ void ConvConvFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
     for (auto conv_has_bias1 : conv_has_bias_cases) {
       for (auto conv_type0 : conv_type_cases) {
         for (auto conv_type1 : {"conv2d"}) {  // it mustbe 1x1s1p0_conv
-          VLOG(4) << "conv_has_bias0:" << conv_has_bias0
+          VLOG(5) << "conv_has_bias0:" << conv_has_bias0
                   << " conv_type0:" << conv_type0;
-          VLOG(4) << "conv_has_bias1:" << conv_has_bias1
+          VLOG(5) << "conv_has_bias1:" << conv_has_bias1
                   << " conv_type1:" << conv_type1;
           fusion::ConvConvFuser fuser(
-              conv_type0, conv_type1, conv_has_bias0, conv_has_bias1);
+              conv_type0, conv_type1, conv_has_bias0, conv_has_bias1, graph);
           fuser(graph.get());
         }
       }

--- a/lite/core/mir/fusion/conv_conv_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_conv_fuse_pass.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "lite/core/mir/fusion/conv_conv_fuse_pass.h"
+#include <list>
 #include <memory>
 #include <vector>
 #include "lite/core/mir/fusion/conv_conv_fuser.h"
@@ -27,13 +28,10 @@ void ConvConvFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   // initialze fuser params
   std::vector<bool> conv_has_bias_cases{true, false};
   std::vector<std::string> conv_type_cases{"conv2d", "depthwise_conv2d"};
-  bool has_fp32 = false;
   bool has_int8 = false;
+  bool has_weight_quant = false;
   for (auto& place : graph->valid_places()) {
     if (place.target == TARGET(kARM) || place.target == TARGET(kHost)) {
-      if (place.precision == PRECISION(kFloat)) {
-        has_fp32 = true;
-      }
       if (place.precision == PRECISION(kInt8)) {
         has_int8 = true;
       }
@@ -42,8 +40,18 @@ void ConvConvFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
       return;
     }
   }
+  const std::list<mir::Node>& nodes = graph->nodes();
+  for (auto& node : nodes) {
+    if (node.IsStmt()) {
+      auto* op_info = (node.stmt())->op_info();
+      if (op_info->HasAttr("quantization_type")) {
+        has_weight_quant = true;
+        break;
+      }
+    }
+  }
   // only support arm-fp32
-  if (has_int8 || (has_fp32 && has_int8)) {
+  if (has_int8 || has_weight_quant) {
     return;
   }
   // only support fp32 fusion

--- a/lite/core/mir/fusion/conv_conv_fuser.cc
+++ b/lite/core/mir/fusion/conv_conv_fuser.cc
@@ -22,7 +22,7 @@ namespace lite {
 namespace mir {
 namespace fusion {
 
-void ConvConvFuser::BuildPattern() {
+inline void ConvConvFuser::createPattern() {
   auto* conv_input0 = VarNode("conv_input0")
                           ->assert_is_op_input(conv_type0_, "Input")
                           ->AsInput();
@@ -81,6 +81,91 @@ void ConvConvFuser::BuildPattern() {
   }
 }
 
+void ConvConvFuser::BuildPattern() {
+  for (auto& node : graph_->StmtTopologicalOrder()) {
+    if (node->IsStmt() &&
+        node->AsStmt().picked_kernel().op_type() == conv_type0_) {
+      auto* scope = node->stmt()->op()->scope();
+      auto conv_op_desc0 = node->stmt()->mutable_op_info();
+      // find outlinks of conv2d: in_arg_node
+      auto conv2d_outlinks = node->outlinks;
+      VLOG(5) << "conv2d_outlinks.size():" << conv2d_outlinks.size();
+      if (conv2d_outlinks.size() == 1) {
+        auto next_node_tmp = conv2d_outlinks.front();
+        if (next_node_tmp->IsArg() && next_node_tmp->outlinks.size() == 1) {
+          auto next_node = next_node_tmp->outlinks.front();
+          auto conv0_in = node->inlinks;
+          auto conv0_wei_name = conv0_in.front();
+          VLOG(5) << "next_node->IsStmt(): " << next_node->IsStmt();
+          VLOG(5) << ", next op_type:"
+                  << next_node->AsStmt().picked_kernel().op_type();
+          if (next_node->IsStmt() &&
+              next_node->AsStmt().picked_kernel().op_type() == conv_type1_) {
+            // find conv->conv pattern
+            auto conv1_in = next_node->inlinks;
+            auto conv1_wei_name = conv1_in.front();
+            auto a = conv0_wei_name->AsArg().name;
+            auto b = conv1_wei_name->AsArg().name;
+            VLOG(5) << "conv0_wei_name: " << a;
+            VLOG(5) << "conv1_wei_name: " << b;
+            auto conv_op_desc1 = next_node->stmt()->mutable_op_info();
+            auto weight0_dims = scope->FindVar(a)->Get<lite::Tensor>().dims();
+            auto weight1_dims = scope->FindVar(b)->Get<lite::Tensor>().dims();
+            auto groups0 = conv_op_desc0->GetAttr<int>("groups");
+            auto groups1 = conv_op_desc1->GetAttr<int>("groups");
+            auto strides1 = conv_op_desc1->GetAttr<std::vector<int>>("strides");
+            auto paddings1 =
+                conv_op_desc1->GetAttr<std::vector<int>>("paddings");
+            auto dilations1 =
+                conv_op_desc1->GetAttr<std::vector<int>>("dilations");
+            auto ch_out_0 = weight0_dims[0];
+            auto ch_in_0 = weight0_dims[1] * groups0;
+            auto ch_out_1 = weight1_dims[0];
+            auto ch_in_1 = weight1_dims[1] * groups1;
+            auto kh = weight1_dims[2];
+            auto kw = weight1_dims[3];
+            bool enable0_int8 =
+                conv_op_desc0->HasAttr("enable_int8") ? true : false;
+            bool enable1_int8 =
+                conv_op_desc1->HasAttr("enable_int8") ? true : false;
+            if (!(kw == 1 && kh == 1)) {
+              VLOG(5) << "The kernel size of the second conv must be 1x1";
+              continue;
+            }
+            if (groups1 != 1) {
+              VLOG(5) << "The groups of weight1_dim must be 1";
+              continue;
+            }
+            if (ch_out_0 != ch_in_1) {
+              VLOG(5) << "channel0_out must be equal channel1_in";
+              continue;
+            }
+            if (enable0_int8 || enable0_int8 != enable1_int8) {
+              VLOG(5) << "The Conv-compute type must be same and be false";
+              continue;
+            }
+            // computation: ic0 x (oc1-oc0) < oc0 x oc1
+            VLOG(5) << "a: " << (ch_in_0 * (ch_out_1 - ch_out_0)) << " <= "
+                    << "b: " << (ch_out_0 * ch_out_1);
+
+            if (ch_in_0 * (ch_out_1 - ch_out_0) > ch_out_0 * ch_out_1) {
+              VLOG(5) << "it dose not meet the requirment of conv+conv fusion "
+                      << "computation "
+                      << "a: " << (ch_in_0 * (ch_out_1 - ch_out_0)) << " <= "
+                      << "b: " << (ch_out_0 * ch_out_1);
+              continue;
+            }
+            // create pattern
+            VLOG(5) << "matched: " << conv_type0_ << " and " << conv_type1_;
+            createPattern();
+            return;
+          }
+        }
+      }
+    }
+  }
+}
+
 void ConvConvFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
   auto conv_instruct = matched.at("conv2d0")->stmt();
   auto conv_op_desc = conv_instruct->mutable_op_info();
@@ -95,24 +180,10 @@ void ConvConvFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
   // conv1
   auto weight1_t = scope->FindVar(matched.at("conv_weight1")->arg()->name)
                        ->GetMutable<lite::Tensor>();
-  // auto groups0 = conv_op_desc->GetAttr<int>("groups");
-  auto groups1 = conv_op_desc1->GetAttr<int>("groups");
+  bool enable0_int8 = conv_op_desc->HasAttr("enable_int8") ? true : false;
   auto strides1 = conv_op_desc1->GetAttr<std::vector<int>>("strides");
   auto paddings1 = conv_op_desc1->GetAttr<std::vector<int>>("paddings");
   auto dilations1 = conv_op_desc1->GetAttr<std::vector<int>>("dilations");
-
-  bool enable0_int8 = conv_op_desc->HasAttr("enable_int8") ? true : false;
-  bool enable1_int8 = conv_op_desc1->HasAttr("enable_int8") ? true : false;
-  int kw = weight1_t->dims()[2];
-  int kh = weight1_t->dims()[3];
-  if (!(kw == 1 && kh == 1)) {
-    LOG(FATAL) << "The kernel size of the second conv must be 1x1";
-  }
-  auto channel0_out = weight0_t->dims()[0];
-  auto channel1_in = weight1_t->dims()[1] * groups1;
-  CHECK_EQ(enable0_int8, enable1_int8) << "The Conv compute type must be same";
-  CHECK_EQ(groups1, 1) << "The groups of weight1_dim must be 1";
-  CHECK_EQ(channel0_out, channel1_in) << "channel0_out == channel1_in";
 
   for (int i = 0; i < strides1.size(); i++) {
     CHECK_EQ(strides1[i], 1) << "strides[" << i << "]: " << strides1[i]

--- a/lite/core/mir/fusion/conv_conv_fuser.h
+++ b/lite/core/mir/fusion/conv_conv_fuser.h
@@ -30,13 +30,16 @@ class ConvConvFuser : public FuseBase {
   explicit ConvConvFuser(const std::string& conv_type0,
                          const std::string& conv_type1,
                          const bool conv_has_bias0,
-                         const bool conv_has_bias1)
+                         const bool conv_has_bias1,
+                         const std::unique_ptr<SSAGraph>& graph)
       : conv_type0_(conv_type0),
         conv_type1_(conv_type1),
         conv_has_bias0_(conv_has_bias0),
-        conv_has_bias1_(conv_has_bias1) {}
+        conv_has_bias1_(conv_has_bias1),
+        graph_(graph) {}
   void BuildPattern() override;
   void InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) override;
+  inline void createPattern();
 
  private:
   void ComputeNewWeight(float* dout,
@@ -112,6 +115,7 @@ class ConvConvFuser : public FuseBase {
   std::string conv_type1_{"conv2d"};
   bool conv_has_bias0_{false};
   bool conv_has_bias1_{false};
+  const std::unique_ptr<SSAGraph>& graph_;
 };
 
 }  // namespace fusion

--- a/lite/model_parser/base/block_desc.h
+++ b/lite/model_parser/base/block_desc.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include "lite/model_parser/base/traits.h"
 #include "lite/utils/cp_logging.h"
 
 namespace paddle {
@@ -47,30 +48,29 @@ class BlockDescReadAPI {
 
 class BlockDescWriteAPI {
  public:
-  virtual void SetIdx(int32_t idx) { NotImplemented(); }
-  virtual void SetParentIdx(int32_t idx) { NotImplemented(); }
-  virtual void ClearVars() { NotImplemented(); }
-  virtual void ClearOps() { NotImplemented(); }
-  virtual void SetForwardBlockIdx(int32_t idx) { NotImplemented(); }
+  virtual void SetIdx(int32_t idx) { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  virtual void SetParentIdx(int32_t idx) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void ClearVars() { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  virtual void ClearOps() { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  virtual void SetForwardBlockIdx(int32_t idx) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
 
   template <typename T>
   T* AddVar() {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
   template <typename T>
   T* AddOp() {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
   virtual ~BlockDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "BlockDescWriteAPI is not available in model read-only mode.";
-  }
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/base/op_desc.h
+++ b/lite/model_parser/base/op_desc.h
@@ -62,27 +62,24 @@ class OpDescReadAPI {
 
 class OpDescWriteAPI {
  public:
-  virtual void SetType(const std::string& type) { NotImplemented(); }
+  virtual void SetType(const std::string& type) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
   virtual void SetInput(const std::string& param,
                         const std::vector<std::string>& args) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
   }
   virtual void SetOutput(const std::string& param,
                          const std::vector<std::string>& args) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
   }
 
   template <typename T>
   void SetAttr(const std::string& name, const T& v) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
   }
 
   virtual ~OpDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "OpDescWriteAPI is not available in model read-only mode.";
-  }
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/base/param_desc.h
+++ b/lite/model_parser/base/param_desc.h
@@ -34,17 +34,20 @@ class ParamDescReadAPI {
 
 class ParamDescWriteAPI {
  public:
-  virtual void SetName(const std::string &name) { NotImplemented(); }
-  virtual void SetDim(const std::vector<int64_t> &dim) { NotImplemented(); }
-  virtual void SetDataType(VarDataType data_type) { NotImplemented(); }
-  virtual void SetData(const void *data, size_t byte_size) { NotImplemented(); }
+  virtual void SetName(const std::string &name) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetDim(const std::vector<int64_t> &dim) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetDataType(VarDataType data_type) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetData(const void *data, size_t byte_size) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
 
   virtual ~ParamDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "ParamDescWriteAPI is not available in model read-only mode.";
-  }
 };
 
 class CombinedParamsDescReadAPI {
@@ -57,16 +60,10 @@ class CombinedParamsDescReadAPI {
 class CombinedParamsDescWriteAPI {
  public:
   virtual ParamDescWriteAPI *AddParamDesc() {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
   virtual ~CombinedParamsDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "CombinedParamsDescWriteAPI is not available in model "
-                  "read-only mode.";
-  }
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/base/program_desc.h
+++ b/lite/model_parser/base/program_desc.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "lite/model_parser/base/traits.h"
 #include "lite/utils/cp_logging.h"
 
 namespace paddle {
@@ -36,22 +37,18 @@ class ProgramDescReadAPI {
 
 class ProgramDescWriteAPI {
  public:
-  virtual void ClearBlocks() { NotImplemented(); }
-  virtual void SetVersion(int64_t version) { NotImplemented(); }
+  virtual void ClearBlocks() { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  virtual void SetVersion(int64_t version) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
 
   template <typename T>
   T* AddBlock() {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
   virtual ~ProgramDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL)
-        << "ProgramDescWriteAPI is not available in model read-only mode.";
-  }
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/base/traits.h
+++ b/lite/model_parser/base/traits.h
@@ -19,6 +19,10 @@
 #include "lite/api/paddle_place.h"
 #include "lite/utils/cp_logging.h"
 
+#define LITE_MODEL_INTERFACE_NOT_IMPLEMENTED                \
+  LOG(FATAL) << "This additional interface is temporarily " \
+                "unavailable in flatbuffers read-only mode."
+
 namespace paddle {
 namespace lite {
 

--- a/lite/model_parser/base/var_desc.h
+++ b/lite/model_parser/base/var_desc.h
@@ -33,16 +33,19 @@ class VarDescReadAPI {
 
 class VarDescWriteAPI {
  public:
-  virtual void SetName(std::string name) { NotImplemented(); }
-  virtual void SetType(VarDataType type) { NotImplemented(); }
-  virtual void SetPersistable(bool persistable) { NotImplemented(); }
-  virtual void SetShape(const std::vector<int64_t>& dims) { NotImplemented(); }
-  virtual ~VarDescWriteAPI() = default;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "VarDescWriteAPI is not available in model read-only mode.";
+  virtual void SetName(std::string name) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
   }
+  virtual void SetType(VarDataType type) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetPersistable(bool persistable) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual void SetShape(const std::vector<int64_t>& dims) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
+  virtual ~VarDescWriteAPI() = default;
 };
 
 // The reading and writing of the model are one-time and separate.

--- a/lite/model_parser/flatbuffers/block_desc.h
+++ b/lite/model_parser/flatbuffers/block_desc.h
@@ -51,7 +51,7 @@ class BlockDescView : public BlockDescAPI {
 
   template <typename T>
   T* GetVar(int32_t idx) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
@@ -66,7 +66,7 @@ class BlockDescView : public BlockDescAPI {
 
   template <typename T>
   T* GetOp(int32_t idx) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
@@ -82,12 +82,6 @@ class BlockDescView : public BlockDescAPI {
   proto::BlockDesc const* desc_;  // not_own
   std::vector<VarDescView> vars_;
   std::vector<OpDescView> ops_;
-
- private:
-  void NotImplemented() const {
-    LOG(FATAL) << "The additional interfaces of BlockDescView is temporarily "
-                  "unavailable in read-only mode.";
-  }
 };
 
 #ifdef LITE_WITH_FLATBUFFERS_DESC

--- a/lite/model_parser/flatbuffers/io.cc
+++ b/lite/model_parser/flatbuffers/io.cc
@@ -23,12 +23,20 @@ namespace paddle {
 namespace lite {
 namespace fbs {
 
-std::vector<char> LoadFile(const std::string& path) {
+std::vector<char> LoadFile(const std::string& path,
+                           const size_t& offset,
+                           const size_t& size) {
+  // open file in readonly mode
   FILE* file = fopen(path.c_str(), "rb");
-  CHECK(file);
-  fseek(file, 0, SEEK_END);
-  uint64_t length = ftell(file);
-  rewind(file);
+  CHECK(file) << "Unable to open file: " << path;
+  // move fstream pointer backward for offset
+  uint64_t length = size;
+  if (size == 0) {
+    fseek(file, 0L, SEEK_END);
+    length = ftell(file) - offset;
+  }
+  fseek(file, offset, SEEK_SET);
+  // read data of `length` into buf
   std::vector<char> buf(length);
   CHECK_EQ(fread(buf.data(), 1, length, file), length);
   fclose(file);

--- a/lite/model_parser/flatbuffers/io.h
+++ b/lite/model_parser/flatbuffers/io.h
@@ -26,7 +26,9 @@ namespace paddle {
 namespace lite {
 namespace fbs {
 
-std::vector<char> LoadFile(const std::string& path);
+std::vector<char> LoadFile(const std::string& path,
+                           const size_t& offset = 0,
+                           const size_t& size = 0);
 void SaveFile(const std::string& path, const std::vector<char>& cache);
 
 void SetScopeWithCombinedParams(lite::Scope* scope,

--- a/lite/model_parser/flatbuffers/op_desc.h
+++ b/lite/model_parser/flatbuffers/op_desc.h
@@ -154,11 +154,33 @@ class OpDescView : public OpDescAPI {
   }
 
   const std::map<std::string, std::vector<std::string>>& inputs() const {
-    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+    for (const auto& var : *desc_->inputs()) {
+      std::pair<std::string, std::vector<std::string>> pair;
+      pair.first = var->parameter()->str();
+      auto& args_vec = pair.second;
+      if (var && var->arguments()) {
+        args_vec.resize(var->arguments()->size());
+        for (size_t i = 0; i < var->arguments()->size(); ++i) {
+          args_vec[i] = (*var->arguments())[i]->str();
+        }
+      }
+      inputs_.insert(std::move(pair));
+    }
     return inputs_;
   }
   const std::map<std::string, std::vector<std::string>>& outputs() const {
-    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+    for (const auto& var : *desc_->outputs()) {
+      std::pair<std::string, std::vector<std::string>> pair;
+      pair.first = var->parameter()->str();
+      auto& args_vec = pair.second;
+      if (var && var->arguments()) {
+        args_vec.resize(var->arguments()->size());
+        for (size_t i = 0; i < var->arguments()->size(); ++i) {
+          args_vec[i] = (*var->arguments())[i]->str();
+        }
+      }
+      outputs_.insert(std::move(pair));
+    }
     return outputs_;
   }
   std::map<std::string, std::vector<std::string>>* mutable_inputs() {
@@ -202,8 +224,8 @@ class OpDescView : public OpDescAPI {
 
  private:
   std::string type_;
-  std::map<std::string, std::vector<std::string>> inputs_;
-  std::map<std::string, std::vector<std::string>> outputs_;
+  mutable std::map<std::string, std::vector<std::string>> inputs_;
+  mutable std::map<std::string, std::vector<std::string>> outputs_;
   std::map<std::string, Any> attrs_;
   std::map<std::string, AttrType> attr_types_;
 };

--- a/lite/model_parser/flatbuffers/op_desc.h
+++ b/lite/model_parser/flatbuffers/op_desc.h
@@ -154,18 +154,22 @@ class OpDescView : public OpDescAPI {
   }
 
   const std::map<std::string, std::vector<std::string>>& inputs() const {
+    VLOG(8) << "[additional interfaces] OpDescView::inputs()";
     NotImplemented();
     return inputs_;
   }
   const std::map<std::string, std::vector<std::string>>& outputs() const {
+    VLOG(8) << "[additional interfaces] OpDescView::outputs()";
     NotImplemented();
     return outputs_;
   }
   std::map<std::string, std::vector<std::string>>* mutable_inputs() {
+    VLOG(8) << "[additional interfaces] OpDescView::mutable_inputs()";
     NotImplemented();
     return &inputs_;
   }
   std::map<std::string, std::vector<std::string>>* mutable_outputs() {
+    VLOG(8) << "[additional interfaces] OpDescView::mutable_outputs()";
     NotImplemented();
     return &outputs_;
   }
@@ -183,6 +187,7 @@ class OpDescView : public OpDescAPI {
   }
 
   std::vector<std::string> output_vars() const {
+    VLOG(8) << "[additional interfaces] OpDescView::output_vars()";
     NotImplemented();
     return std::vector<std::string>();
   }
@@ -192,10 +197,12 @@ class OpDescView : public OpDescAPI {
   }
 
   const std::map<std::string, Any>& attrs() const {
+    VLOG(8) << "[additional interfaces] OpDescView::attrs()";
     NotImplemented();
     return attrs_;
   }
   const std::map<std::string, AttrType>& attr_types() const {
+    VLOG(8) << "[additional interfaces] OpDescView::attr_types()";
     NotImplemented();
     return attr_types_;
   }

--- a/lite/model_parser/flatbuffers/op_desc.h
+++ b/lite/model_parser/flatbuffers/op_desc.h
@@ -154,23 +154,19 @@ class OpDescView : public OpDescAPI {
   }
 
   const std::map<std::string, std::vector<std::string>>& inputs() const {
-    VLOG(8) << "[additional interfaces] OpDescView::inputs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return inputs_;
   }
   const std::map<std::string, std::vector<std::string>>& outputs() const {
-    VLOG(8) << "[additional interfaces] OpDescView::outputs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return outputs_;
   }
   std::map<std::string, std::vector<std::string>>* mutable_inputs() {
-    VLOG(8) << "[additional interfaces] OpDescView::mutable_inputs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return &inputs_;
   }
   std::map<std::string, std::vector<std::string>>* mutable_outputs() {
-    VLOG(8) << "[additional interfaces] OpDescView::mutable_outputs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return &outputs_;
   }
 
@@ -187,8 +183,7 @@ class OpDescView : public OpDescAPI {
   }
 
   std::vector<std::string> output_vars() const {
-    VLOG(8) << "[additional interfaces] OpDescView::output_vars()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return std::vector<std::string>();
   }
 
@@ -197,21 +192,15 @@ class OpDescView : public OpDescAPI {
   }
 
   const std::map<std::string, Any>& attrs() const {
-    VLOG(8) << "[additional interfaces] OpDescView::attrs()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return attrs_;
   }
   const std::map<std::string, AttrType>& attr_types() const {
-    VLOG(8) << "[additional interfaces] OpDescView::attr_types()";
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return attr_types_;
   }
 
  private:
-  void NotImplemented() const {
-    LOG(FATAL) << "The additional interfaces of OpDescView is temporarily "
-                  "unavailable in read-only mode.";
-  }
   std::string type_;
   std::map<std::string, std::vector<std::string>> inputs_;
   std::map<std::string, std::vector<std::string>> outputs_;

--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -66,7 +66,7 @@ class ProgramDescView : public ProgramDescAPI {
 
   template <typename T>
   T* GetBlock(int32_t idx) {
-    NotImplemented();
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return nullptr;
   }
 
@@ -91,10 +91,6 @@ class ProgramDescView : public ProgramDescAPI {
  private:
   ProgramDescView& operator=(const ProgramDescView&) = delete;
   ProgramDescView(const ProgramDescView&) = delete;
-  void NotImplemented() const {
-    LOG(FATAL) << "The additional interfaces of ProgramDescView is temporarily "
-                  "unavailable in read-only mode.";
-  }
 };
 
 #ifdef LITE_WITH_FLATBUFFERS_DESC

--- a/lite/model_parser/flatbuffers/var_desc.h
+++ b/lite/model_parser/flatbuffers/var_desc.h
@@ -67,14 +67,12 @@ class VarDescView : public VarDescAPI {
 
  public:
   VarDescView() = default;
-  void SetDataType(Type data_type) { NotImplemented(); }
-  void SetShape(const std::vector<int64_t>& dims) { NotImplemented(); }
+  void SetDataType(Type data_type) { LITE_MODEL_INTERFACE_NOT_IMPLEMENTED; }
+  void SetShape(const std::vector<int64_t>& dims) {
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
+  }
 
  private:
-  void NotImplemented() const {
-    LOG(FATAL) << "The additional interfaces of VarDescView is temporarily "
-                  "unavailable in read-only mode.";
-  }
   std::vector<int64_t> shape_;
 };
 

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -546,64 +546,57 @@ void SaveCombinedParamsNaive(const std::string &path,
   table.AppendToFile(path);
 }
 
-void SaveModelNaive(const std::string &model_dir,
+////////////////////////////////////////////////////////////////////////////////////
+// Save model: meta_version = 1
+// Flatbuffer model + params
+////////////////////////////////////////////////////////////////////////////////////
+// Create a new file and write data into it.
+void WriteToFile(const std::string &filename,
+                 const void *src,
+                 size_t byte_size) {
+  CHECK(src);
+  FILE *file = fopen(filename.c_str(), "wb");
+  CHECK(file);
+  CHECK(fwrite(src, sizeof(char), byte_size, file) == byte_size);
+  fclose(file);
+}
+// Append data into an existed file.
+void AppendToFile(const std::string &filename,
+                  const void *src,
+                  size_t byte_size) {
+  CHECK(src);
+  FILE *fp = fopen(filename.c_str(), "ab");
+  CHECK(fp) << "Unable to open file: " << filename;
+  if (fwrite(reinterpret_cast<const char *>(src), 1, byte_size, fp) !=
+      byte_size) {
+    fclose(fp);
+    LOG(FATAL) << "Write file error: " << filename;
+  }
+  fclose(fp);
+}
+/* ---------- Flatbuffers ---------- */
+void SaveModelNaive(const std::string &model_file,
                     const Scope &exec_scope,
-                    const cpp::ProgramDesc &cpp_prog,
-                    bool combined) {
-  // Save program
-  const std::string prog_path = model_dir + ".nb";
-  naive_buffer::BinaryTable table;
-  naive_buffer::proto::ProgramDesc nb_proto_prog(&table);
-  naive_buffer::ProgramDesc nb_prog(&nb_proto_prog);
-  TransformProgramDescCppToAny(cpp_prog, &nb_prog);
-  nb_proto_prog.Save();
-
+                    const cpp::ProgramDesc &cpp_prog) {
+  /* 1. Save model to model.fbs */
+  const std::string prog_path = model_file + ".nb";
   // Save meta_version(uint16) into file
-  naive_buffer::BinaryTable meta_version_table;
-  meta_version_table.Require(sizeof(uint16_t));
-  uint16_t meta_version = 0;
-  memcpy(meta_version_table.cursor(), &meta_version, sizeof(uint16_t));
-  meta_version_table.Consume(sizeof(uint16_t));
-  meta_version_table.SaveToFile(prog_path);
+  uint16_t meta_version = 1;
+  WriteToFile(prog_path, &meta_version, sizeof(uint16_t));
 
   // Save lite_version(char[16]) into file
   const int paddle_version_length = 16 * sizeof(char);
-  naive_buffer::BinaryTable paddle_version_table;
-  paddle_version_table.Require(paddle_version_length);
   std::string paddle_version = version();
-  memcpy(paddle_version_table.cursor(),
-         paddle_version.c_str(),
-         paddle_version_length);
-  paddle_version_table.Consume(paddle_version_length);
-  paddle_version_table.AppendToFile(prog_path);
+  AppendToFile(prog_path, paddle_version.c_str(), paddle_version_length);
   VLOG(4) << "paddle_version:" << paddle_version;
 
-  // Save topology_size(uint64) into file
-  naive_buffer::BinaryTable topology_size_table;
-  topology_size_table.Require(sizeof(uint64_t));
-  uint64_t topology_size = table.size();
-  memcpy(topology_size_table.cursor(), &topology_size, sizeof(uint64_t));
-  topology_size_table.Consume(sizeof(uint64_t));
-  topology_size_table.AppendToFile(prog_path);
-
-  // save topology data into model file
-  table.AppendToFile(prog_path);
-  // Save Params
-  SaveCombinedParamsNaive(prog_path, exec_scope, cpp_prog);
-
-  LOG(INFO) << "Save naive buffer model in '" << model_dir
-            << ".nb' successfully";
-}
-
-/* ---------- Flatbuffers ---------- */
-void SaveModelFbs(const std::string &model_dir,
-                  const Scope &exec_scope,
-                  const cpp::ProgramDesc &cpp_prog) {
-  /* 1. Save model to model.fbs */
-  const std::string prog_path = model_dir + "/model.fbs";
   fbs::ProgramDesc fbs_prog;
   TransformProgramDescCppToAny(cpp_prog, &fbs_prog);
-  fbs::SaveFile(prog_path, fbs_prog.data());
+  uint64_t topology_size = (fbs_prog.data()).size();
+  AppendToFile(prog_path, &topology_size, sizeof(uint64_t));
+  /* 1. Save model to model.fbs */
+  AppendToFile(prog_path, (fbs_prog.data()).data(), topology_size);
+  VLOG(4) << "save topology_size:" << topology_size;
 
   /* 2. Get param names from cpp::ProgramDesc */
   auto &main_block_desc = *cpp_prog.GetBlock<cpp::BlockDesc>(0);
@@ -618,37 +611,14 @@ void SaveModelFbs(const std::string &model_dir,
   }
 
   /* 3. Save combined params to params.fbs */
-  const std::string params_path = model_dir + "/params.fbs";
   fbs::CombinedParamsDesc params_prog;
   fbs::SetCombinedParamsWithScope(exec_scope, unique_var_names, &params_prog);
-  fbs::SaveFile(params_path, params_prog.data());
+  AppendToFile(
+      prog_path, (params_prog.data()).data(), (params_prog.data()).size());
+
+  LOG(INFO) << "Save naive buffer model in '" << prog_path << " successfully";
 }
 #endif  // LITE_ON_TINY_PUBLISH
-
-void LoadModelFbsFromFile(const std::string &filename,
-                          Scope *scope,
-                          cpp::ProgramDesc *cpp_prog) {
-  CHECK(cpp_prog);
-  CHECK(scope);
-
-  /* 1. Load cpp::ProgramDesc with model.fbs */
-  const std::string prog_path = filename + "/model.fbs";
-#ifdef LITE_ON_FLATBUFFERS_DESC_VIEW
-  cpp_prog->Init(fbs::LoadFile(prog_path));
-#elif LITE_ON_TINY_PUBLISH
-  LOG(FATAL) << "Since no data structure of Flatbuffers has been constructed, "
-                "the model cannot be loaded.";
-#else
-  fbs::ProgramDesc program(fbs::LoadFile(prog_path));
-  TransformProgramDescAnyToCpp(program, cpp_prog);
-#endif
-
-  /* 2. Load scope with params.fbs */
-  const std::string params_path = filename + "/params.fbs";
-  fbs::CombinedParamsDescView params(fbs::LoadFile(params_path));
-  fbs::SetScopeWithCombinedParams(scope, params);
-}
-
 template <typename T>
 void SetTensorDataNaive(T *out, size_t size, const std::vector<T> &src) {
   CHECK(out);
@@ -746,7 +716,10 @@ void LoadCombinedParamsNaive(const std::string &path,
                                          << "] not found";
   }
 }
-
+///////////////////////////////////////////////////////////////////////////////
+/* Old Method of loading and saving model, before V2.3.0                     */
+/* Warning: this is an old inference and will be abandened in release/v3.0.0 */
+///////////////////////////////////////////////////////////////////////////////
 void LoadModelNaive(const std::string &model_dir,
                     Scope *scope,
                     cpp::ProgramDesc *cpp_prog,
@@ -802,6 +775,43 @@ void LoadModelNaive(const std::string &model_dir,
   VLOG(4) << "Load naive buffer model in '" << model_dir << "' successfully";
 }
 
+void LoadModelNaiveFromMemory(const std::string &model_buffer,
+                              const std::string &param_buffer,
+                              Scope *scope,
+                              cpp::ProgramDesc *cpp_prog) {
+  CHECK(cpp_prog);
+  CHECK(scope);
+  cpp_prog->ClearBlocks();
+
+  // Load model
+  naive_buffer::BinaryTable table;
+  table.LoadFromMemory(model_buffer.c_str(), model_buffer.length());
+
+  naive_buffer::proto::ProgramDesc nb_proto_prog(&table);
+  nb_proto_prog.Load();
+  naive_buffer::ProgramDesc nb_prog(&nb_proto_prog);
+
+  // Transform to cpp::ProgramDesc
+  TransformProgramDescAnyToCpp(nb_prog, cpp_prog);
+
+  // Load Params
+  LoadCombinedParamsNaive(param_buffer, 0, scope, *cpp_prog, true);
+
+  VLOG(4) << "Load model from naive buffer memory successfully";
+}
+//////////////////////////////////////////////////////////////////////
+
+// usage: LoadModelNaiveFromFile is used for loading model from file.
+template <typename T>
+void ReadModelDataFromFile(T *data,
+                           const std::string &prog_path,
+                           uint64_t *offset,
+                           const uint64_t &size) {
+  naive_buffer::BinaryTable data_table;
+  data_table.LoadFromFile(prog_path, *offset, size);
+  memcpy(data, data_table.cursor(), size);
+  *offset = *offset + size;
+}
 /*
  * Binary structure of naive_buffer model: model.nb
  * ----------------------------------------------------------
@@ -820,21 +830,39 @@ void LoadModelNaive(const std::string &model_dir,
  *      param_data:   contains model's params data.
 */
 
-// usage: LoadModelNaiveFromFile is used for loading model from file.
-template <typename T>
-void ReadModelDataFromFile(T *data,
-                           const std::string &prog_path,
-                           uint64_t *offset,
-                           const uint64_t &size) {
-  naive_buffer::BinaryTable data_table;
-  data_table.LoadFromFile(prog_path, *offset, size);
-  memcpy(data, data_table.cursor(), size);
-  *offset = *offset + size;
-}
-
 void LoadModelNaiveFromFile(const std::string &filename,
                             Scope *scope,
                             cpp::ProgramDesc *cpp_prog) {
+  CHECK(cpp_prog);
+  CHECK(scope);
+  cpp_prog->ClearBlocks();
+  // ModelFile
+  const std::string prog_path = filename;
+
+  // Offset
+  uint64_t offset = 0;
+
+  // (1)get meta version
+  uint16_t meta_version;
+  ReadModelDataFromFile<uint16_t>(
+      &meta_version, prog_path, &offset, sizeof(uint16_t));
+  VLOG(4) << "Meta_version:" << meta_version;
+
+  switch (meta_version) {
+    case 0:
+      LoadModelNaiveV0FromFile(filename, scope, cpp_prog);
+      break;
+    case 1:
+      LoadModelFbsFromFile(filename, scope, cpp_prog);
+      break;
+    default:
+      LOG(FATAL) << "Error, this model file is not supported.";
+      break;
+  }
+}
+void LoadModelNaiveV0FromFile(const std::string &filename,
+                              Scope *scope,
+                              cpp::ProgramDesc *cpp_prog) {
   CHECK(cpp_prog);
   CHECK(scope);
   cpp_prog->ClearBlocks();
@@ -890,34 +918,53 @@ void LoadModelNaiveFromFile(const std::string &filename,
   VLOG(4) << "Load naive buffer model in '" << filename << "' successfully";
 }
 
-// warning: this is an old inference and is not suggested.
-// todo: this inference will be abandened in release/v3.0.0
-void LoadModelNaiveFromMemory(const std::string &model_buffer,
-                              const std::string &param_buffer,
-                              Scope *scope,
-                              cpp::ProgramDesc *cpp_prog) {
+void LoadModelFbsFromFile(const std::string &filename,
+                          Scope *scope,
+                          cpp::ProgramDesc *cpp_prog) {
   CHECK(cpp_prog);
   CHECK(scope);
   cpp_prog->ClearBlocks();
+  // Offset
+  uint64_t offset = sizeof(uint16_t);
 
-  // Load model
+  // get opt version
+  char opt_version[16];
+  const uint64_t opt_version_length = 16 * sizeof(char);
+  ReadModelDataFromFile<char>(
+      opt_version, filename, &offset, opt_version_length);
+  VLOG(4) << "Opt_version:" << static_cast<const char *>(opt_version);
+  // check version, opt's version should be consistent with current Paddle-Lite
+  // version.
+  const std::string paddle_version = version();
+  const std::string opt_version_str = opt_version;
+  if (paddle_version != opt_version_str) {
+    LOG(WARNING) << "warning: the version of opt that transformed this model "
+                    "is not consistent with current Paddle-Lite version."
+                    "\n      version of opt:"
+                 << static_cast<const char *>(opt_version)
+                 << "\n      version of current Paddle-Lite:" << paddle_version;
+  }
+  // (3)get topo_size
+  uint64_t topo_size;
+  ReadModelDataFromFile<uint64_t>(
+      &topo_size, filename, &offset, sizeof(uint64_t));
 
-  naive_buffer::BinaryTable table;
-  table.LoadFromMemory(model_buffer.c_str(), model_buffer.length());
+#ifdef LITE_ON_FLATBUFFERS_DESC_VIEW
+  cpp_prog->Init(fbs::LoadFile(filename, offset, topo_size));
+#elif LITE_ON_TINY_PUBLISH
+  LOG(FATAL) << "Since no data structure of Flatbuffers has been constructed, "
+                "the model cannot be loaded.";
+#else
+  fbs::ProgramDesc program(fbs::LoadFile(filename, offset, topo_size));
+  TransformProgramDescAnyToCpp(program, cpp_prog);
+#endif
+  offset = offset + topo_size;
 
-  naive_buffer::proto::ProgramDesc nb_proto_prog(&table);
-  nb_proto_prog.Load();
-  naive_buffer::ProgramDesc nb_prog(&nb_proto_prog);
+  /* 2. Load scope from params.fbs */
+  fbs::CombinedParamsDescView params(fbs::LoadFile(filename, offset));
+  fbs::SetScopeWithCombinedParams(scope, params);
 
-  // Transform to cpp::ProgramDesc
-  TransformProgramDescAnyToCpp(nb_prog, cpp_prog);
-
-  // Load Params
-  // NOTE: Only main block be used now.
-  // only combined Params are supported in Loading Model from memory
-  LoadCombinedParamsNaive(param_buffer, 0, scope, *cpp_prog, true);
-
-  VLOG(4) << "Load model from naive buffer memory successfully";
+  VLOG(4) << "Load naive buffer model in '" << filename << "' successfully";
 }
 
 // usage: LoadModelNaiveFromMemory is used for loading naive model from memory
@@ -931,6 +978,7 @@ void ReadModelDataFromBuffer(T *data,
   memcpy(data, data_table.cursor(), size);
   *offset = *offset + size;
 }
+
 void LoadModelNaiveFromMemory(const std::string &model_buffer,
                               Scope *scope,
                               cpp::ProgramDesc *cpp_prog) {
@@ -938,14 +986,30 @@ void LoadModelNaiveFromMemory(const std::string &model_buffer,
   CHECK(scope);
   cpp_prog->ClearBlocks();
 
-  // Offset
   uint64_t offset = 0;
-
   // (1)get meta version
   uint16_t meta_version;
   ReadModelDataFromBuffer<uint16_t>(
       &meta_version, model_buffer, &offset, sizeof(uint16_t));
   VLOG(4) << "Meta_version:" << meta_version;
+  switch (meta_version) {
+    case 0:
+      LoadModelNaiveV0FromMemory(model_buffer, scope, cpp_prog);
+      break;
+    case 1:
+      LoadModelNaiveV1FromMemory(model_buffer, scope, cpp_prog);
+      break;
+    default:
+      LOG(FATAL) << "Error: Unsupported model type.";
+      break;
+  }
+}
+
+void LoadModelNaiveV0FromMemory(const std::string &model_buffer,
+                                Scope *scope,
+                                cpp::ProgramDesc *cpp_prog) {
+  // Offset
+  uint64_t offset = sizeof(uint16_t);
 
   // (2)get opt version
   char opt_version[16];
@@ -973,6 +1037,53 @@ void LoadModelNaiveFromMemory(const std::string &model_buffer,
   // NOTE: Only main block be used now.
   // only combined Params are supported in Loading Model from memory
   LoadCombinedParamsNaive(model_buffer, offset, scope, *cpp_prog, true);
+
+  VLOG(4) << "Load model from naive buffer memory successfully";
+}
+
+///////////////////////////////////////////////////////////////////
+// Meta_version=1
+///////////////////////////////////////////////////////////////////
+void LoadModelNaiveV1FromMemory(const std::string &model_buffer,
+                                Scope *scope,
+                                cpp::ProgramDesc *cpp_prog) {
+  // Offset
+  uint64_t offset = sizeof(uint16_t);
+
+  // (2)get opt version
+  char opt_version[16];
+  const uint64_t paddle_version_length = 16 * sizeof(char);
+  ReadModelDataFromBuffer<char>(
+      opt_version, model_buffer, &offset, paddle_version_length);
+  VLOG(4) << "Opt_version:" << static_cast<const char *>(opt_version);
+
+  // (3)get prog_size and prog_data
+  uint64_t prog_size;
+  ReadModelDataFromBuffer<uint64_t>(
+      &prog_size, model_buffer, &offset, sizeof(uint64_t));
+  VLOG(4) << "prog_size:" << prog_size;
+
+  std::vector<char> prog_data(prog_size);
+  memcpy(prog_data.data(), model_buffer.c_str() + offset, prog_size);
+#ifdef LITE_ON_FLATBUFFERS_DESC_VIEW
+  cpp_prog->Init(prog_data);
+#elif LITE_ON_TINY_PUBLISH
+  LOG(FATAL) << "Since no data structure of Flatbuffers has been constructed, "
+                "the model cannot be loaded.";
+#else
+  fbs::ProgramDesc program(prog_data);
+  TransformProgramDescAnyToCpp(program, cpp_prog);
+#endif
+  offset = offset + prog_size;
+  VLOG(4) << "param_size:" << model_buffer.length() - offset;
+
+  std::vector<char> params_data(model_buffer.length() - offset);
+  memcpy(params_data.data(),
+         model_buffer.c_str() + offset,
+         model_buffer.length() - offset);
+
+  fbs::CombinedParamsDescView params(params_data);
+  fbs::SetScopeWithCombinedParams(scope, params);
 
   VLOG(4) << "Load model from naive buffer memory successfully";
 }

--- a/lite/model_parser/model_parser.h
+++ b/lite/model_parser/model_parser.h
@@ -35,6 +35,16 @@ namespace lite {
 std::unique_ptr<framework::proto::ProgramDesc> LoadProgram(
     const std::string& path, bool program_from_memory = false);
 
+template <typename T>
+void ReadModelDataFromFile(T* data,
+                           const std::string& prog_path,
+                           uint64_t* offset,
+                           const uint64_t& size);
+
+void AppendToFile(const std::string& filename,
+                  const void* src,
+                  size_t byte_size);
+
 // Read a single file containing all the parameters.
 void LoadParams(const std::string& path);
 
@@ -86,14 +96,12 @@ void SaveCombinedParamsNaive(const std::string& path,
 
 void SaveModelNaive(const std::string& model_dir,
                     const Scope& exec_scope,
-                    const cpp::ProgramDesc& cpp_prog,
-                    bool combined = true);
+                    const cpp::ProgramDesc& cpp_prog);
 
 void SaveModelFbs(const std::string& model_dir,
                   const Scope& exec_scope,
                   const cpp::ProgramDesc& cpp_prog);
 #endif  // LITE_ON_TINY_PUBLISH
-
 void LoadModelFbsFromFile(const std::string& filename,
                           Scope* scope,
                           cpp::ProgramDesc* cpp_prog);
@@ -108,6 +116,12 @@ void LoadModelNaive(const std::string& model_dir,
                     lite::Scope* scope,
                     cpp::ProgramDesc* prog,
                     bool combined = true);
+void LoadModelFbsFromFile(const std::string& filename,
+                          Scope* scope,
+                          cpp::ProgramDesc* cpp_prog);
+void LoadModelNaiveV0FromFile(const std::string& filename,
+                              Scope* scope,
+                              cpp::ProgramDesc* cpp_prog);
 void LoadModelNaiveFromFile(const std::string& filename,
                             lite::Scope* scope,
                             cpp::ProgramDesc* prog);
@@ -118,6 +132,15 @@ void LoadModelNaiveFromMemory(const std::string& model_buffer,
 void LoadModelNaiveFromMemory(const std::string& model_buffer,
                               lite::Scope* scope,
                               cpp::ProgramDesc* cpp_prog);
+void LoadModelNaiveV1FromMemory(const std::string& model_buffer,
+                                Scope* scope,
+                                cpp::ProgramDesc* cpp_prog);
 
+void LoadModelFbsFromMemory(const std::string& model_buffer,
+                            lite::Scope* scope,
+                            cpp::ProgramDesc* cpp_prog);
+void LoadModelNaiveV0FromMemory(const std::string& model_buffer,
+                                Scope* scope,
+                                cpp::ProgramDesc* cpp_prog);
 }  // namespace lite
 }  // namespace paddle

--- a/lite/model_parser/model_parser_test.cc
+++ b/lite/model_parser/model_parser_test.cc
@@ -21,7 +21,6 @@ DEFINE_string(model_dir, "", "");
 
 namespace paddle {
 namespace lite {
-
 TEST(ModelParser, LoadProgram) {
   CHECK(!FLAGS_model_dir.empty());
   auto program = LoadProgram(FLAGS_model_dir + "/__model__");
@@ -117,7 +116,7 @@ TEST(ModelParser, SaveModelNaive) {
   cpp::ProgramDesc prog;
   Scope scope;
   LoadModelPb(FLAGS_model_dir, "", "", &scope, &prog);
-  const std::string save_pb_model_path = FLAGS_model_dir + ".saved.naive";
+  const std::string save_pb_model_path = FLAGS_model_dir + ".saved";
   SaveModelNaive(save_pb_model_path, scope, prog);
 }
 
@@ -126,7 +125,7 @@ TEST(ModelParser, LoadModelNaiveFromFile) {
   cpp::ProgramDesc prog;
   Scope scope;
 
-  auto model_path = std::string(FLAGS_model_dir) + ".saved.naive.nb";
+  auto model_path = std::string(FLAGS_model_dir) + ".saved.nb";
   LoadModelNaiveFromFile(model_path, &scope, &prog);
 }
 
@@ -135,7 +134,7 @@ TEST(ModelParser, LoadModelNaiveFromMemory) {
   cpp::ProgramDesc prog;
   Scope scope;
 
-  auto model_path = std::string(FLAGS_model_dir) + ".saved.naive.nb";
+  auto model_path = std::string(FLAGS_model_dir) + ".saved.nb";
   std::string model_buffer = lite::ReadFile(model_path);
   LoadModelNaiveFromMemory(model_buffer, &scope, &prog);
 }


### PR DESCRIPTION
[背景] 将Flatbuffer和opt相关修改 cherry-pick到develop分支
Flatbuffer和opt相关修改先前在`OPT_TEST_V2.6.4`分支进行测试，当前测试完毕，需要合入develop分支

[主要修改]
- opt工具转化的模型为`flatbuffer`格式( meta_version=1)
- 加载模型过程可以加载`flatbuffer`和`naive_buffer`两种
- `LOG(FATAL)` 会导致程序直接退出