### PR TITLE
[Op] Update instance_norm for paddle 1.8 and 2.0

### DIFF
--- a/lite/kernels/arm/instance_norm_compute.cc
+++ b/lite/kernels/arm/instance_norm_compute.cc
@@ -27,8 +27,10 @@ void InstanceNormCompute::PrepareForRun() {}
 void InstanceNormCompute::Run() {
   auto& param = this->Param<param_t>();
   const float* in = param.x->data<float>();
-  const float* scale = param.scale == nullptr ? nullptr : param.scale->data<float>();
-  const float* bias = param.bias == nullptr ? nullptr : param.bias->data<float>();
+  const float* scale =
+      param.scale == nullptr ? nullptr : param.scale->data<float>();
+  const float* bias =
+      param.bias == nullptr ? nullptr : param.bias->data<float>();
   float* out = param.out->mutable_data<float>();
   float* saved_mean = param.saved_mean->mutable_data<float>();
   float* saved_variance = param.saved_variance->mutable_data<float>();
@@ -124,7 +126,8 @@ void InstanceNormCompute::Run() {
     const float* in_p = in + i * spatial_size;
     float* out_p = out + i * spatial_size;
     int j = spatial_size;
-    const float sstd_val = scale == nullptr ? saved_variance[i] : scale[i % c] * saved_variance[i];
+    const float sstd_val =
+        scale == nullptr ? saved_variance[i] : scale[i % c] * saved_variance[i];
     const float bias_val = bias == nullptr ? 0. : bias[i % c];
     const float mean_val = saved_mean[i];
     const float32x4_t vsstd = vdupq_n_f32(sstd_val);

--- a/lite/kernels/arm/instance_norm_compute.cc
+++ b/lite/kernels/arm/instance_norm_compute.cc
@@ -27,8 +27,8 @@ void InstanceNormCompute::PrepareForRun() {}
 void InstanceNormCompute::Run() {
   auto& param = this->Param<param_t>();
   const float* in = param.x->data<float>();
-  const float* scale = param.scale->data<float>();
-  const float* bias = param.bias->data<float>();
+  const float* scale = param.scale == nullptr ? nullptr : param.scale->data<float>();
+  const float* bias = param.bias == nullptr ? nullptr : param.bias->data<float>();
   float* out = param.out->mutable_data<float>();
   float* saved_mean = param.saved_mean->mutable_data<float>();
   float* saved_variance = param.saved_variance->mutable_data<float>();
@@ -124,8 +124,8 @@ void InstanceNormCompute::Run() {
     const float* in_p = in + i * spatial_size;
     float* out_p = out + i * spatial_size;
     int j = spatial_size;
-    const float sstd_val = scale[i % c] * saved_variance[i];
-    const float bias_val = bias[i % c];
+    const float sstd_val = scale == nullptr ? saved_variance[i] : scale[i % c] * saved_variance[i];
+    const float bias_val = bias == nullptr ? 0. : bias[i % c];
     const float mean_val = saved_mean[i];
     const float32x4_t vsstd = vdupq_n_f32(sstd_val);
     const float32x4_t vbias = vdupq_n_f32(bias_val);

--- a/lite/operators/instance_norm_op.cc
+++ b/lite/operators/instance_norm_op.cc
@@ -28,7 +28,7 @@ bool InstanceNormOp::CheckShape() const {
   CHECK_OR_FALSE(param_.out);
   CHECK_OR_FALSE(param_.saved_mean);
   CHECK_OR_FALSE(param_.saved_variance);
-  
+
   auto x_dims = param_.x->dims();
   CHECK(x_dims.size() >= 2 && x_dims.size() <= 5)
       << "Input X must have 2 to 5 dimensions.";
@@ -36,13 +36,13 @@ bool InstanceNormOp::CheckShape() const {
     auto scale_dims = param_.scale->dims();
     CHECK_EQ(scale_dims.size(), 1UL) << "Input Scale must have 1 dimensions.";
     CHECK_EQ(scale_dims[0], x_dims[1]) << "ShapeError: the shape of scale must "
-      << "equal to the channel of input.";
+                                       << "equal to the channel of input.";
   }
   if (param_.bias != nullptr) {
     auto bias_dims = param_.bias->dims();
     CHECK_EQ(bias_dims.size(), 1UL) << "Input Bias must have 1 dimensions.";
     CHECK_EQ(bias_dims[0], x_dims[1]) << "ShapeError: the shape of bias must "
-      << "equal to the channel of input.";
+                                      << "equal to the channel of input.";
   }
   return true;
 }

--- a/lite/operators/instance_norm_op.cc
+++ b/lite/operators/instance_norm_op.cc
@@ -25,20 +25,25 @@ namespace operators {
 
 bool InstanceNormOp::CheckShape() const {
   CHECK_OR_FALSE(param_.x);
-  CHECK_OR_FALSE(param_.scale);
-  CHECK_OR_FALSE(param_.bias);
   CHECK_OR_FALSE(param_.out);
   CHECK_OR_FALSE(param_.saved_mean);
   CHECK_OR_FALSE(param_.saved_variance);
+  
   auto x_dims = param_.x->dims();
-  auto scale_dims = param_.scale->dims();
-  auto bias_dims = param_.bias->dims();
   CHECK(x_dims.size() >= 2 && x_dims.size() <= 5)
       << "Input X must have 2 to 5 dimensions.";
-  CHECK_EQ(scale_dims.size(), 1UL) << "Input Scale must have 1 dimensions.";
-  CHECK_EQ(bias_dims.size(), 1UL) << "Input Bias must have 1 dimensions.";
-  CHECK_GT(param_.epsilon, 0.f) << "epsilon should be greater than 0.f";
-  CHECK_LT(param_.epsilon, 0.01f) << "epsilon should be less than 0.01f";
+  if (param_.scale != nullptr) {
+    auto scale_dims = param_.scale->dims();
+    CHECK_EQ(scale_dims.size(), 1UL) << "Input Scale must have 1 dimensions.";
+    CHECK_EQ(scale_dims[0], x_dims[1]) << "ShapeError: the shape of scale must "
+      << "equal to the channel of input.";
+  }
+  if (param_.bias != nullptr) {
+    auto bias_dims = param_.bias->dims();
+    CHECK_EQ(bias_dims.size(), 1UL) << "Input Bias must have 1 dimensions.";
+    CHECK_EQ(bias_dims[0], x_dims[1]) << "ShapeError: the shape of bias must "
+      << "equal to the channel of input.";
+  }
   return true;
 }
 
@@ -54,18 +59,12 @@ bool InstanceNormOp::InferShapeImpl() const {
 
 bool InstanceNormOp::AttachImpl(const cpp::OpDesc& op_desc,
                                 lite::Scope* scope) {
-  param_.x = scope->FindVar(op_desc.Input("X").front())->GetMutable<Tensor>();
-  param_.scale =
-      scope->FindVar(op_desc.Input("Scale").front())->GetMutable<Tensor>();
-  param_.bias =
-      scope->FindVar(op_desc.Input("Bias").front())->GetMutable<Tensor>();
-  param_.saved_mean =
-      scope->FindVar(op_desc.Output("SavedMean").front())->GetMutable<Tensor>();
-  param_.saved_variance =
-      scope->FindVar(op_desc.Output("SavedVariance").front())
-          ->GetMutable<Tensor>();
-  param_.out =
-      scope->FindVar(op_desc.Output("Y").front())->GetMutable<Tensor>();
+  AttachInput(op_desc, scope, "X", false /*is_dispensable*/, &param_.x);
+  AttachInput(op_desc, scope, "Scale", true, &param_.scale);
+  AttachInput(op_desc, scope, "Bias", true, &param_.bias);
+  AttachOutput(op_desc, scope, "SavedMean", false, &param_.saved_mean);
+  AttachOutput(op_desc, scope, "SavedVariance", false, &param_.saved_variance);
+  AttachOutput(op_desc, scope, "Y", false, &param_.out);
   param_.epsilon = op_desc.GetAttr<float>("epsilon");
   return true;
 }

--- a/lite/tests/kernels/instance_norm_compute_test.cc
+++ b/lite/tests/kernels/instance_norm_compute_test.cc
@@ -33,18 +33,25 @@ class InstanceNormComputeTest : public arena::TestCase {
 
   DDim dims_{{4, 5, 19, 19}};
   float epsilon_ = 1e-5f;
+  bool has_scale_bias_ = true;
 
  public:
   InstanceNormComputeTest(const Place& place,
                           const std::string& alias,
                           DDim dims,
-                          float epsilon)
-      : TestCase(place, alias), dims_(dims), epsilon_(epsilon) {}
+                          float epsilon,
+                          bool has_scale_bias)
+      : TestCase(place, alias), dims_(dims), epsilon_(epsilon),
+        has_scale_bias_(has_scale_bias) {}
 
   void RunBaseline(Scope* scope) override {
-    auto x = scope->FindTensor(x_);
-    auto scale = scope->FindTensor(scale_);
-    auto bias = scope->FindTensor(bias_);
+    const Tensor* x = scope->FindTensor(x_);
+    const float*  x_data = x->data<float>();
+    const float* scale_data = has_scale_bias_ ? 
+      scope->FindTensor(scale_)->data<float>() : nullptr;
+    const float*  bias_data = has_scale_bias_ ?
+      scope->FindTensor(bias_)->data<float>() : nullptr;
+
     auto y = scope->NewTensor(y_);
     auto saved_mean = scope->NewTensor(saved_mean_);
     auto saved_variance = scope->NewTensor(saved_variance_);
@@ -56,9 +63,6 @@ class InstanceNormComputeTest : public arena::TestCase {
     saved_mean->Resize(saved_dim);
     saved_variance->Resize(saved_dim);
 
-    auto x_data = x->data<float>();
-    auto scale_data = scale->data<float>();
-    auto bias_data = bias->data<float>();
     auto y_data = y->mutable_data<float>();
     auto saved_mean_data = saved_mean->mutable_data<float>();
     auto saved_variance_data = saved_variance->mutable_data<float>();
@@ -90,8 +94,8 @@ class InstanceNormComputeTest : public arena::TestCase {
     for (int i = 0; i < n * c; ++i) {
       const float* x_ptr = x_data + i * spatial_size;
       float* y_ptr = y_data + i * spatial_size;
-      float scale_val = scale_data[i % c];
-      float bias_val = bias_data[i % c];
+      float scale_val = scale_data == nullptr ? 1 : scale_data[i % c];
+      float bias_val = bias_data == nullptr ? 0 : bias_data[i % c];
       for (int j = 0; j < spatial_size; ++j) {
         y_ptr[j] = scale_val * (x_ptr[j] - saved_mean_data[i]) *
                        saved_variance_data[i] +
@@ -103,8 +107,10 @@ class InstanceNormComputeTest : public arena::TestCase {
   void PrepareOpDesc(cpp::OpDesc* op_desc) {
     op_desc->SetType("instance_norm");
     op_desc->SetInput("X", {x_});
-    op_desc->SetInput("Bias", {bias_});
-    op_desc->SetInput("Scale", {scale_});
+    if (has_scale_bias_) {
+      op_desc->SetInput("Bias", {bias_});
+      op_desc->SetInput("Scale", {scale_});
+    }
     op_desc->SetOutput("Y", {y_});
     op_desc->SetOutput("SavedMean", {saved_mean_});
     op_desc->SetOutput("SavedVariance", {saved_variance_});
@@ -114,16 +120,17 @@ class InstanceNormComputeTest : public arena::TestCase {
   void PrepareData() override {
     std::vector<float> x(dims_.production());
     fill_data_rand(x.data(), -1.f, 1.f, dims_.production());
-
-    DDim scale_bias_dims{{dims_[1]}};
-    std::vector<float> scale(scale_bias_dims.production());
-    fill_data_rand(scale.data(), -1.f, 1.f, scale_bias_dims.production());
-    std::vector<float> bias(scale_bias_dims.production());
-    fill_data_rand(bias.data(), -1.f, 1.f, scale_bias_dims.production());
-
     SetCommonTensor(x_, dims_, x.data());
-    SetCommonTensor(scale_, scale_bias_dims, scale.data(), {}, true);
-    SetCommonTensor(bias_, scale_bias_dims, bias.data(), {}, true);
+
+    if (has_scale_bias_) {
+      DDim scale_bias_dims{{dims_[1]}};
+      std::vector<float> scale(scale_bias_dims.production());
+      fill_data_rand(scale.data(), -1.f, 1.f, scale_bias_dims.production());
+      std::vector<float> bias(scale_bias_dims.production());
+      fill_data_rand(bias.data(), -1.f, 1.f, scale_bias_dims.production());
+      SetCommonTensor(scale_, scale_bias_dims, scale.data(), {}, true);
+      SetCommonTensor(bias_, scale_bias_dims, bias.data(), {}, true);
+    }
   }
 };
 
@@ -133,22 +140,24 @@ void TestInstanceNorm(Place place,
   for (auto& n : {1, 3, 16}) {
     for (auto& c : {1, 4, 16}) {
       for (auto& h : {1, 16, 33, 56}) {
-        for (auto& w : {1, 17, 34, 55}) {
-          DDim dim_in({n, c, h, w});
-          float epsilon = 1e-5f;
-          std::unique_ptr<arena::TestCase> tester(
-              new InstanceNormComputeTest(place, "def", dim_in, epsilon));
+        for (auto& w : {1, 5, 34, 55}) {
+          for (auto& has_scale_bias : {true, false}) {
+            DDim dim_in({n, c, h, w});
+            float epsilon = 1e-5f;
+            std::unique_ptr<arena::TestCase> tester(
+                new InstanceNormComputeTest(place, "def", dim_in, epsilon, has_scale_bias));
 #ifdef LITE_WITH_ARM
-          if (place == TARGET(kARM)) {
-            auto& ctx = tester->context()->As<ARMContext>();
-            ctx.SetRunMode(lite_api::LITE_POWER_HIGH, 4);
-          }
+            if (place == TARGET(kARM)) {
+              auto& ctx = tester->context()->As<ARMContext>();
+              ctx.SetRunMode(lite_api::LITE_POWER_HIGH, 4);
+            }
 #endif
-          arena::Arena arena(std::move(tester), place, abs_error);
-          if (!arena.TestPrecision(ignored_outs)) {
-            LOG(ERROR) << "run n: " << n << ", c: " << c << ", h: " << h
-                       << ", w: " << w;
-            return;
+            arena::Arena arena(std::move(tester), place, abs_error);
+            if (!arena.TestPrecision(ignored_outs)) {
+              LOG(ERROR) << "run n: " << n << ", c: " << c << ", h: " << h
+                         << ", w: " << w << ", has_scale_bias:" << has_scale_bias;
+              return;
+            }
           }
         }
       }

--- a/lite/tests/kernels/instance_norm_compute_test.cc
+++ b/lite/tests/kernels/instance_norm_compute_test.cc
@@ -41,16 +41,18 @@ class InstanceNormComputeTest : public arena::TestCase {
                           DDim dims,
                           float epsilon,
                           bool has_scale_bias)
-      : TestCase(place, alias), dims_(dims), epsilon_(epsilon),
+      : TestCase(place, alias),
+        dims_(dims),
+        epsilon_(epsilon),
         has_scale_bias_(has_scale_bias) {}
 
   void RunBaseline(Scope* scope) override {
     const Tensor* x = scope->FindTensor(x_);
-    const float*  x_data = x->data<float>();
-    const float* scale_data = has_scale_bias_ ? 
-      scope->FindTensor(scale_)->data<float>() : nullptr;
-    const float*  bias_data = has_scale_bias_ ?
-      scope->FindTensor(bias_)->data<float>() : nullptr;
+    const float* x_data = x->data<float>();
+    const float* scale_data =
+        has_scale_bias_ ? scope->FindTensor(scale_)->data<float>() : nullptr;
+    const float* bias_data =
+        has_scale_bias_ ? scope->FindTensor(bias_)->data<float>() : nullptr;
 
     auto y = scope->NewTensor(y_);
     auto saved_mean = scope->NewTensor(saved_mean_);
@@ -144,8 +146,8 @@ void TestInstanceNorm(Place place,
           for (auto& has_scale_bias : {true, false}) {
             DDim dim_in({n, c, h, w});
             float epsilon = 1e-5f;
-            std::unique_ptr<arena::TestCase> tester(
-                new InstanceNormComputeTest(place, "def", dim_in, epsilon, has_scale_bias));
+            std::unique_ptr<arena::TestCase> tester(new InstanceNormComputeTest(
+                place, "def", dim_in, epsilon, has_scale_bias));
 #ifdef LITE_WITH_ARM
             if (place == TARGET(kARM)) {
               auto& ctx = tester->context()->As<ARMContext>();
@@ -155,7 +157,8 @@ void TestInstanceNorm(Place place,
             arena::Arena arena(std::move(tester), place, abs_error);
             if (!arena.TestPrecision(ignored_outs)) {
               LOG(ERROR) << "run n: " << n << ", c: " << c << ", h: " << h
-                         << ", w: " << w << ", has_scale_bias:" << has_scale_bias;
+                         << ", w: " << w
+                         << ", has_scale_bias:" << has_scale_bias;
               return;
             }
           }


### PR DESCRIPTION
Update instance_norm for paddle 1.8 and 2.0: scale and bias is dispensable.
The OpVersion bind by instance_norm kernel is 0 by default.