### PR TITLE
supprot x2paddle models

### DIFF
--- a/lite/api/benchmark.cc
+++ b/lite/api/benchmark.cc
@@ -90,9 +90,9 @@ void OutputOptModel(const std::string& save_optimized_model_dir) {
     config.set_param_file(FLAGS_model_dir + "/" + FLAGS_param_filename);
   }
   std::vector<Place> vaild_places = {
-      Place{TARGET(kARM), PRECISION(kFloat)},
       Place{TARGET(kARM), PRECISION(kInt32)},
       Place{TARGET(kARM), PRECISION(kInt64)},
+      Place{TARGET(kARM), PRECISION(kFloat)},
   };
   config.set_valid_places(vaild_places);
   auto predictor = lite_api::CreatePaddlePredictor(config);

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -437,8 +437,8 @@ void SaveModelNaive(const std::string &model_file,
   /* 3. Save combined params to params.fbs */
   fbs::CombinedParamsDesc params_prog;
   fbs::SetCombinedParamsWithScope(exec_scope, unique_var_names, &params_prog);
-  AppendToFile(
-      prog_path, (params_prog.data()).data(), (params_prog.data()).size());
+  auto data_cache = params_prog.data();
+  AppendToFile(prog_path, data_cache.data(), data_cache.size());
 
   LOG(INFO) << "Save naive buffer model in '" << prog_path << " successfully";
 }

--- a/lite/operators/transpose_op.cc
+++ b/lite/operators/transpose_op.cc
@@ -84,7 +84,7 @@ bool Transpose2Op::CheckShape() const {
   size_t axis_size = axis.size();
   // "The input tensor's rank(%d) should be equal to the axis's size(%d)",
   // x_rank, axis_size
-  CHECK_OR_FALSE(x_rank == axis_size);
+  CHECK_EQ(x_rank, axis_size);
 
   std::vector<int> count(axis_size, 0);
   for (size_t i = 0; i < axis_size; i++) {


### PR DESCRIPTION
- 之前elemenwtwise的x维度小于y的维度时，计算会发生错误。
    - 当x和y是可交换的情况下，如果x维度小于y的维度，则交换x和y，保证x的维度大于y的维度。
    - TODO：看代码当axis==-1时，是支持 "x维度小于y的维度" 的，否则计算会有问题。 @edimetia3d  确认下吧
- crop_tensor在pick kernel的时候总是会优先选择float的kernel，因此需要调整benchmark中place的顺序。
    - TODO：现在的kernel pick逻辑有些不太合理，不会完全拒绝输入输出注册类型不一致的情况。所以如果同时注册了float和int kernel的话，需要把int的place放在前面。
- armv7下保存模型出错。#4193 可能和这里有关系，不是很确定。 @Shixiaowei02  确认下吧