### PR TITLE
[OpenCL][Kernel] fix leaky_relu cl bug & make macro(MUTABLE_DATA_GPU etc..) robust

### DIFF
--- a/lite/backends/opencl/cl_utility.h
+++ b/lite/backends/opencl/cl_utility.h
@@ -65,24 +65,25 @@ const char* opencl_error_to_str(cl_int error);
       kernel, gws_offset, gws, lws, event_wait_list, &event)
 
 // mutable_data
-#define MUTABLE_DATA_GPU(tensor_instance_p, img_w, img_h, ptr) \
-  (fp16_support_)                                              \
-      ? tensor_instance_p->mutable_data<half_t, cl::Image2D>(  \
-            img_w, img_h, ptr)                                 \
-      : tensor_instance_p->mutable_data<float, cl::Image2D>(img_w, img_h, ptr)
+#define MUTABLE_DATA_GPU(tensor_instance_p, img_w, img_h, ptr)     \
+  (fp16_support_)                                                  \
+      ? (tensor_instance_p)                                        \
+            ->mutable_data<half_t, cl::Image2D>(img_w, img_h, ptr) \
+      : (tensor_instance_p)                                        \
+            ->mutable_data<float, cl::Image2D>(img_w, img_h, ptr)
 
-#define DATA_GPU(tensor_instance_p)                                        \
-  (fp16_support_) ? tensor_instance_p->mutable_data<half_t, cl::Image2D>() \
-                  : tensor_instance_p->mutable_data<float, cl::Image2D>()
+#define DATA_GPU(tensor_instance_p)                                          \
+  (fp16_support_) ? (tensor_instance_p)->mutable_data<half_t, cl::Image2D>() \
+                  : (tensor_instance_p)->mutable_data<float, cl::Image2D>()
 
-#define GET_DATA_GPU(tensor_instance_p)                            \
-  (fp16_support_) ? tensor_instance_p->data<half_t, cl::Image2D>() \
-                  : tensor_instance_p->data<float, cl::Image2D>()
+#define GET_DATA_GPU(tensor_instance_p)                              \
+  (fp16_support_) ? (tensor_instance_p)->data<half_t, cl::Image2D>() \
+                  : (tensor_instance_p)->data<float, cl::Image2D>()
 
-#define MUTABLE_DATA_CPU(tensor_instance_p)                           \
-  (fp16_support_)                                                     \
-      ? static_cast<void*>(tensor_instance_p->mutable_data<half_t>()) \
-      : static_cast<void*>(tensor_instance_p->mutable_data<float>())
+#define MUTABLE_DATA_CPU(tensor_instance_p)                             \
+  (fp16_support_)                                                       \
+      ? static_cast<void*>((tensor_instance_p)->mutable_data<half_t>()) \
+      : static_cast<void*>((tensor_instance_p)->mutable_data<float>())
 
 }  // namespace lite
 }  // namespace paddle


### PR DESCRIPTION
【问题】
- 当前融合实现的 leaky_relu 计算结果错误，conv 单测可复现问题：
![image](https://user-images.githubusercontent.com/24290792/100330683-3f048880-300a-11eb-89c7-6970012bbe8a.png)
上图中，opencl计算出的 conv 输出不论正负值均乘上了`leaky_relu_alpha`(该值为`0.1`)，与baseline不一致。
**备注：单测中之所以没发现，定义的误差阈值较高，后续需要降低阈值。**
```
#define FP16_MAX_DIFF (1e0)
#define FP16_ABS_DIFF (1e-1)
```

- 最近新增定义的几个宏`MUTABLE_DATA_GPU`等中有指针操作，当输入参数中有取址操作时，编译会报错，原因是`->`的优先级高于`&`，因此编译时会报参数类型不一致错误。


【修改后】
- opencl fp16 vs baseline fp32 的结果如下，输入和filter数据是 [-2,2) 范围内随机生成数，输出最大绝对误差 0.00487，最大相对误差 0.00122：
![image](https://user-images.githubusercontent.com/24290792/100331099-b76b4980-300a-11eb-92d8-f506ddd5f45a.png)

- 增强了宏的鲁棒性，解决了编译问题。