### PR TITLE
win32 thread-local support, test=develop

### DIFF
--- a/lite/utils/macros.h
+++ b/lite/utils/macros.h
@@ -59,8 +59,11 @@
 // Thread local storage will be ignored because the linker for iOS 8 does not
 // support it.
 #define LITE_THREAD_LOCAL
-#elif __cplusplus >= 201103
+#elif defined(__cplusplus) && (__cplusplus >= 201103)
+#define LITE_THREAD_LOCAL thread_local
+#elif defined(_WIN32)
+// The MSVC compiler does not support standards switches for C++11.
 #define LITE_THREAD_LOCAL thread_local
 #else
-#error "C++11 support is required for paddle-lite compilation."
+#error "[Paddle-Lite] C++11 support is required for paddle-lite compilation."
 #endif


### PR DESCRIPTION

<img width="752" alt="42e25864f1b66b04722024431d4bf8fd" src="https://user-images.githubusercontent.com/39303645/93847796-8a34af00-fcda-11ea-926f-39e4c64942f2.png">

msvc 错误定义了 `__cplusplus` 宏，此提交处理这个兼容问题。
https://developercommunity.visualstudio.com/content/problem/139261/msvc-incorrectly-defines-cplusplus.html