### PR TITLE
[OpenCL][Demo] Fix valid_places when using opencl

### DIFF
--- a/lite/demo/cxx/mobile_full/mobilenetv1_full_api.cc
+++ b/lite/demo/cxx/mobile_full/mobilenetv1_full_api.cc
@@ -45,8 +45,7 @@ void RunModel() {
 #ifdef DEMO_WITH_OPENCL
   std::vector<Place> valid_places{
       Place{TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNCHW)},
-      Place{TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNHWC)},
-      Place{TARGET(kARM), PRECISION(kFloat)}};
+      Place{TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNHWC)}};
 #else
   std::vector<Place> valid_places{Place{TARGET(kARM), PRECISION(kFloat)}};
 #endif


### PR DESCRIPTION
【问题】当用户打算使用 opencl(gpu)时，开启`DEMO_WITH_OPENCL`宏，编译后运行发现还是在ARM上跑。
【解决方法】当开启`DEMO_WITH_OPENCL`宏时，`valid_places`中不含 kARM.