### PR TITLE
[Ops] align the kernel_versions with the op_versions in PaddlePaddle 2.0 [part II]

### DIFF
--- a/lite/kernels/arm/activation_compute.cc
+++ b/lite/kernels/arm/activation_compute.cc
@@ -258,6 +258,7 @@ REGISTER_LITE_KERNEL(leaky_relu,
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("alpha", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindPaddleOpVersion("leaky_relu", 1)
     .Finalize();
 REGISTER_LITE_KERNEL(relu_clipped,
                      kARM,

--- a/lite/kernels/arm/clip_compute.cc
+++ b/lite/kernels/arm/clip_compute.cc
@@ -59,4 +59,5 @@ REGISTER_LITE_KERNEL(
     .BindInput("Min", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Max", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindPaddleOpVersion("clip", 1)
     .Finalize();

--- a/lite/kernels/arm/lookup_table_compute.cc
+++ b/lite/kernels/arm/lookup_table_compute.cc
@@ -83,4 +83,5 @@ REGISTER_LITE_KERNEL(lookup_table_v2,
     .BindInput("W", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Ids", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindPaddleOpVersion("lookup_table_v2", 1)
     .Finalize();

--- a/lite/kernels/cuda/leaky_relu_compute.cu
+++ b/lite/kernels/cuda/leaky_relu_compute.cu
@@ -67,4 +67,5 @@ REGISTER_LITE_KERNEL(leaky_relu,
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kCUDA))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kCUDA))})
     .SetVersion("1.5.0")
+    .BindPaddleOpVersion("leaky_relu", 1)
     .Finalize();

--- a/lite/kernels/cuda/lookup_table_compute.cu
+++ b/lite/kernels/cuda/lookup_table_compute.cu
@@ -108,4 +108,5 @@ REGISTER_LITE_KERNEL(lookup_table_v2,
     .BindInput("Ids", {LiteType::GetTensorTy(TARGET(kCUDA), PRECISION(kInt64))})
     .BindOutput("Out",
                 {LiteType::GetTensorTy(TARGET(kCUDA), PRECISION(kFloat))})
+    .BindPaddleOpVersion("lookup_table_v2", 1)
     .Finalize();

--- a/lite/kernels/host/compare_compute.cc
+++ b/lite/kernels/host/compare_compute.cc
@@ -123,6 +123,7 @@ REGISTER_LITE_KERNEL(equal, kHost, kFloat, kAny, equal_float, def)
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("equal", 1)
     .Finalize();
 
 using equal_int32 = paddle::lite::kernels::host::CompareCompute<
@@ -138,6 +139,7 @@ REGISTER_LITE_KERNEL(equal, kHost, kInt32, kAny, equal_int32, def)
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("equal", 1)
     .Finalize();
 
 using not_equal_float = paddle::lite::kernels::host::CompareCompute<
@@ -153,6 +155,7 @@ REGISTER_LITE_KERNEL(not_equal, kHost, kFloat, kAny, not_equal_float, def)
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("not_equal", 1)
     .Finalize();
 
 using less_than_float = paddle::lite::kernels::host::CompareCompute<
@@ -168,6 +171,7 @@ REGISTER_LITE_KERNEL(less_than, kHost, kFloat, kAny, less_than_float, def)
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("less_than", 1)
     .Finalize();
 
 using less_than_int32 = paddle::lite::kernels::host::CompareCompute<
@@ -183,6 +187,7 @@ REGISTER_LITE_KERNEL(less_than, kHost, kInt32, kAny, less_than_int32, def)
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("less_than", 1)
     .Finalize();
 
 using less_than_int64 = paddle::lite::kernels::host::CompareCompute<
@@ -198,6 +203,7 @@ REGISTER_LITE_KERNEL(less_than, kHost, kInt64, kAny, less_than_int64, def)
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("less_than", 1)
     .Finalize();
 
 using less_equal_float = paddle::lite::kernels::host::CompareCompute<
@@ -213,6 +219,7 @@ REGISTER_LITE_KERNEL(less_equal, kHost, kFloat, kAny, less_equal_float, def)
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("less_equal", 1)
     .Finalize();
 
 using greater_than_float = paddle::lite::kernels::host::CompareCompute<
@@ -228,6 +235,7 @@ REGISTER_LITE_KERNEL(greater_than, kHost, kFloat, kAny, greater_than_float, def)
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("greater_than", 1)
     .Finalize();
 
 using greater_than_int64 = paddle::lite::kernels::host::CompareCompute<
@@ -243,6 +251,7 @@ REGISTER_LITE_KERNEL(greater_than, kHost, kInt64, kAny, greater_than_int64, def)
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("greater_than", 1)
     .Finalize();
 
 using greater_equal_float = paddle::lite::kernels::host::CompareCompute<
@@ -259,6 +268,7 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("greater_equal", 1)
     .Finalize();
 
 using greater_equal_int64 = paddle::lite::kernels::host::CompareCompute<
@@ -275,4 +285,5 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out",
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kBool), DATALAYOUT(kAny), -1)})
+    .BindPaddleOpVersion("greater_equal", 1)
     .Finalize();

--- a/lite/kernels/host/matrix_nms_compute.cc
+++ b/lite/kernels/host/matrix_nms_compute.cc
@@ -337,4 +337,5 @@ REGISTER_LITE_KERNEL(matrix_nms,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost))})
     .BindOutput("Index",
                 {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindPaddleOpVersion("matrix_nms", 1)
     .Finalize();

--- a/lite/kernels/x86/activation_compute.cc
+++ b/lite/kernels/x86/activation_compute.cc
@@ -45,6 +45,7 @@ REGISTER_LITE_KERNEL(leaky_relu,
                      def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindPaddleOpVersion("leaky_relu", 1)
     .Finalize();
 
 // float

--- a/lite/kernels/x86/fill_constant_compute.cc
+++ b/lite/kernels/x86/fill_constant_compute.cc
@@ -92,4 +92,5 @@ REGISTER_LITE_KERNEL(fill_constant,
     .BindInput("ShapeTensorList",
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindPaddleOpVersion("fill_constant", 1)
     .Finalize();

--- a/lite/kernels/x86/lookup_table_compute.cc
+++ b/lite/kernels/x86/lookup_table_compute.cc
@@ -41,4 +41,5 @@ REGISTER_LITE_KERNEL(lookup_table_v2,
     .BindInput("W", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindInput("Ids", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
+    .BindPaddleOpVersion("lookup_table_v2", 1)
     .Finalize();


### PR DESCRIPTION
[Background]

- New feature `OP Version` has been applied into PaddlePaddle `v2.0`
  - OPs will be registered with version. 
  - OP versions will be stored into the resulted model
- Paddle-Lite has introduced `OP Version` method into itself since Paddle-Lite `V2.8.0`
  - Step1:  add op_version binding method in kernel registry function  #4826 
  - Step2: Update `model_parser` method to parse `OP Version` from Paddle Model   #4858 
  - Step3:  add `version_checker` method to compare `OP Version` of Current Paddle-Lite and inputed paddle model  #4883 

[Effect of Current PR]


- [clip](https://github.com/PaddlePaddle/Paddle/blob/a829357e4d2e6f05060455625b4e7cfbb1bff8dd/paddle/fluid/operators/clip_op.cc#L128)      version 1
- [fill_constant](https://github.com/PaddlePaddle/Paddle/blob/d7cfee9b315bd5a54a07b388b2b3c2dedd55a63a/paddle/fluid/operators/fill_constant_op.cc#L148)     version 1
- [less_than、less_equal、greater_than、greater_equal、equal、not_equal](https://github.com/PaddlePaddle/Paddle/blob/a829357e4d2e6f05060455625b4e7cfbb1bff8dd/paddle/fluid/operators/controlflow/compare_op.cc#L155)     version 1
- [lookup_table_v2](https://github.com/PaddlePaddle/Paddle/blob/c9a8801325eb5a9f70724f5709a5ddf8fa639c5a/paddle/fluid/operators/lookup_table_v2_op.cc#L206)     version 1
- [leaky_relu](https://github.com/PaddlePaddle/Paddle/blob/bc902044a47920347a3e005f995eb9b68ded57b4/paddle/fluid/operators/activation_op.cc#L1347)     version 1
- [matrix_nms](https://github.com/PaddlePaddle/Paddle/blob/41d26a828790e578291875ce4b0245450fc7f5ed/paddle/fluid/operators/detection/matrix_nms_op.cc#L407)     version 1