### PR TITLE
fix tensor persistable bugs, test=develop

### DIFF
--- a/lite/core/tensor.h
+++ b/lite/core/tensor.h
@@ -260,6 +260,8 @@ TensorLite TensorLite::Slice(int64_t begin, int64_t end) const {
 template <typename TensorT>
 bool TensorCompareWith(const TensorT &a, const TensorT &b) {
   if (a.dims() != b.dims()) return false;
+  if (a.precision() != b.precision()) return false;
+  if (a.persistable() != b.persistable()) return false;
   if (memcmp(a.raw_data(), b.raw_data(), a.data_size()) != 0) return false;
   return true;
 }

--- a/lite/model_parser/flatbuffers/io.cc
+++ b/lite/model_parser/flatbuffers/io.cc
@@ -85,6 +85,7 @@ void SetScopeWithCombinedParams(lite::Scope* scope,
     const auto& param = *params.GetParamDesc(i);
     auto* tensor = scope->Var(param.Name())->GetMutable<lite::Tensor>();
     SetTensorWithParam(tensor, param);
+    tensor->set_persistable(true);
   }
 }
 

--- a/lite/model_parser/flatbuffers/io_test.cc
+++ b/lite/model_parser/flatbuffers/io_test.cc
@@ -30,6 +30,7 @@ void set_tensor(paddle::lite::Tensor* tensor,
   auto production =
       std::accumulate(begin(dims), end(dims), 1, std::multiplies<int64_t>());
   tensor->Resize(dims);
+  tensor->set_persistable(true);
   std::vector<T> data;
   data.resize(production);
   for (int i = 0; i < production; ++i) {


### PR DESCRIPTION
1、修复权重读取丢失 `persistable` 属性的问题，
2、修正 `Tensor` 相等条件，以避免测试遗漏。