### PR TITLE
add exception detail when fatal throw exception

### DIFF
--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -259,7 +259,7 @@ class Voidify {
 class VoidifyFatal : public Voidify {
  public:
 #ifdef LITE_WITH_EXCEPTION
-  ~VoidifyFatal() noexcept(false) { throw PaddleLiteException("VoidifyFatal"); }
+  ~VoidifyFatal() noexcept(false) { throw std::exception(); }
 #else
   ~VoidifyFatal() { assert(false); }
 #endif

--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -122,10 +122,7 @@ struct PaddleLiteException : public std::exception {
   const std::string exception_prefix = "Paddle-Lite C++ Exception: \n";
   std::string message;
   PaddleLiteException(const char* detail) {
-    char buffer[1500];
-    snprintf(
-        buffer, sizeof(buffer), "%s%s\n", exception_prefix.c_str(), detail);
-    message = std::string(buffer);
+    message = exception_prefix + std::string(detail);
   }
   const char* what() const noexcept { return message.c_str(); }
 };


### PR DESCRIPTION
开LOG && 开异常的时候, 带上log的信息.

本想在LOG关闭时也可以知道异常在那个文件哪个函数抛出的.  考虑拼LOG影响性能,暂时去掉.