### PR TITLE
[cherry-pick] fix building of xpu operators, test=develop (#4332)

### DIFF
--- a/lite/operators/__xpu__conv2d_op.cc
+++ b/lite/operators/__xpu__conv2d_op.cc
@@ -133,7 +133,7 @@ bool XPUConv2dOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
       scope->FindVar(op_desc.Output("OutputMax").front())->GetMutable<Tensor>();
 
   param_.strides = op_desc.GetAttr<std::vector<int>>("strides");
-  auto paddings = op_desc.GetAttr<std::vector<int>>("paddings");
+  std::vector<int> paddings = op_desc.GetAttr<std::vector<int>>("paddings");
   auto dilations = op_desc.GetAttr<std::vector<int>>("dilations");
   param_.dilations = std::make_shared<std::vector<int>>(dilations);
   param_.groups = op_desc.GetAttr<int>("groups");

--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -189,9 +189,7 @@ class LogMessageFatal : public LogMessage {
 #ifndef LITE_ON_TINY_PUBLISH
     abort();
 #else
-    // If we decide whether the process exits according to the NDEBUG macro
-    // definition, assert() can be used here.
-    abort();
+    assert(false);
 #endif
 #endif
   }
@@ -252,11 +250,7 @@ class VoidifyFatal : public Voidify {
 #ifdef LITE_WITH_EXCEPTION
   ~VoidifyFatal() noexcept(false) { throw std::exception(); }
 #else
-  ~VoidifyFatal() {
-    // If we decide whether the process exits according to the NDEBUG macro
-    // definition, assert() can be used here.
-    abort();
-  }
+  ~VoidifyFatal() { assert(false); }
 #endif
 };
 


### PR DESCRIPTION
修复 `XPU` 编译错误，在 `release/v2.7` 分支中保持 `logging.h` 不变。