### PR TITLE
[API] Update fill_constant op to adapt for Paddle1.7&1.8

### DIFF
--- a/lite/kernels/host/fill_constant_compute.cc
+++ b/lite/kernels/host/fill_constant_compute.cc
@@ -43,7 +43,7 @@ void FillConstantCompute::Run() {
     FillConstData<int8_t>();
   } else if (param.dtype ==
              static_cast<int32_t>(lite::core::FluidType::INT64)) {
-    FillConstData<int32_t>();
+    FillConstData<int64_t>();
   } else {
     LOG(FATAL) << "not supported dtype " << param.dtype;
   }

--- a/lite/kernels/host/fill_constant_compute.cc
+++ b/lite/kernels/host/fill_constant_compute.cc
@@ -63,6 +63,8 @@ REGISTER_LITE_KERNEL(fill_constant,
                      def)
     .BindInput("ShapeTensor",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindInput("ValueTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
     .BindInput("ShapeTensorList",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})

--- a/lite/kernels/host/fill_constant_compute.cc
+++ b/lite/kernels/host/fill_constant_compute.cc
@@ -19,31 +19,31 @@ namespace lite {
 namespace kernels {
 namespace host {
 
+template <typename T>
+void FillConstantCompute::FillConstData() {
+  auto& param = *param_.get_mutable<param_t>();
+  T value = param.value;
+  if (param.value_tensor) {
+    value = param.value_tensor->template mutable_data<T>()[0];
+  }
+  auto data = param.out->template mutable_data<T>();
+  for (int i = 0; i < param.out->numel(); i++) {
+    data[i] = value;
+  }
+}
+
 void FillConstantCompute::Run() {
   auto& param = *param_.get_mutable<param_t>();
-
   if (param.dtype == static_cast<int32_t>(lite::core::FluidType::FP32)) {
-    auto data = param.out->template mutable_data<float>();
-    for (int i = 0; i < param.out->numel(); i++) {
-      data[i] = param.value;
-    }
+    FillConstData<float>();
   } else if (param.dtype ==
              static_cast<int32_t>(lite::core::FluidType::INT32)) {
-    auto data = param.out->template mutable_data<int32_t>();
-    for (int i = 0; i < param.out->numel(); i++) {
-      data[i] = param.value;
-    }
+    FillConstData<int32_t>();
   } else if (param.dtype == static_cast<int32_t>(lite::core::FluidType::INT8)) {
-    auto data = param.out->template mutable_data<int8_t>();
-    for (int i = 0; i < param.out->numel(); i++) {
-      data[i] = param.value;
-    }
+    FillConstData<int8_t>();
   } else if (param.dtype ==
              static_cast<int32_t>(lite::core::FluidType::INT64)) {
-    auto data = param.out->template mutable_data<int64_t>();
-    for (int i = 0; i < param.out->numel(); i++) {
-      data[i] = param.value;
-    }
+    FillConstData<int32_t>();
   } else {
     LOG(FATAL) << "not supported dtype " << param.dtype;
   }

--- a/lite/kernels/host/fill_constant_compute.h
+++ b/lite/kernels/host/fill_constant_compute.h
@@ -25,6 +25,9 @@ class FillConstantCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
  public:
   using param_t = operators::FillConstantParam;
 
+  template <typename T>
+  void FillConstData();
+
   void Run() override;
 
   ~FillConstantCompute() {}

--- a/lite/operators/fill_constant_op.cc
+++ b/lite/operators/fill_constant_op.cc
@@ -59,6 +59,15 @@ bool FillConstantOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   param_.value = opdesc.GetAttr<float>("value");
   param_.force_cpu = opdesc.GetAttr<bool>("force_cpu");
 
+  if (opdesc.HasInput("ValueTensor") && !opdesc.Input("ValueTensor").empty()) {
+    auto value_tensor_name = opdesc.Input("ValueTensor").front();
+    param_.value_tensor = GetMutableVar<lite::Tensor>(scope, value_tensor_name);
+    CHECK_EQ(param_.value_tensor->numel(), 1)
+        << "When use Tensor as value to set Tensor value in fill_cosntant, "
+           "value input(ValueTensor) size must be 1, but get "
+        << param_.value_tensor->numel();
+  }
+
   if (opdesc.HasInput("ShapeTensor") && !opdesc.Input("ShapeTensor").empty()) {
     auto shape_tensor_name = opdesc.Input("ShapeTensor").front();
     param_.shape_tensor = GetMutableVar<lite::Tensor>(scope, shape_tensor_name);

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -692,6 +692,7 @@ struct FillConstantParam : ParamBase {
   int dtype{static_cast<int>(VarDescAPI::VarDataType::FP32)};
   std::vector<int64_t> shape{};
   lite::Tensor* shape_tensor{nullptr};
+  lite::Tensor* value_tensor{nullptr};
   std::vector<lite::Tensor*> shape_tensor_list{};
 
   float value{0.0f};

--- a/lite/tests/kernels/fill_constant_compute_test.cc
+++ b/lite/tests/kernels/fill_constant_compute_test.cc
@@ -28,8 +28,8 @@ class FillConstantComputeTester : public arena::TestCase {
   std::string value_tensor_ = "value_tensor";
   std::vector<std::string> shape_tensor_list_{};
 
-  std::vector<float> tensor_value_{};
   std::vector<int64_t> shape_{};
+  std::vector<float> tensor_value_{};
   float value_{0.0f};
   int dtype_{static_cast<int>(VarDescAPI::VarDataType::FP32)};
 

--- a/lite/tests/kernels/fill_constant_compute_test.cc
+++ b/lite/tests/kernels/fill_constant_compute_test.cc
@@ -25,8 +25,10 @@ class FillConstantComputeTester : public arena::TestCase {
   // common attributes for this op.
   std::string out_ = "out";
   std::string shape_tensor_ = "shape_tensor";
+  std::string value_tensor_ = "value_tensor";
   std::vector<std::string> shape_tensor_list_{};
 
+  std::vector<float> tensor_value_{};
   std::vector<int64_t> shape_{};
   float value_{0.0f};
   int dtype_{static_cast<int>(VarDescAPI::VarDataType::FP32)};
@@ -40,12 +42,14 @@ class FillConstantComputeTester : public arena::TestCase {
   FillConstantComputeTester(const Place& place,
                             const std::string& alias,
                             std::vector<int64_t> shape,
+                            std::vector<float> tensor_value,
                             float value,
                             int dtype,
                             const bool is_use_shape_tensor = false,
                             const bool is_use_shape_tensor_list = false)
       : TestCase(place, alias),
         shape_(shape),
+        tensor_value_(tensor_value),
         value_(value),
         dtype_(dtype),
         is_use_shape_tensor_(is_use_shape_tensor),
@@ -76,6 +80,9 @@ class FillConstantComputeTester : public arena::TestCase {
     }
     out->Resize(out_shape);
 
+    if (!tensor_value_.empty()) {
+      value_ = tensor_value_[0];
+    }
     auto* output_data = out->mutable_data<float>();
     for (int i = 0; i < out->numel(); i++) {
       output_data[i] = value_;
@@ -84,6 +91,9 @@ class FillConstantComputeTester : public arena::TestCase {
 
   void PrepareOpDesc(cpp::OpDesc* op_desc) {
     op_desc->SetType("fill_constant");
+    if (!tensor_value_.empty()) {
+      op_desc->SetInput("ValueTensor", {value_tensor_});
+    }
     if (is_use_shape_tensor_) {
       op_desc->SetInput("ShapeTensor", {shape_tensor_});
     } else if (is_use_shape_tensor_list_) {
@@ -98,6 +108,13 @@ class FillConstantComputeTester : public arena::TestCase {
   }
 
   void PrepareData() override {
+    if (!tensor_value_.empty()) {
+      std::vector<float> ddata_tensor{tensor_value_.begin(),
+                                      tensor_value_.end()};
+      SetCommonTensor(value_tensor_,
+                      DDim({static_cast<int64_t>(tensor_value_.size())}),
+                      ddata_tensor.data());
+    }
     if (is_use_shape_tensor_) {
       std::vector<int> dshape_tensor(shape_.begin(), shape_.end());
       SetCommonTensor(shape_tensor_,
@@ -117,10 +134,12 @@ void TestFillConstantShape(Place place, float abs_error) {
   std::vector<std::vector<int64_t>> out_shapes{
       {2, 3, 4, 5}, {2, 3, 4}, {3, 4}, {4}};
   for (auto out_shape : out_shapes) {
+    std::vector<float> value_tensor = {2.f};
     std::unique_ptr<arena::TestCase> tester(new FillConstantComputeTester(
         place,
         "def",
         out_shape,
+        value_tensor,
         1.f,
         static_cast<int>(VarDescAPI::VarDataType::FP32)));
     arena::Arena arena(std::move(tester), place, abs_error);
@@ -135,6 +154,7 @@ void TestFillConstantValue(Place place, float abs_error) {
         place,
         "def",
         {2, 3},
+        {},
         value,
         static_cast<int>(VarDescAPI::VarDataType::FP32)));
     arena::Arena arena(std::move(tester), place, abs_error);
@@ -147,6 +167,7 @@ void TestFillConstantShapeTensor(Place place, float abs_error) {
       place,
       "def",
       {2, 3, 4},
+      {},
       1.f,
       static_cast<int>(VarDescAPI::VarDataType::FP32),
       true));
@@ -159,6 +180,7 @@ void TestFillConstantShapeTensorList(Place place, float abs_error) {
       place,
       "def",
       {2, 3, 4},
+      {},
       1.f,
       static_cast<int>(VarDescAPI::VarDataType::FP32),
       false,


### PR DESCRIPTION
[Background]
Compared with  Paddle1.7, the definition of `fill_constant` api is modified in Paddle1.8:
-   new input : `ValueTensor`
- effect of new input: if `ValueTensor` exists, we will fill the output tensor with value stored in `ValueTensor` , instead of data in attribute `data`.

[Effect of current PR]
- add input `ValueTensor` in Paddle-Lite `fill_constant op` to make it adapt for Paddle1.7&1.8

[Steps for adding an input]
- add input `ValueTensor`  in `FillConstantParam`
- modify  `FillConstantOp::AttachImpl`
- modify `FillConstantCompute::Run() `
- update the unit_test:  `lite\test\kernels\fill_constant_compute_test.cc`