### PR TITLE
[ARM] fix int8 m=1 sgemv error and small size in 2x2s2p0 pooling compute error…

### DIFF
--- a/lite/backends/arm/math/conv_impl.cc
+++ b/lite/backends/arm/math/conv_impl.cc
@@ -312,27 +312,6 @@ void conv1x1s1_gemm_int8(const int8_t* i_data,
                   ctx,
                   act_param.Relu_clipped_coef,
                   act_param.Leaky_relu_alpha);
-      } else if (m == 1) {
-        float bias_ptr[n];  // NOLINT
-        if (flag_bias) {
-          for (int i = 0; i < n; i++) {
-            bias_ptr[i] = bias_group[0];
-          }
-        }
-        gemv_int8(din_group,
-                  weights_group,
-                  dout_group,
-                  true,
-                  n,
-                  k,
-                  scale_group,
-                  flag_bias,
-                  bias_ptr,
-                  act_param.has_active,
-                  act_param.active_type,
-                  ctx,
-                  act_param.Relu_clipped_coef,
-                  act_param.Leaky_relu_alpha);
       } else {
         gemm_prepack_int8(weights_group,
                           din_group,
@@ -595,27 +574,6 @@ void conv_im2col_gemm_int8(const int8_t* i_data,
                   scale_group,
                   flag_bias,
                   bias_group,
-                  act_param.has_active,
-                  act_param.active_type,
-                  ctx,
-                  act_param.Relu_clipped_coef,
-                  act_param.Leaky_relu_alpha);
-      } else if (m == 1) {
-        float bias_ptr[n];  // NOLINT
-        if (flag_bias) {
-          for (int i = 0; i < n; i++) {
-            bias_ptr[i] = bias_group[0];
-          }
-        }
-        gemv_int8(dB,
-                  weights_group,
-                  dout_group,
-                  true,
-                  n,
-                  k,
-                  scale_group,
-                  flag_bias,
-                  bias_ptr,
                   act_param.has_active,
                   act_param.active_type,
                   ctx,

--- a/lite/kernels/arm/conv_gemmlike.cc
+++ b/lite/kernels/arm/conv_gemmlike.cc
@@ -130,11 +130,11 @@ void GemmLikeConv<PRECISION(kInt8), PRECISION(kFloat)>::ReInitWhenNeeded() {
     flag_1x1gemm_ = false;
     workspace_size_ = k * n * sizeof(float);
   }
-  if (!flag_trans_weights_ && n > 1 && m > 1) {
-    lite::arm::math::trans_gemm_weights<PrecisionType::kFloat>(
+  if (!flag_trans_weights_ && n > 1) {
+    lite::arm::math::trans_gemm_weights<PrecisionType::kInt8>(
         *(param.filter), weights_, param.groups, &ctx);
     flag_trans_weights_ = true;
-  } else if (n == 1 || m == 1) {
+  } else if (n == 1) {
     flag_trans_weights_ = false;
   }
   last_shape_ = x_dims;
@@ -189,11 +189,11 @@ void GemmLikeConv<PRECISION(kInt8), PRECISION(kInt8)>::ReInitWhenNeeded() {
     flag_1x1gemm_ = false;
     workspace_size_ = k * n * sizeof(float);
   }
-  if (!flag_trans_weights_ && n > 1 && m > 1) {
-    lite::arm::math::trans_gemm_weights<PrecisionType::kFloat>(
+  if (!flag_trans_weights_ && n > 1) {
+    lite::arm::math::trans_gemm_weights<PrecisionType::kInt8>(
         *(param.filter), weights_, param.groups, &ctx);
     flag_trans_weights_ = true;
-  } else if (n == 1 || m == 1) {
+  } else if (n == 1) {
     flag_trans_weights_ = false;
   }
   last_shape_ = x_dims;

--- a/lite/kernels/arm/conv_gemmlike.cc
+++ b/lite/kernels/arm/conv_gemmlike.cc
@@ -201,12 +201,12 @@ void GemmLikeConv<PRECISION(kInt8), PRECISION(kInt8)>::ReInitWhenNeeded() {
 
 template <>
 void GemmLikeConv<PRECISION(kFloat), PRECISION(kFloat)>::PrepareForRun() {
-  ReInitWhenNeeded<float>();
+  ReInitWhenNeeded();
 }
 
 template <>
 void GemmLikeConv<PRECISION(kInt8), PRECISION(kFloat)>::PrepareForRun() {
-  ReInitWhenNeeded<int8>();
+  ReInitWhenNeeded();
   auto& param = this->Param<param_t>();
   /// update scale
   w_scale_ = param.weight_scale;
@@ -227,7 +227,7 @@ void GemmLikeConv<PRECISION(kInt8), PRECISION(kFloat)>::PrepareForRun() {
 
 template <>
 void GemmLikeConv<PRECISION(kInt8), PRECISION(kInt8)>::PrepareForRun() {
-  ReInitWhenNeeded<float>();
+  ReInitWhenNeeded();
   auto& param = this->Param<param_t>();
   /// update scale
   /// update scale

--- a/lite/kernels/arm/conv_gemmlike.cc
+++ b/lite/kernels/arm/conv_gemmlike.cc
@@ -23,13 +23,190 @@ namespace kernels {
 namespace arm {
 
 template <>
+void GemmLikeConv<PRECISION(kFloat), PRECISION(kFloat)>::ReInitWhenNeeded() {
+  auto& param = this->template Param<param_t>();
+  CHECK(this->ctx_);
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.x->dims();
+  auto w_dims = param.filter->dims();
+  auto o_dims = param.output->dims();
+  if (last_shape_ == x_dims) {
+    return;
+  }
+
+  int iw = x_dims[3];  // nchw
+  int ih = x_dims[2];
+  int ic = x_dims[1];
+  int ow = o_dims[3];
+  int oh = o_dims[2];
+  int oc = o_dims[1];
+  int kw = w_dims[3];
+  int kh = w_dims[2];
+
+  auto paddings = *param.paddings;
+  auto dilations = *param.dilations;
+
+  int sw = param.strides[1];
+  int sh = param.strides[0];
+  int pw = paddings[2];
+  int ph = paddings[0];
+  int dw = dilations[1];
+  int dh = dilations[0];
+
+  bool pads_equal =
+      ((paddings[0] == paddings[1]) && (paddings[2] == paddings[3]));
+
+  int m = oc / param.groups;
+  int k = ic * kh * kw / param.groups;
+  int n = oh * ow;
+
+  bool kps_equal = (pw == ph) && (sw == sh) && (kw == kh);
+  bool ks_equal = (sw == sh) && (kw == kh);
+  //! select conv gemmlike kernel
+  if (kw == 1 && sw == 1 && pw == 0 && kps_equal && pads_equal) {
+    //! 1x1s1p0 gemmlike conv
+    flag_1x1gemm_ = true;
+  } else {
+    //! im2col gemmlike conv
+    flag_1x1gemm_ = false;
+    workspace_size_ = k * n * sizeof(float);
+  }
+  if (!flag_trans_weights_ && n > 1 && m > 1) {
+    lite::arm::math::trans_gemm_weights<PrecisionType::kFloat>(
+        *(param.filter), weights_, param.groups, &ctx);
+    flag_trans_weights_ = true;
+  } else if (n == 1 || m == 1) {
+    flag_trans_weights_ = false;
+  }
+  last_shape_ = x_dims;
+}
+
+template <>
+void GemmLikeConv<PRECISION(kInt8), PRECISION(kFloat)>::ReInitWhenNeeded() {
+  auto& param = this->template Param<param_t>();
+  CHECK(this->ctx_);
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.x->dims();
+  auto w_dims = param.filter->dims();
+  auto o_dims = param.output->dims();
+  if (last_shape_ == x_dims) {
+    return;
+  }
+
+  int iw = x_dims[3];  // nchw
+  int ih = x_dims[2];
+  int ic = x_dims[1];
+  int ow = o_dims[3];
+  int oh = o_dims[2];
+  int oc = o_dims[1];
+  int kw = w_dims[3];
+  int kh = w_dims[2];
+
+  auto paddings = *param.paddings;
+  auto dilations = *param.dilations;
+
+  int sw = param.strides[1];
+  int sh = param.strides[0];
+  int pw = paddings[2];
+  int ph = paddings[0];
+  int dw = dilations[1];
+  int dh = dilations[0];
+
+  bool pads_equal =
+      ((paddings[0] == paddings[1]) && (paddings[2] == paddings[3]));
+
+  int m = oc / param.groups;
+  int k = ic * kh * kw / param.groups;
+  int n = oh * ow;
+
+  bool kps_equal = (pw == ph) && (sw == sh) && (kw == kh);
+  bool ks_equal = (sw == sh) && (kw == kh);
+  //! select conv gemmlike kernel
+  if (kw == 1 && sw == 1 && pw == 0 && kps_equal && pads_equal) {
+    //! 1x1s1p0 gemmlike conv
+    flag_1x1gemm_ = true;
+  } else {
+    //! im2col gemmlike conv
+    flag_1x1gemm_ = false;
+    workspace_size_ = k * n * sizeof(float);
+  }
+  if (!flag_trans_weights_ && n > 1 && m > 1) {
+    lite::arm::math::trans_gemm_weights<PrecisionType::kFloat>(
+        *(param.filter), weights_, param.groups, &ctx);
+    flag_trans_weights_ = true;
+  } else if (n == 1 || m == 1) {
+    flag_trans_weights_ = false;
+  }
+  last_shape_ = x_dims;
+}
+
+template <>
+void GemmLikeConv<PRECISION(kInt8), PRECISION(kInt8)>::ReInitWhenNeeded() {
+  auto& param = this->template Param<param_t>();
+  CHECK(this->ctx_);
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.x->dims();
+  auto w_dims = param.filter->dims();
+  auto o_dims = param.output->dims();
+  if (last_shape_ == x_dims) {
+    return;
+  }
+
+  int iw = x_dims[3];  // nchw
+  int ih = x_dims[2];
+  int ic = x_dims[1];
+  int ow = o_dims[3];
+  int oh = o_dims[2];
+  int oc = o_dims[1];
+  int kw = w_dims[3];
+  int kh = w_dims[2];
+
+  auto paddings = *param.paddings;
+  auto dilations = *param.dilations;
+
+  int sw = param.strides[1];
+  int sh = param.strides[0];
+  int pw = paddings[2];
+  int ph = paddings[0];
+  int dw = dilations[1];
+  int dh = dilations[0];
+
+  bool pads_equal =
+      ((paddings[0] == paddings[1]) && (paddings[2] == paddings[3]));
+
+  int m = oc / param.groups;
+  int k = ic * kh * kw / param.groups;
+  int n = oh * ow;
+
+  bool kps_equal = (pw == ph) && (sw == sh) && (kw == kh);
+  bool ks_equal = (sw == sh) && (kw == kh);
+  //! select conv gemmlike kernel
+  if (kw == 1 && sw == 1 && pw == 0 && kps_equal && pads_equal) {
+    //! 1x1s1p0 gemmlike conv
+    flag_1x1gemm_ = true;
+  } else {
+    //! im2col gemmlike conv
+    flag_1x1gemm_ = false;
+    workspace_size_ = k * n * sizeof(float);
+  }
+  if (!flag_trans_weights_ && n > 1 && m > 1) {
+    lite::arm::math::trans_gemm_weights<PrecisionType::kFloat>(
+        *(param.filter), weights_, param.groups, &ctx);
+    flag_trans_weights_ = true;
+  } else if (n == 1 || m == 1) {
+    flag_trans_weights_ = false;
+  }
+  last_shape_ = x_dims;
+}
+
+template <>
 void GemmLikeConv<PRECISION(kFloat), PRECISION(kFloat)>::PrepareForRun() {
-  ReInitWhenNeeded();
+  ReInitWhenNeeded<float>();
 }
 
 template <>
 void GemmLikeConv<PRECISION(kInt8), PRECISION(kFloat)>::PrepareForRun() {
-  ReInitWhenNeeded();
+  ReInitWhenNeeded<int8>();
   auto& param = this->Param<param_t>();
   /// update scale
   w_scale_ = param.weight_scale;
@@ -50,7 +227,7 @@ void GemmLikeConv<PRECISION(kInt8), PRECISION(kFloat)>::PrepareForRun() {
 
 template <>
 void GemmLikeConv<PRECISION(kInt8), PRECISION(kInt8)>::PrepareForRun() {
-  ReInitWhenNeeded();
+  ReInitWhenNeeded<float>();
   auto& param = this->Param<param_t>();
   /// update scale
   /// update scale

--- a/lite/kernels/arm/conv_gemmlike.h
+++ b/lite/kernels/arm/conv_gemmlike.h
@@ -34,64 +34,7 @@ class GemmLikeConv : public KernelLite<TARGET(kARM), Ptype> {
   GemmLikeConv() = default;
   ~GemmLikeConv() {}
 
-  virtual void ReInitWhenNeeded() {
-    auto& param = this->template Param<param_t>();
-    CHECK(this->ctx_);
-    auto& ctx = this->ctx_->template As<ARMContext>();
-    auto x_dims = param.x->dims();
-    auto w_dims = param.filter->dims();
-    auto o_dims = param.output->dims();
-    if (last_shape_ == x_dims) {
-      return;
-    }
-
-    int iw = x_dims[3];  // nchw
-    int ih = x_dims[2];
-    int ic = x_dims[1];
-    int ow = o_dims[3];
-    int oh = o_dims[2];
-    int oc = o_dims[1];
-    int kw = w_dims[3];
-    int kh = w_dims[2];
-
-    auto paddings = *param.paddings;
-    auto dilations = *param.dilations;
-
-    int sw = param.strides[1];
-    int sh = param.strides[0];
-    int pw = paddings[2];
-    int ph = paddings[0];
-    int dw = dilations[1];
-    int dh = dilations[0];
-
-    bool pads_equal =
-        ((paddings[0] == paddings[1]) && (paddings[2] == paddings[3]));
-
-    int m = oc / param.groups;
-    int k = ic * kh * kw / param.groups;
-    int n = oh * ow;
-
-    bool kps_equal = (pw == ph) && (sw == sh) && (kw == kh);
-    bool ks_equal = (sw == sh) && (kw == kh);
-    //! select conv gemmlike kernel
-    if (kw == 1 && sw == 1 && pw == 0 && kps_equal && pads_equal) {
-      //! 1x1s1p0 gemmlike conv
-      flag_1x1gemm_ = true;
-    } else {
-      //! im2col gemmlike conv
-      flag_1x1gemm_ = false;
-      workspace_size_ = k * n * sizeof(float);
-    }
-    if (!flag_trans_weights_ && n > 1 && m > 1) {
-      lite::arm::math::trans_gemm_weights<Ptype>(
-          *(param.filter), weights_, param.groups, &ctx);
-      flag_trans_weights_ = true;
-    } else if (n == 1) {
-      flag_trans_weights_ = false;
-    }
-    last_shape_ = x_dims;
-  }
-
+  virtual void ReInitWhenNeeded();
   virtual void PrepareForRun();
   virtual void Run();
 

--- a/lite/kernels/arm/pool_compute.cc
+++ b/lite/kernels/arm/pool_compute.cc
@@ -60,6 +60,7 @@ void PoolCompute::Run() {
   bool win_ksize = (in_dims[2] > ksize[0]) && (in_dims[3] > ksize[1]);
   global_pooling = param.global_pooling || global_pooling;
   kps_equal = kps_equal && win_ksize;
+  auto x_dims = param.x->dims();
 
   if (global_pooling) {
     for (size_t i = 0; i < ksize.size(); ++i) {
@@ -91,7 +92,8 @@ void PoolCompute::Run() {
       return;
     }
   } else {
-    if (ksize[0] == 1 && strides[0] == 2 && paddings[0] == 0 && kps_equal) {
+    if (x_dims[-1] > 8 && ksize[0] == 1 && strides[0] == 2 &&
+        paddings[0] == 0 && kps_equal) {
       auto& ctx = this->ctx_->template As<ARMContext>();
       if (pooling_type == "max") {
         lite::arm::math::pooling1x1s2p0_max(din,
@@ -107,8 +109,8 @@ void PoolCompute::Run() {
                                             paddings[3]);
         return;
       }
-    } else if (ksize[0] == 2 && strides[0] == 2 && paddings[0] == 0 &&
-               kps_equal) {
+    } else if (x_dims[-1] > 8 && ksize[0] == 2 && strides[0] == 2 &&
+               paddings[0] == 0 && kps_equal) {
       if (pooling_type == "max") {
         lite::arm::math::pooling2x2s2p0_max(din,
                                             dout,
@@ -137,8 +139,8 @@ void PoolCompute::Run() {
                                             paddings[3]);
         return;
       }
-    } else if (ksize[0] == 2 && strides[0] == 2 && paddings[0] == 1 &&
-               kps_equal) {
+    } else if (x_dims[-1] > 8 && ksize[0] == 2 && strides[0] == 2 &&
+               paddings[0] == 1 && kps_equal) {
       if (pooling_type == "max") {
         lite::arm::math::pooling2x2s2p1_max(din,
                                             dout,


### PR DESCRIPTION
修复m=1 时，选择sgemv_int8的计算错误；原因：sgemv_int8没有实现，trans_A=true的case
修复输入width < 8 时，2x2s2p0 pooling计算错误；原因：ld2 取数据不正确