### PR TITLE
fix the memory leak of scope, test=develop

### DIFF
--- a/lite/core/scope.cc
+++ b/lite/core/scope.cc
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 #include "lite/core/scope.h"
-#define SCOPE_KIDS_READER_LOCK lite::fluid::AutoRDLock auto_lock(kids_lock_);
-#define SCOPE_KIDS_WRITER_LOCK lite::fluid::AutoWRLock auto_lock(kids_lock_);
-#define SCOPE_VARS_READER_LOCK lite::fluid::AutoRDLock auto_lock(vars_lock_);
-#define SCOPE_VARS_WRITER_LOCK lite::fluid::AutoWRLock auto_lock(vars_lock_);
+#define SCOPE_KIDS_READER_LOCK \
+  lite::fluid::AutoRDLock auto_lock(kids_lock_.get());
+#define SCOPE_KIDS_WRITER_LOCK \
+  lite::fluid::AutoWRLock auto_lock(kids_lock_.get());
+#define SCOPE_VARS_READER_LOCK \
+  lite::fluid::AutoRDLock auto_lock(vars_lock_.get());
+#define SCOPE_VARS_WRITER_LOCK \
+  lite::fluid::AutoWRLock auto_lock(vars_lock_.get());
 
 namespace paddle {
 namespace lite {

--- a/lite/core/scope.h
+++ b/lite/core/scope.h
@@ -27,11 +27,10 @@ namespace lite {
 
 class Scope final {
  public:
-  Scope() {
-    kids_lock_ = new lite::fluid::RWLock;
-    vars_lock_ = new lite::fluid::RWLock;
-    rwlock_.reset(new lite::fluid::RWLock);
-  }
+  Scope()
+      : kids_lock_{new lite::fluid::RWLock},
+        vars_lock_{new lite::fluid::RWLock},
+        rwlock_{new lite::fluid::RWLock} {}
   // delete below two functions to allow pybind to recognise it cannot make a
   // copy
   // link:
@@ -99,8 +98,8 @@ class Scope final {
   mutable std::list<Scope*> kids_;
   const Scope* parent_{nullptr};
   std::map<std::string, std::unique_ptr<Variable>> vars_;
-  lite::fluid::RWLock* kids_lock_{nullptr};
-  lite::fluid::RWLock* vars_lock_{nullptr};
+  std::unique_ptr<lite::fluid::RWLock> kids_lock_{nullptr};
+  std::unique_ptr<lite::fluid::RWLock> vars_lock_{nullptr};
   std::unique_ptr<lite::fluid::RWLock> rwlock_{nullptr};
 };
 


### PR DESCRIPTION
在 Scope 中使用智能指针以避免重复构造析构过程中发生的内存泄漏。