### PR TITLE
[Win32][OpenCL] Fix win32 compile with opencl error

### DIFF
--- a/lite/backends/opencl/cl_wrapper.h
+++ b/lite/backends/opencl/cl_wrapper.h
@@ -45,7 +45,9 @@ class CLWrapper final {
                                         cl_uint,
                                         const cl_device_id *,
                                         const char *,
-                                        void (*pfn_notify)(cl_program, void *),
+                                        void(CL_CALLBACK *)(  // NOLINT
+                                            cl_program,
+                                            void *),
                                         void *);
   using clEnqueueNDRangeKernelType = cl_int (*)(cl_command_queue,
                                                 cl_kernel,

--- a/lite/operators/range_op.cc
+++ b/lite/operators/range_op.cc
@@ -41,6 +41,9 @@ void GetSize(T start, T end, T step, int64_t* size) {
               : std::ceil(std::abs((end - start) / step));
 }
 
+#if defined(_MSC_VER) && !defined(_WIN64)
+#pragma optimize("", off)
+#endif
 bool RangeOpLite::InferShapeImpl() const {
   int64_t size = 0;
   switch (param_.Start->precision()) {
@@ -64,6 +67,9 @@ bool RangeOpLite::InferShapeImpl() const {
   param_.Out->Resize(std::vector<int64_t>({size}));
   return true;
 }
+#if defined(_MSC_VER) && !defined(_WIN64)
+#pragma optimize("", on)
+#endif
 
 bool RangeOpLite::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   auto start = opdesc.Input("Start").front();


### PR DESCRIPTION
在编译32位预测库时会有如下两个错误：
【问题1】在`cl_wrapper.cc`第48行报错：error C2664: cannot convert  from void(__stdcall *)(cl_program, void *) to void(__cdecl *)(cl_program, void *) 
【原因分析和解决方法】在宏`_WIN32`被 defined 情况下，`CL_CALLBACK`等于 `__stdcall`(可查阅 cl_platform.h line49)；然而C/C++则默认使用`__cdecl`作为calling convention。之前`void(* pfn_notify)`并没有显示指定 calling convention，故使用了`__cdecl`，与OpenCL 头文件中的声明方式不一致。

【问题2】在`range_op.cc`第66行报错：fatal error C1001: An internal error has occurred in compiler
【解决方法】解决方法是将强制设置对`RangeOpLite::InferShapeImpl()`函数不进行编译优化：
```
#pragma optimize( "", off )
/* unoptimized code section */
#pragma optimize( "", on )
```
参考链接：https://stackoverflow.com/questions/7076494/fatal-error-c1001-an-internal-error-has-occurred-in-the-compiler
 https://docs.microsoft.com/en-us/cpp/preprocessor/optimize?view=msvc-160&viewFallbackFrom=vs-2017