### PR TITLE
[OPENCL] Fix OpenCL CI about Leaky relu scale & select func usage

### DIFF
--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -110,7 +110,16 @@ inline CL_DTYPE activation(CL_DTYPE in
 #endif
 
 #ifdef LEAKY_RELU
-  output = select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, in >= (CL_DTYPE)0);
+#ifdef CL_DTYPE_float
+  output = select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in,
+                  in,
+                  (int)(isgreaterequal(in, 0)));  // NOLINT
+#endif
+
+#ifdef CL_DTYPE_half
+  output = select(
+      (CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, (ushort)(isgreaterequal(in, 0)));
+#endif
 #endif
   return output;
 }

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -299,7 +299,7 @@ void ConvImageCompute::PrepareForRun() {
       std::string leaky_relu_alpha_str =
           std::to_string(conv_param_->activation_param.Leaky_relu_alpha);
       build_options_single +=
-          " -DLEAKY_RELU -DLEAKY_RELU_ALPHA=" + leaky_relu_alpha_str;
+          " -DLEAKY_RELU -DLEAKY_RELU_ALPHA=" + leaky_relu_alpha_str + "f";
     } else {
       LOG(FATAL) << "Unsupported activation type:"
                  << static_cast<int>(conv_param_->activation_param.active_type);


### PR DESCRIPTION
# 状态：等待review

## 主要内容

> 背景：OPENCL的CI挂了报错显示是挂在cl kernel内某个地方显示是leaky relu的scale值是double，但不支持fp64的情况。

因此做了如下修改：

1. 在conv_compute里对leaky relu的传入的字符串后缀追加`f`表示该值为fp32类型；
2. 修改后发现有select的方法的用法歧义，根据文档（`https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/select.html`）发现selelct在这里的用法有两种情况，即第三个参数是ushort和int的情况，前者是当以half计算的时候第三个参数需要是ushort，当以float计算的时候（近期已经支持）第三个参数需要是int。

## 验证

在高通和华为（之前CI上问题手机mali-G52）上验证单测通过。

## 性能变化：caffe_mobilenetv1

测试环境：root xiaomi9，骁龙855

1. 修改前：9.002ms，output std:0.00191348，output mean：0.001；
2. 修改后：9.006ms，output std:0.00191348，output mean：0.001。

对性能没有影响。