### PR TITLE
[OpenCL][Kernel] Tune concat image impl when num of inputs > 4

### DIFF
--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -190,13 +190,12 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       status = kernel.setArg(7, width_);
       CL_CHECK_FATAL(status);
 
-      status = context.cl_context()->GetCommandQueue().enqueueNDRangeKernel(
-          kernel,
-          cl::NullRange,
-          global_work_size,
-          cl::NullRange,
-          nullptr,
-          nullptr);
+      status = EnqueueNDRangeKernel(kernel,
+                                    cl::NullRange,
+                                    global_work_size,
+                                    cl::NullRange,
+                                    nullptr,
+                                    event_);
       CL_CHECK_FATAL(status);
     } else if (kernel_func_name_ == "concatByCWith3Inputs" ||
                kernel_func_name_ == "concatByCWith4Inputs") {
@@ -309,8 +308,6 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
           std::move(buf_to_img_kernels.front());
 
       // step3. create and set param, context to kernel
-      std::unique_ptr<KernelContext> kernel_context(new KernelContext);
-      kernel_context->As<OpenCLContext>().InitOnce();
       // 3.1 img_to_buf
       std::vector<operators::LayoutParam> img_to_buf_params(inputs_num);
       std::vector<lite::Tensor> outputs_vec(inputs_num);
@@ -324,7 +321,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
         img_to_buf_kernel_vec[i]->SetParam(img_to_buf_params[i]);
 
         std::unique_ptr<KernelContext> img_to_buf_context(new KernelContext);
-        kernel_context->As<OpenCLContext>().CopySharedTo(
+        ctx_->As<OpenCLContext>().CopySharedTo(
             &(img_to_buf_context->As<OpenCLContext>()));
         img_to_buf_kernel_vec[i]->SetContext(std::move(img_to_buf_context));
       }
@@ -345,7 +342,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       buf_to_img_kernel->SetParam(buf_to_img_param);
 
       std::unique_ptr<KernelContext> buf_to_img_context(new KernelContext);
-      kernel_context->As<OpenCLContext>().CopySharedTo(
+      ctx_->As<OpenCLContext>().CopySharedTo(
           &(buf_to_img_context->As<OpenCLContext>()));
       buf_to_img_kernel->SetContext(std::move(buf_to_img_context));
 
@@ -360,7 +357,9 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       for (size_t i = 0; i < inputs_num; ++i) {
         auto* x_buf = outputs_buffer_pointers[i];
         int axis_dim_size = inputs[i]->dims()[axis_];
-        global_work_size = cl::NDRange{static_cast<size_t>(axis_dim_size)};
+        global_work_size = cl::NDRange{static_cast<size_t>(post_size_),
+                                       static_cast<size_t>(axis_dim_size),
+                                       static_cast<size_t>(pre_size_)};
         int total0 = axis_dim_size * post_size_;
 #ifdef LITE_WITH_LOG
         VLOG(2) << "--------------- i:" << i << " -----------------";
@@ -376,17 +375,11 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
         CL_CHECK_FATAL(status);
         status = kernel.setArg(1, *conat_mul_buf_output_data);
         CL_CHECK_FATAL(status);
-        status = kernel.setArg(2, axis_dim_size);
+        status = kernel.setArg(2, cur_axis_start_idx);
         CL_CHECK_FATAL(status);
-        status = kernel.setArg(3, pre_size_);
+        status = kernel.setArg(3, total);
         CL_CHECK_FATAL(status);
-        status = kernel.setArg(4, post_size_);
-        CL_CHECK_FATAL(status);
-        status = kernel.setArg(5, cur_axis_start_idx);
-        CL_CHECK_FATAL(status);
-        status = kernel.setArg(6, total);
-        CL_CHECK_FATAL(status);
-        status = kernel.setArg(7, total0);
+        status = kernel.setArg(4, total0);
         CL_CHECK_FATAL(status);
 
         status = EnqueueNDRangeKernel(context,

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -190,7 +190,8 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       status = kernel.setArg(7, width_);
       CL_CHECK_FATAL(status);
 
-      status = EnqueueNDRangeKernel(kernel,
+      status = EnqueueNDRangeKernel(context,
+                                    kernel,
                                     cl::NullRange,
                                     global_work_size,
                                     cl::NullRange,

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -322,8 +322,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
         img_to_buf_kernel_vec[i]->SetParam(img_to_buf_params[i]);
 
         std::unique_ptr<KernelContext> img_to_buf_context(new KernelContext);
-        ctx_->As<OpenCLContext>().CopySharedTo(
-            &(img_to_buf_context->As<OpenCLContext>()));
+        context.CopySharedTo(&(img_to_buf_context->As<OpenCLContext>()));
         img_to_buf_kernel_vec[i]->SetContext(std::move(img_to_buf_context));
       }
       // 3.2 concat_mul_buf
@@ -343,8 +342,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       buf_to_img_kernel->SetParam(buf_to_img_param);
 
       std::unique_ptr<KernelContext> buf_to_img_context(new KernelContext);
-      ctx_->As<OpenCLContext>().CopySharedTo(
-          &(buf_to_img_context->As<OpenCLContext>()));
+      context.CopySharedTo(&(buf_to_img_context->As<OpenCLContext>()));
       buf_to_img_kernel->SetContext(std::move(buf_to_img_context));
 
       // step4. run kernels


### PR DESCRIPTION
【问题】`concat` image 实现中，当 input 个数大于 4 时，执行时间过长（如 1x336x3/1x168x3/1x48x3/1x12x3/1x6x3/1x6x3 输入，耗时103ms，其中在第一次`image2d` -> `buffer` 中的`PrepareForRun`函数执行时间 86ms，且多次`Run`均出现这个情况）。

【分析】
- `concat` image 实现中，当 input 个数大于 4 时，采用 `image2d` -> `buffer` -> concat mul -> `image2d` 的通用方式。该过程会引入 2 个关于 layout 的 kernel 转换操作，对应的 .cl 文件是`image/layout_kernel.cl`。这两个 kernel 所在的 context 在`Run`函数执行每次都创建和销毁。因此每次`Run`都会编译`image/layout_kernel.cl`这个文件，导致运行时间过长。
- `concat_mul_buffer`kernel 实现可提速：当前分配的线程数少（线程数等于当前tensor[axis]的值），kernel 内存在 for 循环。

【解决方法】
- 针对额外引入的在线编译耗时，layout kernel 与 concat kernel 共用一个 context。
- 针对`concat_mul_buffer`kernel，调整线程分配方式，让更多的线程参与计算，x/y/z 方向的线程数改为 post_size/axis_size/pre_size. 

【性能】处理上面的输入：
- 仅使用合并 context 方法，整个 concat 耗时由 103ms 降至 24ms（profile 工具统计得出的数据）；
- 同时使用优化 kernel 的方法，整个 concat 耗时由 103ms 降至 16ms（profile 工具统计得出的数据）。

【备注】编译一次~380行左右的.cl文件需要约80ms
﻿
【TODO kernel 耗时波动较大】尝试使用cl自身的计时函数，**发现设置`CL_QUEUE_PROFILING_ENABLE`失效**，因此无法使用cl自身的计时函数，进而无法精确统计kernel耗时，调试中。