### PR TITLE
[APU] Fix the missing of return statement that causes an infinite loop is generated by clang (#4551)

### DIFF
--- a/lite/kernels/apu/subgraph_compute.cc
+++ b/lite/kernels/apu/subgraph_compute.cc
@@ -331,6 +331,7 @@ bool SubgraphEngine::BuildDeviceProgram() {
             << origin_otensors_[i]->dims() << " memory_size "
             << origin_otensors_[i]->memory_size();
   }
+  return true;
 }
 
 bool SubgraphEngine::LaunchDeviceProgram() {


### PR DESCRIPTION
ref to #4551 