### PR TITLE
[Cherrypick][BugFix][ARM][OP] Fix arm op: reduce_mean & sequence_expand_as (#4492)

### DIFF
--- a/lite/kernels/arm/reduce_mean_compute.cc
+++ b/lite/kernels/arm/reduce_mean_compute.cc
@@ -37,10 +37,15 @@ void ReduceMeanCompute::Run() {
       }
     }
   }
-  int n_in = x_dims[0];
-  int c_in = x_dims[1];
-  int h_in = x_dims[2];
-  int w_in = x_dims[3];
+
+  size_t new_dims[] = {1, 1, 1, 1};
+  for (size_t j = 0; j < x_dims.size(); ++j) {
+    new_dims[j] = x_dims[j];
+  }
+  int n_in = new_dims[0];
+  int c_in = new_dims[1];
+  int h_in = new_dims[2];
+  int w_in = new_dims[3];
   if (dim.size() == 0) {
     lite::arm::math::reduce_mean_all(input, output, n_in, c_in, h_in, w_in);
   } else if (dim.size() == 1) {

--- a/lite/kernels/arm/sequence_expand_as_compute.cc
+++ b/lite/kernels/arm/sequence_expand_as_compute.cc
@@ -25,8 +25,10 @@ void SequenceExpandAsCompute::Run() {
   auto* x = param.x;
   auto* y = param.y;
   auto* out = param.out;
-  auto x_lod = x->lod();
   auto y_lod = y->lod();
+  CHECK_EQ(y_lod.size(), 1u);
+  CHECK_GT(y_lod[0].size(), 1u);
+
   auto dims = x->dims();
   auto out_data = out->mutable_data<float>();
   auto x_data = x->data<float>();
@@ -35,8 +37,8 @@ void SequenceExpandAsCompute::Run() {
   std::vector<uint64_t> out_lod;
   out_lod.push_back(0);
   int sum = 0;
-  for (int i = 0; i < y_lod[0].size(); i++) {
-    int repeat_num = y_lod[0][i];
+  for (int i = 1; i < y_lod[0].size(); i++) {
+    int repeat_num = y_lod[0][i] - y_lod[0][i - 1];
     if (repeat_num == 0) {
       continue;
     } else {

--- a/lite/kernels/x86/reduce_compute.h
+++ b/lite/kernels/x86/reduce_compute.h
@@ -115,6 +115,7 @@ class ReduceMeanCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
       HANDLE_DIM(4, 1, MeanFunctor);
       HANDLE_DIM(3, 2, MeanFunctor);
       HANDLE_DIM(3, 1, MeanFunctor);
+      HANDLE_DIM(2, 2, MeanFunctor);
       HANDLE_DIM(2, 1, MeanFunctor);
       HANDLE_DIM(1, 1, MeanFunctor);
     }

--- a/lite/tests/kernels/sequence_expand_as_compute_test.cc
+++ b/lite/tests/kernels/sequence_expand_as_compute_test.cc
@@ -56,7 +56,7 @@ TEST(sequence_expand_as, run_test) {
     y_data[i] = static_cast<float>(i);
   }
 
-  std::vector<std::vector<uint64_t>> lod{{0, 3, 3, 1, 1}};
+  std::vector<std::vector<uint64_t>> lod{{0, 3, 6, 7, 8}};
   y.set_lod(lod);
   paddle::lite::kernels::arm::SequenceExpandAsCompute sequence_expand_as;
 
@@ -76,7 +76,7 @@ TEST(sequence_expand_as, run_test) {
 
   int index = 1;
   auto out_lod = param.out->lod()[0];
-  int lod_sum = out_lod[index];
+  int lod_sum = out_lod[index] - out_lod[index - 1];
   LOG(INFO) << "output: ";
   for (int i = 0; i < out.dims().production(); i++) {
     LOG(INFO) << out_data[i];


### PR DESCRIPTION
cherry-pick from [PR #4492](https://github.com/PaddlePaddle/Paddle-Lite/pull/4492)