### PR TITLE
[arm] rm redundant time-profile func. test=develop

### DIFF
--- a/lite/kernels/arm/conv_depthwise.cc
+++ b/lite/kernels/arm/conv_depthwise.cc
@@ -402,14 +402,6 @@ void DepthwiseConv<PRECISION(kInt8), PRECISION(kInt8)>::Run() {
         w_scale_.data());
 }
 
-#ifdef LITE_WITH_PROFILE
-template <>
-void DepthwiseConv<PRECISION(kFloat), PRECISION(kFloat)>::
-    SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
-  ch->kernel_func_name = kernel_func_name_;
-}
-#endif
-
 }  // namespace arm
 }  // namespace kernels
 }  // namespace lite


### PR DESCRIPTION
【问题】当开启时间profile时，在编译时会报`SetProfileRuntimeKernelInfo`函数被重定义的错误。
![image](https://user-images.githubusercontent.com/24290792/93966185-9f6f1380-fd96-11ea-8903-4c17c7318f11.png)
