### PR TITLE
[X86] fix fuse conv, test=develop

### DIFF
--- a/lite/core/mir/fusion/conv_elementwise_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_elementwise_fuse_pass.cc
@@ -47,4 +47,4 @@ void ConvElementwiseFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 REGISTER_MIR_PASS(lite_conv_elementwise_fuse_pass,
                   paddle::lite::mir::ConvElementwiseFusePass)
     .BindTargets({TARGET(kAny)})
-    .ExcludeTargets({TARGET(kXPU), TARGET(kBM)});
+    .ExcludeTargets({TARGET(kXPU), TARGET(kBM), TARGET(kX86)});

--- a/lite/tools/build_windows.bat
+++ b/lite/tools/build_windows.bat
@@ -55,8 +55,9 @@ echo "|  BUILD_EXTRA=%BUILD_EXTRA%                                              
 echo "|  WITH_PYTHON=%WITH_PYTHON%                                                                          |"
 echo "|  LITE_WITH_PROFILE=%WITH_PROFILE%                                                                   |"
 echo "|  WITH_TESTING=%WITH_TESTING%                                                                        |"
-echo "|  WITH_STRIP=%WITH_STRIP%                                                                        |"
+echo "|  WITH_STRIP=%WITH_STRIP%                                                                            |"
 echo "|  OPTMODEL_DIR=%OPTMODEL_DIR%                                                                        |"
+echo "|  BUILD_X64=%BUILD_X64%                                                                              |"
 echo "------------------------------------------------------------------------------------------------------|"
 
 


### PR DESCRIPTION
1. 主要修复了X86上conv + elementwise_add不应该做算子融合的问题：
当前Paddle的CPU计算中在Python API中讲带有bias的conv算子处理成为了conv+elementwise_add 2个算子组合。C++的conv_op前向计算中没有bias的处理，Lite X86的conv compute的实现同Paddle一致，没有对bias做处理。因此在做mir_fuse时不能对conv + elementwise_add做算子融合，否则计算结果存在错误。

2. 修复了build_windows.bat里面的一些小的typo问题。