### PR TITLE
[ARM][kernel] fix pool_compute.cc "x_dims[-1]" bugs

### DIFF
--- a/lite/kernels/arm/pool_compute.cc
+++ b/lite/kernels/arm/pool_compute.cc
@@ -61,6 +61,7 @@ void PoolCompute::Run() {
   global_pooling = param.global_pooling || global_pooling;
   kps_equal = kps_equal && win_ksize;
   auto x_dims = param.x->dims();
+  auto w_in = x_dims[x_dims.size() - 1];
 
   if (global_pooling) {
     for (size_t i = 0; i < ksize.size(); ++i) {
@@ -92,8 +93,8 @@ void PoolCompute::Run() {
       return;
     }
   } else {
-    if (x_dims[-1] > 8 && ksize[0] == 1 && strides[0] == 2 &&
-        paddings[0] == 0 && kps_equal) {
+    if (w_in > 8 && ksize[0] == 1 && strides[0] == 2 && paddings[0] == 0 &&
+        kps_equal) {
       auto& ctx = this->ctx_->template As<ARMContext>();
       if (pooling_type == "max") {
         lite::arm::math::pooling1x1s2p0_max(din,
@@ -109,7 +110,7 @@ void PoolCompute::Run() {
                                             paddings[3]);
         return;
       }
-    } else if (x_dims[-1] > 8 && ksize[0] == 2 && strides[0] == 2 &&
+    } else if (w_in > 8 && ksize[0] == 2 && strides[0] == 2 &&
                paddings[0] == 0 && kps_equal) {
       if (pooling_type == "max") {
         lite::arm::math::pooling2x2s2p0_max(din,
@@ -139,7 +140,7 @@ void PoolCompute::Run() {
                                             paddings[3]);
         return;
       }
-    } else if (x_dims[-1] > 8 && ksize[0] == 2 && strides[0] == 2 &&
+    } else if (w_in > 8 && ksize[0] == 2 && strides[0] == 2 &&
                paddings[0] == 1 && kps_equal) {
       if (pooling_type == "max") {
         lite::arm::math::pooling2x2s2p1_max(din,


### PR DESCRIPTION
use x_dims[x_dims.size() - 1] instead of x_dims[-1].