### PR TITLE
[APU] Fix the missing of return statement that causes an infinite loop is generated by clang

### DIFF
--- a/lite/kernels/apu/subgraph_compute.cc
+++ b/lite/kernels/apu/subgraph_compute.cc
@@ -331,6 +331,7 @@ bool SubgraphEngine::BuildDeviceProgram() {
             << origin_otensors_[i]->dims() << " memory_size "
             << origin_otensors_[i]->memory_size();
   }
+  return true;
 }
 
 bool SubgraphEngine::LaunchDeviceProgram() {


### PR DESCRIPTION
`
int func() {
   for(int i=0; i < 2; i++) {
     // do something
  }
}
`
经过clang编译后，会产生如下代码，导致无限循环：
`
int func() {
   for(int i=0; i++) {
     // do something
  }
}
`

具体原因请参考：https://stackoverflow.com/questions/59048660/compiler-error-in-ndk-and-clang-for-arm