### PR TITLE
[Issue] Memory leak test with gperftool

### DIFF
--- a/lite/demo/cxx/x86_mobilenetv1_light_demo/CMakeLists.txt
+++ b/lite/demo/cxx/x86_mobilenetv1_light_demo/CMakeLists.txt
@@ -43,7 +43,7 @@ if (WIN32)
        COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_DIR}/lib/libiomp5md.dll ${CMAKE_BINARY_DIR}/Release
    )
 else()
-    target_link_libraries(${TARGET} -lpaddle_light_api_shared)
+    target_link_libraries(${TARGET} -lpaddle_light_api_shared -ltcmalloc)
     target_link_libraries(${TARGET} -liomp5)
     target_link_libraries(${TARGET} -ldl)
 endif()

--- a/lite/demo/cxx/x86_mobilenetv1_light_demo/mem_rec.sh
+++ b/lite/demo/cxx/x86_mobilenetv1_light_demo/mem_rec.sh
@@ -1,0 +1,7 @@
+#mv 20201106_data.txt 20201106_data.txt_back
+pmap -x 23868 | grep Address >> 20201110_data.txt
+while(true)
+do
+    sleep 50
+    pmap -x 23868 | grep total >> 20201110_data.txt
+done

--- a/lite/demo/cxx/x86_mobilenetv1_light_demo/mem_rec.sh
+++ b/lite/demo/cxx/x86_mobilenetv1_light_demo/mem_rec.sh
@@ -1,7 +1,7 @@
 #mv 20201106_data.txt 20201106_data.txt_back
-pmap -x 23868 | grep Address >> 20201110_data.txt
+pmap -x $(pidof mobilenet_light_api) | grep Address >> 20201111_data.txt
 while(true)
 do
-    sleep 50
-    pmap -x 23868 | grep total >> 20201110_data.txt
+    sleep 20
+    pmap -x $(pidof mobilenet_light_api) | grep total >> 20201111_data.txt
 done

--- a/lite/demo/cxx/x86_mobilenetv1_light_demo/mobilenet_light_api.cc
+++ b/lite/demo/cxx/x86_mobilenetv1_light_demo/mobilenet_light_api.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gperftools/heap-profiler.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+#include <unistd.h>
+#include <cmath>
 #include <iostream>
+#include <string>
 #include <vector>
-#include "paddle_api.h"  // NOLINT
-
+#include "paddle_api.h"            // NOLINT
 using namespace paddle::lite_api;  // NOLINT
 
 int64_t ShapeProduction(const shape_t& shape) {
@@ -24,41 +30,170 @@ int64_t ShapeProduction(const shape_t& shape) {
   return res;
 }
 
-void RunModel(std::string model_name) {
-  // 1. Create MobileConfig
+std::string ShapePrint(const std::vector<shape_t>& shapes) {
+  std::string shapes_str{""};
+  for (size_t shape_idx = 0; shape_idx < shapes.size(); ++shape_idx) {
+    auto shape = shapes[shape_idx];
+    std::string shape_str;
+    for (auto i : shape) {
+      shape_str += std::to_string(i) + ",";
+    }
+    shapes_str += shape_str;
+    shapes_str +=
+        (shape_idx != 0 && shape_idx == shapes.size() - 1) ? "" : " : ";
+  }
+  return shapes_str;
+}
+
+std::string ShapePrint(const shape_t& shape) {
+  std::string shape_str{""};
+  for (auto i : shape) {
+    shape_str += std::to_string(i) + " ";
+  }
+  return shape_str;
+}
+
+std::vector<std::string> split_string(const std::string& str_in) {
+  std::vector<std::string> str_out;
+  std::string tmp_str = str_in;
+  while (!tmp_str.empty()) {
+    size_t next_offset = tmp_str.find(":");
+    str_out.push_back(tmp_str.substr(0, next_offset));
+    if (next_offset == std::string::npos) {
+      break;
+    } else {
+      tmp_str = tmp_str.substr(next_offset + 1);
+    }
+  }
+  return str_out;
+}
+
+std::vector<int64_t> get_shape(const std::string& str_shape) {
+  std::vector<int64_t> shape;
+  std::string tmp_str = str_shape;
+  while (!tmp_str.empty()) {
+    int dim = atoi(tmp_str.data());
+    shape.push_back(dim);
+    size_t next_offset = tmp_str.find(",");
+    if (next_offset == std::string::npos) {
+      break;
+    } else {
+      tmp_str = tmp_str.substr(next_offset + 1);
+    }
+  }
+  return shape;
+}
+
+template <typename T>
+double compute_mean(const T* in, const size_t length) {
+  double sum = 0.;
+  for (size_t i = 0; i < length; ++i) {
+    sum += in[i];
+  }
+  return sum / length;
+}
+
+template <typename T>
+double compute_standard_deviation(const T* in,
+                                  const size_t length,
+                                  bool has_mean = false,
+                                  double mean = 10000) {
+  if (!has_mean) {
+    mean = compute_mean<T>(in, length);
+  }
+
+  double variance = 0.;
+  for (size_t i = 0; i < length; ++i) {
+    variance += pow((in[i] - mean), 2);
+  }
+  variance /= length;
+  return sqrt(variance);
+}
+
+inline double GetCurrentUS() {
+  struct timeval time;
+  gettimeofday(&time, NULL);
+  return 1e+6 * time.tv_sec + time.tv_usec;
+}
+
+void RunModel(std::string model_dir,
+              const std::vector<shape_t>& input_shapes,
+              size_t repeats,
+              size_t warmup,
+              size_t print_output_elem,
+              size_t power_mode) {
+  // 1. Set MobileConfig
+  HeapProfilerStart("MobilenetV1Mem");
   MobileConfig config;
-  config.set_model_from_file(model_name);
-  // 2. Create PaddlePredictor by CxxConfig
-  std::shared_ptr<PaddlePredictor> predictor =
-      CreatePaddlePredictor<MobileConfig>(config);
+  config.set_model_from_file(model_dir);
+  config.set_power_mode(static_cast<paddle::lite_api::PowerMode>(power_mode));
+  for (int i = 0; i < 100; i++) {
+    std::shared_ptr<PaddlePredictor> predictor =
+        CreatePaddlePredictor<MobileConfig>(config);
+  }
+  sleep(20);
+  HeapProfilerDump("initial");
 
-  // 3. Prepare input data
-  std::unique_ptr<Tensor> input_tensor(std::move(predictor->GetInput(0)));
-  input_tensor->Resize({1, 3, 224, 224});
-  auto* data = input_tensor->mutable_data<float>();
-  for (int i = 0; i < ShapeProduction(input_tensor->shape()); ++i) {
-    data[i] = 1;
+  std::cout << "warmup done\n";
+
+  int i = 1000;
+  while (i > 0) {
+    // 2. Create PaddlePredictor by MobileConfig
+    std::shared_ptr<PaddlePredictor> predictor =
+        CreatePaddlePredictor<MobileConfig>(config);
+    i--;
   }
 
-  // 4. Run predictor
-  predictor->Run();
-
-  // 5. Get output
-  std::unique_ptr<const Tensor> output_tensor(
-      std::move(predictor->GetOutput(0)));
-  std::cout << "Output shape " << output_tensor->shape()[1] << std::endl;
-  for (int i = 0; i < ShapeProduction(output_tensor->shape()); i += 100) {
-    std::cout << "Output[" << i << "]: " << output_tensor->data<float>()[i]
-              << std::endl;
-  }
+  sleep(20);
+  HeapProfilerDump("result");
+  HeapProfilerStop();
+  std::cout << "Create 1000 times done\n";
+  std::cin >> name;
 }
 
 int main(int argc, char** argv) {
-  if (argc < 2) {
-    std::cerr << "[ERROR] usage: ./" << argv[0] << " naive_buffer_model_dir\n";
-    exit(1);
+  std::vector<std::string> str_input_shapes;
+  std::vector<shape_t> input_shapes{{1, 3, 224, 224}};
+
+  int repeats = 10;
+  int warmup = 10;
+  int print_output_elem = 0;
+
+  if (argc > 2 && argc < 6) {
+    std::cerr << "usage: ./" << argv[0] << "\n"
+              << "  <naive_buffer_model_dir>\n"
+              << "  <raw_input_shapes>, eg: 1,3,224,224 for 1 input; "
+                 "1,3,224,224:1,5 for 2 inputs\n"
+              << "  <repeats>\n"
+              << "  <warmup>\n"
+              << "  <print_output>" << std::endl;
+    return 0;
   }
+
   std::string model_dir = argv[1];
-  RunModel(model_dir);
+  if (argc >= 6) {
+    input_shapes.clear();
+    std::string raw_input_shapes = argv[2];
+    std::cout << "raw_input_shapes: " << raw_input_shapes << std::endl;
+    str_input_shapes = split_string(raw_input_shapes);
+    for (size_t i = 0; i < str_input_shapes.size(); ++i) {
+      std::cout << "input shape: " << str_input_shapes[i] << std::endl;
+      input_shapes.push_back(get_shape(str_input_shapes[i]));
+    }
+
+    repeats = atoi(argv[3]);
+    warmup = atoi(argv[4]);
+    print_output_elem = atoi(argv[5]);
+  }
+  // set arm power mode:
+  // 0 for big cluster, high performance
+  // 1 for little cluster
+  // 2 for all cores
+  // 3 for no bind
+  size_t power_mode = 0;
+
+  RunModel(
+      model_dir, input_shapes, repeats, warmup, print_output_elem, power_mode);
+
   return 0;
 }

--- a/lite/demo/cxx/x86_mobilenetv1_light_demo/test.sh
+++ b/lite/demo/cxx/x86_mobilenetv1_light_demo/test.sh
@@ -1,0 +1,2 @@
+chmod +x mobilenet_light_api
+./mobilenet_light_api ./mobilenetv1.nb


### PR DESCRIPTION
(1) 使用`gperftool`测试的方法
- 源码安装 gperftool
```
apt-get install graphviz
pip install autoconf automake libtool

wget https://github.com/gperftools/gperftools/releases/download/gperftools-2.8/gperftools-2.8.tar.gz
tar zxf gperftools-2.8.tar.gz
cd gperftools-2.8
./configure
make
make install
```

- 编译Paddle-Lite
```
./lite/tools/build.sh --build_extra=ON x86
```

- 运行demo
[mobilenet_v1](https://paddlelite-data.bj.bcebos.com/doc_models/mobilenet_v1.tar.gz)、转化后的[mobilenetv1.nb](https://paddlelite-data.bj.bcebos.com/tmp/2.7_test/mobilenetv1.nb)
``` shell
# 编译demo
cd build.lite.x86/inference_lite_lib/demo/cxx/mobilenetv1_light
sh build.sh
# 将模型mobilenetv1.nb拷贝到mobilenetv1_light文件夹下
# 运行demo
sh test.sh
```

- 将gperftool(最后一个heap文件）结果转化为pdf 
```
pprof  -pdf mobilenet_light_api  MobilenetV1Mem.****.heap > result.pdf
```

- 结果示例：
![image](https://user-images.githubusercontent.com/45189361/98770666-b7215a80-241d-11eb-8a62-7d1f0d3cd48b.png)
  **删除exec_scope结构后的内存图**
![image](https://user-images.githubusercontent.com/45189361/98769671-66106700-241b-11eb-832a-a8ea190695f9.png)

(2) 不使用gperftool的测试方法
- `mobilenet_light_api.cc` demo中去除 gperftool相关代码
- `mobilenet_light_api.cc`  修改使`warmup` 100次后，代码停顿一段时间。
- 执行单测、warmup100次程序进入停顿时、 使用 `sh mem_rec.sh` 记录当前内存到 txt文档中
- 继续执行，当提示1000次执行完毕后、使用`sh mem_rec.sh` 追加当前内存记录到txt文件中
- 笔记前后内存差距可以得出结论、内存是否有泄漏