### PR TITLE
[Ops] align the kernel_versions with the op_versions in PaddlePaddle 2.0

### DIFF
--- a/lite/kernels/arm/argmax_compute.cc
+++ b/lite/kernels/arm/argmax_compute.cc
@@ -77,6 +77,7 @@ REGISTER_LITE_KERNEL(arg_max,
                      fp32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
     .Finalize();
 
 #ifdef LITE_BUILD_EXTRA
@@ -89,6 +90,7 @@ REGISTER_LITE_KERNEL(arg_max,
                      int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(arg_max,
@@ -99,6 +101,7 @@ REGISTER_LITE_KERNEL(arg_max,
                      int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(arg_max,
@@ -109,6 +112,7 @@ REGISTER_LITE_KERNEL(arg_max,
                      int16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(arg_max,
@@ -119,5 +123,6 @@ REGISTER_LITE_KERNEL(arg_max,
                      uint8)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kUInt8))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
     .Finalize();
 #endif  // LITE_BUILD_EXTRA

--- a/lite/kernels/arm/collect_fpn_proposals_compute.cc
+++ b/lite/kernels/arm/collect_fpn_proposals_compute.cc
@@ -144,4 +144,5 @@ REGISTER_LITE_KERNEL(collect_fpn_proposals,
     .BindInput("MultiLevelRois", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("MultiLevelScores", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("FpnRois", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindPaddleOpVersion("collect_fpn_proposals", 1)
     .Finalize();

--- a/lite/kernels/arm/conv_compute.cc
+++ b/lite/kernels/arm/conv_compute.cc
@@ -204,6 +204,7 @@ REGISTER_LITE_KERNEL(conv2d, kARM, kFloat, kNCHW, ConvFp32, def)
     .BindInput("Bias", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Filter", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Output", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(depthwise_conv2d, kARM, kFloat, kNCHW, ConvFp32, def)
@@ -211,6 +212,7 @@ REGISTER_LITE_KERNEL(depthwise_conv2d, kARM, kFloat, kNCHW, ConvFp32, def)
     .BindInput("Bias", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Filter", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Output", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(conv2d, kARM, kInt8, kNCHW, ConvInt8_Int8, int8_out)
@@ -220,6 +222,7 @@ REGISTER_LITE_KERNEL(conv2d, kARM, kInt8, kNCHW, ConvInt8_Int8, int8_out)
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
     .BindOutput("Output",
                 {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(conv2d, kARM, kInt8, kNCHW, ConvInt8_Fp32, fp32_out)
@@ -229,6 +232,7 @@ REGISTER_LITE_KERNEL(conv2d, kARM, kInt8, kNCHW, ConvInt8_Fp32, fp32_out)
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
     .BindOutput("Output",
                 {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(
@@ -239,6 +243,7 @@ REGISTER_LITE_KERNEL(
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
     .BindOutput("Output",
                 {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
+    .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(
@@ -249,4 +254,5 @@ REGISTER_LITE_KERNEL(
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
     .BindOutput("Output",
                 {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();

--- a/lite/kernels/arm/distribute_fpn_proposals_compute.cc
+++ b/lite/kernels/arm/distribute_fpn_proposals_compute.cc
@@ -148,4 +148,5 @@ REGISTER_LITE_KERNEL(distribute_fpn_proposals,
     .BindInput("FpnRois", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("MultiFpnRois", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("RestoreIndex", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindPaddleOpVersion("distribute_fpn_proposals", 1)
     .Finalize();

--- a/lite/kernels/arm/gather_compute.cc
+++ b/lite/kernels/arm/gather_compute.cc
@@ -81,6 +81,7 @@ REGISTER_LITE_KERNEL(gather,
     .BindInput("Index",
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindPaddleOpVersion("gather", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(gather,
@@ -93,4 +94,5 @@ REGISTER_LITE_KERNEL(gather,
     .BindInput("Index",
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindPaddleOpVersion("gather", 1)
     .Finalize();

--- a/lite/kernels/arm/roi_align_compute.cc
+++ b/lite/kernels/arm/roi_align_compute.cc
@@ -242,4 +242,5 @@ REGISTER_LITE_KERNEL(roi_align,
     .BindInput("RoisLod",
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindPaddleOpVersion("roi_align", 1)
     .Finalize();

--- a/lite/kernels/cuda/conv_compute.cc
+++ b/lite/kernels/cuda/conv_compute.cc
@@ -130,6 +130,7 @@ REGISTER_LITE_KERNEL(conv2d, kCUDA, kFloat, kNCHW, ConvFp32, def)
                 {LiteType::GetTensorTy(TARGET(kCUDA),
                                        PRECISION(kFloat),
                                        DATALAYOUT(kNCHW))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(conv2d, kCUDA, kFP16, kNCHW, ConvFp16, def)
@@ -146,6 +147,7 @@ REGISTER_LITE_KERNEL(conv2d, kCUDA, kFP16, kNCHW, ConvFp16, def)
                 {LiteType::GetTensorTy(TARGET(kCUDA),
                                        PRECISION(kFP16),
                                        DATALAYOUT(kNCHW))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(depthwise_conv2d, kCUDA, kFloat, kNCHW, ConvFp32, def)
@@ -163,6 +165,7 @@ REGISTER_LITE_KERNEL(depthwise_conv2d, kCUDA, kFloat, kNCHW, ConvFp32, def)
                 {LiteType::GetTensorTy(TARGET(kCUDA),
                                        PRECISION(kFloat),
                                        DATALAYOUT(kNCHW))})
+    .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(depthwise_conv2d, kCUDA, kFP16, kNCHW, ConvFp16, def)
@@ -179,6 +182,7 @@ REGISTER_LITE_KERNEL(depthwise_conv2d, kCUDA, kFP16, kNCHW, ConvFp16, def)
                 {LiteType::GetTensorTy(TARGET(kCUDA),
                                        PRECISION(kFP16),
                                        DATALAYOUT(kNCHW))})
+    .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(
@@ -202,6 +206,7 @@ REGISTER_LITE_KERNEL(
                 {LiteType::GetTensorTy(TARGET(kCUDA),
                                        PRECISION(kFloat),
                                        DATALAYOUT(kNHWC))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(
@@ -225,4 +230,5 @@ REGISTER_LITE_KERNEL(
                 {LiteType::GetTensorTy(TARGET(kCUDA),
                                        PRECISION(kInt8),
                                        DATALAYOUT(kNHWC))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();

--- a/lite/kernels/fpga/conv_compute.cc
+++ b/lite/kernels/fpga/conv_compute.cc
@@ -146,6 +146,7 @@ REGISTER_LITE_KERNEL(
                 {LiteType::GetTensorTy(TARGET(kFPGA),
                                        PRECISION(kFP16),
                                        DATALAYOUT(kNHWC))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(depthwise_conv2d,
@@ -164,4 +165,5 @@ REGISTER_LITE_KERNEL(depthwise_conv2d,
                 {LiteType::GetTensorTy(TARGET(kFPGA),
                                        PRECISION(kFP16),
                                        DATALAYOUT(kNHWC))})
+    .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -1046,6 +1046,7 @@ REGISTER_LITE_KERNEL(conv2d,
                 {LiteType::GetTensorTy(TARGET(kOpenCL),
                                        PRECISION(kFP16),
                                        DATALAYOUT(kImageDefault))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(depthwise_conv2d,
@@ -1064,6 +1065,7 @@ REGISTER_LITE_KERNEL(depthwise_conv2d,
                 {LiteType::GetTensorTy(TARGET(kOpenCL),
                                        PRECISION(kFP16),
                                        DATALAYOUT(kImageDefault))})
+    .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();
 
 // kHost(PC)
@@ -1083,6 +1085,7 @@ REGISTER_LITE_KERNEL(conv2d,
                 {LiteType::GetTensorTy(TARGET(kOpenCL),
                                        PRECISION(kFP16),
                                        DATALAYOUT(kImageDefault))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(depthwise_conv2d,
@@ -1101,5 +1104,6 @@ REGISTER_LITE_KERNEL(depthwise_conv2d,
                 {LiteType::GetTensorTy(TARGET(kOpenCL),
                                        PRECISION(kFP16),
                                        DATALAYOUT(kImageDefault))})
+    .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();
 #define LITE_WITH_LOG

--- a/lite/kernels/x86/conv_compute.cc
+++ b/lite/kernels/x86/conv_compute.cc
@@ -24,6 +24,7 @@ REGISTER_LITE_KERNEL(conv2d,
     .BindInput("Filter", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindInput("Bias", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindOutput("Output", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(depthwise_conv2d,
@@ -36,4 +37,5 @@ REGISTER_LITE_KERNEL(depthwise_conv2d,
     .BindInput("Filter", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindInput("Bias", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindOutput("Output", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();

--- a/lite/kernels/x86/gather_compute.cc
+++ b/lite/kernels/x86/gather_compute.cc
@@ -22,6 +22,7 @@ REGISTER_LITE_KERNEL(gather, kX86, kFloat, kNCHW, GatherInt32, def)
     .BindInput("Index",
                {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindPaddleOpVersion("gather", 1)
     .Finalize();
 
 REGISTER_LITE_KERNEL(gather, kX86, kFloat, kNCHW, GatherInt64, int64_in)
@@ -29,4 +30,5 @@ REGISTER_LITE_KERNEL(gather, kX86, kFloat, kNCHW, GatherInt64, int64_in)
     .BindInput("Index",
                {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindPaddleOpVersion("gather", 1)
     .Finalize();

--- a/lite/kernels/xpu/conv_compute.cc
+++ b/lite/kernels/xpu/conv_compute.cc
@@ -74,4 +74,5 @@ REGISTER_LITE_KERNEL(conv2d, kXPU, kFloat, kNCHW, Conv2dFp32, def)
     .BindInput("Bias", {LiteType::GetTensorTy(TARGET(kXPU))})
     .BindInput("Filter", {LiteType::GetTensorTy(TARGET(kXPU))})
     .BindOutput("Output", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .BindPaddleOpVersion("conv2d", 1)
     .Finalize();


### PR DESCRIPTION
[Background]

- New feature `OP Version` has been applied into PaddlePaddle `v2.0`
  - OPs will be registered with version. 
  - OP versions will be stored into the resulted model
- Paddle-Lite has introduced `OP Version` method into itself since Paddle-Lite `V2.8.0`
  - Step1:  add op_version binding method in kernel registry function  #4826 
  - Step2: Update `model_parser` method to parse `OP Version` from Paddle Model   #4858 
  - Step3:  add `version_checker` method to compare `OP Version` of Current Paddle-Lite and inputed paddle model  #4883 

[Effect of Current PR]

We will add kernel_versions to kernels below to make them aligned with PaddlePaddle in commit id `ad01658e3689741bc26fffc87127c9bf4bb8682a`
- [arg_max](https://github.com/PaddlePaddle/Paddle/blob/0a29fc85d64dd7c65aee2e4b8d17f2e2b4cbf4b1/paddle/fluid/operators/arg_max_op.cc#L35)    version 1
- [collect_fpn_proposals](https://github.com/PaddlePaddle/Paddle/blob/a28ae86e11f52f054f1c9dedc78ba9ddc3d83d7e/paddle/fluid/operators/detection/collect_fpn_proposals_op.cc#L139)  version   1
- [distribute_fpn_proposals](https://github.com/PaddlePaddle/Paddle/blob/c41fd033e5b4efd93a1ff738f7ee029a65075b50/paddle/fluid/operators/detection/distribute_fpn_proposals_op.cc#L127)   version  1
- [gather](https://github.com/PaddlePaddle/Paddle/blob/a972c33fd7b93a24cc199ad4f3ae01ea371d3972/paddle/fluid/operators/gather_op.cc#L186)  version   1
- [roi_align](https://github.com/PaddlePaddle/Paddle/blob/a28ae86e11f52f054f1c9dedc78ba9ddc3d83d7e/paddle/fluid/operators/roi_align_op.cc#L235)  version   1
- [conv2d](https://github.com/PaddlePaddle/Paddle/blob/bc902044a47920347a3e005f995eb9b68ded57b4/paddle/fluid/operators/conv_op.cc#L822)   version 1
- [depthwise_conv2d](https://github.com/PaddlePaddle/Paddle/blob/bc902044a47920347a3e005f995eb9b68ded57b4/paddle/fluid/operators/conv_op.cc#L833)   version 1
