### PR TITLE
[OPENCL][KERNEL] add leaky relu in conv for opencl. test=develop

### DIFF
--- a/docs/demo_guides/opencl.md
+++ b/docs/demo_guides/opencl.md
@@ -222,3 +222,8 @@ adb shell "export GLOG_v=4; \
 注：这里给出的链接会跳转到线上最新develop分支的代码，很可能与您本地的代码存在差异，建议参考自己本地位于`lite/demo/cxx/`目录的代码，查看如何使用。
 
 **NOTE：** 对OpenCL的支持还在持续开发中。
+
+## 4. 常见问题
+
+1. opencl计算过程中大多以`cl::Image2D`的数据排布进行计算，不同gpu支持的最大`cl::Image2D`的宽度和高度有限制，模型输入的数据格式是buffer形式的`NCHW`数据排布方式。要计算你的模型是否超出最大支持（大部分手机支持的`cl::Image2D`最大宽度和高度均为16384），可以通过公式`image_h = tensor_n * tensor_h, image_w=tensor_w * (tensor_c + 3) / 4`计算当前层NCHW排布的Tensor所需的`cl::Image2D`的宽度和高度；
+2. 部署时需考虑不支持opencl的情况，可预先使用API`bool ::IsOpenCLBackendValid()`判断，对于不支持的情况加载CPU模型，详见[./lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc)。

--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -117,6 +117,11 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
 #endif
 
 #ifdef LEAKY_RELU
+  // note: `(ushort4)(in >= 0)` causes error: invalid conversion
+  // between ext-vector type 'ushort4' and 'short
+  // __attribute__((ext_vector_type(4)))'
+  // thus, using `(ushort4)(in.x >= 0, in.y >= 0, in.z >= 0, in.w >= 0)`
+  // instead.
   output = select((CL_DTYPE4)(LEAKY_RELU_ALPHA)*in,
                   (CL_DTYPE4)in,
                   (ushort4)(in.x >= 0, in.y >= 0, in.z >= 0, in.w >= 0));

--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -117,10 +117,9 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
 #endif
 
 #ifdef LEAKY_RELU
-  output =
-      select((CL_DTYPE4)(LEAKY_RELU_ALPHA)*in,
-             in,
-             (short __attribute__((ext_vector_type(4))))(in >= 0));  // NOLINT
+  output = select((CL_DTYPE4)(LEAKY_RELU_ALPHA)*in,
+                  (CL_DTYPE4)in,
+                  (ushort4)(in.x >= 0, in.y >= 0, in.z >= 0, in.w >= 0));
 #endif
   return output;
 }

--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -88,6 +88,10 @@ inline CL_DTYPE activation(CL_DTYPE in
 #ifdef RELU6
   output = clamp(in, (CL_DTYPE)0, (CL_DTYPE)6);
 #endif
+
+#ifdef LEAKY_RELU
+  output = select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, in >= (CL_DTYPE)0);
+#endif
   return output;
 }
 
@@ -109,6 +113,10 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
 #ifdef RELU6
   in = fmax((CL_DTYPE4)(0.0f, 0.0f, 0.0f, 0.0f), in);
   output = fmin((CL_DTYPE4)(6.0f, 6.0f, 6.0f, 6.0f), in);
+#endif
+
+#ifdef LEAKY_RELU
+  output = select((CL_DTYPE4)(LEAKY_RELU_ALPHA)*in, in, in >= (CL_DTYPE4)0);
 #endif
   return output;
 }

--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -90,7 +90,8 @@ inline CL_DTYPE activation(CL_DTYPE in
 #endif
 
 #ifdef LEAKY_RELU
-  output = select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, in >= (CL_DTYPE)0);
+  output =
+      select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in, (CL_DTYPE)in, (ushort)(in >= 0));
 #endif
   return output;
 }
@@ -116,7 +117,7 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
 #endif
 
 #ifdef LEAKY_RELU
-  output = select((CL_DTYPE4)(LEAKY_RELU_ALPHA)*in, in, in >= (CL_DTYPE4)0);
+  output = select((CL_DTYPE4)(LEAKY_RELU_ALPHA)*in, in, (ushort4)(in >= 0));
 #endif
   return output;
 }

--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -117,7 +117,10 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
 #endif
 
 #ifdef LEAKY_RELU
-  output = select((CL_DTYPE4)(LEAKY_RELU_ALPHA)*in, in, (ushort4)(in >= 0));
+  output =
+      select((CL_DTYPE4)(LEAKY_RELU_ALPHA)*in,
+             in,
+             (short __attribute__((ext_vector_type(4))))(in >= 0));  // NOLINT
 #endif
   return output;
 }

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -46,7 +46,7 @@ CLRuntime::~CLRuntime() {
 
 bool CLRuntime::Init() {
 #ifdef LITE_WITH_LOG
-  LOG(INFO) << "is_cl_runtime_initialized_:" << is_cl_runtime_initialized_;
+  VLOG(3) << "is_cl_runtime_initialized_:" << is_cl_runtime_initialized_;
 #endif
   if (is_cl_runtime_initialized_) {
     return true;

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -312,12 +312,17 @@ void ConvImageCompute::PrepareForRun() {
           << conv_param_->activation_param.has_active;
   if (conv_param_->activation_param.has_active) {
     if (conv_param_->activation_param.active_type ==
-        lite_api::ActivationType::kRelu) {  // Note: judge using `relu_fused_`
-                                            // also is ok
+        lite_api::ActivationType::kRelu) {
       build_options_single += " -DRELU";
     } else if (conv_param_->activation_param.active_type ==
                lite_api::ActivationType::kRelu6) {
       build_options_single += " -DRELU6";
+    } else if (conv_param_->activation_param.active_type ==
+               lite_api::ActivationType::kLeakyRelu) {
+      std::string leaky_relu_alpha_str =
+          std::to_string(conv_param_->activation_param.Leaky_relu_alpha);
+      build_options_single +=
+          " -DLEAKY_RELU -DLEAKY_RELU_ALPHA=" + leaky_relu_alpha_str;
     } else {
       LOG(FATAL) << "Unsupported activation type:"
                  << static_cast<int>(conv_param_->activation_param.active_type);


### PR DESCRIPTION
# 状态：等待review

## 主要内容

增加这个op的原因是因为yolov3中有leaky relu。

1. 增加conv和leaky relu的融合。在cl_common中增加对这种激活函数的支持，修改conv_image_compute加入对该方法的支持；
2. 单测支持leaky relu。本地loop test在conv和dwconv的单测中都通过；
3. opencl文档增加常见问题标题，其中加入对opencl的`cl::image`的支持大小的说明，让用户参考；
4. `lite/backends/opencl/cl_runtime.cc`中降低对初始化检查的日志级别，否则默认级别的日志太多影响开发效率。