### PR TITLE
[PASS][BugFix] Fix layout pass for opencl when convert model

### DIFF
--- a/lite/core/mir/type_layout_cast_pass.cc
+++ b/lite/core/mir/type_layout_cast_pass.cc
@@ -82,8 +82,11 @@ void TypeLayoutTransformPass::ComplementInputs(SSAGraph* graph,
   // not a good judge, but don't find the source of this issue from
   // static_pick_kernel_pass
   // to this pass.
+  auto is_host = [](TargetType x) -> bool {
+    return x == TARGET(kHost) || x == TARGET(kX86) || x == TARGET(kARM);
+  };
   auto* in_arg_type = const_cast<Type*>(in->AsArg().type);
-  if (in_arg_type->target() == TARGET(kARM) &&
+  if (is_host(in_arg_type->target()) &&
       in_arg_type->layout() == DATALAYOUT(kImageDefault)) {
     return;
   }


### PR DESCRIPTION
# 状态：等待review

## 主要内容

1. 修改layout pass，判断是否为host，而不是只是判断kARM；
2. 其它pass也有类似问题，如conv-conv（.cc第34行），conv_activation_fuse（.cc第34行），因为pass改动影响较多，还请pass负责人来评估。