### PR TITLE
[BugFix][ARM][OP] Fix arm op: reduce_mean & sequence_expand_as

### DIFF
--- a/lite/kernels/arm/reduce_mean_compute.cc
+++ b/lite/kernels/arm/reduce_mean_compute.cc
@@ -37,10 +37,15 @@ void ReduceMeanCompute::Run() {
       }
     }
   }
-  int n_in = x_dims[0];
-  int c_in = x_dims[1];
-  int h_in = x_dims[2];
-  int w_in = x_dims[3];
+
+  size_t new_dims[] = {1, 1, 1, 1};
+  for (size_t j = 0; j < x_dims.size(); ++j) {
+    new_dims[j] = x_dims[j];
+  }
+  int n_in = new_dims[0];
+  int c_in = new_dims[1];
+  int h_in = new_dims[2];
+  int w_in = new_dims[3];
   if (dim.size() == 0) {
     lite::arm::math::reduce_mean_all(input, output, n_in, c_in, h_in, w_in);
   } else if (dim.size() == 1) {

--- a/lite/kernels/arm/sequence_expand_as_compute.cc
+++ b/lite/kernels/arm/sequence_expand_as_compute.cc
@@ -25,8 +25,10 @@ void SequenceExpandAsCompute::Run() {
   auto* x = param.x;
   auto* y = param.y;
   auto* out = param.out;
-  auto x_lod = x->lod();
   auto y_lod = y->lod();
+  CHECK_EQ(y_lod.size(), 1u);
+  CHECK_GT(y_lod[0].size(), 1u);
+
   auto dims = x->dims();
   auto out_data = out->mutable_data<float>();
   auto x_data = x->data<float>();

--- a/lite/kernels/arm/sequence_expand_as_compute.cc
+++ b/lite/kernels/arm/sequence_expand_as_compute.cc
@@ -35,8 +35,8 @@ void SequenceExpandAsCompute::Run() {
   std::vector<uint64_t> out_lod;
   out_lod.push_back(0);
   int sum = 0;
-  for (int i = 0; i < y_lod[0].size(); i++) {
-    int repeat_num = y_lod[0][i];
+  for (int i = 1; i < y_lod[0].size(); i++) {
+    int repeat_num = y_lod[0][i] - y_lod[0][i - 1];
     if (repeat_num == 0) {
       continue;
     } else {

--- a/lite/kernels/x86/reduce_compute.h
+++ b/lite/kernels/x86/reduce_compute.h
@@ -115,6 +115,7 @@ class ReduceMeanCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
       HANDLE_DIM(4, 1, MeanFunctor);
       HANDLE_DIM(3, 2, MeanFunctor);
       HANDLE_DIM(3, 1, MeanFunctor);
+      HANDLE_DIM(2, 2, MeanFunctor);
       HANDLE_DIM(2, 1, MeanFunctor);
       HANDLE_DIM(1, 1, MeanFunctor);
     }

--- a/lite/tests/kernels/reduce_mean_compute_test.cc
+++ b/lite/tests/kernels/reduce_mean_compute_test.cc
@@ -255,10 +255,14 @@ class ReduceMeanComputeTester : public arena::TestCase {
     }
 
     auto* out_data = out->mutable_data<float>();
-    int in_n = x_dims_[0];
-    int in_c = x_dims_[1];
-    int in_h = x_dims_[2];
-    int in_w = x_dims_[3];
+    size_t new_dims[] = {1, 1, 1, 1};
+    for (size_t j = 0; j < x_dims_.size(); ++j) {
+      new_dims[j] = x_dims_[j];
+    }
+    int in_n = new_dims[0];
+    int in_c = new_dims[1];
+    int in_h = new_dims[2];
+    int in_w = new_dims[3];
 
     if (dim_.size() == 0) {
       reduce_mean_all(x_data, out_data, in_n, in_c, in_h, in_w);
@@ -311,7 +315,7 @@ class ReduceMeanComputeTester : public arena::TestCase {
 
 void test_reduce_mean(Place place) {
   std::vector<std::vector<int>> reduce_dim{
-      {}, {0}, {1}, {2}, {3}, {0, 1}, {1, 2}, {2, 3}, {-2, -1}};
+      {0}, {1}, {2}, {3}, {0, 1}, {1, 2}, {2, 3}, {-2, -1}};
   for (auto n : {1, 3}) {
     for (auto c : {1, 2}) {
       for (auto h : {1, 3}) {
@@ -319,7 +323,7 @@ void test_reduce_mean(Place place) {
           for (bool keep_dim : {false, true}) {
             for (auto dim : reduce_dim) {
               DDim x_dims;
-              for (auto dims : {1, 2, 3, 4}) {
+              for (auto dims : {2, 3, 4}) {
                 switch (dims) {
                   case 1:
                     x_dims = DDim(std::vector<int64_t>({n}));
@@ -335,9 +339,14 @@ void test_reduce_mean(Place place) {
                     break;
                   default:
                     x_dims = DDim(std::vector<int64_t>({n, c, h, w}));
-                    break;
                 }
-                if (!dim.empty() && x_dims.size() < dim.back() - 1) continue;
+
+                int last_dim = dim.back();
+                if (dim.back() < 0) {
+                  last_dim += x_dims.size();
+                  if (last_dim < 1) continue;
+                }
+                if (last_dim > x_dims.size() - 1) continue;
 
                 std::unique_ptr<arena::TestCase> tester(
                     new ReduceMeanComputeTester(

--- a/lite/tests/kernels/reduce_mean_compute_test.cc
+++ b/lite/tests/kernels/reduce_mean_compute_test.cc
@@ -311,19 +311,40 @@ class ReduceMeanComputeTester : public arena::TestCase {
 
 void test_reduce_mean(Place place) {
   std::vector<std::vector<int>> reduce_dim{
-      {0}, {1}, {2}, {3}, {0, 1}, {1, 2}, {2, 3}, {-2, -1}};
+      {}, {0}, {1}, {2}, {3}, {0, 1}, {1, 2}, {2, 3}, {-2, -1}};
   for (auto n : {1, 3}) {
     for (auto c : {1, 2}) {
       for (auto h : {1, 3}) {
         for (auto w : {1, 3}) {
           for (bool keep_dim : {false, true}) {
             for (auto dim : reduce_dim) {
-              auto x_dims = DDim(std::vector<int64_t>({n, c, h, w}));
-              std::unique_ptr<arena::TestCase> tester(
-                  new ReduceMeanComputeTester(
-                      place, "def", dim, keep_dim, x_dims));
-              arena::Arena arena(std::move(tester), place, 2e-5);
-              arena.TestPrecision();
+              DDim x_dims;
+              for (auto dims : {1, 2, 3, 4}) {
+                switch (dims) {
+                  case 1:
+                    x_dims = DDim(std::vector<int64_t>({n});
+                    break;
+                  case 2:
+                    x_dims = DDim(std::vector<int64_t>({n, c});
+                    break;
+                  case 3:
+                    x_dims = DDim(std::vector<int64_t>({n, c, h});
+                    break;
+                  case 4:
+                    x_dims = DDim(std::vector<int64_t>({n, c, h, w});
+                    break;
+                  default:
+                    x_dims = DDim(std::vector<int64_t>({n, c, h, w});
+                    break;
+                }
+                if (!dim.empty() && x_dims.size() < dim.back() - 1) continue;
+
+                std::unique_ptr<arena::TestCase> tester(
+                    new ReduceMeanComputeTester(
+                        place, "def", dim, keep_dim, x_dims));
+                arena::Arena arena(std::move(tester), place, 2e-5);
+                arena.TestPrecision();
+              }
             }
           }
         }

--- a/lite/tests/kernels/reduce_mean_compute_test.cc
+++ b/lite/tests/kernels/reduce_mean_compute_test.cc
@@ -322,19 +322,19 @@ void test_reduce_mean(Place place) {
               for (auto dims : {1, 2, 3, 4}) {
                 switch (dims) {
                   case 1:
-                    x_dims = DDim(std::vector<int64_t>({n});
+                    x_dims = DDim(std::vector<int64_t>({n}));
                     break;
                   case 2:
-                    x_dims = DDim(std::vector<int64_t>({n, c});
+                    x_dims = DDim(std::vector<int64_t>({n, c}));
                     break;
                   case 3:
-                    x_dims = DDim(std::vector<int64_t>({n, c, h});
+                    x_dims = DDim(std::vector<int64_t>({n, c, h}));
                     break;
                   case 4:
-                    x_dims = DDim(std::vector<int64_t>({n, c, h, w});
+                    x_dims = DDim(std::vector<int64_t>({n, c, h, w}));
                     break;
                   default:
-                    x_dims = DDim(std::vector<int64_t>({n, c, h, w});
+                    x_dims = DDim(std::vector<int64_t>({n, c, h, w}));
                     break;
                 }
                 if (!dim.empty() && x_dims.size() < dim.back() - 1) continue;

--- a/lite/tests/kernels/reduce_mean_compute_test.cc
+++ b/lite/tests/kernels/reduce_mean_compute_test.cc
@@ -325,9 +325,6 @@ void test_reduce_mean(Place place) {
               DDim x_dims;
               for (auto dims : {2, 3, 4}) {
                 switch (dims) {
-                  case 1:
-                    x_dims = DDim(std::vector<int64_t>({n}));
-                    break;
                   case 2:
                     x_dims = DDim(std::vector<int64_t>({n, c}));
                     break;

--- a/lite/tests/kernels/sequence_expand_as_compute_test.cc
+++ b/lite/tests/kernels/sequence_expand_as_compute_test.cc
@@ -56,7 +56,7 @@ TEST(sequence_expand_as, run_test) {
     y_data[i] = static_cast<float>(i);
   }
 
-  std::vector<std::vector<uint64_t>> lod{{0, 3, 3, 1, 1}};
+  std::vector<std::vector<uint64_t>> lod{{0, 3, 6, 7, 8}};
   y.set_lod(lod);
   paddle::lite::kernels::arm::SequenceExpandAsCompute sequence_expand_as;
 
@@ -76,7 +76,7 @@ TEST(sequence_expand_as, run_test) {
 
   int index = 1;
   auto out_lod = param.out->lod()[0];
-  int lod_sum = out_lod[index];
+  int lod_sum = out_lod[index] - out_lod[index - 1];
   LOG(INFO) << "output: ";
   for (int i = 0; i < out.dims().production(); i++) {
     LOG(INFO) << out_data[i];


### PR DESCRIPTION
【问题】在运行页面理解GCN模型时，定位到在执行如上两个op时会报段错误，原因为：

- `reduce_mean`op实现时假定了输入tensor的dims是4，然而GCN模型中该op的输入dims是2，因此直接运行会出现段错误；
- `sequence_expand_as`op实现时假定了输入`Y`的`LoD`数据是按长度保存，然而实际上是按偏移量的形式保存的。如下是[Paddle官网对`LoD`的描述](https://www.paddlepaddle.org.cn/documentation/docs/zh/beginners_guide/basic_concept/lod_tensor.html#lod)：

> 在 Fluid 中 LoD-Tensor 的序列信息有两种表述形式：原始长度和偏移量。在 Paddle 内部采用偏移量的形式表述 LoD-Tensor，以获得更快的序列访问速度

【解决方法】修复对应 op 实现；可正确运行GCN模型。

【性能】本PR不改变原有kernel的运行性能。

【备注】GCN模型中同时涉及到`elementwise_mul`op的修改，比如在该模型中的`elementwise_mul`op 输入数据 X{31535,4,64}, 输入数据 Y{1,4,64}，需要忽略 Y 的大小为1的头部维度），[PR #4485](https://github.com/PaddlePaddle/Paddle-Lite/pull/4485https://github.com/PaddlePaddle/Paddle-Lite/pull/4485) 已对`elementwise_mul`进行了修复。