### PR TITLE
fix: fast bcast chk rule fixed

### DIFF
--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -59,7 +59,7 @@ inline bool is_fast_broadcast(const DDim& x_dims,
   }
   DDim y_dim_trim = trim_trailing_singular_dims(y_dims);
   axis = (y_dim_trim.size() == 0) ? x_dims.size() : axis;
-  if (x_dims.size() != (y_dim_trim.size() + axis)) {
+  if (x_dims.size() < (y_dim_trim.size() + axis)) {
     VLOG(4) << "Fast broadcast chk fail, for y's shape size doesnt follow the "
                "axis rule";
     return false;

--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -59,9 +59,9 @@ inline bool is_fast_broadcast(const DDim& x_dims,
   }
   DDim y_dim_trim = trim_trailing_singular_dims(y_dims);
   axis = (y_dim_trim.size() == 0) ? x_dims.size() : axis;
-  if (x_dims.size() == y_dim_trim.size()) {
-    VLOG(4)
-        << "Fast broadcast chk fail, for y's shape not really contained in x";
+  if (x_dims.size() != (y_dim_trim.size() + axis)) {
+    VLOG(4) << "Fast broadcast chk fail, for y's shape size doesnt follow the "
+               "axis rule";
     return false;
   }
   *pre = 1;


### PR DESCRIPTION
Before this fix, some case may pass the fast bcast check randomly,  and then, a wrong calculation method will be used, which will lead to an out of bound memory access.