### PR TITLE
[cherry-pick][Python] Add python APIs for data transformation between tensor and numpy.array

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -78,6 +78,10 @@ void Tensor::Resize(const shape_t &shape) {
   tensor(raw_tensor_)->Resize(shape);
 }
 
+bool Tensor::IsInitialized() const {
+  return tensor(raw_tensor_)->IsInitialized();
+}
+
 template <typename T>
 const T *Tensor::data() const {
   return ctensor(raw_tensor_)->data<T>();
@@ -96,18 +100,24 @@ T *Tensor::mutable_data(TargetType type) const {
   return tensor(raw_tensor_)->mutable_data<T>(type);
 }
 
+template const double *Tensor::data<double>() const;
 template const float *Tensor::data<float>() const;
-template const int8_t *Tensor::data<int8_t>() const;
-template const uint8_t *Tensor::data<uint8_t>() const;
 template const int64_t *Tensor::data<int64_t>() const;
 template const int32_t *Tensor::data<int32_t>() const;
+template const int16_t *Tensor::data<int16_t>() const;
+template const int8_t *Tensor::data<int8_t>() const;
+template const uint8_t *Tensor::data<uint8_t>() const;
+template const bool *Tensor::data<bool>() const;
 template const void *Tensor::data<void>() const;
 
-template int *Tensor::mutable_data(TargetType type) const;
+template double *Tensor::mutable_data(TargetType type) const;
 template float *Tensor::mutable_data(TargetType type) const;
+template int64_t *Tensor::mutable_data(TargetType type) const;
+template int *Tensor::mutable_data(TargetType type) const;
+template int16_t *Tensor::mutable_data(TargetType type) const;
 template int8_t *Tensor::mutable_data(TargetType type) const;
 template uint8_t *Tensor::mutable_data(TargetType type) const;
-template int64_t *Tensor::mutable_data(TargetType type) const;
+template bool *Tensor::mutable_data(TargetType type) const;
 
 template <typename T, TargetType type>
 void Tensor::CopyFromCpu(const T *src_data) {
@@ -176,6 +186,7 @@ template void Tensor::CopyFromCpu<uint8_t, TargetType::kARM>(const uint8_t *);
 template void Tensor::CopyFromCpu<int, TargetType::kCUDA>(const int *);
 template void Tensor::CopyFromCpu<int64_t, TargetType::kCUDA>(const int64_t *);
 template void Tensor::CopyFromCpu<float, TargetType::kCUDA>(const float *);
+template void Tensor::CopyFromCpu<uint8_t, TargetType::kCUDA>(const uint8_t *);
 template void Tensor::CopyFromCpu<int8_t, TargetType::kCUDA>(const int8_t *);
 
 template void Tensor::CopyFromCpu<int, TargetType::kMLU>(const int *);

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -78,6 +78,7 @@ struct LITE_API Tensor {
 
   // Set LoD of the tensor
   void SetLoD(const lod_t& lod);
+  bool IsInitialized() const;
 
  private:
   void* raw_tensor_;

--- a/lite/api/paddle_place.cc
+++ b/lite/api/paddle_place.cc
@@ -96,7 +96,8 @@ const std::string& PrecisionToStr(PrecisionType precision) {
                                                  "float16",
                                                  "bool",
                                                  "int64_t",
-                                                 "int16_t"};
+                                                 "int16_t",
+                                                 "uint8_t"};
   auto x = static_cast<int>(precision);
   CHECK_LT(x, static_cast<int>(PRECISION(NUM)));
   return precision2string[x];

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -70,7 +70,8 @@ enum class PrecisionType : int {
   kBool = 6,
   kInt64 = 7,
   kInt16 = 8,
-  NUM = 9,  // number of fields.
+  kUInt8 = 9,
+  NUM = 10,  // number of fields.
 };
 enum class DataLayoutType : int {
   kUnk = 0,
@@ -117,6 +118,8 @@ static size_t PrecisionTypeLength(PrecisionType type) {
   switch (type) {
     case PrecisionType::kFloat:
       return 4;
+    case PrecisionType::kUInt8:
+      return 1;
     case PrecisionType::kInt8:
       return 1;
     case PrecisionType::kInt32:
@@ -141,6 +144,7 @@ struct PrecisionTypeTrait {
 #define _ForEachPrecisionType(callback)                   \
   _ForEachPrecisionTypeHelper(callback, bool, kBool);     \
   _ForEachPrecisionTypeHelper(callback, float, kFloat);   \
+  _ForEachPrecisionTypeHelper(callback, uint8_t, kUInt8); \
   _ForEachPrecisionTypeHelper(callback, int8_t, kInt8);   \
   _ForEachPrecisionTypeHelper(callback, int16_t, kInt16); \
   _ForEachPrecisionTypeHelper(callback, int, kInt32);     \

--- a/lite/api/python/pybind/tensor_py.h
+++ b/lite/api/python/pybind/tensor_py.h
@@ -1,0 +1,166 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LITE_API_PYTHON_PYBIND_TENSOR_PY_H_  // NOLINT
+#define LITE_API_PYTHON_PYBIND_TENSOR_PY_H_
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+#include "lite/api/paddle_api.h"
+#include "lite/api/python/pybind/pybind.h"
+#include "lite/core/tensor.h"
+
+namespace py = pybind11;
+
+namespace paddle {
+namespace lite {
+namespace pybind {
+
+using lite_api::PrecisionType;
+using lite_api::TargetType;
+using lite_api::Tensor;
+
+////////////////////////////////////////////////////////////////
+// Function Name: TensorDTypeToPyDTypeStr
+// Usage: Transform Lite PresionType name into corresponding
+//        numpy name.
+////////////////////////////////////////////////////////////////
+inline std::string TensorDTypeToPyDTypeStr(PrecisionType type) {
+#define TENSOR_DTYPE_TO_PY_DTYPE(T, proto_type)  \
+  if (type == proto_type) {                      \
+    if (proto_type == PrecisionType::kFP16) {    \
+      return "e";                                \
+    } else {                                     \
+      return py::format_descriptor<T>::format(); \
+    }                                            \
+  }
+
+  TENSOR_DTYPE_TO_PY_DTYPE(float, PrecisionType::kFloat)
+  TENSOR_DTYPE_TO_PY_DTYPE(float, PrecisionType::kFP16)
+  TENSOR_DTYPE_TO_PY_DTYPE(bool, PrecisionType::kBool)
+
+  TENSOR_DTYPE_TO_PY_DTYPE(uint8_t, PrecisionType::kUInt8)
+  TENSOR_DTYPE_TO_PY_DTYPE(int8_t, PrecisionType::kInt8)
+  TENSOR_DTYPE_TO_PY_DTYPE(int32_t, PrecisionType::kInt32)
+  TENSOR_DTYPE_TO_PY_DTYPE(int64_t, PrecisionType::kInt64)
+  TENSOR_DTYPE_TO_PY_DTYPE(int16_t, PrecisionType::kInt16)
+
+#undef TENSOR_DTYPE_TO_PY_DTYPE
+  LOG(FATAL) << "Error: Unsupported tensor data type!";
+  return "";
+}
+
+////////////////////////////////////////////////////////////////
+// Function Name: TensorToPyArray
+// Usage: Transform tensor's data into numpy array
+////////////////////////////////////////////////////////////////
+inline py::array TensorToPyArray(const Tensor &tensor,
+                                 bool need_deep_copy = false) {
+  if (!tensor.IsInitialized()) {
+    return py::array();
+  }
+
+  const auto &tensor_dims = tensor.shape();
+  auto tensor_dtype = tensor.precision();
+  size_t sizeof_dtype = lite_api::PrecisionTypeLength(tensor_dtype);
+  std::vector<size_t> py_dims(tensor_dims.size());
+  std::vector<size_t> py_strides(tensor_dims.size());
+
+  size_t numel = 1;
+  for (int i = tensor_dims.size() - 1; i >= 0; --i) {
+    py_dims[i] = (size_t)tensor_dims[i];
+    py_strides[i] = sizeof_dtype * numel;
+    numel *= py_dims[i];
+  }
+
+  const void *tensor_buf_ptr = static_cast<const void *>(tensor.data<int8_t>());
+  std::string py_dtype_str = TensorDTypeToPyDTypeStr(tensor.precision());
+  auto base = py::cast(std::move(tensor));
+  return py::array(py::dtype(py_dtype_str.c_str()),
+                   py_dims,
+                   py_strides,
+                   const_cast<void *>(tensor_buf_ptr),
+                   base);
+}
+
+////////////////////////////////////////////////////////////////
+// Function Name: SetTensorFromPyArrayT
+// Usage: Transform numpy of specified precision into tensor
+////////////////////////////////////////////////////////////////
+template <typename T>
+void SetTensorFromPyArrayT(
+    Tensor *self,
+    const py::array_t<T, py::array::c_style | py::array::forcecast> &array,
+    const TargetType &place) {
+  std::vector<int64_t> dims;
+  dims.reserve(array.ndim());
+  for (decltype(array.ndim()) i = 0; i < array.ndim(); ++i) {
+    dims.push_back(static_cast<int>(array.shape()[i]));
+  }
+  self->Resize(dims);
+
+  auto dst = self->mutable_data<T>(place);
+  std::memcpy(dst, array.data(), array.nbytes());
+}
+
+////////////////////////////////////////////////////////////////
+// Function Name: SetTensorFromPyArrayT
+// Usage: Create a tensor from input numpy array
+// Todo: float16 and uint16_t inputs are not supported on
+//       Paddle-Lite, while these two precision type are supported
+//       on PaddlePaddle.
+////////////////////////////////////////////////////////////////
+void SetTensorFromPyArray(Tensor *self,
+                          const py::object &obj,
+                          const TargetType &place) {
+  auto array = obj.cast<py::array>();
+  if (py::isinstance<py::array_t<float>>(array)) {
+    SetTensorFromPyArrayT<float>(self, array, place);
+  } else if (py::isinstance<py::array_t<int>>(array)) {
+    SetTensorFromPyArrayT<int>(self, array, place);
+  } else if (py::isinstance<py::array_t<int64_t>>(array)) {
+    SetTensorFromPyArrayT<int64_t>(self, array, place);
+  } else if (py::isinstance<py::array_t<double>>(array)) {
+    SetTensorFromPyArrayT<double>(self, array, place);
+  } else if (py::isinstance<py::array_t<int8_t>>(array)) {
+    SetTensorFromPyArrayT<int8_t>(self, array, place);
+  } else if (py::isinstance<py::array_t<int16_t>>(array)) {
+    SetTensorFromPyArrayT<int16_t>(self, array, place);
+  } else if (py::isinstance<py::array_t<uint8_t>>(array)) {
+    SetTensorFromPyArrayT<uint8_t>(self, array, place);
+  } else if (py::isinstance<py::array_t<bool>>(array)) {
+    SetTensorFromPyArrayT<bool>(self, array, place);
+  } else {
+    // obj may be any type, obj.cast<py::array>() may be failed,
+    // then the array.dtype will be string of unknown meaning,
+    LOG(FATAL) << "Input object type error or incompatible array data type. "
+                  "tensor.from_numpy(numpy.array, PrecisionType) supports "
+                  "numpy array input in  bool, float32, "
+                  "float64, int8, int16, int32, int64 or uint8, please check "
+                  "your input or input array data type.";
+  }
+}
+
+}  // namespace pybind
+}  // namespace lite
+}  // namespace paddle
+
+#endif  // NOLINT

--- a/lite/kernels/arm/cast_compute.cc
+++ b/lite/kernels/arm/cast_compute.cc
@@ -84,6 +84,13 @@ void CastCompute::Run() {
     int64_t* out_data = param.Out->mutable_data<int64_t>();
     std::transform(
         x_data_begin, x_data_end, out_data, TransOp<int32_t, int64_t>);
+  } else if (param.in_dtype == 5 &&
+             param.out_dtype == 20) {  // float32 -> uint8
+    const float* x_data_begin = param.X->data<float>();
+    const float* x_data_end = x_data_begin + param.X->numel();
+    unsigned char* out_data = param.Out->mutable_data<unsigned char>();
+    std::transform(
+        x_data_begin, x_data_end, out_data, TransOp<float, unsigned char>);
   } else {
     LOG(FATAL) << "other has not been implemented transform with dtype"
                << param.in_dtype << " X, dtype" << param.out_dtype << " Out";

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -94,6 +94,7 @@ void TensorFromStream(std::istream &is, lite::Tensor *tensor) {
     // SET_TENSOR(BOOL, bool, PRECISION(kBool));
     SET_TENSOR(FP32, float, PRECISION(kFloat));
     SET_TENSOR(INT8, int8_t, PRECISION(kInt8));
+    SET_TENSOR(UINT8, uint8_t, PRECISION(kUInt8));
     SET_TENSOR(INT16, int16_t, PRECISION(kInt16));
     SET_TENSOR(INT32, int32_t, PRECISION(kInt32));
     SET_TENSOR(INT64, int64_t, PRECISION(kInt64));
@@ -660,6 +661,7 @@ void GetParamInfoNaive(const naive_buffer::ParamDesc &desc,
 
     // SET_TENSOR(BOOL, bool, PRECISION(kBool));
     SET_TENSOR(FP32, float, PRECISION(kFloat));
+    SET_TENSOR(UINT8, uint8_t, PRECISION(kUInt8));
     SET_TENSOR(INT8, int8_t, PRECISION(kInt8));
     SET_TENSOR(INT16, int16_t, PRECISION(kInt16));
     SET_TENSOR(INT32, int32_t, PRECISION(kInt32));


### PR DESCRIPTION
[Issues]
 - Data transformation between Tensor and numpy.data is not supported on python API
 - Current Paddle-Lite  python APIs only support input&Output of precision int8、int32 and float32, while PaddlePaddle supports support 8 different precision types.
- Paddle-Lite C++ APIs : mutable_data & data support 5 kinds of data precision. However, PaddlePaddle C++ API: mutable_data & data support 10 kinds of data precision
   - what's the lacked: uint8_t、double、int16_t、 FP16、 FP16b
- Paddle-Lite `PrecisionType` lacks type : UInt8

[Effect of Current PR]
- Add python APIs for data transformation between tensor and numpy.array
``` python
# Get Tensor data from numpy array
paddlelite.lite.Tensor.from_numpy(numpy.array, TargetType=TargetType.Host) # TargetType.CUDA
# Get numpy array from initialized Tensor
paddlelite.lite.Tensor.numpy()
```
- Expand `mutable_data&data`  precision types: double、float、uint8_t、int8_t、int16_t、int32_t、int64_t、bool
- Expand `PrecisionType` contents: add `UINT8`

[Todo]
- `float16` and `bfloat16` are not support by Paddle-Lite yet, we will support it later.
- Remove Python API： `set_float_data`、`float_data`、`set_int16_data`、`int16_data` will be removed later, because these apis can be replaced by `Tensor.numpy` and `Tensor.from_numpy`.
- DataIO C++ API needs to be constructed: `CopyDataFromCpu<PrecisionType>`   is similar to `mutable_data(PrecisionType)` , is `CopyDataFromCpu<PrecisionType>` necessary?

[Warning]
`double` precision has not been registered into `lite_api::PrecisionType`, because there is no double precision in PaddlePaddle TypePrecision.