### PR TITLE
[Framework] Add method for specifying initial size of `workspace_`

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -356,5 +356,12 @@ void MobileConfig::set_model_buffer(const char *model_buffer,
   model_from_memory_ = true;
 }
 
+// This is the method for allocating workspace_size according to L3Cache size
+void MobileConfig::SetArmL3CacheSize(L3CacheSetMethod method,
+                                     int absolute_val) {
+  lite::DeviceInfo::Global().SetArmL3CacheSize(static_cast<int>(method),
+                                               absolute_val);
+}
+
 }  // namespace lite_api
 }  // namespace paddle

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -360,8 +360,7 @@ void MobileConfig::set_model_buffer(const char *model_buffer,
 void MobileConfig::SetArmL3CacheSize(L3CacheSetMethod method,
                                      int absolute_val) {
 #ifdef LITE_WITH_ARM
-  lite::DeviceInfo::Global().SetArmL3CacheSize(static_cast<int>(method),
-                                               absolute_val);
+  lite::DeviceInfo::Global().SetArmL3CacheSize(method, absolute_val);
 #endif
 }
 

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -359,8 +359,10 @@ void MobileConfig::set_model_buffer(const char *model_buffer,
 // This is the method for allocating workspace_size according to L3Cache size
 void MobileConfig::SetArmL3CacheSize(L3CacheSetMethod method,
                                      int absolute_val) {
+#ifdef LITE_WITH_ARM
   lite::DeviceInfo::Global().SetArmL3CacheSize(static_cast<int>(method),
                                                absolute_val);
+#endif
 }
 
 }  // namespace lite_api

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -32,6 +32,14 @@ using shape_t = std::vector<int64_t>;
 using lod_t = std::vector<std::vector<uint64_t>>;
 
 enum class LiteModelType { kProtobuf = 0, kNaiveBuffer, UNK };
+// Methods for allocating L3Cache on Arm platform
+enum class L3CacheSetMethod {
+  kDeviceL3Cache = 0,  // Use the system L3 Cache size, best performance.
+  kDeviceL2Cache = 1,  // Use the system L2 Cache size, trade off performance
+                       // with memory consuption.
+  kAbsolute = 2,       // Use the external setting.
+  // kAutoGrow = 3,   // Not supported yet, least memory consuption.
+};
 
 // return true if current device supports OpenCL model
 LITE_API bool IsOpenCLBackendValid();
@@ -294,6 +302,11 @@ class LITE_API MobileConfig : public ConfigBase {
 
   // NOTE: This is a deprecated API and will be removed in latter release.
   const std::string& param_buffer() const { return param_buffer_; }
+
+  // This is the method for allocating workspace_size according to L3Cache size
+  void SetArmL3CacheSize(
+      L3CacheSetMethod method = L3CacheSetMethod::kDeviceL3Cache,
+      int absolute_val = -1);
 };
 
 template <typename ConfigT>

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -36,9 +36,9 @@ enum class LiteModelType { kProtobuf = 0, kNaiveBuffer, UNK };
 enum class L3CacheSetMethod {
   kDeviceL3Cache = 0,  // Use the system L3 Cache size, best performance.
   kDeviceL2Cache = 1,  // Use the system L2 Cache size, trade off performance
-                       // with memory consuption.
+                       // with less memory consumption.
   kAbsolute = 2,       // Use the external setting.
-  // kAutoGrow = 3,   // Not supported yet, least memory consuption.
+  // kAutoGrow = 3,   // Not supported yet, least memory consumption.
 };
 
 // return true if current device supports OpenCL model

--- a/lite/api/paddle_api_test.cc
+++ b/lite/api/paddle_api_test.cc
@@ -109,7 +109,8 @@ TEST(CxxApi, share_external_data) {
 TEST(LightApi, run) {
   lite_api::MobileConfig config;
   config.set_model_from_file(FLAGS_model_dir + ".opt2.naive.nb");
-
+  // disable L3 cache on workspace_ allocating
+  config.SetArmL3CacheSize(L3CacheSetMethod::kDeviceL2Cache);
   auto predictor = lite_api::CreatePaddlePredictor(config);
 
   auto inputs = predictor->GetInputNames();
@@ -150,6 +151,8 @@ TEST(MobileConfig, LoadfromMemory) {
   // set model buffer and run model
   lite_api::MobileConfig config;
   config.set_model_from_buffer(model_buffer);
+  // allocate 1M initial space for workspace_
+  config.SetArmL3CacheSize(L3CacheSetMethod::kAbsolute, 1024 * 1024);
 
   auto predictor = lite_api::CreatePaddlePredictor(config);
   auto input_tensor = predictor->GetInput(0);

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -17,6 +17,7 @@
 #include <cstdarg>
 #include <string>
 #include <vector>
+#include "lite/api/paddle_api.h"
 #include "lite/core/tensor.h"
 #include "lite/utils/cp_logging.h"
 #ifdef LITE_WITH_MLU
@@ -27,6 +28,7 @@
 namespace paddle {
 namespace lite {
 
+using L3CacheSetMethod = lite_api::L3CacheSetMethod;
 #if ((defined LITE_WITH_ARM) || (defined LITE_WITH_MLU))
 
 typedef enum {
@@ -66,14 +68,10 @@ class DeviceInfo {
   int l2_cache_size() const { return L2_cache_[active_ids_[0]]; }
   int l3_cache_size() const { return L3_cache_[active_ids_[0]]; }
   // Methods for allocating L3Cache on Arm platform
-  // enum class L3CacheSetMethod {
-  //  kDeviceL3Cache = 0, use the system L3 Cache size, best performancei.
-  //  kDeviceL2Cache = 1, use the system L2 Cache size, trade off performance
-  //                      with less memory consumption.
-  //  kAbsolute = 2,      use the external setting.
-  //  // kAutoGrow = 3,   not supported yet, least memory consumption.
-  // };
-  void SetArmL3CacheSize(int method = 0, int absolute_val = -1) {
+  // Enum class L3CacheSetMethod is declared in `lite/api/paddle_api.h`
+  void SetArmL3CacheSize(
+      L3CacheSetMethod method = L3CacheSetMethod::kDeviceL3Cache,
+      int absolute_val = -1) {
     l3_cache_method_ = method;
     absolute_l3cache_size_ = absolute_val;
   }
@@ -82,17 +80,17 @@ class DeviceInfo {
     auto size = absolute_l3cache_size_;
     switch (l3_cache_method_) {
       // kDeviceL3Cache = 0, use the system L3 Cache size, best performance.
-      case 0:
+      case L3CacheSetMethod::kDeviceL3Cache:
         size = L3_cache_[active_ids_[0]] > 0 ? L3_cache_[active_ids_[0]]
                                              : L2_cache_[active_ids_[0]];
         break;
       // kDeviceL2Cache = 1, use the system L2 Cache size, trade off performance
       // with less memory consumption.
-      case 1:
+      case L3CacheSetMethod::kDeviceL2Cache:
         size = L2_cache_[active_ids_[0]];
         break;
       // kAbsolute = 2, use the external setting.
-      case 2:
+      case L3CacheSetMethod::kAbsolute:
         break;
       default:
         LOG(FATAL) << "Error: unknown l3_cache_method_ !";
@@ -152,14 +150,8 @@ class DeviceInfo {
   void RequestPowerRandLowMode(int shift_num, int thread_num);
 
   // Methods for allocating L3Cache on Arm platform
-  // enum class L3CacheSetMethod {
-  //  kDeviceL3Cache = 0, use the system L3 Cache size, best performance.
-  //  kDeviceL2Cache = 1, use the system L2 Cache size, trade off performance
-  //                      with memory consuption.
-  //  kAbsolute = 2,      use the external setting.
-  //  // kAutoGrow = 3,   not supported yet, least memory consumption.
-  // };
-  int l3_cache_method_{0};
+  // Enum class L3CacheSetMethod is declared in `lite/api/paddle_api.h`
+  L3CacheSetMethod l3_cache_method_{L3CacheSetMethod::kDeviceL3Cache};
   int absolute_l3cache_size_{-1};
   DeviceInfo() = default;
 };

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -74,6 +74,10 @@ class DeviceInfo {
       int absolute_val = -1) {
     l3_cache_method_ = method;
     absolute_l3cache_size_ = absolute_val;
+    // Realloc memory for sgemm in this context.
+    workspace_.clear();
+    workspace_.Resize({llc_size()});
+    workspace_.mutable_data<int8_t>();
   }
 
   int llc_size() const {

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -67,11 +67,11 @@ class DeviceInfo {
   int l3_cache_size() const { return L3_cache_[active_ids_[0]]; }
   // Methods for allocating L3Cache on Arm platform
   // enum class L3CacheSetMethod {
-  //  kDeviceL3Cache = 0, // Use the system L3 Cache size, best performancei.
-  //  kDeviceL2Cache = 1, // Use the system L2 Cache size, trade off performance
-  //                      // with less memory consumption.
-  //  kAbsolute = 2,      // Use the external setting.
-  //  // kAutoGrow = 3,   // Not supported yet, least memory consumption.
+  //  kDeviceL3Cache = 0, use the system L3 Cache size, best performancei.
+  //  kDeviceL2Cache = 1, use the system L2 Cache size, trade off performance
+  //                      with less memory consumption.
+  //  kAbsolute = 2,      use the external setting.
+  //  // kAutoGrow = 3,   not supported yet, least memory consumption.
   // };
   void SetArmL3CacheSize(int method = 0, int absolute_val = -1) {
     l3_cache_method_ = method;

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -67,11 +67,11 @@ class DeviceInfo {
   int l3_cache_size() const { return L3_cache_[active_ids_[0]]; }
   // Methods for allocating L3Cache on Arm platform
   // enum class L3CacheSetMethod {
-  //  kDeviceL3Cache = 0, // Use the system L3 Cache size, best performance.
+  //  kDeviceL3Cache = 0, // Use the system L3 Cache size, best performancei.
   //  kDeviceL2Cache = 1, // Use the system L2 Cache size, trade off performance
-  //                      // with memory consuption.
+  //                      // with less memory consumption.
   //  kAbsolute = 2,      // Use the external setting.
-  //  // kAutoGrow = 3,   // Not supported yet, least memory consuption.
+  //  // kAutoGrow = 3,   // Not supported yet, least memory consumption.
   // };
   void SetArmL3CacheSize(int method = 0, int absolute_val = -1) {
     l3_cache_method_ = method;
@@ -87,6 +87,7 @@ class DeviceInfo {
                                              : L2_cache_[active_ids_[0]];
         break;
       // kDeviceL2Cache = 1, use the system L2 Cache size, trade off performance
+      // with less memory consumption.
       case 1:
         size = L2_cache_[active_ids_[0]];
         break;
@@ -156,7 +157,7 @@ class DeviceInfo {
   //  kDeviceL2Cache = 1, use the system L2 Cache size, trade off performance
   //                      with memory consuption.
   //  kAbsolute = 2,      use the external setting.
-  //  // kAutoGrow = 3,   not supported yet, least memory consuption.
+  //  // kAutoGrow = 3,   not supported yet, least memory consumption.
   // };
   int l3_cache_method_{0};
   int absolute_l3cache_size_{-1};


### PR DESCRIPTION
【背景】
`DeviceInfo`会申请`L3Cache`尺寸的`workspace_`，供算子中汇编使用。 
`L3 cache`与手机型号有关，在mate20手机上可达4M，但相应大小的 `workspace_` 在小模型上不能全部被应用，造成内存浪费。


【本PR修改】
     新增接口`MobileConfig::SetArmL3CacheSize `：补充四种设置 `workspace_` 初始大小的方法
``` C++
enum class L3CacheSetMethod {
  kDeviceL3Cache = 0, // Use the system L3 Cache size, best performance.
  kDeviceL2Cache = 1, // Use the system L2 Cache size, trade off performance
                      // with less memory consumption.
  kAbsolute = 2,      // Use the external setting.
  // kAutoGrow = 3,   // Not supported yet, least memory consumption.
};
struct MobileConfig {
  // ...
  // danger area
  void
  SetArmL3CacheSize(L3CacheSetMethod method = L3CacheSetMethod::kDeviceL3Cache,
                    int absolute_val) {}
  // ...
};
```
【使用示例】
`workspace_` 设置为 `L3_Cache`的大小（默认行为）
``` C++
// 不需要修改
```
`workspace_` 设置为 `L2_Cache`的大小
``` C++
MobileConfig::SetArmL3CacheSize(L3CacheSetMethod::kDeviceL2Cache);
```
设置绝对值（以1M为例）
``` C++
MobileConfig::SetArmL3CacheSize(L3CacheSetMethod::kAbsolute, 1024 * 2014);
```