### PR TITLE
[OpenCL][Profiling] Fix invalid opencl profiling setting

### DIFF
--- a/lite/backends/opencl/cl_wrapper.cc
+++ b/lite/backends/opencl/cl_wrapper.cc
@@ -108,9 +108,9 @@ bool CLWrapper::InitFunctions() {
   PADDLE_DLSYM(clEnqueueMapBuffer);
   PADDLE_DLSYM(clEnqueueMapImage);
   PADDLE_DLSYM(clCreateCommandQueue);
-  // note(ysh329): consider compatibility for cl_driver_version 1.10
-  // using clCreateCommandQueue instead.
-  // PADDLE_DLSYM(clCreateCommandQueueWithProperties);
+#if CL_HPP_TARGET_OPENCL_VERSION >= 200
+  PADDLE_DLSYM(clCreateCommandQueueWithProperties);
+#endif
   PADDLE_DLSYM(clGetCommandQueueInfo);
   PADDLE_DLSYM(clReleaseCommandQueue);
   PADDLE_DLSYM(clCreateProgramWithBinary);
@@ -124,14 +124,16 @@ bool CLWrapper::InitFunctions() {
   PADDLE_DLSYM(clRetainKernel);
   PADDLE_DLSYM(clCreateBuffer);
   PADDLE_DLSYM(clCreateImage2D);
-  PADDLE_DLSYM(clCreateImage);
   PADDLE_DLSYM(clCreateUserEvent);
   PADDLE_DLSYM(clCreateProgramWithSource);
   PADDLE_DLSYM(clReleaseKernel);
   PADDLE_DLSYM(clGetDeviceInfo);
   PADDLE_DLSYM(clGetDeviceIDs);
+#if CL_HPP_TARGET_OPENCL_VERSION >= 120
   PADDLE_DLSYM(clRetainDevice);
   PADDLE_DLSYM(clReleaseDevice);
+  PADDLE_DLSYM(clCreateImage);
+#endif
   PADDLE_DLSYM(clRetainEvent);
   PADDLE_DLSYM(clGetKernelWorkGroupInfo);
   PADDLE_DLSYM(clGetEventInfo);
@@ -445,7 +447,7 @@ clGetCommandQueueInfo(cl_command_queue command_queue,
                       cl_command_queue_info param_name,
                       size_t param_value_size,
                       void *param_value,
-                      size_t *param_value_size_ret) {
+                      size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0 {
   return paddle::lite::CLWrapper::Global()->clGetCommandQueueInfo()(
       command_queue,
       param_name,
@@ -459,14 +461,9 @@ CL_API_ENTRY cl_command_queue CL_API_CALL clCreateCommandQueueWithProperties(
     cl_device_id device,
     const cl_queue_properties *properties,
     cl_int *errcode_ret) CL_API_SUFFIX__VERSION_2_0 {
-  // note(ysh329): consider compatibility for cl_driver_version 1.10
-  // using clCreateCommandQueue instead.
-  // return paddle::lite::CLWrapper::Global()
-  //     ->clCreateCommandQueueWithProperties()(
-  //         context, device, properties, errcode_ret);
-  //
-  return paddle::lite::CLWrapper::Global()->clCreateCommandQueue()(
-      context, device, 0, errcode_ret);
+  return paddle::lite::CLWrapper::Global()
+      ->clCreateCommandQueueWithProperties()(
+          context, device, properties, errcode_ret);
 }
 
 CL_API_ENTRY cl_int CL_API_CALL clReleaseCommandQueue(


### PR DESCRIPTION
【问题】开启`LITE_WITH_PROFILE`编译OpenCL预测库时，运行时无法统计到 clkernel 运行耗时。
【原因】当前大部分设备上的`libOpenCL.so`都是 OpenCL 2.0 及以上，在 2.0 及以上的标准`cl2.hpp`中规定：当创建 CommandQueue 时，底层调用`clCreateCommandQueueWithProperties`，该 API 在 Lite 的代码中使用有问题。
【解决方法】本PR方式。
【性能】无影响。
【备注】使用后运行`test_mobilenetv1`效果：
```
===== Concise Dispatch Profiler Summary: N/A, Exclude 10 warm-ups =====
OperatorType         KerneAttr(Place)               KernelFuncName           Avg(ms) Min(ms) Max(ms) Avg(%)  GOPs    CalledTimes clAvg(ms) clMin(ms) clMax(ms) clAvg(%)
conv2d               opencl/float16/ImageDefault    conv2d_1x1_simple        2.862   2.418   8.712   36.16%    1.079   13          6.532     6.532     6.532     73.52%
conv2d               opencl/float16/ImageDefault    conv2d_3x3_opt           0.251   0.193   0.667   3.17%    0.022   1           0.295     0.295     0.295     3.32%
depthwise_conv2d     opencl/float16/ImageDefault    depth_conv2d_3x3         0.855   0.722   4.100   10.80%    0.007   4           0.515     0.515     0.515     5.80%
depthwise_conv2d     opencl/float16/ImageDefault    depth_conv2d_3x3s1       1.940   1.680   5.164   24.50%    0.028   9           0.806     0.806     0.806     9.08%
fc                   opencl/float/NCHW              fc_gemv_1x4              0.211   0.163   0.830   2.66%    0.003   1           0.357     0.357     0.357     4.02%
io_copy              opencl/any/any                 HostToOpenCL             0.664   0.561   1.288   8.39%    0.000   1           0.243     0.243     0.243     2.73%
io_copy              opencl/any/any                 OpenCLToHost             0.127   0.118   0.177   1.61%    0.000   1           0.049     0.049     0.049     0.55%
layout               opencl/any/ImageDefault        buffer_to_image2d        0.420   0.336   1.029   5.30%    0.000   1           0.045     0.045     0.045     0.51%
layout               opencl/any/NCHW                image2d_to_buffer        0.239   0.210   0.548   3.02%    0.000   1           0.010     0.010     0.010     0.11%
pool2d               opencl/float16/ImageDefault    pool_avg_global          0.275   0.236   0.719   3.48%    0.000   1           0.032     0.032     0.032     0.36%
softmax              arm/float/NCHW                 NotImpl                  0.072   0.067   0.096   0.91%    0.000   1           0.000     0.000     0.000     0.00%
```