### PR TITLE
add clear_blocks interface for flatbuffers view, test=develop

### DIFF
--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -83,7 +83,7 @@ class ProgramDescView : public ProgramDescAPI {
     CHECK_EQ(BlocksSize(), 0u) << "For backward compatibility, in the "
                                   "read-only flatbuffers version, this "
                                   "interface degenerates to force the number "
-                                  "of check blocks to be zero.";
+                                  "of blocks to be zero.";
   }
 
   proto::ProgramDesc const* raw_desc() const { return desc_; }

--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -79,6 +79,13 @@ class ProgramDescView : public ProgramDescAPI {
     return desc_->version()->version();
   }
 
+  void ClearBlocks() override {
+    CHECK_EQ(BlocksSize(), 0u) << "For backward compatibility, in the "
+                                  "read-only flatbuffers version, this "
+                                  "interface degenerates to force the number "
+                                  "of check blocks to be zero.";
+  }
+
   proto::ProgramDesc const* raw_desc() const { return desc_; }
 
   const std::vector<char>& buf() const { return buf_; }

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -1000,14 +1000,17 @@ void LoadModelNaiveFromMemory(const std::string &model_buffer,
 #ifndef LITE_ON_TINY_PUBLISH
       LoadModelNaiveV0FromMemory(model_buffer, scope, cpp_prog);
 #else
-      LOG(FATAL) << "Error: Unsupported model type.";
+      LOG(FATAL) << "Paddle-Lite v2.7 has upgraded the naive-buffer model "
+                    "format. Please use the OPT to generate a new model. "
+                    "Thanks!";
 #endif
       break;
     case 1:
       LoadModelNaiveV1FromMemory(model_buffer, scope, cpp_prog);
       break;
     default:
-      LOG(FATAL) << "Error: Unsupported model type.";
+      LOG(FATAL) << "The model format cannot be recognized. Please make sure "
+                    "you use the correct interface and model file.";
       break;
   }
 }


### PR DESCRIPTION
为向后兼容，提供一个退化的 `ClearBlocks()` 接口。