### PR TITLE
[API] Update conv_transpose op to adapt for Paddle2.0

### DIFF
--- a/lite/operators/conv_transpose_op.cc
+++ b/lite/operators/conv_transpose_op.cc
@@ -79,21 +79,20 @@ bool ConvTransposeOpLite::InferShapeImpl() const {
   }
   if (!param_.output_padding.empty()) {
     CHECK_EQ(param_.output_padding.size(), param_.strides.size())
-            << "the size of output_padding and the size of stride should be "
-               "same, "
-            << "but output_padding's size is "
-            << param_.output_padding.size() < < < <
-        ", stride's size is " << param_.strides.size();
+        << "the size of output_padding and the size of stride should be "
+           "same, "
+        << "but output_padding's size is " << param_.output_padding.size()
+        << ", stride's size is " << param_.strides.size();
     for (int i = 0; i < param_.output_padding.size(); i++) {
       CHECK_GE(param_.output_padding[i], 0)
           << "the output_padding should be great than 0, "
-          << "but output_padding is " << output_padding[i];
+          << "but output_padding is " << param_.output_padding[i];
       CHECK_LT(param_.output_padding[i],
-               std::max(param_.strides[i], dilations[i])) < < < <
-          "the output_padding should be less than max(strides, dilations), "
-              << "but output_padding is " << output_padding[i]
-              << ", strides is " << strides[i] << ", dilations is "
-              << dilations[i];
+               std::max(param_.strides[i], dilations[i]))
+          << "the output_padding should be less than max(strides, dilations), "
+          << "but output_padding is " << param_.output_padding[i]
+          << ", strides is " << param_.strides[i] << ", dilations is "
+          << dilations[i];
     }
     for (int i = 0; i < param_.output_padding.size(); i++) {
       output_shape[i] += param_.output_padding[i];

--- a/lite/operators/conv_transpose_op.cc
+++ b/lite/operators/conv_transpose_op.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "lite/operators/conv_transpose_op.h"
+#include <algorithm>
 #include <memory>
 #include "lite/core/op_lite.h"
 #include "lite/core/op_registry.h"
@@ -75,6 +76,28 @@ bool ConvTransposeOpLite::InferShapeImpl() const {
                                                    paddings[i * 2],
                                                    paddings[i * 2 + 1],
                                                    param_.strides[i]));
+  }
+  if (!param_.output_padding.empty()) {
+    CHECK_EQ(param_.output_padding.size(), param_.strides.size())
+            << "the size of output_padding and the size of stride should be "
+               "same, "
+            << "but output_padding's size is "
+            << param_.output_padding.size() < < < <
+        ", stride's size is " << param_.strides.size();
+    for (int i = 0; i < param_.output_padding.size(); i++) {
+      CHECK_GE(param_.output_padding[i], 0)
+          << "the output_padding should be great than 0, "
+          << "but output_padding is " << output_padding[i];
+      CHECK_LT(param_.output_padding[i],
+               std::max(param_.strides[i], dilations[i])) < < < <
+          "the output_padding should be less than max(strides, dilations), "
+              << "but output_padding is " << output_padding[i]
+              << ", strides is " << strides[i] << ", dilations is "
+              << dilations[i];
+    }
+    for (int i = 0; i < param_.output_padding.size(); i++) {
+      output_shape[i] += param_.output_padding[i];
+    }
   }
   if (!param_.output_size.empty()) {
     for (size_t i = 0; i < param_.output_size.size(); ++i) {
@@ -163,6 +186,9 @@ bool ConvTransposeOpLite::AttachImpl(const cpp::OpDesc& op_desc,
   }
   if (op_desc.HasAttr("output_size")) {
     param_.output_size = op_desc.GetAttr<std::vector<int>>("output_size");
+  }
+  if (op_desc.HasAttr("output_padding")) {
+    param_.output_padding = op_desc.GetAttr<std::vector<int>>("output_padding");
   }
   return true;
 }

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -472,6 +472,7 @@ struct ConvParam : ParamBase {
   bool var_length{false};
   // only used in conv_transpose.
   std::vector<int> output_size;
+  std::vector<int> output_padding;
   // for int8
   WITH_INT8_CONFIG
 

--- a/lite/tests/kernels/conv_transpose_compute_test.cc
+++ b/lite/tests/kernels/conv_transpose_compute_test.cc
@@ -39,6 +39,7 @@ class ConvTransposeComputeTester : public arena::TestCase {
   std::vector<int> dilations_{1, 1};
   std::string padding_algorithm_ = "";
   std::vector<int> output_size_{};
+  std::vector<int> output_padding_{};
   std::string bias_ = "";
   bool fuse_relu_ = false;
 
@@ -54,6 +55,7 @@ class ConvTransposeComputeTester : public arena::TestCase {
                              std::vector<int> dilations = {1, 1},
                              std::string padding_algorithm = "",
                              std::vector<int> output_size = {},
+                             std::vector<int> output_padding = {},
                              std::string bias = "",
                              bool fuse_relu = false)
       : TestCase(place, alias),
@@ -66,6 +68,7 @@ class ConvTransposeComputeTester : public arena::TestCase {
         dilations_(dilations),
         padding_algorithm_(padding_algorithm),
         output_size_(output_size),
+        output_padding_(output_padding),
         bias_(bias),
         fuse_relu_(fuse_relu) {}
 
@@ -102,6 +105,12 @@ class ConvTransposeComputeTester : public arena::TestCase {
       int output_size = (dims_[i + 2] - 1) * strides_[i] - paddings_[i * 2] -
                         paddings_[i * 2 + 1] + dkernel;
       output_shape.push_back(output_size);
+    }
+
+    if (!output_padding_.empty()) {
+      for (size_t i = 0; i < output_padding_.size(); ++i) {
+        output_shape[i + 2] += output_padding_[i];
+      }
     }
 
     if (!output_size_.empty()) {
@@ -165,9 +174,13 @@ class ConvTransposeComputeTester : public arena::TestCase {
     if (!padding_algorithm_.empty()) {
       op_desc->SetAttr("padding_algorithm", padding_algorithm_);
     }
+    if (!output_padding_.empty()) {
+      op_desc->SetAttr("output_padding", output_padding_);
+    }
     if (!output_size_.empty()) {
       op_desc->SetAttr("output_size", output_size_);
     }
+
     op_desc->SetAttr("fuse_relu", fuse_relu_);
   }
 
@@ -291,6 +304,28 @@ void TestConvTransposeOutputSize(Place place, float abs_error = 2e-5) {
   }
 }
 
+void TestConvTransposeOutputPadding(Place place, float abs_error = 2e-5) {
+  for (auto dims : std::vector<std::vector<int64_t>>{{5, 6, 12, 12}}) {
+    for (auto output_padding : std::vector<std::vector<int>>{{0, 0}, {1, 1}}) {
+      std::unique_ptr<arena::TestCase> tester(
+          new ConvTransposeComputeTester(place,
+                                         "def",
+                                         DDim(dims),
+                                         3,
+                                         {3, 3},
+                                         {2, 2},
+                                         {0, 0},
+                                         1,
+                                         {1, 1},
+                                         "",
+                                         {},
+                                         output_padding));
+      arena::Arena arena(std::move(tester), place, abs_error);
+      arena.TestPrecision();
+    }
+  }
+}
+
 void TestConvTransposeBiasRelu(Place place, float abs_error = 2e-5) {
   for (auto dims : std::vector<std::vector<int64_t>>{{5, 6, 11, 12}}) {
     for (auto bias : std::vector<std::string>{"", "bias"}) {
@@ -307,6 +342,7 @@ void TestConvTransposeBiasRelu(Place place, float abs_error = 2e-5) {
                                            1,
                                            {1, 1},
                                            "",
+                                           {},
                                            {},
                                            bias,
                                            fuse_relu));
@@ -334,6 +370,7 @@ TEST(Conv_transpose, precision) {
   TestConvTransposeDilations(place, abs_error);
   TestConvTransposePaddingAlgorithm(place, abs_error);
   TestConvTransposeOutputSize(place, abs_error);
+  TestConvTransposeOutputPadding(place, abs_error);
   TestConvTransposeBiasRelu(place, abs_error);
 }
 


### PR DESCRIPTION
[Background]
Compared with Paddle1.8/2.0, the definition of conv_transpose api is modified in Paddle1.8:

new attributes : output_padding
effect of new attributes:
[Effect of current PR]
add output_padding in Paddle-Lite conv_transpose op to make it adapt for Paddle1.7&1.8

[Steps for adding an input]
add output_padding in ConvParam
modify ConvTransposeOp::AttachImpl()
modify ConvTransposeOp::InferShapeImpl()
update the unit_test: lite\test\kernels\ conv_transpose_compute_test.cc