### PR TITLE
update the git address of flatbuffers, test=develop

### DIFF
--- a/cmake/external/flatbuffers.cmake
+++ b/cmake/external/flatbuffers.cmake
@@ -45,7 +45,7 @@ SET(OPTIONAL_ARGS "-DCMAKE_CXX_COMPILER=${HOST_CXX_COMPILER}"
 ExternalProject_Add(
     extern_flatbuffers
     ${EXTERNAL_PROJECT_LOG_ARGS}
-    GIT_REPOSITORY  "https://github.com/Shixiaowei02/flatbuffers.git"
+    GIT_REPOSITORY  "https://github.com/google/flatbuffers.git"
     GIT_TAG         "v1.12.0"
     SOURCE_DIR      ${FLATBUFFERS_SOURCES_DIR}
     PREFIX          ${FLATBUFFERS_PREFIX_DIR}


### PR DESCRIPTION
修复 https://github.com/google/flatbuffers/pull/6133 已合入，所以将依赖改回官方仓储。