### PR TITLE
[Core] Remove the type checking when get the shape from the var_desc of flatbuffer

### DIFF
--- a/lite/model_parser/flatbuffers/var_desc.h
+++ b/lite/model_parser/flatbuffers/var_desc.h
@@ -39,7 +39,6 @@ class VarDescView : public VarDescAPI {
   bool Persistable() const override { return desc_->persistable(); }
 
   std::vector<int64_t> GetShape() const override {
-    CHECK(GetType() == VarDescAPI::Type::LOD_TENSOR);
     const auto& dims = desc_->type()->lod_tensor()->tensor()->dims();
     std::vector<int64_t> dims_vec;
     dims_vec.resize(dims->size());
@@ -109,7 +108,6 @@ class VarDesc : public VarDescAPI {
   }
 
   std::vector<int64_t> GetShape() const override {
-    CHECK(GetType() == VarDescAPI::Type::LOD_TENSOR);
     return type_->lod_tensor->tensor->dims;
   }
 


### PR DESCRIPTION
Transformer模型里含有lod_tensor_array，flatbuffer的var_desc不允许非lod_tensor以外的类型获取shape，将导致模型加载失败出现core dump