### PR TITLE
fix conv_conv fusion error in conv_dw+conv_1x1

### DIFF
--- a/lite/core/mir/fusion/conv_conv_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_conv_fuse_pass.cc
@@ -27,7 +27,7 @@ namespace mir {
 void ConvConvFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   // initialze fuser params
   std::vector<bool> conv_has_bias_cases{true, false};
-  std::vector<std::string> conv_type_cases{"conv2d", "depthwise_conv2d"};
+  std::vector<std::string> conv_type_cases{"conv2d"};
   bool has_int8 = false;
   bool has_weight_quant = false;
   for (auto& place : graph->valid_places()) {

--- a/lite/core/mir/fusion/conv_conv_fuser.cc
+++ b/lite/core/mir/fusion/conv_conv_fuser.cc
@@ -132,7 +132,7 @@ void ConvConvFuser::BuildPattern() {
               VLOG(5) << "The kernel size of the second conv must be 1x1";
               continue;
             }
-            if (groups1 != 1 || groups0 != 1 ) {
+            if (groups0 != 1 || groups1 != 1 ) {
               VLOG(5) << "The all groups of weight_dim must be 1";
               continue;
             }
@@ -267,7 +267,6 @@ void ConvConvFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
     }
   }
   conv_op_desc->SetType(conv_type0_);
-  conv_op_desc->SetAttr("groups", 1);
   conv_op_desc->SetInput("Input", {matched.at("conv_input0")->arg()->name});
   conv_op_desc->SetInput("Filter", {matched.at("conv_weight0")->arg()->name});
   conv_op_desc->SetOutput("Output", {matched.at("conv_out1")->arg()->name});

--- a/lite/core/mir/fusion/conv_conv_fuser.cc
+++ b/lite/core/mir/fusion/conv_conv_fuser.cc
@@ -128,6 +128,7 @@ void ConvConvFuser::BuildPattern() {
                 conv_op_desc0->HasAttr("enable_int8") ? true : false;
             bool enable1_int8 =
                 conv_op_desc1->HasAttr("enable_int8") ? true : false;
+            if (ch_in_0 == ch_out_0 && ch_out_0 == groups0) continue;
             if (!(kw == 1 && kh == 1)) {
               VLOG(5) << "The kernel size of the second conv must be 1x1";
               continue;
@@ -267,6 +268,7 @@ void ConvConvFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
     }
   }
   conv_op_desc->SetType(conv_type0_);
+  conv_op_desc->SetAttr("groups", 1);
   conv_op_desc->SetInput("Input", {matched.at("conv_input0")->arg()->name});
   conv_op_desc->SetInput("Filter", {matched.at("conv_weight0")->arg()->name});
   conv_op_desc->SetOutput("Output", {matched.at("conv_out1")->arg()->name});

--- a/lite/core/mir/fusion/conv_conv_fuser.cc
+++ b/lite/core/mir/fusion/conv_conv_fuser.cc
@@ -132,7 +132,7 @@ void ConvConvFuser::BuildPattern() {
               VLOG(5) << "The kernel size of the second conv must be 1x1";
               continue;
             }
-            if (groups0 != 1 || groups1 != 1 ) {
+            if (groups0 != 1 || groups1 != 1) {
               VLOG(5) << "The all groups of weight_dim must be 1";
               continue;
             }

--- a/lite/core/mir/fusion/conv_conv_fuser.cc
+++ b/lite/core/mir/fusion/conv_conv_fuser.cc
@@ -128,13 +128,12 @@ void ConvConvFuser::BuildPattern() {
                 conv_op_desc0->HasAttr("enable_int8") ? true : false;
             bool enable1_int8 =
                 conv_op_desc1->HasAttr("enable_int8") ? true : false;
-            if (ch_in_0 == ch_out_0 && ch_out_0 == groups0) continue;
             if (!(kw == 1 && kh == 1)) {
               VLOG(5) << "The kernel size of the second conv must be 1x1";
               continue;
             }
-            if (groups1 != 1) {
-              VLOG(5) << "The groups of weight1_dim must be 1";
+            if (groups1 != 1 || groups0 != 1 ) {
+              VLOG(5) << "The all groups of weight_dim must be 1";
               continue;
             }
             if (ch_out_0 != ch_in_1) {


### PR DESCRIPTION
修复conv+conv 融合在conv_dw和conv_1x1融合时的计算错误
解决：conv+conv 融合计算weights，要求group0=1 且group1=1. 这样融合后的新weights不会影响第一个conv的conv_type