### PR TITLE
export cv symbols to the full publish target, test=develop

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -127,9 +127,13 @@ endif()
 
 if (LITE_WITH_ARM)
     add_definitions("-DLITE_WITH_ARM")
-    if (LITE_WITH_CV)
-        add_definitions("-DLITE_WITH_CV")
+endif()
+
+if (LITE_WITH_CV)
+    if(NOT LITE_WITH_ARM)
+        message(FATAL_ERROR "CV functions uses the ARM instructions, so LITE_WITH_ARM must be turned on")
     endif()
+    add_definitions("-DLITE_WITH_CV")
 endif()
 
 if (LITE_WITH_TRAIN)

--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -30,6 +30,9 @@ if ((NOT LITE_ON_TINY_PUBLISH) AND (LITE_WITH_CUDA OR LITE_WITH_X86 OR LITE_WITH
     if(LITE_WITH_CUDA)
         target_link_libraries(paddle_full_api_shared ${math_cuda} "-Wl,--whole-archive" ${cuda_kernels} "-Wl,--no-whole-archive")
     endif(LITE_WITH_CUDA)
+    if(LITE_WITH_CV)
+      target_link_libraries(paddle_full_api_shared "-Wl,--whole-archive" paddle_cv_arm "-Wl,--no-whole-archive")
+    endif(LITE_WITH_CV)
 
     #light api dynamic library
     lite_cc_library(paddle_light_api_shared SHARED SRCS paddle_api.cc light_api.cc light_api_impl.cc

--- a/lite/tools/build_fpga.sh
+++ b/lite/tools/build_fpga.sh
@@ -23,7 +23,8 @@ cmake .. \
         -DLITE_BUILD_EXTRA=ON \
         -DLITE_WITH_PYTHON=OFF \
         -DLITE_WITH_PROFILE=OFF \
-        -DLITE_WITH_LOG=OFF
+        -DLITE_WITH_LOG=OFF \
+        -DLITE_WITH_CV=ON
 
 make -j8
 

--- a/lite/utils/cv/CMakeLists.txt
+++ b/lite/utils/cv/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(LITE_WITH_CV AND (NOT LITE_WITH_FPGA) AND LITE_WITH_ARM)
+if(LITE_WITH_CV AND LITE_WITH_ARM)
     lite_cc_library(paddle_cv_arm SRCS
             image_convert.cc
             bgr_rotate.cc


### PR DESCRIPTION
导出所有 ARM CV 辅助函数符号到 full publish 动态库产出，以满足 FPGA 业务需求。因为 tiny publish 有库体积要求，所以不确保这些函数符号会完整导出。