### PR TITLE
[cherry-pick][API] make `is_model_from_memory` api compatible

### DIFF
--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -317,6 +317,10 @@ class LITE_API MobileConfig : public ConfigBase {
   // return model_from_memory_, which indicates whether to load model from
   // memory buffer.
   bool is_model_from_memory() const { return model_from_memory_; }
+  // note: `model_from_memory` has the same effect as `is_model_from_memory`,
+  // but is_model_from_memory is recommended and `model_from_memory` will be
+  // abandoned in v3.0.
+  bool model_from_memory() const { return model_from_memory_; }
 
   // NOTE: This is a deprecated API and will be removed in latter release.
   void set_model_buffer(const char* model_buffer,


### PR DESCRIPTION
[Issue] `model_from_memory` is named with `is_model_from_memory` since `v2.7.0`. To ensure the compatibility of apis, we registered `model_from_memory` again.