### PR TITLE
[OpenCL] Add opencl func wrapper: clGetCommandQueueInfo

### DIFF
--- a/lite/backends/opencl/cl_wrapper.cc
+++ b/lite/backends/opencl/cl_wrapper.cc
@@ -111,6 +111,7 @@ bool CLWrapper::InitFunctions() {
   // note(ysh329): consider compatibility for cl_driver_version 1.10
   // using clCreateCommandQueue instead.
   // PADDLE_DLSYM(clCreateCommandQueueWithProperties);
+  PADDLE_DLSYM(clGetCommandQueueInfo);
   PADDLE_DLSYM(clReleaseCommandQueue);
   PADDLE_DLSYM(clCreateProgramWithBinary);
   PADDLE_DLSYM(clRetainContext);
@@ -437,6 +438,20 @@ clCreateCommandQueue(cl_context context,
     CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED {
   return paddle::lite::CLWrapper::Global()->clCreateCommandQueue()(
       context, device, properties, errcode_ret);
+}
+
+CL_API_ENTRY cl_int CL_API_CALL
+clGetCommandQueueInfo(cl_command_queue command_queue,
+                      cl_command_queue_info param_name,
+                      size_t param_value_size,
+                      void *param_value,
+                      size_t *param_value_size_ret) {
+  return paddle::lite::CLWrapper::Global()->clGetCommandQueueInfo()(
+      command_queue,
+      param_name,
+      param_value_size,
+      param_value,
+      param_value_size_ret);
 }
 
 CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties(

--- a/lite/backends/opencl/cl_wrapper.h
+++ b/lite/backends/opencl/cl_wrapper.h
@@ -141,6 +141,8 @@ class CLWrapper final {
       cl_device_id,
       cl_command_queue_properties,
       cl_int *);
+  using clGetCommandQueueInfoType = cl_int (*)(
+      cl_command_queue, cl_command_queue_info, size_t, void *, size_t *);
   using clCreateCommandQueueWithPropertiesType = cl_command_queue (*)(
       cl_context, cl_device_id, const cl_queue_properties *, cl_int *);
   using clReleaseCommandQueueType = cl_int (*)(cl_command_queue);
@@ -355,6 +357,12 @@ class CLWrapper final {
     return clCreateCommandQueue_;
   }
 
+  clGetCommandQueueInfoType clGetCommandQueueInfo() {
+    CHECK(clGetCommandQueueInfo_ != nullptr)
+        << "Cannot load clGetCommandQueueInfo!";
+    return clGetCommandQueueInfo_;
+  }
+
   clCreateCommandQueueWithPropertiesType clCreateCommandQueueWithProperties() {
     CHECK(clCreateCommandQueueWithProperties_ != nullptr)
         << "Cannot load clCreateCommandQueueWithProperties!";
@@ -544,6 +552,7 @@ class CLWrapper final {
   clEnqueueMapBufferType clEnqueueMapBuffer_{nullptr};
   clEnqueueMapImageType clEnqueueMapImage_{nullptr};
   clCreateCommandQueueType clCreateCommandQueue_{nullptr};
+  clGetCommandQueueInfoType clGetCommandQueueInfo_{nullptr};
   clCreateCommandQueueWithPropertiesType clCreateCommandQueueWithProperties_{
       nullptr};
   clReleaseCommandQueueType clReleaseCommandQueue_{nullptr};


### PR DESCRIPTION
【问题】lite 中无法直接调用 opencl API `clGetCommandQueueInfo`，提示无该API。
【解决方法】将该API加入到 func wrapper 中，且将该API加入`PADDLE_DLSYM`。
【性能】无影响。