### PR TITLE
[Bugfix][OpenCL][Core] fix opencl multi-run result error when using memory_optimize_pass

### DIFF
--- a/lite/core/memory.h
+++ b/lite/core/memory.h
@@ -153,7 +153,7 @@ class Buffer {
       data_ = TargetWrapperCL::MallocImage<T>(
           cl_image2d_width_, cl_image2d_height_, host_ptr);
       target_ = target;
-      space_ = sizeof(T) * cl_image2d_height_ * cl_image2d_height_ *
+      space_ = sizeof(T) * cl_image2d_width_ * cl_image2d_height_ *
                4;  // un-used for opencl Image2D, 4 for RGBA,
       cl_use_image2d_ = true;
     }

--- a/lite/core/memory.h
+++ b/lite/core/memory.h
@@ -144,7 +144,7 @@ class Buffer {
                         const size_t img_w_req,
                         const size_t img_h_req,
                         void* host_ptr = nullptr) {
-    if (target != target_ || img_w_cur_ < img_w_req ||
+    if (target != target_ || cl_image2d_width_ < img_w_req ||
         cl_image2d_height_ < img_h_req || host_ptr != nullptr) {
       CHECK_EQ(own_data_, true) << "Can not reset unowned buffer.";
       cl_image2d_width_ = std::max(cl_image2d_width_, img_w_req);

--- a/lite/core/memory.h
+++ b/lite/core/memory.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <algorithm>
 #include <string>
 #include "lite/api/paddle_place.h"
 #include "lite/core/target_wrapper.h"
@@ -140,20 +141,21 @@ class Buffer {
 #ifdef LITE_WITH_OPENCL
   template <typename T>
   void ResetLazyImage2D(TargetType target,
-                        const size_t img_w,
-                        const size_t img_h,
+                        const size_t img_w_req,
+                        const size_t img_h_req,
                         void* host_ptr = nullptr) {
-    if (target != target_ || cl_image2d_width_ < img_w ||
-        cl_image2d_height_ < img_h || host_ptr != nullptr) {
+    if (target != target_ || img_w_cur_ < img_w_req ||
+        cl_image2d_height_ < img_h_req || host_ptr != nullptr) {
       CHECK_EQ(own_data_, true) << "Can not reset unowned buffer.";
+      cl_image2d_width_ = std::max(cl_image2d_width_, img_w_req);
+      cl_image2d_height_ = std::max(cl_image2d_height_, img_h_req);
       Free();
-      data_ = TargetWrapperCL::MallocImage<T>(img_w, img_h, host_ptr);
+      data_ = TargetWrapperCL::MallocImage<T>(
+          cl_image2d_width_, cl_image2d_height_, host_ptr);
       target_ = target;
-      space_ = sizeof(T) * img_w * img_h *
+      space_ = sizeof(T) * cl_image2d_height_ * cl_image2d_height_ *
                4;  // un-used for opencl Image2D, 4 for RGBA,
       cl_use_image2d_ = true;
-      cl_image2d_width_ = img_w;
-      cl_image2d_height_ = img_h;
     }
   }
 #endif

--- a/lite/core/memory_test.cc
+++ b/lite/core/memory_test.cc
@@ -28,6 +28,12 @@ TEST(memory, test) {
   ASSERT_TRUE(buf_cuda);
   TargetFree(TARGET(kCUDA), buf_cuda);
 #endif
+
+#ifdef LITE_WITH_OPENCL
+  auto* buf_cl = TargetMalloc(TARGET(kOpenCL), 10);
+  ASSERT_TRUE(buf_cl);
+  TargetFree(TARGET(kOpenCL), buf_cl);
+#endif
 }
 
 }  // namespace lite


### PR DESCRIPTION
【问题】
 - 开启`memory_optimize_pass`情况下，当使用同一个`predictor`，循环执行多次`Run`时，第一次`Run`结果正常，第二次及之后`Run`出的结果有 diff；
 - 如上问题在 mobilenetv1 等其他模型上均存在；
 - 关闭`memory_optimize_pass`情况下，多次`Run`结果正确。

【原因】
- 开启`memory_optimize_pass`情况下，模型中的第一个 layout 为`ImageDefault`的 output (cl image shape <896,112>) 复用了模型中最后一个layout 为`ImageDefault`的 output (cl image shape <1792,56>) 的内存空间，但是实际上这两个 output 的内存空间并不能被复用。

【解决方法】
- 修改 memory 层的 OpenCL 内存空间分配函数`ResetLazyImage2D`，原则是保证当前空间的 image 宽度和高度分别是模型中使用`ImageDefault`类型的所有 output tensor 对应 image 宽度和高度的最大值。

【速度】
经测试，该 PR 不影响首次 Run 及之后 Run 的运行速度。
```
develop 分支，855 芯片	
Model: mobilenetv1

**No pr：**
Note: The output tensor is wrong in this case!
warmup:10	
repeats:100	
max_duration:19.499	
min_duration:11.705	
avg_duration:16.6929	
First warmup time: 530.911	

**Use pr:**
Note: The output tensor is right in this case.
warmup:10
repeats:100
max_duration:18.761
min_duration:16.009
avg_duration:16.8752
First warmup time: 524.615
```
Mobilenet_v1 内存复用逐层分析比对结果：
![image](https://user-images.githubusercontent.com/24290792/93883502-3ba40680-fd14-11ea-9605-d7ea07902f65.png)

