### PR TITLE
[Framework] add PrecisionType::FP64 

### DIFF
--- a/lite/api/paddle_place.cc
+++ b/lite/api/paddle_place.cc
@@ -98,7 +98,8 @@ const std::string& PrecisionToStr(PrecisionType precision) {
                                                  "bool",
                                                  "int64_t",
                                                  "int16_t",
-                                                 "uint8_t"};
+                                                 "uint8_t",
+                                                 "double"};
   auto x = static_cast<int>(precision);
   CHECK_LT(x, static_cast<int>(PRECISION(NUM)));
   return precision2string[x];

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -72,7 +72,8 @@ enum class PrecisionType : int {
   kInt64 = 7,
   kInt16 = 8,
   kUInt8 = 9,
-  NUM = 10,  // number of fields.
+  kFP64 = 10,
+  NUM = 11,  // number of fields.
 };
 enum class DataLayoutType : int {
   kUnk = 0,
@@ -119,6 +120,8 @@ static size_t PrecisionTypeLength(PrecisionType type) {
   switch (type) {
     case PrecisionType::kFloat:
       return 4;
+    case PrecisionType::kFP64:
+      return 8;
     case PrecisionType::kUInt8:
       return 1;
     case PrecisionType::kInt8:
@@ -150,6 +153,7 @@ struct PrecisionTypeTrait {
 #define _ForEachPrecisionType(callback)                   \
   _ForEachPrecisionTypeHelper(callback, bool, kBool);     \
   _ForEachPrecisionTypeHelper(callback, float, kFloat);   \
+  _ForEachPrecisionTypeHelper(callback, double, kFP64);   \
   _ForEachPrecisionTypeHelper(callback, uint8_t, kUInt8); \
   _ForEachPrecisionTypeHelper(callback, int8_t, kInt8);   \
   _ForEachPrecisionTypeHelper(callback, int16_t, kInt16); \

--- a/lite/api/python/pybind/pybind.cc
+++ b/lite/api/python/pybind/pybind.cc
@@ -201,6 +201,7 @@ void BindLitePlace(py::module *m) {
   py::enum_<PrecisionType>(*m, "PrecisionType")
       .value("FP16", PrecisionType::kFP16)
       .value("FP32", PrecisionType::kFloat)
+      .value("FP64", PrecisionType::kFP64)
       .value("UINT8", PrecisionType::kUInt8)
       .value("INT8", PrecisionType::kInt8)
       .value("INT16", PrecisionType::kInt16)

--- a/lite/api/python/pybind/tensor_py.h
+++ b/lite/api/python/pybind/tensor_py.h
@@ -54,6 +54,7 @@ inline std::string TensorDTypeToPyDTypeStr(PrecisionType type) {
   }
 
   TENSOR_DTYPE_TO_PY_DTYPE(float, PrecisionType::kFloat)
+  TENSOR_DTYPE_TO_PY_DTYPE(double, PrecisionType::kFP64)
   TENSOR_DTYPE_TO_PY_DTYPE(float, PrecisionType::kFP16)
   TENSOR_DTYPE_TO_PY_DTYPE(bool, PrecisionType::kBool)
 

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -93,6 +93,7 @@ void TensorFromStream(std::istream &is, lite::Tensor *tensor) {
     break
 
     // SET_TENSOR(BOOL, bool, PRECISION(kBool));
+    SET_TENSOR(FP64, double, PRECISION(kFP64));
     SET_TENSOR(FP32, float, PRECISION(kFloat));
     SET_TENSOR(INT8, int8_t, PRECISION(kInt8));
     SET_TENSOR(UINT8, uint8_t, PRECISION(kUInt8));
@@ -663,6 +664,7 @@ void GetParamInfoNaive(const naive_buffer::ParamDesc &desc,
     break
 
     // SET_TENSOR(BOOL, bool, PRECISION(kBool));
+    SET_TENSOR(FP64, double, PRECISION(kFP64));
     SET_TENSOR(FP32, float, PRECISION(kFloat));
     SET_TENSOR(UINT8, uint8_t, PRECISION(kUInt8));
     SET_TENSOR(INT8, int8_t, PRECISION(kInt8));


### PR DESCRIPTION
添加double 型的PrecisionType:
- `PrecisionType::kFP64`

并注册他的Python接口：
- `PrecisionType.kFP64`