### PR TITLE
[Cherry-pick][op][arm][kernel]fix: yolo_box updated with paddle-fluid (#4443)

### DIFF
--- a/lite/backends/arm/math/yolo_box.h
+++ b/lite/backends/arm/math/yolo_box.h
@@ -29,7 +29,10 @@ void yolobox(lite::Tensor* X,
              std::vector<int> anchors,
              int class_num,
              float conf_thresh,
-             int downsample_ratio);
+             int downsample_ratio,
+             bool clip_bbox,
+             float scale,
+             float bias);
 
 }  // namespace math
 }  // namespace arm

--- a/lite/kernels/arm/yolo_box_compute.cc
+++ b/lite/kernels/arm/yolo_box_compute.cc
@@ -32,6 +32,9 @@ void YoloBoxCompute::Run() {
   int class_num = param.class_num;
   float conf_thresh = param.conf_thresh;
   int downsample_ratio = param.downsample_ratio;
+  bool clip_bbox = param.clip_bbox;
+  float scale_x_y = param.scale_x_y;
+  float bias = -0.5 * (scale_x_y - 1.);
   Boxes->clear();
   Scores->clear();
   lite::arm::math::yolobox(X,
@@ -41,7 +44,10 @@ void YoloBoxCompute::Run() {
                            anchors,
                            class_num,
                            conf_thresh,
-                           downsample_ratio);
+                           downsample_ratio,
+                           clip_bbox,
+                           scale_x_y,
+                           bias);
 }
 
 }  // namespace arm

--- a/lite/kernels/bm/bridges/yolo_box_op.cc
+++ b/lite/kernels/bm/bridges/yolo_box_op.cc
@@ -26,6 +26,7 @@ namespace lite {
 namespace subgraph {
 namespace bm {
 
+// fixme: yolo box has updated, check arm kernel to get more info
 int YoloBoxConverter(void* ctx, OpLite* op, KernelBase* kernel) {
   CHECK(ctx != nullptr);
   CHECK(op != nullptr);

--- a/lite/kernels/cuda/yolo_box_compute_test.cc
+++ b/lite/kernels/cuda/yolo_box_compute_test.cc
@@ -35,9 +35,12 @@ inline static void get_yolo_box(float* box,
                                 int index,
                                 int stride,
                                 int img_height,
-                                int img_width) {
-  box[0] = (i + sigmoid(x[index])) * img_width / grid_size;
-  box[1] = (j + sigmoid(x[index + stride])) * img_height / grid_size;
+                                int img_width,
+                                float scale,
+                                float bias) {
+  box[0] = (i + sigmoid(x[index]) * scale + bias) * img_width / grid_size;
+  box[1] =
+      (j + sigmoid(x[index + stride] * scale + bias)) * img_height / grid_size;
   box[2] = std::exp(x[index + 2 * stride]) * anchors[2 * an_idx] * img_width /
            input_size;
   box[3] = std::exp(x[index + 3 * stride]) * anchors[2 * an_idx + 1] *
@@ -58,12 +61,15 @@ inline static void calc_detection_box(float* boxes,
                                       float* box,
                                       const int box_idx,
                                       const int img_height,
-                                      const int img_width) {
+                                      const int img_width,
+                                      bool clip_bbox) {
   boxes[box_idx] = box[0] - box[2] / 2;
   boxes[box_idx + 1] = box[1] - box[3] / 2;
   boxes[box_idx + 2] = box[0] + box[2] / 2;
   boxes[box_idx + 3] = box[1] + box[3] / 2;
-
+  if (!clip_bbox) {
+    return;
+  }
   boxes[box_idx] = boxes[box_idx] > 0 ? boxes[box_idx] : static_cast<float>(0);
   boxes[box_idx + 1] =
       boxes[box_idx + 1] > 0 ? boxes[box_idx + 1] : static_cast<float>(0);
@@ -100,7 +106,10 @@ static void YoloBoxRef(const T* input,
                        const int an_num,
                        const int class_num,
                        const int box_num,
-                       int input_size) {
+                       int input_size,
+                       bool clip_bbox,
+                       float scale,
+                       float bias) {
   const int stride = h * w;
   const int an_stride = (class_num + 5) * stride;
   float box[4];
@@ -132,9 +141,12 @@ static void YoloBoxRef(const T* input,
                        box_idx,
                        stride,
                        img_height,
-                       img_width);
+                       img_width,
+                       scale,
+                       bias);
           box_idx = (i * box_num + j * stride + k * w + l) * 4;
-          calc_detection_box(boxes, box, box_idx, img_height, img_width);
+          calc_detection_box(
+              boxes, box, box_idx, img_height, img_width, clip_bbox);
 
           int label_idx =
               get_entry_index(i, j, k * w + l, an_num, an_stride, stride, 5);
@@ -163,6 +175,9 @@ TEST(yolo_box, normal) {
   param.downsample_ratio = 2;
   param.conf_thresh = 0.5;
   param.class_num = cls;
+  param.clip_bbox = true;
+  param.scale_x_y = 1.0;
+  float bias = -0.5 * (param.scale_x_y - 1.);
   int m = h * w * param.anchors.size() / 2;
 
   x.Resize({n, c, h, w});
@@ -240,7 +255,10 @@ TEST(yolo_box, normal) {
                     param.anchors.size() / 2,
                     cls,
                     m,
-                    param.downsample_ratio * h);
+                    param.downsample_ratio * h,
+                    param.clip_bbox,
+                    param.scale_x_y,
+                    bias);
 
   for (int i = 0; i < boxes.numel(); i++) {
     EXPECT_NEAR(boxes_cpu_data[i], boxes_ref_data[i], 1e-5);

--- a/lite/kernels/xpu/bridges/yolo_box_op.cc
+++ b/lite/kernels/xpu/bridges/yolo_box_op.cc
@@ -21,6 +21,7 @@ namespace lite {
 namespace subgraph {
 namespace xpu {
 
+// fixme: yolo box has updated, check arm kernel to get more info
 int YoloBoxConverter(void* ctx, OpLite* op, KernelBase* kernel) {
   CHECK(ctx != nullptr);
   CHECK(op != nullptr);

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -264,6 +264,8 @@ struct YoloBoxParam : ParamBase {
   int class_num{0};
   float conf_thresh{0.f};
   int downsample_ratio{0};
+  bool clip_bbox{true};
+  float scale_x_y{1.0f};
 };
 
 // For Scale Op

--- a/lite/operators/yolo_box_op.cc
+++ b/lite/operators/yolo_box_op.cc
@@ -72,8 +72,12 @@ bool YoloBoxOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   param_.class_num = op_desc.GetAttr<int>("class_num");
   param_.conf_thresh = op_desc.GetAttr<float>("conf_thresh");
   param_.downsample_ratio = op_desc.GetAttr<int>("downsample_ratio");
-  param_.clip_bbox = op_desc.GetAttr<bool>("clip_bbox");
-  param_.scale_x_y = op_desc.GetAttr<float>("scale_x_y");
+  if (op_desc.HasAttr("clip_bbox")) {
+    param_.clip_bbox = op_desc.GetAttr<bool>("clip_bbox");
+  }
+  if (op_desc.HasAttr("scale_x_y")) {
+    param_.scale_x_y = op_desc.GetAttr<float>("scale_x_y");
+  }
   return true;
 }
 

--- a/lite/operators/yolo_box_op.cc
+++ b/lite/operators/yolo_box_op.cc
@@ -72,6 +72,8 @@ bool YoloBoxOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   param_.class_num = op_desc.GetAttr<int>("class_num");
   param_.conf_thresh = op_desc.GetAttr<float>("conf_thresh");
   param_.downsample_ratio = op_desc.GetAttr<int>("downsample_ratio");
+  param_.clip_bbox = op_desc.GetAttr<bool>("clip_bbox");
+  param_.scale_x_y = op_desc.GetAttr<float>("scale_x_y");
   return true;
 }
 

--- a/lite/tests/kernels/yolo_box_compute_test.cc
+++ b/lite/tests/kernels/yolo_box_compute_test.cc
@@ -100,6 +100,8 @@ class YoloBoxComputeTester : public arena::TestCase {
   int class_num_ = 0;
   float conf_thresh_ = 0.f;
   int downsample_ratio_ = 0;
+  bool clip_bbox_ = true;
+  float scale_x_y_ = 1.0;
 
   DDim _dims0_{{1, 255, 13, 13}};
   DDim _dims1_{{1, 2}};
@@ -212,6 +214,8 @@ class YoloBoxComputeTester : public arena::TestCase {
     op_desc->SetAttr("class_num", class_num_);
     op_desc->SetAttr("conf_thresh", conf_thresh_);
     op_desc->SetAttr("downsample_ratio", downsample_ratio_);
+    op_desc->SetAttr("clip_bbox", clip_bbox_);
+    op_desc->SetAttr("scale_x_y", scale_x_y_);
   }
 
   void PrepareData() override {


### PR DESCRIPTION
修复yolov3_mobilenetv3 demo检测结果错误的问题（因https://github.com/PaddlePaddle/Paddle-Lite/pull/3948 引起的boxes未初始化所导致），具体错误如下图所示：
![image](https://user-images.githubusercontent.com/9973393/98253258-c172cd00-1fb5-11eb-8841-c6e3dc7638eb.png)
