### PR TITLE
[cherry-pick] update: generate_proposals and fix_roi_align updated with fluid 1.8

### DIFF
--- a/lite/kernels/arm/generate_proposals_compute.cc
+++ b/lite/kernels/arm/generate_proposals_compute.cc
@@ -421,6 +421,7 @@ void GenerateProposalsCompute::Run() {
   lod0.push_back(0);
   anchors->Resize(std::vector<int64_t>({anchors->numel() / 4, 4}));
   variances->Resize(std::vector<int64_t>({variances->numel() / 4, 4}));
+  std::vector<int64_t> tmp_lod;
 
   int64_t num_proposals = 0;
   for (int64_t i = 0; i < num; ++i) {
@@ -451,7 +452,17 @@ void GenerateProposalsCompute::Run() {
 
     num_proposals += proposals.dims()[0];
     lod0.push_back(num_proposals);
+    tmp_lod.push_back(num_proposals);
   }
+
+  if (param.RpnRoisLod != nullptr) {
+    param.RpnRoisLod->Resize(DDim(std::vector<DDim::value_type>({num})));
+    int64_t *lod_data = param.RpnRoisLod->mutable_data<int64_t>();
+    for (int i = 0; i < num; i++) {
+      lod_data[i] = tmp_lod[i];
+    }
+  }
+
   rpn_rois->set_lod(lod);
   rpn_roi_probs->set_lod(lod);
   rpn_rois->Resize({num_proposals, 4});

--- a/lite/kernels/arm/generate_proposals_compute.cc
+++ b/lite/kernels/arm/generate_proposals_compute.cc
@@ -502,4 +502,5 @@ REGISTER_LITE_KERNEL(generate_proposals,
     .BindInput("Variances", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("RpnRois", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("RpnRoiProbs", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("RpnRoisLod", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();

--- a/lite/kernels/arm/roi_align_compute.cc
+++ b/lite/kernels/arm/roi_align_compute.cc
@@ -239,5 +239,6 @@ REGISTER_LITE_KERNEL(roi_align,
                      def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("ROIs", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("RoisLod", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();

--- a/lite/kernels/arm/roi_align_compute.cc
+++ b/lite/kernels/arm/roi_align_compute.cc
@@ -138,14 +138,21 @@ void RoiAlignCompute::Run() {
   roi_batch_id_list.Resize({rois_num});
   int* roi_batch_id_data = roi_batch_id_list.mutable_data<int>();
 
-  auto rois_lod = rois->lod().back();
-  int rois_batch_size = rois_lod.size() - 1;
-  // CHECK_OR_FALSE(rois_batch_size == batch_size);
-  int rois_num_with_lod = rois_lod[rois_batch_size];
-  // CHECK_OR_FALSE(rois_num_with_lod == rois_num);
-  for (int n = 0; n < rois_batch_size; ++n) {
-    for (size_t i = rois_lod[n]; i < rois_lod[n + 1]; ++i) {
-      roi_batch_id_data[i] = n;
+  if (param.RoisLod != nullptr) {
+    int rois_batch_size = param.RoisLod->numel();
+    auto* rois_lod = param.RoisLod->data<int64_t>();
+    for (int n = 0; n < rois_batch_size - 1; ++n) {
+      for (int i = rois_lod[n]; i < rois_lod[n + 1]; ++i) {
+        roi_batch_id_data[i] = n;
+      }
+    }
+  } else {
+    auto rois_lod = rois->lod().back();
+    int rois_batch_size = rois_lod.size() - 1;
+    for (int n = 0; n < rois_batch_size; ++n) {
+      for (size_t i = rois_lod[n]; i < rois_lod[n + 1]; ++i) {
+        roi_batch_id_data[i] = n;
+      }
     }
   }
 

--- a/lite/operators/generate_proposals_op.cc
+++ b/lite/operators/generate_proposals_op.cc
@@ -75,6 +75,11 @@ bool GenerateProposalsOpLite::AttachImpl(const cpp::OpDesc &op_desc,
                        ->GetMutable<lite::Tensor>();
   param_.RpnRoiProbs = scope->FindVar(op_desc.Output("RpnRoiProbs").front())
                            ->GetMutable<lite::Tensor>();
+  if (op_desc.HasOutput("RpnRoisLod") &&
+      !op_desc.Output("RpnRoisLod").empty()) {
+    param_.RpnRoisLod = scope->FindVar(op_desc.Output("RpnRoisLod").front())
+                            ->GetMutable<lite::Tensor>();
+  }
   return true;
 }
 

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -1338,6 +1338,7 @@ struct GenerateProposalsParam : ParamBase {
   // outputs
   lite::Tensor* RpnRois{};
   lite::Tensor* RpnRoiProbs{};
+  lite::Tensor* RpnRoisLod{};
 };
 /// ----------------------- squeeze operators ----------------------
 struct SqueezeParam : ParamBase {

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -1446,6 +1446,7 @@ struct AssignParam : ParamBase {
 struct RoiAlignParam : ParamBase {
   lite::Tensor* X{};
   lite::Tensor* ROIs{};
+  lite::Tensor* RoisLod{};
   lite::Tensor* Out{};
   float spatial_scale{1.0};
   int pooled_height{1};

--- a/lite/operators/roi_align_op.cc
+++ b/lite/operators/roi_align_op.cc
@@ -54,6 +54,11 @@ bool RoiAlignOpLite::AttachImpl(const cpp::OpDesc &op_desc,
   param_.ROIs =
       scope->FindVar(op_desc.Input("ROIs").front())->GetMutable<lite::Tensor>();
 
+  if (op_desc.HasInput("RoisLod") && !op_desc.Input("RoisLod").empty()) {
+    param_.RoisLod = scope->FindVar(op_desc.Input("RoisLod").front())
+                         ->GetMutable<lite::Tensor>();
+  }
+
   param_.spatial_scale = op_desc.GetAttr<float>("spatial_scale");
   param_.pooled_height = op_desc.GetAttr<int>("pooled_height");
   param_.pooled_width = op_desc.GetAttr<int>("pooled_width");


### PR DESCRIPTION
[op][arm][kernel] fix: generate_proposals  updated to paddle fluid 1.8 (#4614)
[op][arm][kernel] fix: fix_roi_align  updated to paddle fluid 1.8 (#4615)
[op][arm][kernel] fix: bind input and output when registering roi_align/generate_proposals kernel (#4642)