### PR TITLE
[op] fix: yolo_box getattr error test=develop

### DIFF
--- a/lite/operators/yolo_box_op.cc
+++ b/lite/operators/yolo_box_op.cc
@@ -72,8 +72,12 @@ bool YoloBoxOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   param_.class_num = op_desc.GetAttr<int>("class_num");
   param_.conf_thresh = op_desc.GetAttr<float>("conf_thresh");
   param_.downsample_ratio = op_desc.GetAttr<int>("downsample_ratio");
-  param_.clip_bbox = op_desc.GetAttr<bool>("clip_bbox");
-  param_.scale_x_y = op_desc.GetAttr<float>("scale_x_y");
+  if (op_desc.HasAttr("clip_bbox")) {
+    param_.clip_bbox = op_desc.GetAttr<bool>("clip_bbox");
+  }
+  if (op_desc.HasAttr("scale_x_y")) {
+    param_.scale_x_y = op_desc.GetAttr<float>("scale_x_y");
+  }
   return true;
 }
 


### PR DESCRIPTION
Paddle fluid 1.8 added some new attr  to yolobox

1. the attr should be checked before using.
2. if attr is missing, it is fine to use default value. the behavior will  be same