### PR TITLE
[Framework]Update kernel registry

### DIFF
--- a/lite/core/CMakeLists.txt
+++ b/lite/core/CMakeLists.txt
@@ -77,7 +77,8 @@ add_custom_command(
   ${kernels_src_list}
   ${CMAKE_SOURCE_DIR}/lite/api/paddle_use_kernels.h
   "${LITE_OPTMODEL_DIR}/.tailored_kernels_list"
-  LITE_BUILD_TAILOR
+  ${LITE_BUILD_TAILOR}
+  ${LITE_BUILD_EXTRA}
   OUTPUT kernels.h # not a real path to the output to force it execute every time.
   )
 # A trick to generate the paddle_use_ops.h
@@ -86,7 +87,7 @@ add_custom_command(
   ${ops_src_list}
   ${CMAKE_SOURCE_DIR}/lite/api/paddle_use_ops.h
   "${LITE_OPTMODEL_DIR}/.tailored_ops_list"
-  LITE_BUILD_TAILOR
+  ${LITE_BUILD_TAILOR}
   OUTPUT ops.h # not a real path to the output to force it execute every time.
   )
 # generate fake kernels for memory_optimize_tool

--- a/lite/kernels/arm/argmax_compute.cc
+++ b/lite/kernels/arm/argmax_compute.cc
@@ -120,4 +120,4 @@ REGISTER_LITE_KERNEL(arg_max,
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kUInt8))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
     .Finalize();
-#endif
+#endif  // LITE_BUILD_EXTRA

--- a/lite/tools/cmake_tools/create_fake_kernel_registry.py
+++ b/lite/tools/cmake_tools/create_fake_kernel_registry.py
@@ -87,7 +87,7 @@ def parse_fake_kernels_from_path(list_path):
             with open(path.strip()) as g:
                 c = g.read()
                 kernel_parser = RegisterLiteKernelParser(c)
-                kernel_parser.parse()
+                kernel_parser.parse("ON")
 
                 for k in kernel_parser.kernels:
                     kernel_name = "{op_type}_{target}_{precision}_{data_layout}_{alias}_class".format(
@@ -138,7 +138,7 @@ def parse_sppported_kernels_from_path(list_path):
             with open(path.strip()) as g:
                 c = g.read()
                 kernel_parser = RegisterLiteKernelParser(c)
-                kernel_parser.parse()
+                kernel_parser.parse("ON")
 
                 for k in kernel_parser.kernels:
                     index = path.rindex('/')

--- a/lite/tools/cmake_tools/parse_kernel_registry.py
+++ b/lite/tools/cmake_tools/parse_kernel_registry.py
@@ -17,13 +17,14 @@ import sys
 import logging
 from ast import RegisterLiteKernelParser
 
-if len(sys.argv) != 5:
+if len(sys.argv) != 6:
     print("Error: parse_kernel_registry.py requires four inputs!")
     exit(1)
 ops_list_path = sys.argv[1]
 dest_path = sys.argv[2]
 minkernels_list_path = sys.argv[3]
 tailored = sys.argv[4]
+with_extra = sys.argv[5]
 
 out_lines = [
     '#pragma once',
@@ -41,7 +42,7 @@ with open(ops_list_path) as f:
         with open(path.strip()) as g:
             c = g.read()
             kernel_parser = RegisterLiteKernelParser(c)
-            kernel_parser.parse()
+            kernel_parser.parse(with_extra)
 
             for k in kernel_parser.kernels:
                   kernel = "%s, %s, %s, %s, %s" % (

--- a/lite/tools/cmake_tools/record_supported_kernel_op.py
+++ b/lite/tools/cmake_tools/record_supported_kernel_op.py
@@ -84,7 +84,7 @@ with open(kernels_list_path) as f:
         with open(path.strip()) as g:
             c = g.read()
             kernel_parser = RegisterLiteKernelParser(c)
-            kernel_parser.parse()
+            kernel_parser.parse("ON")
             for k in kernel_parser.kernels:
                 if hasattr(TargetType, k.target):
                     index = getattr(TargetType, k.target)
@@ -96,7 +96,7 @@ with open(faked_kernels_list_path) as f:
         with open(path.strip()) as g:
             c = g.read()
             kernel_parser = RegisterLiteKernelParser(c)
-            kernel_parser.parse()
+            kernel_parser.parse("ON")
             for k in kernel_parser.kernels:
                 if hasattr(TargetType, k.target):
                     index = getattr(TargetType, k.target)


### PR DESCRIPTION
[Effect of current PR]
- Extra kernels will not be compiled into basic inference library.
- Kernel registries that are surrounded by macro definitions listed blow will be judged as extra kernel registries. 
``` c++
#ifdef LITE_BUILD_EXTRA
#endif  // LITE_BUILD_EXTRA
```
[Example]
`lite/kernels/arm/argmax_compute.cc`

``` c++
REGISTER_LITE_KERNEL(arg_max,
                     kARM,
                     kAny,
                     kNCHW,
                     paddle::lite::kernels::arm::ArgmaxCompute<float>,
                     fp32)
    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
    .Finalize();

#ifdef LITE_BUILD_EXTRA
// arg_max only supports float input except that LITE_WITH_EXTRA=ON

REGISTER_LITE_KERNEL(arg_max,
                     kARM,
                     kAny,
                     kNCHW,
                     paddle::lite::kernels::arm::ArgmaxCompute<uint8_t>,
                     uint8)
    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kUInt8))})
    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
    .Finalize();
#endif  // LITE_BUILD_EXTRA
```