### PR TITLE
add OpLite::GetParam() inferface, test=develop

### DIFF
--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -113,6 +113,8 @@ class OpLite : public Registry {
     return kernel_.get();
   }
 
+  const operators::ParamBase *GetParam() const { return op_param_; }
+
   // Attach input variable from scope by op_desc and input name
   void AttachInput(const cpp::OpDesc &op_desc,
                    lite::Scope *scope,


### PR DESCRIPTION
FPGA 的一些算子通过跳写来支持输出拼接（Concat），跳写的配置需要基于现有算子添加平台相关的额外参数。添加 OpLite::GetParam() 接口满足此需求。