### PR TITLE
[Cherry-pick] Skip checking the precision and target of inputs and outputs in conditional_block op

### DIFF
--- a/lite/core/mir/type_precision_cast_pass.cc
+++ b/lite/core/mir/type_precision_cast_pass.cc
@@ -110,9 +110,12 @@ void PrecisionCastPass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 
   // record the copied node.
   std::map<std::string, Node*> cast_nodes;
+  std::vector<std::string> skip_ops = {"while", "conditional_block"};
 
   for (auto& node : nodes) {
-    if (!node->IsStmt() || node->AsStmt().op_type() == "while") continue;
+    auto op_type = node->AsStmt().op_type();
+    auto iter = std::find(skip_ops.begin(), skip_ops.end(), op_type);
+    if (!node->IsStmt() || iter != skip_ops.end()) continue;
     auto inlinks = node->inlinks;
     for (auto* in : inlinks) {
       ComplementInputs(graph.get(), node, in, &cast_nodes);

--- a/lite/core/mir/type_target_cast_pass.cc
+++ b/lite/core/mir/type_target_cast_pass.cc
@@ -39,9 +39,12 @@ void TypeTargetTransformPass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 
   // record the copied node.
   std::map<std::string, Node*> copied_nodes;
+  std::vector<std::string> skip_ops = {"while", "conditional_block"};
 
   for (auto& node : nodes) {
-    if (!node->IsStmt() || node->AsStmt().op_type() == "while") continue;
+    auto op_type = node->AsStmt().op_type();
+    auto iter = std::find(skip_ops.begin(), skip_ops.end(), op_type);
+    if (!node->IsStmt() || iter != skip_ops.end()) continue;
     auto inlinks = node->inlinks;
     for (auto* in : inlinks) {
       ComplementInputs(graph.get(), node, in, &copied_nodes);

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -354,6 +354,8 @@ void Program::PrepareWorkspace(
   auto VarDescType2PrecisionType =
       [](const lite::VarDescAPI::Type& type) -> PrecisionType {
     switch (type) {
+      case lite::VarDescAPI::Type::BOOL:
+        return PRECISION(kBool);
       case lite::VarDescAPI::Type::FP32:
         return PRECISION(kFloat);
       case lite::VarDescAPI::Type::FP16:

--- a/lite/model_parser/compatible_pb.cc
+++ b/lite/model_parser/compatible_pb.cc
@@ -39,8 +39,15 @@ namespace lite {
     any_desc->SetType(cpp_desc.GetType());                         \
     any_desc->SetPersistable(cpp_desc.Persistable());              \
     if (cpp_desc.Name() != "feed" && cpp_desc.Name() != "fetch") { \
-      any_desc->SetShape(cpp_desc.GetShape());                     \
-      any_desc->SetDataType(cpp_desc.GetDataType());               \
+      VarDataType type = cpp_desc.GetType();                       \
+      if (type == VarDataType::LOD_TENSOR) {                       \
+        any_desc->SetDataType(cpp_desc.GetDataType());             \
+      }                                                            \
+      if (type == VarDataType::LOD_TENSOR ||                       \
+          type == VarDataType::SELECTED_ROWS ||                    \
+          type == VarDataType::LOD_TENSOR_ARRAY) {                 \
+        any_desc->SetShape(cpp_desc.GetShape());                   \
+      }                                                            \
     }                                                              \
   }
 
@@ -52,8 +59,14 @@ void TransformVarDescAnyToCpp<pb::VarDesc>(const pb::VarDesc &any_desc,
   cpp_desc->SetType(any_desc.GetType());
   cpp_desc->SetPersistable(any_desc.Persistable());
   if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
-    cpp_desc->SetDataType(any_desc.GetDataType());
-    cpp_desc->SetShape(any_desc.GetShape());
+    VarDataType type = cpp_desc->GetType();
+    if (type == VarDataType::LOD_TENSOR) {
+      cpp_desc->SetDataType(any_desc.GetDataType());
+    }
+    if (type == VarDataType::LOD_TENSOR || type == VarDataType::SELECTED_ROWS ||
+        type == VarDataType::LOD_TENSOR_ARRAY) {
+      cpp_desc->SetShape(any_desc.GetShape());
+    }
   }
 }
 template <>
@@ -63,8 +76,14 @@ void TransformVarDescAnyToCpp<fbs::VarDesc>(const fbs::VarDesc &any_desc,
   cpp_desc->SetType(any_desc.GetType());
   cpp_desc->SetPersistable(any_desc.Persistable());
   if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
-    cpp_desc->SetDataType(any_desc.GetDataType());
-    cpp_desc->SetShape(any_desc.GetShape());
+    VarDataType type = cpp_desc->GetType();
+    if (type == VarDataType::LOD_TENSOR) {
+      cpp_desc->SetDataType(any_desc.GetDataType());
+    }
+    if (type == VarDataType::LOD_TENSOR || type == VarDataType::SELECTED_ROWS ||
+        type == VarDataType::LOD_TENSOR_ARRAY) {
+      cpp_desc->SetShape(any_desc.GetShape());
+    }
   }
 }
 


### PR DESCRIPTION
* Skip checking the precision and target of inputs and outputs in conditional_block op

* set data type and shape for special variable, test=develop