### PR TITLE
[BUG FIX] Fix the issue that light_api_shared.so can not work on full_publish compiling

### DIFF
--- a/lite/api/light_api_impl.cc
+++ b/lite/api/light_api_impl.cc
@@ -17,6 +17,10 @@
 #include "lite/api/paddle_api.h"
 #include "lite/core/version.h"
 #include "lite/model_parser/model_parser.h"
+#ifndef LITE_ON_TINY_PUBLISH
+#include "lite/api/paddle_use_kernels.h"
+#include "lite/api/paddle_use_ops.h"
+#endif
 
 namespace paddle {
 namespace lite {


### PR DESCRIPTION
cherry-picked from #4359 
【问题描述】
Paddle-Lite full_publish编译出来的预测库，`light_api_shared.so`中缺乏kernel和op的注册符号，导致库文件不能正常使用。
【本PR工作】
在full_publish编译时，加入部分头文件使`light_api_shared.so`中又kernel和op的注册符号
