### PR TITLE
fix: flatbuffers git repo, test=develop

### DIFF
--- a/cmake/external/flatbuffers.cmake
+++ b/cmake/external/flatbuffers.cmake
@@ -45,7 +45,7 @@ SET(OPTIONAL_ARGS "-DCMAKE_CXX_COMPILER=${HOST_CXX_COMPILER}"
 ExternalProject_Add(
     extern_flatbuffers
     ${EXTERNAL_PROJECT_LOG_ARGS}
-    GIT_REPOSITORY  "https://github.com/google/flatbuffers.git"
+    GIT_REPOSITORY  "https://github.com/Shixiaowei02/flatbuffers.git"
     GIT_TAG         "v1.12.0"
     SOURCE_DIR      ${FLATBUFFERS_SOURCES_DIR}
     PREFIX          ${FLATBUFFERS_PREFIX_DIR}


### PR DESCRIPTION
`Flatbuffers` 最新 `master` 分支（提交号 `e0bbaa6`）出现故障，导致从这个提交号拉取的仓储无法切回历史提交 `v1.12.0`。这个问题影响了 CI 编译和版本发布测试，所以临时使用最新提交不是此提交号的私人仓储替换以绕过问题。待 `Flatbuffers` 官方仓储修复完成后将依赖切回。