### PR TITLE
[CHERRY_PICK] [UTILS] add exception detail when fatal 

### DIFF
--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -121,7 +121,7 @@ namespace lite {
 struct PaddleLiteException : public std::exception {
   const std::string exception_prefix = "Paddle-Lite C++ Exception: \n";
   std::string message;
-  PaddleLiteException(const char* detail) {
+  explicit PaddleLiteException(const char* detail) {
     message = exception_prefix + std::string(detail);
   }
   const char* what() const noexcept { return message.c_str(); }

--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -117,6 +117,17 @@ static int gettimeofday(struct timeval* tp, void* tzp) {
 namespace paddle {
 namespace lite {
 
+#ifdef LITE_WITH_EXCEPTION
+struct PaddleLiteException : public std::exception {
+  const std::string exception_prefix = "Paddle-Lite C++ Exception: \n";
+  std::string message;
+  PaddleLiteException(const char* detail) {
+    message = exception_prefix + std::string(detail);
+  }
+  const char* what() const noexcept { return message.c_str(); }
+};
+#endif
+
 #ifdef LITE_WITH_LOG
 void gen_log(STL::ostream& log_stream_,
              const char* file,
@@ -184,7 +195,7 @@ class LogMessageFatal : public LogMessage {
     fprintf(stderr, "%s", log_stream_.str().c_str());
 
 #ifdef LITE_WITH_EXCEPTION
-    throw std::exception();
+    throw PaddleLiteException(log_stream_.str().c_str());
 #else
 #ifndef LITE_ON_TINY_PUBLISH
     abort();


### PR DESCRIPTION
开LOG && 开异常的时候, 带上log的信息.

本想RELEASE包因为check挂的时候可以通过异常解析到是哪里check fail了.
考虑拼LOG影响性能,暂时去掉. 目前只有在开log情况下有信息