### PR TITLE
Including reformat the changes of .cl kernel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         description: Format files with ClangFormat.
         entry: bash ./tools/codestyle/clang_format.hook -i
         language: system
-        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto)$
+        files: \.(c|cc|cxx|cpp|cu|cl|h|hpp|hxx|proto)$
         exclude: ^(mobile/|metal/|web/)
 -   repo: local
     hooks:
@@ -35,7 +35,7 @@ repos:
         description: Check C++ code style using cpplint.py.
         entry: bash ./tools/codestyle/cpplint_pre_commit.hook
         language: system
-        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx)$
+        files: \.(c|cc|cxx|cpp|cu|cl|h|hpp|hxx)$
         exclude: ^(mobile/) | ^(metal/) | ^(web/)
 #-   repo: local
     #hooks:
@@ -51,6 +51,6 @@ repos:
         name: copyright_checker
         entry: python ./tools/codestyle/copyright.hook
         language: system
-        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto|py)$
+        files: \.(c|cc|cxx|cpp|cu|cl|h|hpp|hxx|proto|py)$
         exclude: (?!.*third_party)^.*$|(?!.*book)^.*$
         exclude: ^(mobile/|metal/|web/)


### PR DESCRIPTION
【问题】OpenCL 的 kernel 文件并没有纳入代码风格的检查范围内，导致`.cl`文件的 code style 不一致，不便于维护。
【解决方法】在`.pre-commit-config.yaml`中加入对`.cl`文件的检查。

【备注】由于这个pr提交后ci会检查所有`.cl`文件是否符合格式，因此会提示很多`.cl`文件不符合格式的报错。一种方法是一次性修改所有`.cl`文件（修改量大），另一种方法就是我们在本地先 format 下待 commit 的`.cl`。