### PR TITLE
[host][kernel] fix host kernel of shuffle_channel

### DIFF
--- a/lite/kernels/host/shuffle_channel_compute.h
+++ b/lite/kernels/host/shuffle_channel_compute.h
@@ -22,7 +22,7 @@ namespace kernels {
 namespace host {
 
 class ShuffleChannelCompute
-    : public KernelLite<TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny)> {
+    : public KernelLite<TARGET(kHost), PRECISION(kFloat)> {
  public:
   using param_t = operators::ShuffleChannelParam;
 


### PR DESCRIPTION
【问题】
通过`./lite/tools/ci_build.sh --arm_os=android --arm_abi=armv8 --arm_lang=gcc  build_arm`编译生成`benchmark_bin`，在使用`benchmark_bin --model_dir=<path to shufflenet model> --result_filename=./a`时报错：
```
[F 11/24 15:34:16.998 /pd/Paddle-Lite/lite/core/kernel.cc GetInputDeclType:34] Check failed: type: no type registered for kernel [shuffle_channel] input argument [X] with key shuffle_channel/def
```
直接使用`opt`转换 shufflenet 模型是正常的。

本次PR解决该问题。