### PR TITLE
[cherry-pick][API] Update fill_constant op to adapt for Paddle1.7&1.8

### DIFF
--- a/lite/kernels/host/fill_constant_compute.cc
+++ b/lite/kernels/host/fill_constant_compute.cc
@@ -19,31 +19,31 @@ namespace lite {
 namespace kernels {
 namespace host {
 
+template <typename T>
+void FillConstantCompute::FillConstData() {
+  auto& param = *param_.get_mutable<param_t>();
+  T value = param.value;
+  if (param.value_tensor) {
+    value = param.value_tensor->template mutable_data<T>()[0];
+  }
+  auto data = param.out->template mutable_data<T>();
+  for (int i = 0; i < param.out->numel(); i++) {
+    data[i] = value;
+  }
+}
+
 void FillConstantCompute::Run() {
   auto& param = *param_.get_mutable<param_t>();
-
   if (param.dtype == static_cast<int32_t>(lite::core::FluidType::FP32)) {
-    auto data = param.out->template mutable_data<float>();
-    for (int i = 0; i < param.out->numel(); i++) {
-      data[i] = param.value;
-    }
+    FillConstData<float>();
   } else if (param.dtype ==
              static_cast<int32_t>(lite::core::FluidType::INT32)) {
-    auto data = param.out->template mutable_data<int32_t>();
-    for (int i = 0; i < param.out->numel(); i++) {
-      data[i] = param.value;
-    }
+    FillConstData<int32_t>();
   } else if (param.dtype == static_cast<int32_t>(lite::core::FluidType::INT8)) {
-    auto data = param.out->template mutable_data<int8_t>();
-    for (int i = 0; i < param.out->numel(); i++) {
-      data[i] = param.value;
-    }
+    FillConstData<int8_t>();
   } else if (param.dtype ==
              static_cast<int32_t>(lite::core::FluidType::INT64)) {
-    auto data = param.out->template mutable_data<int64_t>();
-    for (int i = 0; i < param.out->numel(); i++) {
-      data[i] = param.value;
-    }
+    FillConstData<int64_t>();
   } else {
     LOG(FATAL) << "not supported dtype " << param.dtype;
   }
@@ -63,6 +63,8 @@ REGISTER_LITE_KERNEL(fill_constant,
                      def)
     .BindInput("ShapeTensor",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindInput("ValueTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
     .BindInput("ShapeTensorList",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})

--- a/lite/kernels/host/fill_constant_compute.h
+++ b/lite/kernels/host/fill_constant_compute.h
@@ -25,6 +25,9 @@ class FillConstantCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
  public:
   using param_t = operators::FillConstantParam;
 
+  template <typename T>
+  void FillConstData();
+
   void Run() override;
 
   ~FillConstantCompute() {}

--- a/lite/operators/fill_constant_op.cc
+++ b/lite/operators/fill_constant_op.cc
@@ -59,6 +59,15 @@ bool FillConstantOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   param_.value = opdesc.GetAttr<float>("value");
   param_.force_cpu = opdesc.GetAttr<bool>("force_cpu");
 
+  if (opdesc.HasInput("ValueTensor") && !opdesc.Input("ValueTensor").empty()) {
+    auto value_tensor_name = opdesc.Input("ValueTensor").front();
+    param_.value_tensor = GetMutableVar<lite::Tensor>(scope, value_tensor_name);
+    CHECK_EQ(param_.value_tensor->numel(), 1)
+        << "When use Tensor as value to set Tensor value in fill_cosntant, "
+           "value input(ValueTensor) size must be 1, but get "
+        << param_.value_tensor->numel();
+  }
+
   if (opdesc.HasInput("ShapeTensor") && !opdesc.Input("ShapeTensor").empty()) {
     auto shape_tensor_name = opdesc.Input("ShapeTensor").front();
     param_.shape_tensor = GetMutableVar<lite::Tensor>(scope, shape_tensor_name);

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -690,6 +690,7 @@ struct FillConstantParam : ParamBase {
   int dtype{static_cast<int>(VarDescAPI::VarDataType::FP32)};
   std::vector<int64_t> shape{};
   lite::Tensor* shape_tensor{nullptr};
+  lite::Tensor* value_tensor{nullptr};
   std::vector<lite::Tensor*> shape_tensor_list{};
 
   float value{0.0f};


### PR DESCRIPTION
[Background]
Compared with  Paddle1.7, the definition of `fill_constant` api is modified in Paddle1.8:
-   new input : `ValueTensor`
- effect of new input: if `ValueTensor` exists, we will fill the output tensor with value stored in `ValueTensor` , instead of data in attribute `data`.

[Effect of current PR]
- add input `ValueTensor` in Paddle-Lite `fill_constant op` to make it adapt for Paddle1.7&1.8

[Steps for adding an input]
- add input `ValueTensor`  in `FillConstantParam`
- modify  `FillConstantOp::AttachImpl`
- modify `FillConstantCompute::Run() `
- update the unit_test:  `lite\test\kernels\fill_constant_compute_test.cc`