### PR TITLE
[cherry-pick] feat: Initial common-broadcast support for element-wise op (#4485)

### DIFF
--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 #include "lite/kernels/arm/elementwise_compute.h"
+
 #include <string>
 #include <vector>
+
 #include "lite/backends/arm/math/funcs.h"
+#include "lite/kernels/host/elementwise_op_func.h"
 
 namespace paddle {
 namespace lite {
@@ -40,18 +43,24 @@ inline DDim trim_trailing_singular_dims(const DDim& dims) {
   return DDim(trim_dims);
 }
 
-inline bool is_broadcast(const DDim& x_dims,
-                         const DDim& y_dims,
-                         int axis,
-                         int* pre,
-                         int* n,
-                         int* post) {
-  if (axis < 0) {
+inline bool is_fast_broadcast(const DDim& x_dims,
+                              const DDim& y_dims,
+                              int axis,
+                              int* pre,
+                              int* n,
+                              int* post) {
+  if (axis == -1) {
     axis = x_dims.size() - y_dims.size();
+  }
+  if (axis < 0) {
+    LOG(INFO) << "Fast broadcast chk fail, for x_dims smaller.";
+    return false;
   }
   DDim y_dim_trim = trim_trailing_singular_dims(y_dims);
   axis = (y_dim_trim.size() == 0) ? x_dims.size() : axis;
   if (x_dims.size() == y_dim_trim.size()) {
+    LOG(INFO)
+        << "Fast broadcast chk fail, for y's shape not really contained in x";
     return false;
   }
   *pre = 1;
@@ -61,8 +70,10 @@ inline bool is_broadcast(const DDim& x_dims,
     (*pre) *= x_dims[i];
   }
   for (int i = 0; i < y_dim_trim.size(); ++i) {
-    CHECK_EQ(x_dims[i + axis], y_dim_trim[i])
-        << "Broadcast dimension mismatch.";
+    if (x_dims[i + axis] != y_dim_trim[i]) {
+      LOG(WARNING) << "Fast broadcast chk fail, for dimension mismatch.";
+      return false;
+    }
     (*n) *= y_dim_trim[i];
   }
   for (int i = axis + y_dim_trim.size(); i < x_dims.size(); ++i) {
@@ -71,120 +82,68 @@ inline bool is_broadcast(const DDim& x_dims,
   return true;
 }
 
-template <typename T, PrecisionType PType>
-void ElementwiseAddCompute<T, PType>::Run() {
-  auto& param = this->template Param<operators::ElementwiseParam>();
-  const T* x_data = param.X->template data<T>();
-  const T* y_data = param.Y->template data<T>();
-  T* out_data = param.Out->template mutable_data<T>();
-  int axis = param.axis;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  int pre, n, post;
-  if (x_dims.size() < y_dims.size() &&
-      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_add_broadcast<T>(
-        y_data, x_data, out_data, pre, n, post);
-  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_add_broadcast<T>(
-        x_data, y_data, out_data, pre, n, post);
-  } else {
-    lite::arm::math::elementwise_add<T>(
-        x_data, y_data, out_data, x_dims.production());
-  }
-}
+template <class T>
+using FastBCastFn = void(
+    const T* dinx, const T* diny, T* dout, int batch, int channels, int num);
 
-void ElementwiseAddActivationCompute::Run() {
-  auto& param = Param<operators::FusionElementwiseActivationParam>();
-  const float* x_data = param.X->data<float>();
-  const float* y_data = param.Y->data<float>();
-  float* out_data = param.Out->mutable_data<float>();
-  int axis = param.axis;
-  std::string act_type = param.act_type;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  int pre, n, post;
-  if (x_dims.size() < y_dims.size() &&
-      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_add_relu_broadcast(
-          y_data, x_data, out_data, pre, n, post);
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
+template <class T>
+using ElementWiseFn = void(const T* dinx, const T* diny, T* dout, int num);
+
+template <class T>
+using BinaryOpFn = lite::kernels::host::BinaryOpFn<T>;
+
+enum class OprandSwapable { NO, YES };
+
+template <class Elem_t, class DimValue_t>
+void common_elmentwise_op_arm(
+    const lite::kernels::host::BatchElementWiseArg<Elem_t, DimValue_t>&
+        batch_arg,
+    BinaryOpFn<Elem_t> op,
+    ElementWiseFn<Elem_t> elementwise_fn) {
+  int batch_num = batch_arg.BatchNum();
+  auto bcast_type = batch_arg.BcastType();
+  int range_length = batch_arg.ElemNumPerBatch();
+  switch (bcast_type) {
+    case (lite::kernels::host::BroadcastType::X_AS_CONTINUOUS): {
+      for (int batch_id = 0; batch_id < batch_num; ++batch_id) {
+        lite::kernels::host::element_wise_range_to_one<Elem_t>(
+            batch_arg.XAtBatch(batch_id),
+            batch_arg.YAtBatch(batch_id),
+            batch_arg.ZAtBatch(batch_id),
+            range_length,
+            op);
+      }
+      break;
     }
-  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_add_relu_broadcast(
-          x_data, y_data, out_data, pre, n, post);
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
+    case (lite::kernels::host::BroadcastType::Y_AS_CONTINUOUS): {
+      for (int batch_id = 0; batch_id < batch_num; ++batch_id) {
+        lite::kernels::host::element_wise_one_to_range<Elem_t>(
+            batch_arg.XAtBatch(batch_id),
+            batch_arg.YAtBatch(batch_id),
+            batch_arg.ZAtBatch(batch_id),
+            range_length,
+            op);
+      }
+      break;
     }
-  } else {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_add_relu(
-          x_data, y_data, out_data, x_dims.production());
-    } else if (act_type == "tanh") {
-      lite::arm::math::elementwise_add_tanh(
-          x_data, y_data, out_data, x_dims.production());
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
+    case (lite::kernels::host::BroadcastType::BOTH_CONTINUOUS): {
+      for (int batch_id = 0; batch_id < batch_num; ++batch_id) {
+        elementwise_fn(batch_arg.XAtBatch(batch_id),
+                       batch_arg.YAtBatch(batch_id),
+                       batch_arg.ZAtBatch(batch_id),
+                       range_length);
+      }
+      break;
     }
   }
 }
 
-template <typename T, PrecisionType PType>
-void ElementwiseSubCompute<T, PType>::Run() {
-  auto& param = this->template Param<operators::ElementwiseParam>();
-  const T* x_data = param.X->template data<T>();
-  const T* y_data = param.Y->template data<T>();
-  T* out_data = param.Out->template mutable_data<T>();
-  int axis = param.axis;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  int pre, n, post;
-  if (x_dims.size() < y_dims.size() &&
-      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_sub_broadcast<T>(
-        y_data, x_data, out_data, pre, n, post);
-  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_sub_broadcast<T>(
-        x_data, y_data, out_data, pre, n, post);
-  } else {
-    lite::arm::math::elementwise_sub<T>(
-        x_data, y_data, out_data, x_dims.production());
-  }
-}
-
-void ElementwiseSubActivationCompute::Run() {
-  auto& param = Param<operators::FusionElementwiseActivationParam>();
-  const float* x_data = param.X->data<float>();
-  const float* y_data = param.Y->data<float>();
-  float* out_data = param.Out->mutable_data<float>();
-  int axis = param.axis;
-  std::string act_type = param.act_type;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  int pre, n, post;
-
-  if (act_type != "relu") {
-    LOG(FATAL) << "unsupported Activation type: " << act_type;
-  }
-  if (x_dims.size() < y_dims.size() &&
-      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_sub_relu_broadcast(
-        y_data, x_data, out_data, pre, n, post);
-  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_sub_relu_broadcast(
-        x_data, y_data, out_data, pre, n, post);
-  } else {
-    lite::arm::math::elementwise_sub_relu(
-        x_data, y_data, out_data, x_dims.production());
-  }
-}
-
-template <typename T, PrecisionType PType>
-void ElementwiseMulCompute<T, PType>::Run() {
-  auto& param = this->template Param<operators::ElementwiseParam>();
+template <class T, OprandSwapable opd_swap_able>
+void elementwise_compute_template(paddle::lite::KernelBase* kernel,
+                                  FastBCastFn<T> fast_bcast_fn,
+                                  ElementWiseFn<T> elementwise_fn,
+                                  BinaryOpFn<T> op) {
+  auto& param = kernel->template Param<operators::ElementwiseParam>();
   auto* x_data = param.X->template data<T>();
   auto* y_data = param.Y->template data<T>();
   auto* out_data = param.Out->template mutable_data<T>();
@@ -192,186 +151,185 @@ void ElementwiseMulCompute<T, PType>::Run() {
   auto x_dims = param.X->dims();
   auto y_dims = param.Y->dims();
   int pre, n, post;
-  if (x_dims.size() < y_dims.size() &&
-      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_mul_broadcast<T>(
-        y_data, x_data, out_data, pre, n, post);
-  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_mul_broadcast<T>(
-        x_data, y_data, out_data, pre, n, post);
-  } else {
-    lite::arm::math::elementwise_mul<T>(
-        x_data, y_data, out_data, x_dims.production());
+  if (elementwise_fn && x_dims == y_dims) {
+    elementwise_fn(x_data, y_data, out_data, x_dims.production());
+  } else if (fast_bcast_fn &&
+             is_fast_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
+    fast_bcast_fn(x_data, y_data, out_data, pre, n, post);
+  } else if (fast_bcast_fn && opd_swap_able == OprandSwapable::YES &&
+             axis == -1 &&
+             is_fast_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
+    fast_bcast_fn(y_data, x_data, out_data, pre, n, post);
+  } else if (elementwise_fn) {
+    auto batch_arg = lite::kernels::host::GenBatchElementWiseArg<T>(
+        param.X, param.Y, param.Out, axis);
+    common_elmentwise_op_arm<T, int64_t>(batch_arg, op, elementwise_fn);
   }
+  if (!elementwise_fn && !fast_bcast_fn) {
+    LOG(FATAL) << "unsupported elementwise_compute called";
+  }
+}
+
+template <typename T, PrecisionType PType>
+void ElementwiseAddCompute<T, PType>::Run() {
+  elementwise_compute_template<T, OprandSwapable::YES>(
+      this,
+      lite::arm::math::elementwise_add_broadcast<T>,
+      lite::arm::math::elementwise_add<T>,
+      paddle::lite::kernels::host::naive_add<T>);
+}
+
+void ElementwiseAddActivationCompute::Run() {
+  auto& param = Param<operators::FusionElementwiseActivationParam>();
+  bool act_supported = false;
+  if (param.act_type == "relu") {
+    act_supported = true;
+    elementwise_compute_template<float, OprandSwapable::YES>(
+        this,
+        lite::arm::math::elementwise_add_relu_broadcast<float>,
+        lite::arm::math::elementwise_add_relu<float>,
+        paddle::lite::kernels::host::naive_fused_op<
+            float,
+            paddle::lite::kernels::host::naive_add<float>,
+            paddle::lite::kernels::host::naive_relu<float>>);
+  }
+
+  if (param.act_type == "tanh") {
+    act_supported = true;
+    elementwise_compute_template<float, OprandSwapable::YES>(
+        this,
+        nullptr,
+        lite::arm::math::elementwise_add_tanh<float>,
+        paddle::lite::kernels::host::naive_fused_op<
+            float,
+            paddle::lite::kernels::host::naive_add<float>,
+            paddle::lite::kernels::host::naive_tanh<float>>);
+  }
+  if (!act_supported) {
+    LOG(FATAL) << "unsupported Activation type: " << param.act_type;
+  }
+}
+
+template <typename T, PrecisionType PType>
+void ElementwiseSubCompute<T, PType>::Run() {
+  elementwise_compute_template<T, OprandSwapable::NO>(
+      this,
+      lite::arm::math::elementwise_sub_broadcast<T>,
+      lite::arm::math::elementwise_sub<T>,
+      paddle::lite::kernels::host::naive_sub<T>);
+}
+
+void ElementwiseSubActivationCompute::Run() {
+  auto& param = Param<operators::FusionElementwiseActivationParam>();
+  bool act_supported = false;
+  if (param.act_type == "relu") {
+    act_supported = true;
+    elementwise_compute_template<float, OprandSwapable::NO>(
+        this,
+        lite::arm::math::elementwise_sub_relu_broadcast<float>,
+        lite::arm::math::elementwise_sub_relu<float>,
+        paddle::lite::kernels::host::naive_fused_op<
+            float,
+            paddle::lite::kernels::host::naive_sub<float>,
+            paddle::lite::kernels::host::naive_relu<float>>);
+  }
+  if (!act_supported) {
+    LOG(FATAL) << "unsupported Activation type: " << param.act_type;
+  }
+}
+
+template <typename T, PrecisionType PType>
+void ElementwiseMulCompute<T, PType>::Run() {
+  elementwise_compute_template<T, OprandSwapable::YES>(
+      this,
+      lite::arm::math::elementwise_mul_broadcast<T>,
+      lite::arm::math::elementwise_mul<T>,
+      paddle::lite::kernels::host::naive_mul<T>);
 }
 
 template <typename T, PrecisionType PType>
 void ElementwiseMulActivationCompute<T, PType>::Run() {
   auto& param =
       this->template Param<operators::FusionElementwiseActivationParam>();
-  auto* x_data = param.X->template data<T>();
-  auto* y_data = param.Y->template data<T>();
-  auto* out_data = param.Out->template mutable_data<T>();
-  int axis = param.axis;
-  std::string act_type = param.act_type;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  int pre, n, post;
-  if (x_dims.size() < y_dims.size() &&
-      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_mul_relu_broadcast<T>(
-          y_data, x_data, out_data, pre, n, post);
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
-    }
-  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_mul_relu_broadcast<T>(
-          x_data, y_data, out_data, pre, n, post);
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
-    }
-  } else {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_mul_relu<T>(
-          x_data, y_data, out_data, x_dims.production());
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
-    }
+  bool act_supported = false;
+  if (param.act_type == "relu") {
+    act_supported = true;
+    elementwise_compute_template<T, OprandSwapable::YES>(
+        this,
+        lite::arm::math::elementwise_mul_relu_broadcast<T>,
+        lite::arm::math::elementwise_mul_relu<T>,
+        paddle::lite::kernels::host::naive_fused_op<
+            T,
+            paddle::lite::kernels::host::naive_mul<T>,
+            paddle::lite::kernels::host::naive_relu<T>>);
+  }
+  if (!act_supported) {
+    LOG(FATAL) << "unsupported Activation type: " << param.act_type;
   }
 }
 
 void ElementwiseMaxCompute::Run() {
-  auto& param = Param<operators::ElementwiseParam>();
-  const float* x_data = param.X->data<float>();
-  const float* y_data = param.Y->data<float>();
-  float* out_data = param.Out->mutable_data<float>();
-  int axis = param.axis;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  int pre, n, post;
-  if (x_dims.size() < y_dims.size() &&
-      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_max_broadcast(
-        y_data, x_data, out_data, pre, n, post);
-  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_max_broadcast(
-        x_data, y_data, out_data, pre, n, post);
-  } else {
-    lite::arm::math::elementwise_max(
-        x_data, y_data, out_data, x_dims.production());
-  }
+  elementwise_compute_template<float, OprandSwapable::YES>(
+      this,
+      lite::arm::math::elementwise_max_broadcast<float>,
+      lite::arm::math::elementwise_max<float>,
+      paddle::lite::kernels::host::naive_max<float>);
 }
 
 void ElementwiseMaxActivationCompute::Run() {
   auto& param = Param<operators::FusionElementwiseActivationParam>();
-  const float* x_data = param.X->data<float>();
-  const float* y_data = param.Y->data<float>();
-  float* out_data = param.Out->mutable_data<float>();
-  int axis = param.axis;
-  std::string act_type = param.act_type;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  int pre, n, post;
-  if (x_dims.size() < y_dims.size() &&
-      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_max_relu_broadcast<float>(
-          y_data, x_data, out_data, pre, n, post);
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
-    }
-  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_max_relu_broadcast(
-          x_data, y_data, out_data, pre, n, post);
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
-    }
-  } else {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_max_relu(
-          x_data, y_data, out_data, x_dims.production());
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
-    }
+  bool act_supported = false;
+  if (param.act_type == "relu") {
+    act_supported = true;
+    elementwise_compute_template<float, OprandSwapable::YES>(
+        this,
+        lite::arm::math::elementwise_max_relu_broadcast<float>,
+        lite::arm::math::elementwise_max_relu<float>,
+        paddle::lite::kernels::host::naive_fused_op<
+            float,
+            paddle::lite::kernels::host::naive_max<float>,
+            paddle::lite::kernels::host::naive_relu<float>>);
+  }
+  if (!act_supported) {
+    LOG(FATAL) << "unsupported Activation type: " << param.act_type;
   }
 }
 
 template <typename T, PrecisionType PType>
 void ElementwiseDivCompute<T, PType>::Run() {
-  auto& param = this->template Param<operators::ElementwiseParam>();
-  auto* x_data = param.X->template data<T>();
-  auto* y_data = param.Y->template data<T>();
-  auto* out_data = param.Out->template mutable_data<T>();
-  int axis = param.axis;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  int pre, n, post;
-  if (x_dims.size() < y_dims.size()) {
-    LOG(FATAL) << "elewise div don't support x_dims size < y_dims size";
-  }
-  if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_div_broadcast<T>(
-        x_data, y_data, out_data, pre, n, post);
-  } else {
-    lite::arm::math::elementwise_div<T>(
-        x_data, y_data, out_data, x_dims.production());
-  }
+  elementwise_compute_template<T, OprandSwapable::NO>(
+      this,
+      lite::arm::math::elementwise_div_broadcast<T>,
+      lite::arm::math::elementwise_div<T>,
+      paddle::lite::kernels::host::naive_div<T>);
 }
 
 void ElementwiseDivActivationCompute::Run() {
   auto& param = Param<operators::FusionElementwiseActivationParam>();
-  const float* x_data = param.X->data<float>();
-  const float* y_data = param.Y->data<float>();
-  float* out_data = param.Out->mutable_data<float>();
-  int axis = param.axis;
-  std::string act_type = param.act_type;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  if (x_dims.size() < y_dims.size()) {
-    LOG(FATAL) << "elewise div don't support x_dims size < y_dims size";
+  bool act_supported = false;
+  if (param.act_type == "relu") {
+    act_supported = true;
+    elementwise_compute_template<float, OprandSwapable::NO>(
+        this,
+        lite::arm::math::elementwise_div_relu_broadcast<float>,
+        lite::arm::math::elementwise_div_relu<float>,
+        paddle::lite::kernels::host::naive_fused_op<
+            float,
+            paddle::lite::kernels::host::naive_div<float>,
+            paddle::lite::kernels::host::naive_relu<float>>);
   }
-  int pre, n, post;
-  if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_div_relu_broadcast(
-          x_data, y_data, out_data, pre, n, post);
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
-    }
-  } else {
-    if (act_type == "relu") {
-      lite::arm::math::elementwise_div_relu(
-          x_data, y_data, out_data, x_dims.production());
-    } else {
-      LOG(FATAL) << "unsupported Activation type: " << act_type;
-    }
+  if (!act_supported) {
+    LOG(FATAL) << "unsupported Activation type: " << param.act_type;
   }
 }
 
 template <typename T, PrecisionType PType>
 void ElementwiseModCompute<T, PType>::Run() {
-  auto& param = this->template Param<operators::ElementwiseParam>();
-  auto* x_data = param.X->template data<T>();
-  auto* y_data = param.Y->template data<T>();
-  auto* out_data = param.Out->template mutable_data<T>();
-  int axis = param.axis;
-  auto x_dims = param.X->dims();
-  auto y_dims = param.Y->dims();
-  int pre, n, post;
-  if (x_dims.size() < y_dims.size() &&
-      is_broadcast(y_dims, x_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_mod_broadcast<T>(
-        y_data, x_data, out_data, pre, n, post);
-  } else if (is_broadcast(x_dims, y_dims, axis, &pre, &n, &post)) {
-    lite::arm::math::elementwise_mod_broadcast<T>(
-        x_data, y_data, out_data, pre, n, post);
-  } else {
-    lite::arm::math::elementwise_mod<T>(
-        x_data, y_data, out_data, x_dims.production());
-  }
+  elementwise_compute_template<T, OprandSwapable::NO>(
+      this,
+      lite::arm::math::elementwise_mod_broadcast<T>,
+      lite::arm::math::elementwise_mod<T>,
+      paddle::lite::kernels::host::naive_mod<T>);
 }
 
 }  // namespace arm

--- a/lite/kernels/host/elementwise_op_func.h
+++ b/lite/kernels/host/elementwise_op_func.h
@@ -1,0 +1,539 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstring>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <class T>
+T naive_add(T a, T b) {
+  return a + b;
+}
+
+template <class T>
+T naive_sub(T a, T b) {
+  return a - b;
+}
+
+template <class T>
+T naive_mul(T a, T b) {
+  return a * b;
+}
+
+template <class T>
+T naive_max(T a, T b) {
+  return a > b ? a : b;
+}
+
+template <class T>
+T naive_div(T a, T b) {
+  return a / b;
+}
+
+template <class T>
+T naive_mod(T a, T b) {
+  return a % b;
+}
+
+template <class T>
+using BinaryOpFn = T(T, T);
+
+template <class T>
+using UaryOpFn = T(T);
+
+template <class T, BinaryOpFn<T> binary_op, UaryOpFn<T> uary_op>
+T naive_fused_op(T a, T b) {
+  return uary_op(binary_op(a, b));
+}
+
+template <class T>
+T naive_relu(T a) {
+  return a > 0 ? a : 0;
+}
+
+template <class T>
+T naive_tanh(T a) {
+  return std::tanh(static_cast<double>(a));
+}
+
+enum class ElementwiseFusedActType { NONE, RELU, TANH };
+
+/**
+ * in Z = X op Y , there must be a minimal continuous mem in X or Y that could
+ * do SIMD.
+ */
+enum class BroadcastType {
+  UNKNOWN,
+  DIM_NOT_MATCH,  // could not do elementwise
+  SAME_DIM,  // if x and y had a same dim, it could be treated as broadcast,but
+  // not recommended.
+  X_AS_CONTINUOUS,  // e.g. X.shape=[1,1,3,5],Y.shape=[2,4,1,1]
+  Y_AS_CONTINUOUS,  // e.g. X.shape=[2,4,1,1],Y.shape=[1,1,3,5]
+  BOTH_CONTINUOUS   // e.g. X.Shape=[1,1,3,5],Y.shape=[8,9,3,5]
+};
+
+/**
+ * Get broadcast type, x_dims and x_dims must have same dim_size. The dimension
+ * which will be broadcast should be set to 1, and the 1 at high dimension
+ * should not be omitted
+ * e.g. x_dims=[3,1,1,5] and y_dims=[1,2,4,1] is fine, but y_dims should not be
+ * [2,4,1]
+ * @tparam DimValue_t data type of dim's value
+ * @param x_dims pointer to x's dim array, which is `dim_size` length
+ * @param y_dims pointer to y's dim array, which is `dim_size` length
+ * @param dim_size dim_size of x and y
+ */
+template <class DimValue_t>
+BroadcastType get_broadcast_type(DimValue_t *x_dims,
+                                 DimValue_t *y_dims,
+                                 int dim_size) {
+  if (memcmp(x_dims, y_dims, sizeof(DimValue_t) * dim_size) == 0) {
+    return BroadcastType::SAME_DIM;
+  }
+
+  // check if it is broadcast
+  for (int i = 0; i < dim_size; ++i) {
+    if (x_dims[i] != 1 && y_dims[i] != 1 && x_dims[i] != y_dims[i]) {
+      return BroadcastType::DIM_NOT_MATCH;
+    }
+  }
+
+  int pos = dim_size - 1;
+  while (pos >= 0 && x_dims[pos] == y_dims[pos] && x_dims[pos] == 1) {
+    --pos;
+  }
+  if (x_dims[pos] == y_dims[pos]) {
+    return BroadcastType::BOTH_CONTINUOUS;
+  }
+  if (x_dims[pos] != 1) {
+    return BroadcastType::X_AS_CONTINUOUS;
+  }
+  if (y_dims[pos] != 1) {
+    return BroadcastType::Y_AS_CONTINUOUS;
+  }
+  return BroadcastType::UNKNOWN;
+}
+
+template <class Elem_t>
+struct BatchElementWiseArgMemPointer {
+  const Elem_t *x_data = nullptr;
+  const Elem_t *y_data = nullptr;
+  Elem_t *z_data = nullptr;
+};
+
+template <class Elem_t, class DimValue_t>
+struct BatchElementWiseArg {
+  BroadcastType BcastType() const { return broadcast_type_; }
+  int64_t ElemNumPerBatch() const { return continuous_length_; }
+  int64_t BatchNum() const { return z_num_ / continuous_length_; }
+
+  BatchElementWiseArgMemPointer<Elem_t> AllAtBatch(int64_t elem_id) {
+    BatchElementWiseArgMemPointer<Elem_t> ret = {x_data_, y_data_, z_data_};
+    int64_t ind = 0;
+    for (int64_t i = 0; i < dim_size_; ++i) {
+      ind = elem_id / element_id_stride_[i];
+      ret.x_data += bcast_x_stride_[i] * ind;
+      ret.y_data += bcast_y_stride_[i] * ind;
+      ret.z_data += z_stride_[i] * ind;
+      elem_id -= (element_id_stride_[i] * ind);
+    }
+    return ret;
+  }
+
+  const Elem_t *XAtBatch(int64_t batch_id) const {
+    return x_data_ +
+           ElemID2Offset(batch_id * continuous_length_, bcast_x_stride_);
+  }
+  const Elem_t *YAtBatch(int64_t batch_id) const {
+    return y_data_ +
+           ElemID2Offset(batch_id * continuous_length_, bcast_y_stride_);
+  }
+  Elem_t *ZAtBatch(int64_t batch_id) const {
+    return z_data_ + ElemID2Offset(batch_id * continuous_length_, z_stride_);
+  }
+
+  /**
+   * @tparam Elem_t data type of element
+   * @tparam DimValue_t data type of dim's value
+   * @param x_data pointer to x's data
+   * @param y_data pointer to y's data
+   * @param z_data pointer to z's data
+   * @param x_dims pointer to x's dim array, which is `dim_size` length
+   * @param y_dims pointer to y's dim array, which is `dim_size` length
+   * @param z_dims pointer to z's dim array, which is `dim_size` length
+   * @param x_stride x's memory stride
+   * @param y_stride y's memory stride
+   * @param z_stride z's memory stride
+   * @param dim_size dim array's length
+   * @param broadcast_type Could get from get_broadcast_type(), if set to
+   * BroadcastType::UNKNOWN, this function will call get_broadcast_type
+   * automatically
+   *
+   * @Note the memory stride describes how element are stored in memory.
+   * e.g. Given tensor X has a dim [C,H,W], then X.At(i,j,k) should be stored
+   * at X.data() + x_stride[0]*i + x_stride[1]*j + x_stride[2]*k
+   *
+   * @Warning the element in X, Y and Z must be stored as low dimension first,
+   * e.g. Tensor X has a dim [5,6,7] ,then X.At(0,0,0) -> X.At(0,0,7) must be
+   * stored at X.data() continuously
+   */
+  void Update(const Elem_t *x_data,
+              const Elem_t *y_data,
+              Elem_t *z_data,
+              const DimValue_t *x_dims,
+              const DimValue_t *y_dims,
+              const DimValue_t *z_dims,
+              const DimValue_t *x_stride,
+              const DimValue_t *y_stride,
+              const DimValue_t *z_stride,
+              int dim_size,
+              BroadcastType broadcast_type = BroadcastType::UNKNOWN);
+
+ private:
+  const Elem_t *x_data_ = nullptr;
+  const Elem_t *y_data_ = nullptr;
+  Elem_t *z_data_ = nullptr;
+  int64_t z_num_ = 0;
+
+  int dim_size_ = 0;
+  int64_t continuous_length_ = 0;
+  BroadcastType broadcast_type_ = BroadcastType::UNKNOWN;
+
+  std::vector<DimValue_t> bcast_x_stride_;
+  std::vector<DimValue_t> bcast_y_stride_;
+  std::vector<DimValue_t> z_stride_;
+  std::vector<DimValue_t> element_id_stride_;
+
+  /**
+   * Every element of some **FULL** tensor has its own logic id, ElemID2Offset
+   * will convert this id to its memory offset
+   * eg. given x.dims=[1,1,2,3] y.dims=[4,5,1,1],
+   * then the full tensor's dim should be [4,5,2,3],
+   * and, the element at [i,j,k,l] will get the
+   * elem_id of `i*30 + j*6 + k*3 +l`
+   * this elem_id works for all tensor X, Y and Z.
+   */
+  int64_t ElemID2Offset(int64_t elem_id,
+                        const std::vector<DimValue_t> &bcast_stride) const {
+    int64_t ind = 0;
+    int64_t offset = 0;
+    for (int64_t i = 0; i < dim_size_; ++i) {
+      ind = elem_id / element_id_stride_[i];
+      offset += bcast_stride[i] * ind;
+      elem_id -= (element_id_stride_[i] * ind);
+    }
+    return offset;
+  }
+
+  bool HasGapToNextDim(const DimValue_t *dims,
+                       const DimValue_t *stride,
+                       int this_dim) const {
+    return (dims[this_dim + 1] * stride[this_dim + 1]) != stride[this_dim];
+  }
+};
+
+template <class Elem_t, class DimValue_t>
+void BatchElementWiseArg<Elem_t, DimValue_t>::Update(
+    const Elem_t *x_data,
+    const Elem_t *y_data,
+    Elem_t *z_data,
+    const DimValue_t *x_dims,
+    const DimValue_t *y_dims,
+    const DimValue_t *z_dims,
+    const DimValue_t *x_stride,
+    const DimValue_t *y_stride,
+    const DimValue_t *z_stride,
+    int dim_size,
+    BroadcastType broadcast_type) {
+  // arg checking
+  if (broadcast_type == BroadcastType::UNKNOWN) {
+    LOG(INFO) << "No broadcast type input";
+    broadcast_type = get_broadcast_type(x_dims, y_dims, dim_size);
+  }
+  if (broadcast_type == BroadcastType::UNKNOWN ||
+      broadcast_type == BroadcastType::DIM_NOT_MATCH) {
+    LOG(FATAL) << "Wrong broadcast type";
+    return;
+  }
+  if (broadcast_type == BroadcastType::SAME_DIM) {
+    broadcast_type = BroadcastType::BOTH_CONTINUOUS;
+    LOG(INFO) << "Same dim detected";
+    // SAME_DIM should not be treated as broadcast. For SAME_DIM is a special
+    // case of BOTH_CONTINUOUS, we could still process it.
+  }
+
+  if (x_stride[dim_size - 1] != 1 || y_stride[dim_size - 1] != 1 ||
+      z_stride[dim_size - 1] != 1) {
+    LOG(FATAL) << "data are not stored continuously";
+    return;
+  }
+
+  // generate element_id stride
+  std::vector<DimValue_t> element_id_stride(dim_size, 1);
+  for (int i = dim_size - 2; i >= 0; --i) {
+    element_id_stride[i] = z_dims[i + 1] * element_id_stride[i + 1];
+  }
+
+  // generate broadcast_stride
+  std::vector<DimValue_t> bcast_x_stride(x_stride, x_stride + dim_size);
+  std::vector<DimValue_t> bcast_y_stride(y_stride, y_stride + dim_size);
+  int total_elem_num = 1;
+  for (int i = 0; i < dim_size; ++i) {
+    if (x_dims[i] == 1) {
+      bcast_x_stride[i] = 0;
+    }
+    if (y_dims[i] == 1) {
+      bcast_y_stride[i] = 0;
+    }
+    total_elem_num *= z_dims[i];
+  }
+
+  // get_continuous_length
+  int64_t continuous_elem_num = z_dims[dim_size - 1];
+  int end_pos = dim_size - 2;
+  switch (broadcast_type) {
+    case BroadcastType::X_AS_CONTINUOUS: {
+      while (end_pos >= 0 && y_dims[end_pos] == 1) {
+        if (HasGapToNextDim(z_dims, z_stride, end_pos) ||
+            HasGapToNextDim(x_dims, x_stride, end_pos)) {
+          break;
+        }
+        continuous_elem_num *= z_dims[end_pos];
+        --end_pos;
+      }
+      break;
+    }
+    case BroadcastType::Y_AS_CONTINUOUS: {
+      while (end_pos >= 0 && x_dims[end_pos] == 1) {
+        if (HasGapToNextDim(z_dims, z_stride, end_pos) ||
+            HasGapToNextDim(y_dims, y_stride, end_pos)) {
+          break;
+        }
+        continuous_elem_num *= z_dims[end_pos];
+        --end_pos;
+      }
+      break;
+    }
+    case BroadcastType::BOTH_CONTINUOUS: {
+      while (end_pos >= 0 && x_dims[end_pos] == y_dims[end_pos]) {
+        if (HasGapToNextDim(z_dims, z_stride, end_pos) ||
+            HasGapToNextDim(x_dims, x_stride, end_pos) ||
+            HasGapToNextDim(y_dims, y_stride, end_pos)) {
+          break;
+        }
+        continuous_elem_num *= z_dims[end_pos];
+        --end_pos;
+      }
+      break;
+    }
+    default: {
+      return;  // code should never goes to here
+    }
+  }
+
+  // do update
+  x_data_ = x_data;
+  y_data_ = y_data;
+  z_data_ = z_data;
+  z_num_ = total_elem_num;
+
+  dim_size_ = dim_size;
+  continuous_length_ = continuous_elem_num;
+  broadcast_type_ = broadcast_type;
+
+  bcast_x_stride_ = std::move(bcast_x_stride);
+  bcast_y_stride_ = std::move(bcast_y_stride);
+  z_stride_ = std::vector<DimValue_t>(z_stride, z_stride + dim_size);
+  element_id_stride_ = std::move(element_id_stride);
+}
+
+template <class T>
+void element_wise_one_to_range(const T *x,
+                               const T *y,
+                               T *z,
+                               int64_t range_length,
+                               std::function<T(T, T)> op) {
+  for (int64_t i = 0; i < range_length; ++i) {
+    z[i] = op(*x, y[i]);
+  }
+}
+
+template <class T>
+void element_wise_range_to_one(const T *x,
+                               const T *y,
+                               T *z,
+                               int64_t range_length,
+                               std::function<T(T, T)> op) {
+  for (int64_t i = 0; i < range_length; ++i) {
+    z[i] = op(x[i], *y);
+  }
+}
+
+template <class T>
+void element_wise_range_to_range(const T *x,
+                                 const T *y,
+                                 T *z,
+                                 int64_t range_length,
+                                 std::function<T(T, T)> op) {
+  for (int64_t i = 0; i < range_length; ++i) {
+    z[i] = op(x[i], y[i]);
+  }
+}
+
+/**
+ * This function can handle any kinds of element-wise operation technically,
+ * But it's recommended to use this function only when there is broadcast
+ * needed.
+ * @note: This function is easy to parallelized, check the final part,
+ *  1. in every loop, we are handling a batch
+ *  2. different loop process individual batch
+ *
+ * @note see BatchElementWiseArg::Update to get info about args
+ */
+template <class Elem_t, class DimValue_t>
+void common_elmentwise_op_naive_cpu(
+    const BatchElementWiseArg<Elem_t, DimValue_t> &batch_arg,
+    std::function<Elem_t(Elem_t, Elem_t)> op) {
+  int batch_num = batch_arg.BatchNum();
+  auto bcast_type = batch_arg.BcastType();
+  int range_length = batch_arg.ElemNumPerBatch();
+  switch (bcast_type) {
+    case (BroadcastType::X_AS_CONTINUOUS): {
+      for (int batch_id = 0; batch_id < batch_num; ++batch_id) {
+        element_wise_range_to_one(batch_arg.XAtBatch(batch_id),
+                                  batch_arg.YAtBatch(batch_id),
+                                  batch_arg.ZAtBatch(batch_id),
+                                  range_length,
+                                  op);
+      }
+      break;
+    }
+    case (BroadcastType::Y_AS_CONTINUOUS): {
+      for (int batch_id = 0; batch_id < batch_num; ++batch_id) {
+        element_wise_one_to_range(batch_arg.XAtBatch(batch_id),
+                                  batch_arg.YAtBatch(batch_id),
+                                  batch_arg.ZAtBatch(batch_id),
+                                  range_length,
+                                  op);
+      }
+      break;
+    }
+    case (BroadcastType::BOTH_CONTINUOUS): {
+      for (int batch_id = 0; batch_id < batch_num; ++batch_id) {
+        element_wise_range_to_range(batch_arg.XAtBatch(batch_id),
+                                    batch_arg.YAtBatch(batch_id),
+                                    batch_arg.ZAtBatch(batch_id),
+                                    range_length,
+                                    op);
+      }
+      break;
+    }
+  }
+}
+
+/**
+ * fix missing dim of paddle lite tensor to fit this broadcast system.
+ * @tparam DimValue_t
+ * @param X
+ * @param Y
+ * @param Out
+ * @param axis axis defined by paddle
+ * @param out_dim_size dim size of Out
+ * @param [out] p_x_dims fixed dim value of x
+ * @param [out] p_y_dims fixed dim value of y
+ */
+template <class DimValue_t>
+void fix_x_y_dims(const Tensor *X,
+                  const Tensor *Y,
+                  const Tensor *Out,
+                  int axis,
+                  std::vector<DimValue_t> *p_x_dims,
+                  std::vector<DimValue_t> *p_y_dims) {
+  auto &x_dims = *p_x_dims;
+  auto &y_dims = *p_y_dims;
+  int out_dim_size = Out->dims().size();
+  x_dims.resize(out_dim_size, 1);
+  y_dims.resize(out_dim_size, 1);
+
+  if (axis == -1) {
+    int i_raw = 0;
+    int i_new = out_dim_size - X->dims().size();
+    for (; i_raw < X->dims().size(); ++i_raw, ++i_new) {
+      x_dims[i_new] = X->dims()[i_raw];
+    }
+    i_raw = 0;
+    i_new = out_dim_size - Y->dims().size();
+    for (; i_raw < Y->dims().size(); ++i_raw, ++i_new) {
+      y_dims[i_new] = Y->dims()[i_raw];
+    }
+  } else {
+    if (X->dims().size() != Out->dims().size()) {
+      LOG(FATAL) << "X and OUT dim size mismatch";
+    }
+    for (int i = 0; i < out_dim_size; ++i) {
+      x_dims[i] = X->dims()[i];
+    }
+    for (int i = axis; i < out_dim_size; ++i) {
+      y_dims[i + axis] = Y->dims()[i];
+    }
+  }
+}
+
+template <class T>
+BatchElementWiseArg<T, int64_t> GenBatchElementWiseArg(const lite::Tensor *X,
+                                                       const lite::Tensor *Y,
+                                                       lite::Tensor *Out,
+                                                       int axis = -1) {
+  int out_dim_size = Out->dims().size();
+  std::vector<int64_t> x_dims;
+  std::vector<int64_t> y_dims;
+  fix_x_y_dims<int64_t>(X, Y, Out, axis, &x_dims, &y_dims);
+
+  auto &z_dims = Out->dims().data();
+  // gen stride
+  std::vector<int64_t> x_stride(out_dim_size, 1);
+  std::vector<int64_t> y_stride(out_dim_size, 1);
+  std::vector<int64_t> z_stride(out_dim_size, 1);
+  for (int i = out_dim_size - 2; i >= 0; --i) {
+    x_stride[i] = x_stride[i + 1] * x_dims[i + 1];
+    y_stride[i] = y_stride[i + 1] * y_dims[i + 1];
+    z_stride[i] = z_stride[i + 1] * z_dims[i + 1];
+  }
+
+  BatchElementWiseArg<T, int64_t> batch_arg;
+  batch_arg.Update(X->data<T>(),
+                   Y->data<T>(),
+                   Out->mutable_data<T>(),
+                   x_dims.data(),
+                   y_dims.data(),
+                   z_dims.data(),
+                   x_stride.data(),
+                   y_stride.data(),
+                   z_stride.data(),
+                   out_dim_size);
+  return batch_arg;
+}
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle


### PR DESCRIPTION

* [host][arm][kernel]feat: elementwise_op should support all kinds of broadcast now

* ref: fix spell err

* ref: clean up code

* feat: add AllAtBatch() to BatchElementWiseArg

* ref: update document

* ref: clean up code

* ref: clean up code

* fix: add axis when gen batch arg test=develop

* add: fused op template

* add: enum class of fuse act type

* feat: arm kernel fused with activation should work test=develop

* ref: use function param to replace template param to avoid binary inflation test=develop

* ref: move test-case to a new PR later to avoid huge PR test=develop

* revert: changes in elementwise_grad_compute.cc reverted test=develop

* ref: disable inline to avoid binary inflation test=develop