### PR TITLE
[OpenCL][Kernel] Add OpenCL image kernel: split

### DIFF
--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -54,6 +54,9 @@ limitations under the License. */
 #define _CONVERT_TYPE_TO(value, type) convert_##type(value)
 #define CONVERT_TYPE_TO(value, type) _CONVERT_TYPE_TO(value, type)
 
+__constant sampler_t SAMPLER =
+    CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
 /////////////////////////////////
 // WRITE_IMG_TYPE / READ_IMG_TYPE
 /////////////////////////////////

--- a/lite/backends/opencl/cl_kernel/image/split_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/split_kernel.cl
@@ -17,6 +17,69 @@ limitations under the License. */
 __kernel void split2(__read_only image2d_t input,
                     __write_only image2d_t output0,
                     __write_only image2d_t output1,
+                    __private const int axis,
+                    __private const int out0_dims_axis,
+                    __private const int in_dims_second,
+                    __private const int in_dims_last,
+                    __private const int width) {
+  const int channel_blk_idx = get_global_id(0);
+  const int width_idx = get_global_id(1);
+  const int hb_idx = get_global_id(2);
+
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE |
+                            CLK_ADDRESS_CLAMP |
+                            CLK_FILTER_NEAREST;
+
+  int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
+  CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, in_pos);
+  int c = channel_blk_idx * 4;
+
+  // write all data to output0 directly
+  if (c < out0_dims_axis) {
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output0, in_pos, in_data);
+  }
+
+  // deal with the last channel of output0
+  int channel_offset = out0_dims_axis % 4;
+  if (channel_blk_idx == out0_dims_axis / 4) { // only the last channel_blk of output0 hits this
+    if (channel_offset != 0) {
+      CL_DTYPE4 out0_last_val;
+      if (channel_offset == 1) {
+        out0_last_val = (CL_DTYPE4)(in_data.x, 0, 0, 0);
+      } else if (channel_offset == 2) {
+        out0_last_val = (CL_DTYPE4)(in_data.x, in_data.y, 0, 0);
+      } else if (channel_offset == 3) {
+        out0_last_val = (CL_DTYPE4)(in_data.x, in_data.y, in_data.z, 0);
+      }
+      WRITE_IMG_TYPE(CL_DTYPE_CHAR, output0, in_pos, out0_last_val);
+    }
+  }
+
+  // deal with output1
+  if (c + 4 >= out0_dims_axis) { // only theads for output1 hit this
+    int2 out_pos = (int2)((channel_blk_idx - out0_dims_axis / 4) * in_dims_last + width_idx, hb_idx);
+    if (channel_offset == 0) { // write all data to output1 directly
+      WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, in_data);
+    } else {
+      CL_DTYPE4 combined_val;
+      CL_DTYPE4 latter = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, (int2)(in_pos.x + in_dims_last, in_pos.y));
+      if (channel_offset == 1) {
+        combined_val = (CL_DTYPE4)(in_data.y, in_data.z, in_data.w, latter.x);
+      } else if (channel_offset == 2) {
+        combined_val = (CL_DTYPE4)(in_data.z, in_data.w, latter.x, latter.y);
+      } else if (channel_offset == 3) {
+        combined_val = (CL_DTYPE4)(in_data.w, latter.x, latter.y, latter.z);
+      }
+      WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, combined_val);
+    }
+  }
+}
+
+/*
+
+__kernel void split2(__read_only image2d_t input,
+                    __write_only image2d_t output0,
+                    __write_only image2d_t output1,
                     __private const int flag,
                     __private const int out0_dims_axis,
                     __private const int in_dims_second,
@@ -83,4 +146,4 @@ __kernel void split2(__read_only image2d_t input,
   } else if (flag == 2) {
       printf("not imple in split kernel\n");
   }
-}
+} */

--- a/lite/backends/opencl/cl_kernel/image/split_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/split_kernel.cl
@@ -15,17 +15,18 @@ limitations under the License. */
 #include <cl_common.h>
 
 __kernel void SplitBatch(__read_only image2d_t input,
-                    __write_only image2d_t output0,
-                    __write_only image2d_t output1,
-                    __private const int axis,
-                    __private const int out0_dims_axis,
-                    __private const int in_dims_second,
-                    __private const int in_dims_last,
-                    __private const int width) {
-  const int cw_idx = get_global_id(0);
-  const int hb_idx = get_global_id(1);
+                         __write_only image2d_t output0,
+                         __write_only image2d_t output1,
+                         __private const int axis,
+                         __private const int out0_dims_axis,
+                         __private const int in_dims_second,
+                         __private const int in_dims_last,
+                         __private const int width) {
+  const int channel_blk_idx = get_global_id(0);
+  const int width_idx = get_global_id(1);
+  const int hb_idx = get_global_id(2);
 
-  const int2 in_pos = (int2)(cw_idx, hb_idx);
+  const int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
   const CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, in_pos);
   const int n = hb_idx / width;
 
@@ -40,13 +41,13 @@ __kernel void SplitBatch(__read_only image2d_t input,
 }
 
 __kernel void SplitChannel(__read_only image2d_t input,
-                    __write_only image2d_t output0,
-                    __write_only image2d_t output1,
-                    __private const int axis,
-                    __private const int out0_dims_axis,
-                    __private const int in_dims_second,
-                    __private const int in_dims_last,
-                    __private const int width) {
+                           __write_only image2d_t output0,
+                           __write_only image2d_t output1,
+                           __private const int axis,
+                           __private const int out0_dims_axis,
+                           __private const int in_dims_second,
+                           __private const int in_dims_last,
+                           __private const int width) {
   const int channel_blk_idx = get_global_id(0);
   const int width_idx = get_global_id(1);
   const int hb_idx = get_global_id(2);
@@ -97,17 +98,18 @@ __kernel void SplitChannel(__read_only image2d_t input,
 }
 
 __kernel void SplitHeight(__read_only image2d_t input,
-                    __write_only image2d_t output0,
-                    __write_only image2d_t output1,
-                    __private const int axis,
-                    __private const int out0_dims_axis,
-                    __private const int in_dims_second,
-                    __private const int in_dims_last,
-                    __private const int width) {
-  const int cw_idx = get_global_id(0);
-  const int hb_idx = get_global_id(1);
+                          __write_only image2d_t output0,
+                          __write_only image2d_t output1,
+                          __private const int axis,
+                          __private const int out0_dims_axis,
+                          __private const int in_dims_second,
+                          __private const int in_dims_last,
+                          __private const int width) {
+  const int channel_blk_idx = get_global_id(0);
+  const int width_idx = get_global_id(1);
+  const int hb_idx = get_global_id(2);
 
-  const int2 in_pos = (int2)(cw_idx, hb_idx);
+  const int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
   const CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, in_pos);
   const int h = hb_idx % width;
 
@@ -122,26 +124,26 @@ __kernel void SplitHeight(__read_only image2d_t input,
 }
 
 __kernel void SplitWidth(__read_only image2d_t input,
-                    __write_only image2d_t output0,
-                    __write_only image2d_t output1,
-                    __private const int axis,
-                    __private const int out0_dims_axis,
-                    __private const int in_dims_second,
-                    __private const int in_dims_last,
-                    __private const int width) {
-  const int cw_idx = get_global_id(0);
-  const int hb_idx = get_global_id(1);
+                         __write_only image2d_t output0,
+                         __write_only image2d_t output1,
+                         __private const int axis,
+                         __private const int out0_dims_axis,
+                         __private const int in_dims_second,
+                         __private const int in_dims_last,
+                         __private const int width) {
+  const int channel_blk_idx = get_global_id(0);
+  const int width_idx = get_global_id(1);
+  const int hb_idx = get_global_id(2);
 
-  const int2 in_pos = (int2)(cw_idx, hb_idx);
+  const int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
   const CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, in_pos);
-  const int w = cw_idx % in_dims_last;
 
   int2 out_pos;
-  if (w < out0_dims_axis) {
+  if (width_idx < out0_dims_axis) {
     out_pos = in_pos;
     WRITE_IMG_TYPE(CL_DTYPE_CHAR, output0, out_pos, in_data);
   } else {
-    out_pos.x = cw_idx - out0_dims_axis;
+    out_pos.x = width_idx - out0_dims_axis;
     WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, in_data);
   }
 }

--- a/lite/backends/opencl/cl_kernel/image/split_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/split_kernel.cl
@@ -30,9 +30,9 @@ __kernel void split2(__read_only image2d_t input,
                             CLK_ADDRESS_CLAMP |
                             CLK_FILTER_NEAREST;
 
-  int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
-  CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, in_pos);
-  int c = channel_blk_idx * 4;
+  const int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
+  const CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, in_pos);
+  const int c = channel_blk_idx * 4;
 
   // write all data to output0 directly
   if (c < out0_dims_axis) {
@@ -57,7 +57,7 @@ __kernel void split2(__read_only image2d_t input,
 
   // deal with output1
   if (c + 4 >= out0_dims_axis) { // only theads for output1 hit this
-    int2 out_pos = (int2)((channel_blk_idx - out0_dims_axis / 4) * in_dims_last + width_idx, hb_idx);
+    const int2 out_pos = (int2)((channel_blk_idx - out0_dims_axis / 4) * in_dims_last + width_idx, hb_idx);
     if (channel_offset == 0) { // write all data to output1 directly
       WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, in_data);
     } else {

--- a/lite/backends/opencl/cl_kernel/image/split_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/split_kernel.cl
@@ -1,0 +1,86 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cl_common.h>
+
+__kernel void split2(__read_only image2d_t input,
+                    __write_only image2d_t output0,
+                    __write_only image2d_t output1,
+                    __private const int flag,
+                    __private const int out0_dims_axis,
+                    __private const int in_dims_second,
+                    __private const int in_dims_last,
+                    __private const int width) {
+
+  const int width_idx = get_global_id(0);
+  const int channel_blk_idx = get_global_id(1);
+  const int hb_idx = get_global_id(2);
+
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE |
+                            CLK_ADDRESS_CLAMP |
+                            CLK_FILTER_NEAREST;
+
+
+  int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
+  int2 out_pos;
+  CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, in_pos);
+  CL_DTYPE4 out_data;
+  int c;
+
+  if (flag == 1) {
+    for (int i = 0; i < 4; i++) {
+      c = channel_blk_idx * 4 + i;
+      if (c >= in_dims_second) break;
+
+      int c_out;
+      CL_DTYPE4 in_data;
+      if (c < out0_dims_axis) {
+          out_pos = in_pos;
+      } else {
+          c_out = c - out0_dims_axis;
+          out_pos = (int2)((c_out / 4) * in_dims_last + width_idx, hb_idx);
+      }
+
+      int offset = c % 4;
+      CL_DTYPE val;
+      if (offset == 0) {
+          val = in_data.x;
+      } else if (offset == 1) {
+          val = in_data.y;
+      } else if (offset == 2) {
+          val = in_data.z;
+      } else if (offset == 3) {
+          val = in_data.w;
+      }
+
+      if (i == 0) {
+        out_data.x = val;
+      } else if (i == 1) {
+        out_data.y = val;
+      } else if (i == 2) {
+        out_data.z = val;
+      } else if (i == 3) {
+        out_data.w = val;
+      }
+    }
+
+    if (c < out0_dims_axis) {
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output0, out_pos, out_data);
+    } else {
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, out_data);
+    }
+  } else if (flag == 2) {
+      printf("not imple in split kernel\n");
+  }
+}

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -25,6 +25,7 @@ add_kernel(transpose_opencl_image OPENCL basic SRCS transpose_image_compute.cc D
 add_kernel(conv_opencl_image OPENCL basic SRCS conv_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(layout_opencl_image OPENCL basic SRCS layout_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(concat_opencl_image OPENCL basic SRCS concat_image_compute.cc DEPS ${cl_kernel_deps})
+add_kernel(split_opencl_image OPENCL basic SRCS split_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(nearest_interp_opencl_image OPENCL basic SRCS nearest_interp_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(scale_opencl_image OPENCL basic SRCS scale_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(grid_sampler_opencl_image OPENCL basic SRCS grid_sampler_image_compute.cc DEPS ${cl_kernel_deps})

--- a/lite/kernels/opencl/split_image_compute.cc
+++ b/lite/kernels/opencl/split_image_compute.cc
@@ -1,0 +1,232 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "lite/backends/opencl/cl_half.h"
+#include "lite/backends/opencl/cl_include.h"
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+#include "lite/kernels/opencl/image_helper.h"
+#include "lite/operators/op_params.h"
+#include "lite/utils/replace_stl/stream.h"
+#include "lite/utils/string.h"
+#ifdef LITE_WITH_PROFILE
+#include "lite/core/profile/profiler.h"
+#endif
+#include "lite/backends/opencl/cl_utility.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace opencl {
+
+void GetVar(const DDimLite& in_dims, const int axis, int* width, int* flag) {
+  if (in_dims.size() < 4) {
+    if (in_dims.size() - axis == 1) {
+      *width = in_dims[1];
+      *flag = 3;
+    } else {
+      *width = in_dims[0];
+      *flag = 2;
+    }
+  } else {
+    switch (axis) {
+      case 0:
+        *width = in_dims[2];
+        break;
+      case 1:
+        *width = in_dims[3];
+        break;
+      case 2:
+        *width = in_dims[0];
+        break;
+      case 3:
+        *width = in_dims[1];
+        break;
+      default:
+        LOG(FATAL) << "Unsupported axis: " << axis;
+    }
+    *flag = axis;
+  }
+}
+
+class SplitComputeImage2D : public KernelLite<TARGET(kOpenCL),
+                                              PRECISION(kFP16),
+                                              DATALAYOUT(kImageDefault)> {
+ public:
+  using param_t = operators::SplitParam;
+
+  std::string doc() const override { return "Split using cl::Image2D, kFP16"; }
+
+  void PrepareForRun() override {
+    auto& context = ctx_->As<OpenCLContext>();
+    split_param_ = param_.get_mutable<param_t>();
+    auto& x_dims = split_param_->x->dims();
+    auto& outs = split_param_->output;
+    axis_ = split_param_->axis;
+    if (axis_ < 0) {
+      axis_ += x_dims.size() - 1;
+    }
+
+    if (outs.size() == 2) {
+      kernel_func_name_ = "split2";
+    } else {
+      kernel_func_name_ = "split_mul";
+      build_options_ = " -DCL_DTYPE_float";
+      LOG(FATAL) << "NOT imple yet";
+    }
+
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
+    context.cl_context()->AddKernel(kernel_func_name_,
+                                    kernel_func_name_ == "split2"
+                                        ? "image/split_kernel.cl"
+                                        : "buffer/split_kernel.cl",
+                                    build_options_,
+                                    time_stamp_);
+
+    STL::stringstream kernel_key;
+    kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
+    kernel_ = context.cl_context()->GetKernel(kernel_key.str());
+
+    GetVar(x_dims, axis_, &width_, &flag_);
+  }
+
+  void ReInitWhenNeeded() override {
+    split_param_ = param_.get_mutable<param_t>();
+    auto& x_dims = split_param_->x->dims();
+
+    if ((!first_epoch_for_reinit_ && x_dims != last_x_dims_) ||
+        first_epoch_for_reinit_) {
+      last_x_dims_ = x_dims;
+      first_epoch_for_reinit_ = false;
+
+      // compute image shape
+      lite::CLImageConverterDefault convertor;
+      x_img_shape_ = convertor.InitImageDimInfoWith(x_dims);
+      VLOG(1) << "x_img_shape_:  " << x_img_shape_[0] << "  "
+              << x_img_shape_[1];
+
+      // compute global work size
+      auto image_width = x_dims[3] * ((x_dims[1] + 3) / 4);
+      size_t work_size0 = x_dims[3];                // W
+      size_t work_size1 = image_width / x_dims[3];  // (C+3)/4
+      size_t work_size2 = x_dims[0] * x_dims[2];    // NH
+      gws_ = cl::NDRange{work_size0, work_size1, work_size2};
+
+      GetVar(x_dims, axis_, &width_, &flag_);
+    }
+  }
+
+  void Run() override {
+    const auto& x_dims = split_param_->x->dims();
+    const int out0_dims_axis = split_param_->output[0]->dims()[axis_];
+    const auto out_num = split_param_->output.size();
+    const auto* x_img = split_param_->x->data<half_t, cl::Image2D>();
+
+    std::vector<cl::Image2D*> out_img{out_num};
+    for (auto i = 0; i < split_param_->output.size(); i++) {
+      auto image_shape = InitImageDimInfoWith(split_param_->output[i]->dims());
+      out_img[i] = split_param_->output[i]->mutable_data<half_t, cl::Image2D>(
+          image_shape["width"], image_shape["height"]);
+    }
+
+    auto& context = ctx_->As<OpenCLContext>();
+    CHECK(context.cl_context() != nullptr);
+
+    if (out_num == 2) {
+      cl_int status;
+      int arg_idx = 0;
+      status = kernel_.setArg(arg_idx++, *x_img);
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, *(out_img[0]));
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, *(out_img[1]));
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, flag_);
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, out0_dims_axis);
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, static_cast<int>(x_dims[1]));  // in_c
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(
+          arg_idx++, static_cast<int>(x_dims[x_dims.size() - 1]));  // in_w
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, width_);
+      CL_CHECK_FATAL(status);
+
+      status = EnqueueNDRangeKernel(context,
+                                    kernel_,
+                                    cl::NullRange,
+                                    gws_,
+                                    cl::NullRange,
+                                    nullptr,
+                                    event_);
+      CL_CHECK_FATAL(status);
+    } else {
+    }
+  }
+
+#ifdef LITE_WITH_PROFILE
+  void SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
+    ch->kernel_func_name = kernel_func_name_;
+    ch->cl_event =
+        event_;  // `event_` defined in `kernel.h`, valid after kernel::Run
+  }
+#endif
+
+ private:
+  int axis_{-1};
+  int flag_{-1};   // the axis after expanding input tensor to 4 dims
+  int width_{-1};  // this var and `flag_` form the one OpenCL image dim
+  param_t* split_param_{nullptr};
+  bool first_epoch_for_reinit_{true};
+  DDim last_x_dims_;
+  DDim x_img_shape_ = DDim(std::vector<DDim::value_type>(
+      {static_cast<DDim::value_type>(1), static_cast<DDim::value_type>(1)}));
+  std::string kernel_func_name_{};
+  std::string build_options_{"-DCL_DTYPE_half"};
+  std::string time_stamp_{GetTimeStamp()};
+  cl::Kernel kernel_;
+  cl::NDRange gws_ = cl::NDRange{
+      static_cast<size_t>(1), static_cast<size_t>(1), static_cast<size_t>(1)};
+};
+
+}  // namespace opencl
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(split,
+                     kOpenCL,
+                     kFP16,
+                     kImageDefault,
+                     paddle::lite::kernels::opencl::SplitComputeImage2D,
+                     def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kFP16),
+                                      DATALAYOUT(kImageDefault))})
+    .BindInput("AxisTensor",
+               {LiteType::GetTensorTy(TARGET(kARM),
+                                      PRECISION(kInt32),
+                                      DATALAYOUT(kNCHW))})
+    .BindInput("SectionsTensorList",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kInt32),
+                                      DATALAYOUT(kNCHW))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kFP16),
+                                       DATALAYOUT(kImageDefault))})
+    .Finalize();

--- a/lite/kernels/opencl/split_image_compute.cc
+++ b/lite/kernels/opencl/split_image_compute.cc
@@ -119,8 +119,8 @@ class SplitComputeImage2D : public KernelLite<TARGET(kOpenCL),
 
       // compute global work size
       auto image_width = x_dims[3] * ((x_dims[1] + 3) / 4);
-      size_t work_size0 = x_dims[3];                // W
-      size_t work_size1 = image_width / x_dims[3];  // (C+3)/4
+      size_t work_size0 = image_width / x_dims[3];  // (C+3)/4
+      size_t work_size1 = x_dims[3];                // W
       size_t work_size2 = x_dims[0] * x_dims[2];    // NH
       gws_ = cl::NDRange{work_size0, work_size1, work_size2};
 

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -581,7 +581,7 @@ struct DropoutParam : ParamBase {
 struct SplitParam : ParamBase {
   lite::Tensor* x{};
   std::vector<lite::Tensor*> output{};
-  lite::Tensor* axis_tensor;
+  lite::Tensor* axis_tensor{};
   std::vector<lite::Tensor*> sections_tensor_list{};
 
   int axis{-1};

--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -32,9 +32,18 @@ bool SplitOp::CheckShape() const {
 bool SplitOp::InferShapeImpl() const {
   const auto &outs = param_.output;
   auto in_dims = param_.x->dims();
-  int axis = param_.axis;
   int num = param_.num;
   const auto &sections = param_.sections;
+
+  int axis = 0;
+  if (param_.axis_tensor != nullptr) {
+    axis = param_.axis_tensor->data<int>()[0];
+  } else {
+    axis = param_.axis;
+  }
+  if (axis < 0) {
+    axis += in_dims.size();
+  }
 
   const int outs_number = outs.size();
   std::vector<lite::DDim> outs_dims;
@@ -61,10 +70,6 @@ bool SplitOp::InferShapeImpl() const {
       dim[axis] = sections[i];
       outs_dims.push_back(dim);
     }
-  }
-
-  if (param_.axis_tensor != nullptr) {
-    axis = param_.axis_tensor->data<int>()[0];
   }
 
   for (size_t j = 0; j < outs_dims.size(); ++j) {

--- a/lite/operators/split_op.h
+++ b/lite/operators/split_op.h
@@ -42,7 +42,7 @@ class SplitOp : public OpLite {
     ch->input_shape = ch->DimToStr(param_.x->dims());
     ch->output_shape = ch->DimToStr(param_.output->dims());
     ch->remark = "axis" + std::to_string(param_.axis) + "num" +
-                 std::string(param_.num) + "sections" +
+                 std::to_string(param_.num) + "sections" +
                  ch->DimToStr(param_.sections);
   }
 #endif

--- a/lite/operators/split_op.h
+++ b/lite/operators/split_op.h
@@ -37,6 +37,16 @@ class SplitOp : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "split"; }
 
+#ifdef LITE_WITH_PROFILE
+  void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
+    ch->input_shape = ch->DimToStr(param_.x->dims());
+    ch->output_shape = ch->DimToStr(param_.output->dims());
+    ch->remark = "axis" + std::to_string(param_.axis) + "num" +
+                 std::string(param_.num) + "sections" +
+                 ch->DimToStr(param_.sections);
+  }
+#endif
+
  private:
   mutable SplitParam param_;
 };

--- a/lite/operators/split_op.h
+++ b/lite/operators/split_op.h
@@ -40,10 +40,21 @@ class SplitOp : public OpLite {
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     ch->input_shape = ch->DimToStr(param_.x->dims());
-    ch->output_shape = ch->DimToStr(param_.output->dims());
+
+    std::string outputs_shape = "";
+    for (size_t i = 0; i < param_.output.size(); ++i) {
+      outputs_shape += ch->DimToStr(param_.output[i]->dims());
+      if (i != param_.output.size() - 1) outputs_shape += "/";
+    }
+    ch->output_shape = outputs_shape;
+
+    std::string sections = "";
+    for (size_t i = 0; i < param_.sections.size(); ++i) {
+      sections += std::to_string(param_.sections[i]);
+      if (i != param_.sections.size() - 1) sections += "/";
+    }
     ch->remark = "axis" + std::to_string(param_.axis) + "num" +
-                 std::to_string(param_.num) + "sections" +
-                 ch->DimToStr(param_.sections);
+                 std::to_string(param_.num) + "sections" + sections;
   }
 #endif
 


### PR DESCRIPTION
【问题】`split`作为一个常用 op，之前没有 OpenCL 实现，这样会引起不必要的`io_copy`和`layout_cast`执行，进而增加运行耗时。

【解决方法】本 PR 新增`split`的 OpenCL image 实现。

【效果】测试 shufflenetv2，已验证精度与ARM 无 diff。该模型中含有 16 个`concat -> shuffle_channel -> split`这种 block 结构。其中`shuffle_channel`的 GPU 实现 [PR](https://github.com/PaddlePaddle/Paddle-Lite/pull/4550) 尚未合入。因此：如果仅有`split`的 GPU 实现，并不会减少`io_copy`和`layout_cast`的执行次数，且`split`操作是纯数据拷贝无计算量，因此理论上该 op 使用 GPU 并无优势（下表第三行数据也验证了这一点）。但是，当`split`和`shuffle_channel`均有 GPU 实现时，一个 block 就可以降低 3 次`io_copy`和 3 次`layout_cast`的执行耗时，因此最终在 shufflenetv2 上有速度提升。

 855 | Run time(ms)
---|---
 ARM    | 10.68
OpenCL | 58.36
+PR(split) | 43.52
+PR(split) + PR(shuffle_channel) | 15.11

备注：仅使用 GPU 版`shuffle_channel`时，在 835 上运行 shufflenetv2 由 43ms 降为 41ms。因此必须`shuffle_channel`和`split`均有 GPU 实现时才有意义（1+1>2哈哈）。

【TODO】
- 当前 repo 中没有针对 ARM / OpenCL 等 target 的`split`单测。由于 OpenCL 的单测会迁移至 tests 文件夹下，对应修改较多。因此`split`的单测会在新的一个 PR 中添加。
- `shufflenetv2` OpenCL 比 ARM 慢，需要详细耗时分析。