### PR TITLE
[X86] fix tailor and windows build scripts, test=develop

### DIFF
--- a/lite/backends/x86/math/prior_box.cc
+++ b/lite/backends/x86/math/prior_box.cc
@@ -71,13 +71,13 @@ void density_prior_box(const int64_t img_width,
             for (int dj = 0; dj < density; ++dj) {
               float center_x_temp = density_center_x + dj * shift;
               float center_y_temp = density_center_y + di * shift;
-              boxes_data[offset++] = std::max(
+              boxes_data[offset++] = (std::max)(
                   (center_x_temp - box_width_ratio / 2.) / img_width, 0.);
-              boxes_data[offset++] = std::max(
+              boxes_data[offset++] = (std::max)(
                   (center_y_temp - box_height_ratio / 2.) / img_height, 0.);
-              boxes_data[offset++] = std::min(
+              boxes_data[offset++] = (std::min)(
                   (center_x_temp + box_width_ratio / 2.) / img_width, 1.);
-              boxes_data[offset++] = std::min(
+              boxes_data[offset++] = (std::min)(
                   (center_y_temp + box_height_ratio / 2.) / img_height, 1.);
             }
           }
@@ -92,7 +92,7 @@ void density_prior_box(const int64_t img_width,
 #pragma omp parallel for
 #endif
     for (int d = 0; d < channel_size; ++d) {
-      boxes_data[d] = std::min(std::max(boxes_data[d], 0.f), 1.f);
+      boxes_data[d] = (std::min)((std::max)(boxes_data[d], 0.f), 1.f);
     }
   }
 //! set the variance.

--- a/lite/backends/x86/port.h
+++ b/lite/backends/x86/port.h
@@ -64,6 +64,7 @@ static void *dlopen(const char *filename, int flag) {
   return reinterpret_cast<void *>(hModule);
 }
 
+#ifdef LITE_WITH_LOG
 extern struct timeval;
 static int gettimeofday(struct timeval *tp, void *tzp) {
   time_t clock;
@@ -84,6 +85,7 @@ static int gettimeofday(struct timeval *tp, void *tzp) {
 
   return (0);
 }
+#endif  // LITE_WITH_LOG
 #endif  // !_WIN32
 
 static void ExecShellCommand(const std::string &cmd, std::string *message) {

--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -43,6 +43,10 @@ readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/t
 
 readonly workspace=$PWD
 
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
 # if operating in mac env, we should expand the maximum file num
 os_name=`uname -s`
 if [ ${os_name} == "Darwin" ]; then
@@ -385,7 +389,7 @@ function make_x86 {
 
   prepare_workspace $root_dir $build_directory
 
-  cmake ..  -DWITH_MKL=ON       \
+  cmake $root_dir  -DWITH_MKL=ON       \
             -DWITH_MKLDNN=OFF    \
             -DLITE_WITH_X86=ON  \
             -DLITE_WITH_PROFILE=OFF \
@@ -395,7 +399,9 @@ function make_x86 {
             -DWITH_GPU=OFF \
             -DLITE_SHUTDOWN_LOG=ON \
             -DLITE_WITH_PYTHON=${BUILD_PYTHON} \
-            -DLITE_BUILD_EXTRA=ON \
+            -DLITE_BUILD_EXTRA=${BUILD_EXTRA} \
+            -DLITE_BUILD_TAILOR=${BUILD_TAILOR} \
+            -DLITE_OPTMODEL_DIR=${OPTMODEL_DIR} \
             -DLITE_WITH_LOG=${WITH_LOG} \
             -DLITE_WITH_EXCEPTION=$WITH_EXCEPTION \
             -DLITE_WITH_PROFILE=${WITH_PROFILE} \
@@ -504,6 +510,7 @@ function main {
 		;;
             --opt_model_dir=*)
                 OPTMODEL_DIR="${i#*=}"
+                OPTMODEL_DIR=$(readlinkf $OPTMODEL_DIR)
                 shift
                 ;;
             --build_tailor=*)

--- a/lite/tools/build_windows.bat
+++ b/lite/tools/build_windows.bat
@@ -10,6 +10,8 @@ set WITH_LOG=ON
 set WITH_PROFILE=OFF
 set WITH_TESTING=OFF
 set BUILD_FOR_CI=OFF
+set BUILD_TAILOR=OFF
+set OPTMODEL_DIR=""
 set THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
 
 set workspace=%source_path%
@@ -22,6 +24,11 @@ if /I "%1"=="with_extra" (
     set WITH_PYTHON=ON
 ) else if /I  "%1"=="with_profile" (
     set WITH_PROFILE=ON
+) else if /I  "%1"=="without_log" (
+    set WITH_LOG=OFF
+) else if /I  "%1"=="build_tailor" (
+    set BUILD_TAILOR=ON
+    set OPTMODEL_DIR="%2"
 ) else if /I  "%1"=="build_for_ci" (
     set BUILD_FOR_CI=ON
     set WITH_TESTING=ON
@@ -40,20 +47,19 @@ goto round
 cd "%workspace%"
 
 echo "------------------------------------------------------------------------------------------------------|"
+echo "|  WITH_LOG=%WITH_LOG%                                                                                |"
 echo "|  BUILD_EXTRA=%BUILD_EXTRA%                                                                          |"
-echo "|  WITH_PYTHON=%WITH_PYTHON%                                                                         |"
+echo "|  WITH_PYTHON=%WITH_PYTHON%                                                                          |"
 echo "|  LITE_WITH_PROFILE=%WITH_PROFILE%                                                                   |"
 echo "|  WITH_TESTING=%WITH_TESTING%                                                                        |"
+echo "|  BUILD_TAILOR=%BUILD_TAILOR%                                                                        |"
+echo "|  OPTMODEL_DIR=%OPTMODEL_DIR%                                                                        |"
 echo "------------------------------------------------------------------------------------------------------|"
 
-:set_vcvarsall_dir
-SET /P vcvarsall_dir="Please input the path of visual studio command Prompt, such as C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat   =======>"
-set tmp_var=!vcvarsall_dir!
-call:remove_space
-set vcvarsall_dir=!tmp_var!   
+
+set vcvarsall_dir=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
 IF NOT EXIST "%vcvarsall_dir%" (
-    echo "------------%vcvarsall_dir% not exist------------"
-    goto:eof
+  goto set_vcvarsall_dir
 )
 
 call:prepare_thirdparty
@@ -86,7 +92,8 @@ copy "%root_dir%\lite\tools\debug\analysis_tool.py" "%DEBUG_TOOL_PATH_PREFIX%\"
 
 cd "%build_directory%"
 
-  cmake ..   -G "Visual Studio 14 2015 Win64" -T host=x64  -DWITH_MKL=ON      ^
+  cmake %root_dir%  -G "Visual Studio 14 2015 Win64" ^
+            -T host=x64  -DWITH_MKL=ON      ^
             -DWITH_MKLDNN=OFF   ^
             -DLITE_WITH_X86=ON  ^
             -DLITE_WITH_PROFILE=%WITH_PROFILE% ^
@@ -97,34 +104,28 @@ cd "%build_directory%"
             -DLITE_BUILD_EXTRA=%BUILD_EXTRA% ^
             -DLITE_WITH_PYTHON=%WITH_PYTHON% ^
             -DWITH_TESTING=%WITH_TESTING%    ^
+            -DLITE_WITH_LOG=%WITH_LOG%       ^
+            -DLITE_BUILD_TAILOR=%BUILD_TAILOR%  ^
+            -DLITE_OPTMODEL_DIR=%OPTMODEL_DIR%  ^
             -DPYTHON_EXECUTABLE="%python_path%"
 
 call "%vcvarsall_dir%" amd64
 
 if "%BUILD_FOR_CI%"=="ON" (
-    msbuild /m /p:Configuration=Release lite\lite_compile_deps.vcxproj
+    msbuild /m:4 /p:Configuration=Release lite\lite_compile_deps.vcxproj
     call:test_server
     cmake ..   -G "Visual Studio 14 2015 Win64" -T host=x64 -DWITH_LITE=ON -DLITE_ON_MODEL_OPTIMIZE_TOOL=ON -DWITH_TESTING=OFF -DLITE_BUILD_EXTRA=ON
-    msbuild /m /p:Configuration=Release lite\api\opt.vcxproj
+    msbuild /m:4 /p:Configuration=Release lite\api\opt.vcxproj
 ) else (
-    msbuild /m /p:Configuration=Release lite\publish_inference.vcxproj 
+    msbuild /m:4 /p:Configuration=Release lite\publish_inference.vcxproj 
 )
 goto:eof
 
 :prepare_thirdparty 
-    SET /P python_path="Please input the path of python.exe, such as C:\Python35\python.exe, C:\Python35\python3.exe   =======>"
-    set tmp_var=!python_path!
-    call:remove_space
-    set python_path=!tmp_var!   
-    if "!python_path!"=="" (
-      set python_path=python.exe
-    ) else (
-      if NOT exist "!python_path!" (
-        echo "------------!python_path! not exist------------" 
-        goto:eof
-      )  
+    set python_path=C:\Python27\python.exe
+    IF NOT EXIST "%python_path%" (
+      goto set_python_path
     )
-
     if  EXIST "%workspace%\third-party" (
         if NOT EXIST "%workspace%\third-party-05b862.tar.gz" (
             echo "The directory of third_party exists, the third-party-05b862.tar.gz not exists."            
@@ -161,6 +162,31 @@ goto:eof
     rd /s /q  "%~1" >nul 2>&1
 goto:eof
 
+:set_vcvarsall_dir
+SET /P vcvarsall_dir="Please input the path of visual studio command Prompt, such as C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat   =======>"
+set tmp_var=!vcvarsall_dir!
+call:remove_space
+set vcvarsall_dir=!tmp_var!   
+IF NOT EXIST "%vcvarsall_dir%" (
+    echo "------------%vcvarsall_dir% not exist------------"
+    goto:eof
+)
+goto:eof
+
+:set_python_path
+SET /P python_path="Please input the path of python.exe, such as C:\Python35\python.exe, C:\Python35\python3.exe   =======>"
+set tmp_var=!python_path!
+call:remove_space
+set python_path=!tmp_var!   
+if "!python_path!"=="" (
+  set python_path=python.exe
+) else (
+  if NOT exist "!python_path!" (
+    echo "------------!python_path! not exist------------" 
+    goto:eof
+  )  
+)
+goto:eof
 
 :remove_space
 :remove_left_space
@@ -186,11 +212,14 @@ echo "|  print help information:                                                
 echo "|      build_windows.bat help                                                                         |"
 echo "|                                                                                                     |"
 echo "|  optional argument:                                                                                 |"
+echo "|      without_log: Diable print log information. Default  ON.                                        |"
 echo "|      with_profile: Enable profile mode in lite framework. Default  OFF.                             |"
 echo "|      with_python: Enable Python api lib in lite mode. Default  OFF.                                 |"
 echo "|      with_extra: Enable extra algorithm support in Lite, both kernels and operators. Default OFF.   |"
+echo "|      build_tailor: Enable tailoring library according to model. Default OFF.                        |"
 echo "|  for example:                                                                                       |"   
-echo "|      build_windows.bat with_profile  with_python with_extra                                         |"
+echo "|      build_windows.bat with_profile with_python with_extra                                          |"
+echo "|      build_windows.bat build_tailor D:\Paddle-Lite\opt_model_dir                                    |"
 echo "------------------------------------------------------------------------------------------------------|"
 goto:eof
 

--- a/lite/tools/build_windows.bat
+++ b/lite/tools/build_windows.bat
@@ -122,10 +122,19 @@ if "%BUILD_FOR_CI%"=="ON" (
 goto:eof
 
 :prepare_thirdparty 
-    set python_path=C:\Python27\python.exe
-    IF NOT EXIST "%python_path%" (
-      goto set_python_path
+    SET /P python_path="Please input the path of python.exe, such as C:\Python35\python.exe, C:\Python35\python3.exe   =======>"
+    set tmp_var=!python_path!
+    call:remove_space
+    set python_path=!tmp_var!   
+    if "!python_path!"=="" (
+      set python_path=python.exe
+    ) else (
+      if NOT exist "!python_path!" (
+        echo "------------!python_path! not exist------------" 
+        goto:eof
+      )  
     )
+
     if  EXIST "%workspace%\third-party" (
         if NOT EXIST "%workspace%\third-party-05b862.tar.gz" (
             echo "The directory of third_party exists, the third-party-05b862.tar.gz not exists."            
@@ -170,21 +179,6 @@ set vcvarsall_dir=!tmp_var!
 IF NOT EXIST "%vcvarsall_dir%" (
     echo "------------%vcvarsall_dir% not exist------------"
     goto:eof
-)
-goto:eof
-
-:set_python_path
-SET /P python_path="Please input the path of python.exe, such as C:\Python35\python.exe, C:\Python35\python3.exe   =======>"
-set tmp_var=!python_path!
-call:remove_space
-set python_path=!tmp_var!   
-if "!python_path!"=="" (
-  set python_path=python.exe
-) else (
-  if NOT exist "!python_path!" (
-    echo "------------!python_path! not exist------------" 
-    goto:eof
-  )  
 )
 goto:eof
 

--- a/lite/tools/build_windows.bat
+++ b/lite/tools/build_windows.bat
@@ -6,11 +6,11 @@ set source_path=%~dp0\\..\\..\\
 set BUILD_EXTRA=OFF
 set WITH_PYTHON=OFF
 set BUILD_DIR=%source_path%
-set WITH_LOG=ON  
+set WITH_LOG=OFF
 set WITH_PROFILE=OFF
 set WITH_TESTING=OFF
 set BUILD_FOR_CI=OFF
-set BUILD_TAILOR=OFF
+set WITH_STRIP=OFF
 set OPTMODEL_DIR=""
 set THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
 
@@ -24,10 +24,10 @@ if /I "%1"=="with_extra" (
     set WITH_PYTHON=ON
 ) else if /I  "%1"=="with_profile" (
     set WITH_PROFILE=ON
-) else if /I  "%1"=="without_log" (
-    set WITH_LOG=OFF
-) else if /I  "%1"=="build_tailor" (
-    set BUILD_TAILOR=ON
+) else if /I  "%1"=="with_log" (
+    set WITH_LOG=ON
+) else if /I  "%1"=="with_strip" (
+    set WITH_STRIP=ON
     set OPTMODEL_DIR="%2"
 ) else if /I  "%1"=="build_for_ci" (
     set BUILD_FOR_CI=ON
@@ -52,7 +52,7 @@ echo "|  BUILD_EXTRA=%BUILD_EXTRA%                                              
 echo "|  WITH_PYTHON=%WITH_PYTHON%                                                                          |"
 echo "|  LITE_WITH_PROFILE=%WITH_PROFILE%                                                                   |"
 echo "|  WITH_TESTING=%WITH_TESTING%                                                                        |"
-echo "|  BUILD_TAILOR=%BUILD_TAILOR%                                                                        |"
+echo "|  WITH_STRIP=%WITH_STRIP%                                                                        |"
 echo "|  OPTMODEL_DIR=%OPTMODEL_DIR%                                                                        |"
 echo "------------------------------------------------------------------------------------------------------|"
 
@@ -105,7 +105,7 @@ cd "%build_directory%"
             -DLITE_WITH_PYTHON=%WITH_PYTHON% ^
             -DWITH_TESTING=%WITH_TESTING%    ^
             -DLITE_WITH_LOG=%WITH_LOG%       ^
-            -DLITE_BUILD_TAILOR=%BUILD_TAILOR%  ^
+            -DLITE_BUILD_TAILOR=%WITH_STRIP%  ^
             -DLITE_OPTMODEL_DIR=%OPTMODEL_DIR%  ^
             -DPYTHON_EXECUTABLE="%python_path%"
 
@@ -212,14 +212,14 @@ echo "|  print help information:                                                
 echo "|      build_windows.bat help                                                                         |"
 echo "|                                                                                                     |"
 echo "|  optional argument:                                                                                 |"
-echo "|      without_log: Diable print log information. Default  ON.                                        |"
+echo "|      with_log: Enable print log information. Default  OFF.                                          |"
 echo "|      with_profile: Enable profile mode in lite framework. Default  OFF.                             |"
 echo "|      with_python: Enable Python api lib in lite mode. Default  OFF.                                 |"
 echo "|      with_extra: Enable extra algorithm support in Lite, both kernels and operators. Default OFF.   |"
-echo "|      build_tailor: Enable tailoring library according to model. Default OFF.                        |"
+echo "|      with_strip: Enable tailoring library according to model. Default OFF.                        |"
 echo "|  for example:                                                                                       |"   
-echo "|      build_windows.bat with_profile with_python with_extra                                          |"
-echo "|      build_windows.bat build_tailor D:\Paddle-Lite\opt_model_dir                                    |"
+echo "|      build_windows.bat with_log with_profile with_python with_extra                                 |"
+echo "|      build_windows.bat with_strip D:\Paddle-Lite\opt_model_dir                                    |"
 echo "------------------------------------------------------------------------------------------------------|"
 goto:eof
 

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -820,7 +820,7 @@ function test_huawei_ascend_npu {
 function build_test_huawei_ascend_npu {
     cur_dir=$(pwd)
 
-    build_dir=$cur_dir/build.lite.huawei_ascend_npu_test
+    build_dir=$cur_dir/build.lite.huawei_ascend_npu
     mkdir -p $build_dir
     cd $build_dir
 


### PR DESCRIPTION
修复X86在MAC/Win平台上的编译问题

- lite/backends/x86/math/prior_box.cc
  - std::max在Windows平台上编译冲突 - Lite代码在include <windows.h>之前都有define NOMINMAX, 但是include的第三方库没有，所以需要修改代码为std::max ==> (std::max)的形式，来避免windows平台上的编译冲突
- lite/backends/x86/port.h 
  - 修复WIndows平台在编译时的gettimeofday与logging.h文件中存在重定义的错误，当with_log打开的时候采用第三方glog，因此可以编译通过；当with_log关闭的时候，采用自带的logging.h，此时就需要移除gettimeofday的定义避免重定义错误
- lite/tools/build.sh 修复了3个问题
  - 增加了x86 cmake中的BUILD_EXTRA， BUILD_TAILOR，OPT_MODEL_DIR的可配置参数输入支持X86模型裁剪
  - 修复了当输入指定--build_dir时，build_dir和源码隔了2层目录，此时cmake ..就会失败，改成cmake $root_dir就可以成功
  - 修复了当输入--opt_model_dir为相对目录时，比如./dir时，cmake会抛出Paddle-Lite/lite/.dir/无法找错误，实际目录位于Paddle-Lite/dir而不是Paddle-Lite/lite/.dir/中，脚本修改成获取绝对路径从而避免这个错误
- lite/tools/build_windows.bat 修复了3个问题
  - 同样增加了x86 cmake中的BUILD_EXTRA， BUILD_TAILOR，OPT_MODEL_DIR的可配置参数输入支持X86模型裁剪
  - 增加了vcvarsall_dir和python_path的默认输入值，当不存在时才需要指定新的路径
  - 增加了windows的编译线程为4线程，加快Windows上的编译速度
- lite/tools/ci_build.sh 
  - 修复因为build.sh和ci_build.sh中build dir目录不一致导致CI编译任务中cmakecache.txt因目录变化产生的build error