### PR TITLE
[cherry-pick] fix xiaodu run kernnel in a53 problem. test=develop

### DIFF
--- a/lite/backends/arm/math/packed_sgemm.cc
+++ b/lite/backends/arm/math/packed_sgemm.cc
@@ -355,7 +355,7 @@ void sgemm_prepack(bool is_transB,
         (has_act == false) ||
         (has_act == true && act_type == lite_api::ActivationType::kRelu);
     bool has_beta = fabsf(beta) > 1e-8f ? true : false;
-    bool a53_sgemm = act_flag && !has_beta;
+    bool a53_sgemm = act_flag && !has_beta && ctx->has_a53_valid();
     if (a53_sgemm) {
       sgemm_prepacked_6x8_a53(is_transB,
                               M,

--- a/lite/core/context.h
+++ b/lite/core/context.h
@@ -217,6 +217,7 @@ class Context<TargetType::kARM> {
   int llc_size() const { return DeviceInfo::Global().llc_size(); }
   bool has_dot() const { return DeviceInfo::Global().has_dot(); }
   bool has_fp16() const { return DeviceInfo::Global().has_fp16(); }
+  bool has_a53_valid() const { return DeviceInfo::Global().set_a53_valid(); }
 
   template <typename T>
   T* workspace_data() {

--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -1009,6 +1009,17 @@ void DeviceInfo::RequestPowerRandLowMode(int shift_num, int thread_num) {
   }
 }
 
+bool DeviceInfo::set_a53_valid() {
+  auto dev_name = get_cpu_name();
+  // xiaodu device_name
+  if (dev_name.find("MT8765WA") != std::string::npos ||
+      dev_name.find("MT8167S") != std::string::npos) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
 int DeviceInfo::Setup() {
   core_num_ = get_cpu_num();
   mem_size_ = get_mem_size();

--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -1010,7 +1010,7 @@ void DeviceInfo::RequestPowerRandLowMode(int shift_num, int thread_num) {
 }
 
 bool DeviceInfo::set_a53_valid() {
-  auto dev_name = "null";
+  std::string dev_name = "null";
 #ifdef LITE_WITH_LINUX
   dev_name = get_cpu_name();
 #endif

--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -1010,7 +1010,10 @@ void DeviceInfo::RequestPowerRandLowMode(int shift_num, int thread_num) {
 }
 
 bool DeviceInfo::set_a53_valid() {
-  auto dev_name = get_cpu_name();
+  auto dev_name = "null";
+#ifdef LITE_WITH_LINUX
+  dev_name = get_cpu_name();
+#endif
   // xiaodu device_name
   if (dev_name.find("MT8765WA") != std::string::npos ||
       dev_name.find("MT8167S") != std::string::npos) {

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -56,7 +56,7 @@ class DeviceInfo {
   }
 
   int Setup();
-
+  bool set_a53_valid();
   void SetRunMode(lite_api::PowerMode mode, int thread_num);
   void SetCache(int l1size, int l2size, int l3size);
   void SetArch(ARMArch arch) { arch_ = arch; }


### PR DESCRIPTION
fix 小度a53 crash问题。
通过添加has_a53_valid 函数设置是否选择6x8_a53 gemm
目前，在小度设备上不许跑6x8_a53 gemm 以防止压测crash