### PR TITLE
[Windows][OpenCL] fix min/max confilct & set not use opencl as default

### DIFF
--- a/lite/api/benchmark.cc
+++ b/lite/api/benchmark.cc
@@ -16,8 +16,6 @@
 #if !defined(_WIN32)
 #include <sys/time.h>
 #else
-#define NOMINMAX  // msvc max/min macro conflict with std::min/max
-#include <windows.h>
 #include "lite/backends/x86/port.h"
 #endif
 #define GLOG_NO_ABBREVIATED_SEVERITIES  // msvc conflict logging with windows.h

--- a/lite/api/test_helper.h
+++ b/lite/api/test_helper.h
@@ -18,8 +18,6 @@
 #if !defined(_WIN32)
 #include <sys/time.h>
 #else
-#define NOMINMAX  // msvc max/min macro conflict with std::min/max
-#include <windows.h>
 #include "lite/backends/x86/port.h"
 #endif
 #include <time.h>

--- a/lite/backends/x86/port.h
+++ b/lite/backends/x86/port.h
@@ -41,7 +41,9 @@
 #include <windows.h>
 #include <winsock.h>
 #include <numeric>  // std::accumulate in msvc
-#ifndef S_ISDIR     // windows port for sys/stat.h
+#undef min
+#undef max
+#ifndef S_ISDIR  // windows port for sys/stat.h
 #define S_ISDIR(mode) (((mode)&S_IFMT) == S_IFDIR)
 #endif  // S_ISDIR
 

--- a/lite/demo/cxx/x86_mobilenetv1_full_demo/mobilenet_full_api.cc
+++ b/lite/demo/cxx/x86_mobilenetv1_full_demo/mobilenet_full_api.cc
@@ -34,7 +34,7 @@ int64_t ShapeProduction(const shape_t& shape) {
 }
 
 // Enable `DEMO_WITH_OPENCL` macro below, if user need use gpu(opencl)
-#define DEMO_WITH_OPENCL
+// #define DEMO_WITH_OPENCL
 void RunModel(std::string model_dir) {
   // 1. Create CxxConfig
   CxxConfig config;

--- a/lite/tests/utils/tensor_utils.h
+++ b/lite/tests/utils/tensor_utils.h
@@ -20,6 +20,8 @@
 #elif defined(_WIN32)
 #define NOMINMAX  // msvc max/min macro conflict with std::min/max
 #include <windows.h>
+#undef min
+#undef max
 #else
 #include <unistd.h>
 #endif  // _WIN32

--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -29,6 +29,8 @@
 #else
 #define NOMINMAX  // msvc max/min macro conflict with std::min/max
 #include <windows.h>
+#undef min
+#undef max
 extern struct timeval;
 static int gettimeofday(struct timeval* tp, void* tzp) {
   time_t clock;

--- a/lite/utils/macros.h
+++ b/lite/utils/macros.h
@@ -25,6 +25,8 @@
 #if defined(_WIN32)
 #define UNUSED
 #define __builtin_expect(EXP, C) (EXP)
+#undef min
+#undef max
 #else
 #define UNUSED __attribute__((unused))
 #endif

--- a/lite/utils/macros.h
+++ b/lite/utils/macros.h
@@ -25,8 +25,6 @@
 #if defined(_WIN32)
 #define UNUSED
 #define __builtin_expect(EXP, C) (EXP)
-#undef min
-#undef max
 #else
 #define UNUSED __attribute__((unused))
 #endif


### PR DESCRIPTION
两个方面的修改：
- windows 平台编译时报 min/max 相关错误：
参考链接：https://stackoverflow.com/questions/5004858/why-is-stdmin-failing-when-windows-h-is-included
- 编译 x86 full demo 时 默认关闭 OpenCL 。