### PR TITLE
revert flatbuffers op_info interfaces, test=develop

### DIFF
--- a/lite/model_parser/flatbuffers/op_desc.h
+++ b/lite/model_parser/flatbuffers/op_desc.h
@@ -154,33 +154,11 @@ class OpDescView : public OpDescAPI {
   }
 
   const std::map<std::string, std::vector<std::string>>& inputs() const {
-    for (const auto& var : *desc_->inputs()) {
-      std::pair<std::string, std::vector<std::string>> pair;
-      pair.first = var->parameter()->str();
-      auto& args_vec = pair.second;
-      if (var && var->arguments()) {
-        args_vec.resize(var->arguments()->size());
-        for (size_t i = 0; i < var->arguments()->size(); ++i) {
-          args_vec[i] = (*var->arguments())[i]->str();
-        }
-      }
-      inputs_.insert(std::move(pair));
-    }
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return inputs_;
   }
   const std::map<std::string, std::vector<std::string>>& outputs() const {
-    for (const auto& var : *desc_->outputs()) {
-      std::pair<std::string, std::vector<std::string>> pair;
-      pair.first = var->parameter()->str();
-      auto& args_vec = pair.second;
-      if (var && var->arguments()) {
-        args_vec.resize(var->arguments()->size());
-        for (size_t i = 0; i < var->arguments()->size(); ++i) {
-          args_vec[i] = (*var->arguments())[i]->str();
-        }
-      }
-      outputs_.insert(std::move(pair));
-    }
+    LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
     return outputs_;
   }
   std::map<std::string, std::vector<std::string>>* mutable_inputs() {
@@ -224,8 +202,8 @@ class OpDescView : public OpDescAPI {
 
  private:
   std::string type_;
-  mutable std::map<std::string, std::vector<std::string>> inputs_;
-  mutable std::map<std::string, std::vector<std::string>> outputs_;
+  std::map<std::string, std::vector<std::string>> inputs_;
+  std::map<std::string, std::vector<std::string>> outputs_;
   std::map<std::string, Any> attrs_;
   std::map<std::string, AttrType> attr_types_;
 };


### PR DESCRIPTION
因为 https://github.com/PaddlePaddle/Paddle-Lite/pull/4308 已合入，所以撤销此接口修改