### PR TITLE
[cherry-pick][opencl] Refine opencl tune. test=develop

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -262,7 +262,7 @@ ConfigBase::ConfigBase(PowerMode mode, int threads) {
 #endif
 }
 
-void ConfigBase::set_opencl_tune(bool enable_tune) {
+void ConfigBase::set_opencl_tune(size_t enable_tune) {
 #ifdef LITE_WITH_OPENCL
   if (paddle::lite_api::IsOpenCLBackendValid()) {
     enable_opencl_tune_ = enable_tune;

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -140,7 +140,7 @@ class LITE_API ConfigBase {
   int threads_{1};
   PowerMode mode_{LITE_POWER_NO_BIND};
   // gpu
-  bool enable_opencl_tune_{false};
+  size_t enable_opencl_tune_{0};
   // to save subgraph model for npu/xpu/...
   std::string subgraph_model_cache_dir_{""};
   int device_id_{0};
@@ -157,8 +157,8 @@ class LITE_API ConfigBase {
   void set_power_mode(PowerMode mode);
   PowerMode power_mode() const { return mode_; }
   // set GPU opencl tune
-  void set_opencl_tune(bool enable_tune);
-  bool opencl_tune() const { return enable_opencl_tune_; }
+  void set_opencl_tune(size_t enable_tune);
+  size_t opencl_tune() const { return enable_opencl_tune_; }
   // set subgraph_model_dir
   void set_subgraph_model_cache_dir(std::string subgraph_model_cache_dir) {
     subgraph_model_cache_dir_ = subgraph_model_cache_dir;

--- a/lite/backends/opencl/cl_context.h
+++ b/lite/backends/opencl/cl_context.h
@@ -58,21 +58,17 @@ class CLContext {
 
   cl::Kernel &GetKernel(const std::string &name);
 
-  cl::NDRange DefaultWorkSize(const CLImage &image);
+  cl::NDRange DefaultGlobalWorkSize(const CLImage &image);
 
-  cl::NDRange LocalWorkSize(cl::NDRange global_work_size, size_t max_work_size);
+  cl::NDRange DefaultLocalWorkSize(cl::NDRange global_work_size,
+                                   size_t max_work_size,
+                                   int divitor = 2,
+                                   bool tune_reverse = false,
+                                   size_t user_defined_max_work_size = 0);
 
-  cl::NDRange LocalWorkSizeTune(cl::NDRange global_work_size,
-                                size_t max_work_size,
-                                int divitor = 2);
-
-  cl::NDRange LocalWorkSizeTuneReverse(cl::NDRange global_work_size,
-                                       size_t max_work_size,
-                                       int divitor = 2);
-
+  std::vector<cl::NDRange> GenerateLocalWorkSizes(cl::NDRange global_work_size,
+                                                  size_t max_work_size);
   bool IsArmMali();
-  //  cl::NDRange LocalWorkSizeConv1x1(cl::NDRange global_work_size,
-  //                                   size_t max_work_size);
 
  private:
   std::map<std::string, std::unique_ptr<cl::Program>> programs_;

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -89,7 +89,10 @@ class CLRuntime {
     return is_device_avaliable_for_opencl_;
   }
 
-  void set_auto_tune(bool enable_tune) { auto_tune_ = enable_tune; }
+  void set_auto_tune(size_t enable_tune) {
+    auto_tune_ = enable_tune;
+    command_queue_ = CreateCommandQueue(context());
+  }
 
   bool auto_tune() { return auto_tune_; }
 
@@ -169,6 +172,10 @@ class CLRuntime {
 #ifdef LITE_WITH_PROFILE
     properties |= CL_QUEUE_PROFILING_ENABLE;
 #endif  // LITE_WITH_PROFILE
+    if (auto_tune_ > 0) {
+      properties |= CL_QUEUE_PROFILING_ENABLE;
+    }
+
     auto queue = std::make_shared<cl::CommandQueue>(
         context, device(), properties, &status_);
     // use in is opencl valid check, do not exit here when release.
@@ -200,7 +207,7 @@ class CLRuntime {
 
   bool is_platform_device_init_success_{false};
 
-  bool auto_tune_{false};
+  size_t auto_tune_{0};  // 0 - None, 1 - Rapid, 2 - Normal, 3 - Exhaustive
 };
 
 }  // namespace lite

--- a/lite/backends/opencl/cl_utility.h
+++ b/lite/backends/opencl/cl_utility.h
@@ -59,17 +59,10 @@ const char* opencl_error_to_str(cl_int error);
 #define CL_CHECK_FATAL(err_code__)
 #endif
 
-#ifdef LITE_WITH_PROFILE
 #define EnqueueNDRangeKernel(                                      \
     context, kernel, gws_offset, gws, lws, event_wait_list, event) \
   context.cl_context()->GetCommandQueue().enqueueNDRangeKernel(    \
       kernel, gws_offset, gws, lws, event_wait_list, &event)
-#else
-#define EnqueueNDRangeKernel(                                      \
-    context, kernel, gws_offset, gws, lws, event_wait_list, event) \
-  context.cl_context()->GetCommandQueue().enqueueNDRangeKernel(    \
-      kernel, gws_offset, gws, lws, event_wait_list, nullptr)
-#endif
 
 }  // namespace lite
 }  // namespace paddle

--- a/lite/core/kernel.h
+++ b/lite/core/kernel.h
@@ -209,9 +209,9 @@ class KernelBase {
   int profile_id_{-1};
   bool is_first_epoch_for_profiler_{true};
   bool is_kernel_test_{true};
+#endif
 #ifdef LITE_WITH_OPENCL
   cl::Event event_;
-#endif
 #endif
 };
 

--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -138,7 +138,8 @@ void RunModel(std::string model_dir,
   if (is_opencl_backend_valid) {
     // give opencl nb model dir
     config.set_model_from_file(model_dir);
-    config.set_opencl_tune(false); // default is false
+    // opencl tune option: 0 - None, 1 - Rapid, 2 - Normal, 3 - Exhaustive
+    config.set_opencl_tune(0);
   } else {
     std::cout << "Unsupport opencl nb model." << std::endl;
     exit(1);

--- a/lite/kernels/opencl/bilinear_interp_image_compute.cc
+++ b/lite/kernels/opencl/bilinear_interp_image_compute.cc
@@ -113,11 +113,11 @@ class BilinearInterpImageCompute
     auto kernel = context.cl_context()->GetKernel(kernel_key.str());
 
     int arg_idx = 0;
-    auto default_work_size =
-        DefaultWorkSize(out_dims,
-                        DDim(std::vector<DDim::value_type>{
-                            static_cast<int64_t>(out_image_shape["width"]),
-                            static_cast<int64_t>(out_image_shape["height"])}));
+    auto default_work_size = DefaultGlobalWorkSize(
+        out_dims,
+        DDim(std::vector<DDim::value_type>{
+            static_cast<int64_t>(out_image_shape["width"]),
+            static_cast<int64_t>(out_image_shape["height"])}));
 #ifdef LITE_WITH_LOG
     VLOG(4) << "default_work_size: " << default_work_size[0] << ", "
             << default_work_size[1] << ", " << default_work_size[2];

--- a/lite/kernels/opencl/box_coder_image_compute.cc
+++ b/lite/kernels/opencl/box_coder_image_compute.cc
@@ -89,11 +89,11 @@ class BoxCoderComputeImage : public KernelLite<TARGET(kOpenCL),
       kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
       auto kernel = context.cl_context()->GetKernel(kernel_key.str());
 
-      auto default_work_size =
-          DefaultWorkSize(out_dims,
-                          DDim(std::vector<DDim::value_type>{
-                              static_cast<int64_t>(image_shape["width"]),
-                              static_cast<int64_t>(image_shape["height"])}));
+      auto default_work_size = DefaultGlobalWorkSize(
+          out_dims,
+          DDim(std::vector<DDim::value_type>{
+              static_cast<int64_t>(image_shape["width"]),
+              static_cast<int64_t>(image_shape["height"])}));
 
       int out_C = new_dims[1];
       int out_H = new_dims[2];

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -222,7 +222,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       int output_tensor_c = output_tensor_dims[1];
       int output_tensor_w = output_tensor_dims[3];
 
-      const std::vector<size_t>& default_work_size = DefaultWorkSize(
+      const std::vector<size_t>& default_work_size = DefaultGlobalWorkSize(
           output_tensor_dims,
           DDim(std::vector<DDim::value_type>{
               static_cast<int64_t>(output_image_shape["width"]),

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -34,15 +34,6 @@ void ConvImageCompute::PrepareForRun() {
 
   auto& context = ctx_->As<OpenCLContext>();
   CHECK(context.cl_context() != nullptr);
-  const bool is_mali = context.cl_context()->IsArmMali();
-
-  use_tune_ = CLRuntime::Global()->auto_tune();
-  if (!is_mali) {
-    use_tune_ = false;
-  }
-#ifdef LITE_WITH_LOG
-  LOG(INFO) << "use_tune_" << use_tune_;
-#endif
 
   auto filter_dims = conv_param_->filter->dims();
   filter_tensor_n_ = filter_dims[0];
@@ -74,7 +65,6 @@ void ConvImageCompute::PrepareForRun() {
   bool dilation_equal = dilation_h_ == dilation_w_;
 
 #ifdef LITE_WITH_LOG
-  VLOG(3) << "Is arm mali  / " << (is_mali ? "Yes" : "No");
   VLOG(3) << "Is relu fused? / " << (relu_fused_ ? "Yes" : "No");
   VLOG(3) << "groups:" << groups_ << " stride_h_:" << stride_h_
           << " stride_w_:" << stride_w_ << " pad_left_:" << pad_left_
@@ -323,7 +313,7 @@ void ConvImageCompute::PrepareForRun() {
                  << static_cast<int>(conv_param_->activation_param.active_type);
     }
   }
-  GetGlobalWorkSize();
+  SetGlobalWorkSize();
 
   // bias options
   const bool is_element_wise_bias =
@@ -378,79 +368,55 @@ void ConvImageCompute::PrepareForRun() {
   VLOG(4) << "global_work_size_[3D]: {" << global_work_size_[0] << ","
           << global_work_size_[1] << "," << global_work_size_[2] << "}";
 
+  SetLocalWorkSize();
+}
+
+void ConvImageCompute::SetLocalWorkSize(size_t repeats /*=4*/) {
+  auto& context = ctx_->As<OpenCLContext>();
   std::stringstream kernel_key;
   kernel_key << kernel_func_names_[0] << build_options_[0] << time_stamp_;
   kernel_ = context.cl_context()->GetKernel(kernel_key.str());
   VLOG(4) << "kernel_key: " << kernel_key.str();
   VLOG(4) << "kernel ready ... " << kernel_key.str();
+
   size_t max_work_group_size = 0;
   kernel_.getWorkGroupInfo<size_t>(CLRuntime::Global()->device(),
                                    CL_KERNEL_WORK_GROUP_SIZE,
                                    &max_work_group_size);
-
   VLOG(4) << "max_work_group_size: " << max_work_group_size;
-
-  if (max_work_group_size > 0 && use_lws_) {
-    double min_tune_time = DBL_MAX;
-    cl::NDRange best_local_work_size = context.cl_context()->LocalWorkSize(
-        global_work_size_, max_work_group_size);
-    VLOG(3) << "origin  :local_work_size_ : " << best_local_work_size[0] << " "
-            << best_local_work_size[1] << " " << best_local_work_size[2];
-    cl::NDRange last_local_work_size = cl::NDRange{
-        static_cast<size_t>(0), static_cast<size_t>(0), static_cast<size_t>(0)};
-    if (use_tune_) {
-      for (size_t i = 1; i < 15; i++) {
-        if (filter_tensor_h_ == 1 && filter_tensor_w_ == 1) {
-          // todo use diff logics
-          local_work_size_ = context.cl_context()->LocalWorkSizeTune(
-              global_work_size_, max_work_group_size, i);
-        } else {
-          local_work_size_ = context.cl_context()->LocalWorkSizeTune(
-              global_work_size_, max_work_group_size, i);
-        }
-        if (last_local_work_size[0] == local_work_size_[0] &&
-            last_local_work_size[1] == local_work_size_[1] &&
-            last_local_work_size[2] == local_work_size_[2]) {
-          // skiped tuneed lws
-          continue;
-        }
-        auto tune_time = this->Tune(10);
-        if (min_tune_time > tune_time) {
-          min_tune_time = tune_time;
-          best_local_work_size = local_work_size_;
-        }
-        last_local_work_size = local_work_size_;
-      }
-      // reverse
-      for (size_t i = 1; i < 15; i++) {
-        if (filter_tensor_h_ == 1 && filter_tensor_w_ == 1) {
-          // todo use diff logics
-          local_work_size_ = context.cl_context()->LocalWorkSizeTuneReverse(
-              global_work_size_, max_work_group_size, i);
-        } else {
-          local_work_size_ = context.cl_context()->LocalWorkSizeTuneReverse(
-              global_work_size_, max_work_group_size, i);
-        }
-        if (last_local_work_size[0] == local_work_size_[0] &&
-            last_local_work_size[1] == local_work_size_[1] &&
-            last_local_work_size[2] == local_work_size_[2]) {
-          // skiped tuneed lws
-          continue;
-        }
-        auto tune_time = this->Tune(10);
-        if (min_tune_time > tune_time) {
-          min_tune_time = tune_time;
-          best_local_work_size = local_work_size_;
-        }
-        last_local_work_size = local_work_size_;
-      }
+  std::vector<cl::NDRange> lwss = context.cl_context()->GenerateLocalWorkSizes(
+      global_work_size_, max_work_group_size);
+  CHECK(lwss.size() > 0) << "Possible local work sizes should bigger than zero";
+  local_work_size_ = lwss[0];
+  VLOG(1) << "local_work_size:" << static_cast<int>(local_work_size_[0]) << ","
+          << static_cast<int>(local_work_size_[1]) << ","
+          << static_cast<int>(local_work_size_[2]) << ",";
+  if (max_work_group_size <= 0 || !use_lws_ ||
+      CLRuntime::Global()->auto_tune() <= 0) {
+    if (!use_lws_) {
+      local_work_size_ = cl::NullRange;
     }
-    local_work_size_ = best_local_work_size;
-    VLOG(3) << "chossen :local_work_size_ : " << local_work_size_[0] << " "
-            << local_work_size_[1] << " " << local_work_size_[2];
-    VLOG(4) << "local_work_size_[3D]: {" << local_work_size_[0] << ","
-            << local_work_size_[1] << "," << local_work_size_[2] << "}";
+    return;
   }
+
+  double min_lws_time = DBL_MAX;
+  cl::NDRange min_lws = lwss[0];
+  for (size_t i = 0; i < lwss.size(); ++i) {
+    local_work_size_ = lwss[i];
+    double cur_lws_time = 0.0f;
+    for (size_t i = 0; i < repeats; ++i) {
+      Run();
+      cur_lws_time += CLRuntime::Global()->GetCommandTime(event_);
+    }
+    cur_lws_time /= repeats;
+    if (min_lws_time > cur_lws_time) {
+      min_lws = lwss[i];
+      min_lws_time = cur_lws_time;
+    }
+  }
+  local_work_size_ = min_lws;
+  VLOG(3) << "selected local_work_size_ : " << local_work_size_[0] << " "
+          << local_work_size_[1] << " " << local_work_size_[2];
 }
 
 void ConvImageCompute::ReInitWhenNeeded() {
@@ -504,11 +470,11 @@ void ConvImageCompute::ReInitWhenNeeded() {
     output_image_p_ = conv_param_->output->mutable_data<half_t, cl::Image2D>(
         output_image_w_, output_image_h_);
 
-    GetGlobalWorkSize();
+    SetGlobalWorkSize();
   }
 }
 
-void ConvImageCompute::GetGlobalWorkSize() {
+void ConvImageCompute::SetGlobalWorkSize() {
   if (kernel_func_names_.size() <= 0) return;
   // general input_c_block
   input_c_block_ = static_cast<int>(input_image_w_ / input_tensor_w_);
@@ -516,10 +482,10 @@ void ConvImageCompute::GetGlobalWorkSize() {
   // general gws
   auto output_dims = conv_param_->output->dims();
   const std::vector<size_t>& default_work_size =
-      DefaultWorkSize(output_dims,
-                      DDim(std::vector<DDim::value_type>{
-                          static_cast<int64_t>(output_image_w_),
-                          static_cast<int64_t>(output_image_h_)}));
+      DefaultGlobalWorkSize(output_dims,
+                            DDim(std::vector<DDim::value_type>{
+                                static_cast<int64_t>(output_image_w_),
+                                static_cast<int64_t>(output_image_h_)}));
   default_c_blk_ = default_work_size[0];
   default_w_blk_ = default_work_size[1];
   default_nh_blk_ = default_work_size[2];
@@ -617,12 +583,7 @@ void ConvImageCompute::GetGlobalWorkSize() {
   }
 }
 
-void ConvImageCompute::Conv2d1x1opt(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::Conv2d1x1opt() {
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -657,26 +618,10 @@ void ConvImageCompute::Conv2d1x1opt(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(16, default_w_blk_);
   CL_CHECK_FATAL(status_);
-
-  status_ = EnqueueNDRangeKernel(context,
-                                 kernel_,
-                                 cl::NullRange,
-                                 global_work_size_,
-                                 local_work_size_,
-                                 nullptr,
-                                 event_);
-  CL_CHECK_FATAL(status_);
-  if (enable_tune) {
-    CLRuntime::Global()->command_queue().finish();
-  }
 }
 
-void ConvImageCompute::Conv2d3x3(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::Conv2d3x3() {
+  use_lws_ = false;
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -719,23 +664,9 @@ void ConvImageCompute::Conv2d3x3(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(20, input_tensor_c_);
   CL_CHECK_FATAL(status_);
-
-  status_ = EnqueueNDRangeKernel(context,
-                                 kernel_,
-                                 cl::NullRange,
-                                 global_work_size_,
-                                 cl::NullRange,
-                                 nullptr,
-                                 event_);
-  CL_CHECK_FATAL(status_);
 }
 
-void ConvImageCompute::Conv2d3x3opt(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::Conv2d3x3opt() {
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -768,32 +699,10 @@ void ConvImageCompute::Conv2d3x3opt(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(15, output_tensor_h_);
   CL_CHECK_FATAL(status_);
-
-#ifdef LITE_WITH_LOG
-  //  VLOG(4) << "out_image: " << out_image;
-  VLOG(4) << "global_work_size_[3D]: {" << global_work_size_[0] << ","
-          << global_work_size_[1] << "," << global_work_size_[2] << "}";
-#endif
-
-  status_ = EnqueueNDRangeKernel(context,
-                                 kernel_,
-                                 cl::NullRange,
-                                 global_work_size_,
-                                 local_work_size_,
-                                 nullptr,
-                                 event_);
-  CL_CHECK_FATAL(status_);
-  if (enable_tune) {
-    CLRuntime::Global()->command_queue().finish();
-  }
 }
 
-void ConvImageCompute::Conv2d5x5(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::Conv2d5x5() {
+  use_lws_ = false;
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -824,26 +733,9 @@ void ConvImageCompute::Conv2d5x5(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(14, output_tensor_h_);
   CL_CHECK_FATAL(status_);
-
-  status_ = EnqueueNDRangeKernel(context,
-                                 kernel_,
-                                 cl::NullRange,
-                                 global_work_size_,
-                                 cl::NullRange,
-                                 nullptr,
-                                 event_);
-  CL_CHECK_FATAL(status_);
-  if (enable_tune) {
-    CLRuntime::Global()->command_queue().finish();
-  }
 }
 
-void ConvImageCompute::Conv2d5x5opt(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::Conv2d5x5opt() {
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -876,26 +768,10 @@ void ConvImageCompute::Conv2d5x5opt(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(15, output_tensor_h_);
   CL_CHECK_FATAL(status_);
-
-  status_ = EnqueueNDRangeKernel(context,
-                                 kernel_,
-                                 cl::NullRange,
-                                 global_work_size_,
-                                 local_work_size_,
-                                 nullptr,
-                                 event_);
-  CL_CHECK_FATAL(status_);
-  if (enable_tune) {
-    CLRuntime::Global()->command_queue().finish();
-  }
 }
 
-void ConvImageCompute::Conv2d7x7(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::Conv2d7x7() {
+  use_lws_ = false;
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -926,26 +802,9 @@ void ConvImageCompute::Conv2d7x7(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(13, output_tensor_h_);
   CL_CHECK_FATAL(status_);
-
-  status_ = EnqueueNDRangeKernel(context,
-                                 kernel_,
-                                 cl::NullRange,
-                                 global_work_size_,
-                                 cl::NullRange,
-                                 nullptr,
-                                 event_);
-  CL_CHECK_FATAL(status_);
-  if (enable_tune) {
-    CLRuntime::Global()->command_queue().finish();
-  }
 }
 
-void ConvImageCompute::Conv2d7x7opt(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::Conv2d7x7opt() {
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -978,27 +837,9 @@ void ConvImageCompute::Conv2d7x7opt(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(15, output_tensor_h_);
   CL_CHECK_FATAL(status_);
-
-  status_ = EnqueueNDRangeKernel(context,
-                                 kernel_,
-                                 cl::NullRange,
-                                 global_work_size_,
-                                 local_work_size_,
-                                 nullptr,
-                                 event_);
-  CL_CHECK_FATAL(status_);
-
-  if (enable_tune) {
-    CLRuntime::Global()->command_queue().finish();
-  }
 }
 
-void ConvImageCompute::DepthwiseConv2d3x3s1(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::DepthwiseConv2d3x3s1() {
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -1029,27 +870,10 @@ void ConvImageCompute::DepthwiseConv2d3x3s1(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(14, output_tensor_h_);
   CL_CHECK_FATAL(status_);
-
-  status_ = EnqueueNDRangeKernel(context,
-                                 kernel_,
-                                 cl::NullRange,
-                                 global_work_size_,
-                                 local_work_size_,
-                                 nullptr,
-                                 event_);
-  CL_CHECK_FATAL(status_);
-
-  if (enable_tune) {
-    CLRuntime::Global()->command_queue().finish();
-  }
 }
 
-void ConvImageCompute::DepthwiseConv2d3x3(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::DepthwiseConv2d3x3() {
+  use_lws_ = false;
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -1080,27 +904,10 @@ void ConvImageCompute::DepthwiseConv2d3x3(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(14, output_tensor_h_);
   CL_CHECK_FATAL(status_);
-
-  status_ = EnqueueNDRangeKernel(context,
-                                 kernel_,
-                                 cl::NullRange,
-                                 global_work_size_,
-                                 cl::NullRange,
-                                 nullptr,
-                                 event_);
-  CL_CHECK_FATAL(status_);
-
-  if (enable_tune) {
-    CLRuntime::Global()->command_queue().finish();
-  }
 }
 
-void ConvImageCompute::DepthwiseConv2d(bool enable_tune) {
-#ifdef LITE_WITH_LOG
-  PrintConvInfo();
-#endif
-  auto& context = ctx_->As<OpenCLContext>();
-
+void ConvImageCompute::DepthwiseConv2d() {
+  use_lws_ = false;
   status_ = kernel_.setArg(0, c_blk_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(1, w_blk_);
@@ -1135,22 +942,25 @@ void ConvImageCompute::DepthwiseConv2d(bool enable_tune) {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(16, filter_tensor_h_);
   CL_CHECK_FATAL(status_);
+}
 
+void ConvImageCompute::Run() {
+#ifdef LITE_WITH_LOG
+  PrintConvInfo();
+#endif
+  // setArg
+  (this->*impl_)();
+
+  auto& context = ctx_->As<OpenCLContext>();
   status_ = EnqueueNDRangeKernel(context,
                                  kernel_,
                                  cl::NullRange,
                                  global_work_size_,
-                                 cl::NullRange,
+                                 local_work_size_,
                                  nullptr,
                                  event_);
   CL_CHECK_FATAL(status_);
-
-  if (enable_tune) {
-    CLRuntime::Global()->command_queue().finish();
-  }
 }
-
-void ConvImageCompute::Run() { (this->*impl_)(false); }
 
 void ConvImageCompute::PrintConvInfo() {
   const bool is_element_wise_bias =
@@ -1177,10 +987,10 @@ void ConvImageCompute::PrintConvInfo() {
   LOG(INFO) << "================================";
   LOG(INFO) << "c_blk_=" << c_blk_ << ", w_blk_=" << w_blk_
             << ",nh_blk_=" << nh_blk_;
-  LOG(INFO) << "input_image_p_:" << input_image_p_;
-  LOG(INFO) << "filter_image_p_:" << filter_image_p_;
-  LOG(INFO) << "bias_image_p_:" << bias_image_p_;
-  LOG(INFO) << "output_image_p_:" << output_image_p_;
+  //  LOG(INFO) << "input_image_p_:" << input_image_p_;
+  //  LOG(INFO) << "filter_image_p_:" << filter_image_p_;
+  //  LOG(INFO) << "bias_image_p_:" << bias_image_p_;
+  //  LOG(INFO) << "output_image_p_:" << output_image_p_;
 
   LOG(INFO) << "stride_h_:" << stride_h_;
   LOG(INFO) << "stride_w_:" << stride_w_;
@@ -1222,20 +1032,6 @@ void ConvImageCompute::PrintConvInfo() {
 
   LOG(INFO) << "bias_image_h_" << bias_image_h_;
   LOG(INFO) << "bias_image_w_" << bias_image_w_;
-}
-
-double ConvImageCompute::Tune(int times) {
-  auto GetCurrentUS = []() -> double {
-    struct timeval time;
-    gettimeofday(&time, NULL);
-    return 1e+6 * time.tv_sec + time.tv_usec;
-  };
-  auto start = GetCurrentUS();
-  for (size_t i = 0; i < times; i++) {
-    (this->*impl_)(true);
-  }
-  auto time_diff = (GetCurrentUS() - start) / times;
-  return time_diff;
 }
 
 }  // namespace opencl

--- a/lite/kernels/opencl/conv_image_compute.h
+++ b/lite/kernels/opencl/conv_image_compute.h
@@ -39,15 +39,11 @@ class ConvImageCompute : public KernelLite<TARGET(kOpenCL),
                                            DATALAYOUT(kImageDefault)> {
  public:
   using param_t = operators::ConvParam;
-  using kernel_t = void (ConvImageCompute::*)(bool);
+  using kernel_t = void (ConvImageCompute::*)();
 
   void PrepareForRun() override;
-
   void ReInitWhenNeeded() override;
-
   void Run() override;
-
-  double Tune(int times = 5);
 
 #ifdef LITE_WITH_PROFILE
   void SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
@@ -61,17 +57,18 @@ class ConvImageCompute : public KernelLite<TARGET(kOpenCL),
 
  private:
   void PrintConvInfo();
-  void GetGlobalWorkSize();
-  void Conv2d1x1opt(bool enable_tune = false);
-  void Conv2d3x3(bool enable_tune = false);
-  void Conv2d3x3opt(bool enable_tune = false);
-  void Conv2d5x5(bool enable_tune = false);
-  void Conv2d5x5opt(bool enable_tune = false);
-  void Conv2d7x7(bool enable_tune = false);
-  void Conv2d7x7opt(bool enable_tune = false);
-  void DepthwiseConv2d3x3s1(bool enable_tune = false);
-  void DepthwiseConv2d3x3(bool enable_tune = false);
-  void DepthwiseConv2d(bool enable_tune = false);
+  void SetGlobalWorkSize();
+  void SetLocalWorkSize(size_t repeats = 4);
+  void Conv2d1x1opt();
+  void Conv2d3x3();
+  void Conv2d3x3opt();
+  void Conv2d5x5();
+  void Conv2d5x5opt();
+  void Conv2d7x7();
+  void Conv2d7x7opt();
+  void DepthwiseConv2d3x3s1();
+  void DepthwiseConv2d3x3();
+  void DepthwiseConv2d();
 
   param_t* conv_param_{nullptr};
 
@@ -152,7 +149,6 @@ class ConvImageCompute : public KernelLite<TARGET(kOpenCL),
   cl::NDRange local_work_size_ = cl::NDRange{
       static_cast<size_t>(1), static_cast<size_t>(1), static_cast<size_t>(1)};
   bool use_lws_{true};
-  bool use_tune_{false};
 };
 
 }  // namespace opencl

--- a/lite/kernels/opencl/dropout_image_compute.cc
+++ b/lite/kernels/opencl/dropout_image_compute.cc
@@ -83,11 +83,11 @@ class DropoutComputeImage2D : public KernelLite<TARGET(kOpenCL),
     status = kernel.setArg(++arg_idx, dropout_prob);
     CL_CHECK_FATAL(status);
 
-    const std::vector<size_t>& default_work_size =
-        DefaultWorkSize(out_dims,
-                        DDim(std::vector<DDim::value_type>{
-                            static_cast<int64_t>(out_image_shape["width"]),
-                            static_cast<int64_t>(out_image_shape["height"])}));
+    const std::vector<size_t>& default_work_size = DefaultGlobalWorkSize(
+        out_dims,
+        DDim(std::vector<DDim::value_type>{
+            static_cast<int64_t>(out_image_shape["width"]),
+            static_cast<int64_t>(out_image_shape["height"])}));
     auto global_work_size =
         cl::NDRange{static_cast<cl::size_type>(default_work_size.data()[0]),
                     static_cast<cl::size_type>(default_work_size.data()[1]),

--- a/lite/kernels/opencl/grid_sampler_image_compute.cc
+++ b/lite/kernels/opencl/grid_sampler_image_compute.cc
@@ -76,10 +76,10 @@ class GridSamplerImageCompute : public KernelLite<TARGET(kOpenCL),
 
   void GetGlobalWorkSize() {
     auto default_work_size =
-        DefaultWorkSize(grid_param_->out->dims(),
-                        DDim(std::vector<DDim::value_type>{
-                            static_cast<int64_t>(out_img_shape_[0]),
-                            static_cast<int64_t>(out_img_shape_[1])}));
+        DefaultGlobalWorkSize(grid_param_->out->dims(),
+                              DDim(std::vector<DDim::value_type>{
+                                  static_cast<int64_t>(out_img_shape_[0]),
+                                  static_cast<int64_t>(out_img_shape_[1])}));
     global_work_size_ =
         cl::NDRange{static_cast<cl::size_type>(default_work_size[0]),
                     static_cast<cl::size_type>(default_work_size[1]),

--- a/lite/kernels/opencl/image_helper.h
+++ b/lite/kernels/opencl/image_helper.h
@@ -40,12 +40,13 @@ static std::map<std::string, size_t> InitImageDimInfoWith(
   size_t height = H * N;
   return std::map<std::string, size_t>({{"width", width}, {"height", height}});
 }
+
 inline static int maptofactor(int i, int factor) {
   return (i + factor - 1) / factor;
 }
 
-static std::vector<size_t> DefaultWorkSize(const DDim& image_dim,
-                                           const DDim& image_shape) {
+static std::vector<size_t> DefaultGlobalWorkSize(const DDim& image_dim,
+                                                 const DDim& image_shape) {
   // n c h w
   //  auto image_dim = image.dims();
   if (image_dim.size() == 4) {

--- a/lite/kernels/opencl/lrn_image_compute.cc
+++ b/lite/kernels/opencl/lrn_image_compute.cc
@@ -101,11 +101,11 @@ class LrnImageCompute : public KernelLite<TARGET(kOpenCL),
     int arg_idx = 0;
     int out_channel = out_dims[1];
     int out_width = out_dims[3];
-    auto default_work_size =
-        DefaultWorkSize(out_dims,
-                        DDim(std::vector<DDim::value_type>{
-                            static_cast<int64_t>(out_image_shape["width"]),
-                            static_cast<int64_t>(out_image_shape["height"])}));
+    auto default_work_size = DefaultGlobalWorkSize(
+        out_dims,
+        DDim(std::vector<DDim::value_type>{
+            static_cast<int64_t>(out_image_shape["width"]),
+            static_cast<int64_t>(out_image_shape["height"])}));
 #ifdef LITE_WITH_LOG
     VLOG(4) << "default_work_size: " << default_work_size[0] << ", "
             << default_work_size[1] << ", " << default_work_size[3];

--- a/lite/kernels/opencl/nearest_interp_image_compute.cc
+++ b/lite/kernels/opencl/nearest_interp_image_compute.cc
@@ -104,11 +104,11 @@ class NearestInterpComputeImageDefault
             << y_dims[1] << " " << y_dims[2] << " " << y_dims[3];
 #endif
 
-    const std::vector<size_t>& default_work_size =
-        DefaultWorkSize(y_dims,
-                        DDim(std::vector<DDim::value_type>{
-                            static_cast<int64_t>(out_image_shape["width"]),
-                            static_cast<int64_t>(out_image_shape["height"])}));
+    const std::vector<size_t>& default_work_size = DefaultGlobalWorkSize(
+        y_dims,
+        DDim(std::vector<DDim::value_type>{
+            static_cast<int64_t>(out_image_shape["width"]),
+            static_cast<int64_t>(out_image_shape["height"])}));
     auto global_work_size =
         cl::NDRange{static_cast<cl::size_type>(default_work_size.data()[0]),
                     static_cast<cl::size_type>(default_work_size.data()[1]),

--- a/lite/kernels/opencl/pad2d_image_compute.cc
+++ b/lite/kernels/opencl/pad2d_image_compute.cc
@@ -103,11 +103,11 @@ class Pad2dCompute : public KernelLite<TARGET(kOpenCL),
     auto kernel = context.cl_context()->GetKernel(kernel_key.str());
 
     int arg_idx = 0;
-    auto default_work_size =
-        DefaultWorkSize(out_dims,
-                        DDim(std::vector<DDim::value_type>{
-                            static_cast<int64_t>(out_image_shape["width"]),
-                            static_cast<int64_t>(out_image_shape["height"])}));
+    auto default_work_size = DefaultGlobalWorkSize(
+        out_dims,
+        DDim(std::vector<DDim::value_type>{
+            static_cast<int64_t>(out_image_shape["width"]),
+            static_cast<int64_t>(out_image_shape["height"])}));
 #ifdef LITE_WITH_LOG
     VLOG(4) << "default_work_size: " << default_work_size[0] << ", "
             << default_work_size[1] << ", " << default_work_size[2];

--- a/lite/kernels/opencl/reshape_image_compute.cc
+++ b/lite/kernels/opencl/reshape_image_compute.cc
@@ -81,7 +81,7 @@ class ReshapeComputeFloatImage : public KernelLite<TARGET(kOpenCL),
 #ifdef LITE_WITH_LOG
     VLOG(4) << "out_dims=   " << out_dims;
 #endif
-    const std::vector<size_t>& default_work_size = DefaultWorkSize(
+    const std::vector<size_t>& default_work_size = DefaultGlobalWorkSize(
         out_dims,
         DDim(std::vector<DDim::value_type>{
             static_cast<int64_t>(out_image_shape.at("width")),

--- a/lite/kernels/opencl/slice_image_compute.cc
+++ b/lite/kernels/opencl/slice_image_compute.cc
@@ -90,11 +90,11 @@ class SliceComputeImage2D : public KernelLite<TARGET(kOpenCL),
     status = kernel.setArg(++arg_idx, dim_w);
     CL_CHECK_FATAL(status);
 
-    const std::vector<size_t>& default_work_size =
-        DefaultWorkSize(out_dims,
-                        DDim(std::vector<DDim::value_type>{
-                            static_cast<int64_t>(out_image_shape["width"]),
-                            static_cast<int64_t>(out_image_shape["height"])}));
+    const std::vector<size_t>& default_work_size = DefaultGlobalWorkSize(
+        out_dims,
+        DDim(std::vector<DDim::value_type>{
+            static_cast<int64_t>(out_image_shape["width"]),
+            static_cast<int64_t>(out_image_shape["height"])}));
     auto global_work_size =
         cl::NDRange{static_cast<cl::size_type>(default_work_size.data()[0]),
                     static_cast<cl::size_type>(default_work_size.data()[1]),

--- a/lite/kernels/opencl/transpose_image_compute.cc
+++ b/lite/kernels/opencl/transpose_image_compute.cc
@@ -85,7 +85,7 @@ class TransposeComputeFloatImage
 #ifdef LITE_WITH_LOG
     VLOG(4) << "out_dims=   " << out_dims;
 #endif
-    const std::vector<size_t>& default_work_size = DefaultWorkSize(
+    const std::vector<size_t>& default_work_size = DefaultGlobalWorkSize(
         out_dims,
         DDim(std::vector<DDim::value_type>{
             static_cast<int64_t>(out_image_shape.at("width")),


### PR DESCRIPTION
# 状态：cherry-pick，等待review

## 主要内容

cherry-pick https://github.com/PaddlePaddle/Paddle-Lite/pull/4700
1. set_opencl_tune接口传入参数由原本bool类型，改为size_t类型，考虑后续增加多种tune_type。其中修改涉及到paddle_api.cc，paddle_api.h，cl_runtime.h，mobilenetv1_light_api.cc；
2. 方法名规范化。
    1. 原DefaultWorkSize改为DefaultGlobalWorkSize，调用该方法的kernel较多：bilinear_interp_image_compute.cc，box_coder_image_compute.cc，concat_image_compute.cc，conv_image_compute.cc，dropout_image_compute.cc，grid_sample_image_compute.cc，lrn_image_compute.cc，nearest_interp_image_compute.cc，pad2d_image_compute.cc，reshape_image_compute.cc，slice_image_compute.cc，split_image_compute.cc；；
    2. 原LocalWorkSize改为DefaultLocalWorkSize，因为原先有一个DefaultGlobalWorksize，方法名统一：
3. 默认计算LWS的方法、正向调试LWS的方法、反向调试LWS的方法，这3个方法存在冗余，合为1个DefaultLocalWorkSize，原有正反向通过bool reverse来控制；
4. 解耦conv和auto-tune，将auto-tune策略的生成LWS的过程封装到GenerateLocalWorkSizes中，见cl_context.cc；
5. 默认开启event，默认enqueue加入event，创建CommandQueue在开启tune选项时带上Profile。见cl_context.cc，cl_runtime.cc。

## 性能

### 骁龙835

- 测试模型：caffe_mobilenetv1
- 原性能：14.5ms，性能区间：22~12ms
- tune后性能：11.9ms，性能区间：11~12ms
- 收益：性能提升17%，性能稳定性大幅增强

### 麒麟990

- 测试模型：caffe_mobilenetv1
- 原性能：13.7ms，性能区间：12.6~15.3ms
- 旧tune后性能：13.0ms，性能区间：10.5~21.1ms，首次跑+tune过程为3.3秒；
- 新tune后性能：12.5ms，性能区间：11.3~14.2ms，首次跑+tune过程为4.5秒；
- 收益：
    1. 新tune相比旧tune：性能提升3.8%，性能稳定性大幅增加，但tune过程时间延长；
    2. 新tune相比未tune：性能提升8.7，性能稳定性无变化。