### PR TITLE
[OPENCL] Add fast auto-tune method; Improve auto-tune procedure; Fix typo etc. test=develop

### DIFF
--- a/lite/backends/opencl/cl_context.cc
+++ b/lite/backends/opencl/cl_context.cc
@@ -142,6 +142,7 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
       static_cast<size_t>(0), static_cast<size_t>(0), static_cast<size_t>(0)};
 
   std::vector<cl::NDRange> lwss{tmp_lws};
+  VLOG(1) << "generate_lws_type:" << generate_lws_type;
   // 0 - None, 1 - Rapid, 2 - Normal, 3 - Exhaustive
   if (generate_lws_type == 0) {
     // 0 - None: nothing to do
@@ -149,6 +150,19 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
              generate_lws_type == 3) {
     for (auto tune_reverse : {true, false}) {
       for (size_t divisor = 1; divisor < /*max_divisor=*/15; divisor++) {
+        tmp_lws = DefaultLocalWorkSize(
+            global_work_size, max_work_size, divisor, tune_reverse);
+        if (last_lws[0] == tmp_lws[0] && last_lws[1] == tmp_lws[1] &&
+            last_lws[2] == tmp_lws[2]) {
+          // skip tuned lws
+          continue;
+        }
+        lwss.emplace_back(tmp_lws);
+      }
+    }
+  } else if (generate_lws_type == 2) {
+    for (auto tune_reverse : {true, false}) {
+      for (size_t divisor = 1; divisor < /*max_divisor=*/7; divisor++) {
         tmp_lws = DefaultLocalWorkSize(
             global_work_size, max_work_size, divisor, tune_reverse);
         if (last_lws[0] == tmp_lws[0] && last_lws[1] == tmp_lws[1] &&

--- a/lite/backends/opencl/cl_context.cc
+++ b/lite/backends/opencl/cl_context.cc
@@ -146,10 +146,10 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
   // 0 - None, 1 - Rapid, 2 - Normal, 3 - Exhaustive
   if (generate_lws_type == 0) {
     // 0 - None: nothing to do
-  } else if (generate_lws_type == 1 || generate_lws_type == 2 ||
-             generate_lws_type == 3) {
+  } else if (generate_lws_type == 1) {
+    // 1 - Rapid
     for (auto tune_reverse : {true, false}) {
-      for (size_t divisor = 1; divisor < /*max_divisor=*/15; divisor++) {
+      for (size_t divisor = 1; divisor < /*max_divisor=*/15; divisor += 2) {
         tmp_lws = DefaultLocalWorkSize(
             global_work_size, max_work_size, divisor, tune_reverse);
         if (last_lws[0] == tmp_lws[0] && last_lws[1] == tmp_lws[1] &&
@@ -160,9 +160,11 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
         lwss.emplace_back(tmp_lws);
       }
     }
-  } else if (generate_lws_type == 2) {
-    for (auto tune_reverse : {true, /*false*/}) {
-      for (size_t divisor = 1; divisor < /*max_divisor=*/7; divisor++) {
+  } else if (generate_lws_type == 2 || generate_lws_type == 3) {
+    // 2 - Normal
+    // 3 - Exhaustive
+    for (auto tune_reverse : {true, false}) {
+      for (size_t divisor = 1; divisor < /*max_divisor=*/15; divisor++) {
         tmp_lws = DefaultLocalWorkSize(
             global_work_size, max_work_size, divisor, tune_reverse);
         if (last_lws[0] == tmp_lws[0] && last_lws[1] == tmp_lws[1] &&
@@ -247,10 +249,11 @@ void CLContext::SetTunedLocalWorkSizeMap(const std::string &key,
   auto it = tuned_lwss_map_.find(key);
   if (it != tuned_lwss_map_.end()) {
     auto lws_old = it->second;
-    LOG(FATAL) << "===================================> found lws_old with "
-                  "same key <======================================";
-    << "\n lws_old:" << lws_old[0] << "," << lws_old[1] << "," << lws_old[2];
-    << "\n lws_new:" << lws[0] << "," << lws[1] << "," << lws[2];
+    LOG(FATAL) << "===> found lws_old with same key, please add more detailed "
+                  "info to key <==="
+               << "\n lws_old:" << lws_old[0] << "," << lws_old[1] << ","
+               << lws_old[2] << "\n lws_new:" << lws[0] << "," << lws[1] << ","
+               << lws[2];
   }
   tuned_lwss_map_.insert(std::pair<std::string, cl::NDRange>(key, lws));
 }

--- a/lite/backends/opencl/cl_context.h
+++ b/lite/backends/opencl/cl_context.h
@@ -70,10 +70,19 @@ class CLContext {
                                                   size_t max_work_size);
   bool IsArmMali();
 
+  bool HasTunedLocalWorkSizeMap(const std::string &key, cl::NDRange *lws);
+
+  void SetTunedLocalWorkSizeMap(const std::string &key, const cl::NDRange lws);
+
+  std::map<std::string, cl::NDRange> GetTunedLocalWorkSizeMap();
+
+  cl::NDRange GetTunedLocalWorkSizeFromMap(const std::string &key);
+
  private:
   std::map<std::string, std::unique_ptr<cl::Program>> programs_;
   std::vector<std::shared_ptr<cl::Kernel>> kernels_;
   std::map<std::string, int> kernel_offset_;
+  std::map<std::string, cl::NDRange> tuned_lwss_map_;
 };
 
 }  // namespace lite

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -97,7 +97,7 @@ class CLRuntime {
     command_queue_ = CreateCommandQueue(context());
   }
 
-  bool auto_tune() { return auto_tune_; }
+  size_t auto_tune() { return auto_tune_; }
 
   bool Init();
 

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -365,15 +365,10 @@ void ConvImageCompute::SetLocalWorkSize(size_t repeats /*=4*/) {
   kernel_key << kernel_func_names_[0] << build_options_[0] << time_stamp_;
   kernel_ = context.cl_context()->GetKernel(kernel_key.str());
 
-#ifdef LITE_WITH_LOG
-  VLOG(4) << "kernel_key: " << kernel_key.str();
-  VLOG(4) << "kernel ready ... " << kernel_key.str();
-#endif
-
   auto tuned_map_key = GenerateTunedKey();
   cl::NDRange lws_in_map = cl::NullRange;
   if (context.cl_context()->HasTunedLocalWorkSizeMap(tuned_map_key,
-                                                     lws_in_map)) {
+                                                     &lws_in_map)) {
     local_work_size_ = lws_in_map;
     return;
   }

--- a/lite/kernels/opencl/conv_image_compute.h
+++ b/lite/kernels/opencl/conv_image_compute.h
@@ -59,6 +59,7 @@ class ConvImageCompute : public KernelLite<TARGET(kOpenCL),
   void PrintConvInfo();
   void SetGlobalWorkSize();
   void SetLocalWorkSize(size_t repeats = 4);
+  std::string GenerateTunedKey();
   void Conv2d1x1opt();
   void Conv2d3x3();
   void Conv2d3x3opt();


### PR DESCRIPTION
# 状态：等待review

ref: https://github.com/PaddlePaddle/Paddle-Lite/pull/4774/commits/6db5a0b0854780c2e13e5e01b9f4e761116156cc

## 主要内容

1. 修复auto_tune应为size_t但写成了bool的typo bug；
2. 增加一种简化的tune方式，相比tune(1)时间更短；
3. 优化tune流程，针对conv复用tuned lws，tuned时间变短。

## 性能优化点

- 模型：caffe_mobilenetv1；
- 测试平台：骁龙855，root过的xiaomi9；
- 每次repeats=1000，warmup=1，取多次执行结果的范围。

### 0. baseline（原有实现）

- 默认(tune(0))：8.999 ~ 9.006 ms；
    - 第一次耗时475~485 ms，取均值480ms；
- tune(1)：7.666 ~ 7.861 ms：
    - 第一次耗时（未做下面2的tune优化）2200~2212 ms，取均值2206ms；

### 1. 增加一种简化的tune方式：tune(2)

- root sdm855，tune(2)耗时相比tune(1)快35%
    - tune(1)：第一次耗时1700ms，caffe_mobilenetv1性能：7.83 ~ 7.84 ms；
    - tune(2)：第一次耗时1100ms，caffe_mobilenetv1性能：7.84 ~ 7.87 ms；
- unroot kirin810，tune(2)耗时相比tune(1)快45%
    - tune(1)：第一次耗时6000ms，caffe_mobilenetv1性能：23.6~24.6ms：
    - tune(2)：第一次耗时3350ms，caffe_mobilenetv1性能：24.6~25.0 ms，极个别情况lws会选到30+ms。

### 2.优化tune流程 

tune过程优化，下面数据以tune(1)为例，tune(2)更快。

- 骁龙855，tune耗时相比之前降低22%
    - 优化前：第一次耗时为2200~2212 ms，取均值2206ms；
    - 优化后，第一次耗时为1687~1715ms，取中间1700ms。
- 麒麟810，tune耗时相比之前降低34%
    - 优化前：第一次耗时为9100~9300 ms，取9200ms；
    - 优化后：第一次耗时为5800~6300 ms，取6050ms。