### PR TITLE
add precision in io_copy

### DIFF
--- a/lite/operators/io_copy_op.cc
+++ b/lite/operators/io_copy_op.cc
@@ -27,6 +27,8 @@ bool IoCopyOp::CheckShape() const {
 bool IoCopyOp::InferShapeImpl() const {
   param_.y->Resize(param_.x->dims());
   param_.y->set_lod(param_.x->lod());
+  param_.y->set_precision(param_.x->precision());
+  param_.y->set_persistable(param_.x->persistable());
   return true;
 }
 bool IoCopyOp::Run() { return OpLite::Run(); }


### PR DESCRIPTION
- io_copy的kernel一般只进行内存的拷贝，因此会丢失precision和persistable的信息