### PR TITLE
add clear_blocks interface for flatbuffers view, test=develop

### DIFF
--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -83,7 +83,7 @@ class ProgramDescView : public ProgramDescAPI {
     CHECK_EQ(BlocksSize(), 0u) << "For backward compatibility, in the "
                                   "read-only flatbuffers version, this "
                                   "interface degenerates to force the number "
-                                  "of check blocks to be zero.";
+                                  "of blocks to be zero.";
   }
 
   proto::ProgramDesc const* raw_desc() const { return desc_; }

--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -79,6 +79,13 @@ class ProgramDescView : public ProgramDescAPI {
     return desc_->version()->version();
   }
 
+  void ClearBlocks() override {
+    CHECK_EQ(BlocksSize(), 0u) << "For backward compatibility, in the "
+                                  "read-only flatbuffers version, this "
+                                  "interface degenerates to force the number "
+                                  "of check blocks to be zero.";
+  }
+
   proto::ProgramDesc const* raw_desc() const { return desc_; }
 
   const std::vector<char>& buf() const { return buf_; }


### PR DESCRIPTION
为向后兼容，提供一个退化的 `ClearBlocks()` 接口。