### PR TITLE
[cherry-pick] fix conv+conv compute error

### DIFF
--- a/lite/core/mir/fusion/conv_conv_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_conv_fuse_pass.cc
@@ -27,7 +27,7 @@ namespace mir {
 void ConvConvFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   // initialze fuser params
   std::vector<bool> conv_has_bias_cases{true, false};
-  std::vector<std::string> conv_type_cases{"conv2d", "depthwise_conv2d"};
+  std::vector<std::string> conv_type_cases{"conv2d"};
   bool has_int8 = false;
   bool has_weight_quant = false;
   for (auto& place : graph->valid_places()) {

--- a/lite/core/mir/fusion/conv_conv_fuser.cc
+++ b/lite/core/mir/fusion/conv_conv_fuser.cc
@@ -132,8 +132,8 @@ void ConvConvFuser::BuildPattern() {
               VLOG(5) << "The kernel size of the second conv must be 1x1";
               continue;
             }
-            if (groups1 != 1) {
-              VLOG(5) << "The groups of weight1_dim must be 1";
+            if (groups0 != 1 || groups1 != 1) {
+              VLOG(5) << "The all groups of weight_dim must be 1";
               continue;
             }
             if (ch_out_0 != ch_in_1) {

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -86,6 +86,7 @@ class Optimizer {
           "lite_conv_elementwise_fuse_pass",      // conv-elemwise-bn
           "lite_conv_bn_fuse_pass",               //
           "lite_conv_elementwise_fuse_pass",      // conv-bn-elemwise
+          "lite_conv_conv_fuse_pass",
           // TODO(Superjomn) Refine the fusion related design to select fusion
           // kernels for devices automatically.
           "lite_conv_activation_fuse_pass",              //


### PR DESCRIPTION
修复conv+conv 融合在conv_dw和conv_1x1融合时的计算错误, 已在模型里验证其正确性
解决：conv+conv 融合计算weights，要求group0=1 且group1=1. 这样融合后的新weights不会影响第一个conv的conv_type