### PR TITLE
[OPENCL] Enhance tune api & Add precision api for opencl. test=develop

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -40,7 +40,7 @@
 namespace paddle {
 namespace lite_api {
 
-bool IsOpenCLBackendValid() {
+bool IsOpenCLBackendValid(bool check_fp16_valid) {
   bool opencl_valid = false;
 
 #ifdef LITE_WITH_OPENCL
@@ -55,12 +55,12 @@ bool IsOpenCLBackendValid() {
   LOG(INFO) << "dlsym_success:" << dlsym_success;
 #endif
   if (dlsym_success == false) return false;
-
-  opencl_valid = paddle::lite::CLRuntime::Global()->OpenCLAvaliableForDevice();
-#endif
+  opencl_valid = paddle::lite::CLRuntime::Global()->OpenCLAvaliableForDevice(
+      check_fp16_valid);
 
 #ifdef LITE_WITH_LOG
   LOG(INFO) << "opencl_valid:" << opencl_valid;
+#endif
 #endif
   return opencl_valid;
 }
@@ -266,13 +266,28 @@ ConfigBase::ConfigBase(PowerMode mode, int threads) {
 #endif
 }
 
-void ConfigBase::set_opencl_tune(size_t enable_tune) {
+void ConfigBase::set_opencl_tune(CLTuneMode tune_mode) {
 #ifdef LITE_WITH_OPENCL
   if (paddle::lite_api::IsOpenCLBackendValid()) {
-    enable_opencl_tune_ = enable_tune;
-    paddle::lite::CLRuntime::Global()->set_auto_tune(enable_opencl_tune_);
+    opencl_tune_mode_ = tune_mode;
+    paddle::lite::CLRuntime::Global()->set_auto_tune(opencl_tune_mode_);
+#ifdef LITE_WITH_LOG
+    LOG(INFO) << "opencl_tune_mode:"
+              << paddle::lite::CLRuntime::Global()->auto_tune();
+#endif
+  }
+#endif
+}
+
+void ConfigBase::set_opencl_precision(CLPrecisionType p) {
 #ifdef LITE_WITH_OPENCL
-    LOG(INFO) << "auto_tune:" << paddle::lite::CLRuntime::Global()->auto_tune();
+  if (paddle::lite_api::IsOpenCLBackendValid()) {
+    opencl_precision_ = p;
+    paddle::lite::CLRuntime::Global()->set_precision(p);
+#ifdef LITE_WITH_LOG
+    LOG(INFO) << "set opencl precision:" << static_cast<size_t>(p);
+    LOG(INFO) << "get opencl precision:"
+              << paddle::lite::CLRuntime::Global()->get_precision();
 #endif
   }
 #endif

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -43,7 +43,7 @@ enum class L3CacheSetMethod {
 };
 
 // return true if current device supports OpenCL model
-LITE_API bool IsOpenCLBackendValid();
+LITE_API bool IsOpenCLBackendValid(bool check_fp16_valid = false);
 
 struct LITE_API Tensor {
   explicit Tensor(void* raw);
@@ -140,8 +140,9 @@ class LITE_API ConfigBase {
   std::string model_dir_;
   int threads_{1};
   PowerMode mode_{LITE_POWER_NO_BIND};
-  // gpu
-  size_t enable_opencl_tune_{0};
+  // gpu opencl
+  CLTuneMode opencl_tune_mode_{CL_TUNE_NONE};
+  CLPrecisionType opencl_precision_{CL_PRECISION_AUTO};
   // to save subgraph model for npu/xpu/...
   std::string subgraph_model_cache_dir_{""};
   int device_id_{0};
@@ -159,8 +160,9 @@ class LITE_API ConfigBase {
   void set_power_mode(PowerMode mode);
   PowerMode power_mode() const { return mode_; }
   // set GPU opencl tune
-  void set_opencl_tune(size_t enable_tune);
-  size_t opencl_tune() const { return enable_opencl_tune_; }
+  void set_opencl_tune(CLTuneMode tune_mode = CL_TUNE_NONE);
+  // set GPU opencl precision
+  void set_opencl_precision(CLPrecisionType p = CL_PRECISION_AUTO);
   // set subgraph_model_dir
   void set_subgraph_model_cache_dir(std::string subgraph_model_cache_dir) {
     subgraph_model_cache_dir_ = subgraph_model_cache_dir;

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -95,6 +95,19 @@ typedef enum {
   LITE_POWER_RAND_LOW = 5
 } PowerMode;
 
+typedef enum {
+  CL_TUNE_NONE = 0,
+  CL_TUNE_RAPID = 1,
+  CL_TUNE_NORMAL = 2,
+  CL_TUNE_EXHAUSTIVE = 3
+} CLTuneMode;
+
+typedef enum {
+  CL_PRECISION_AUTO = 0,
+  CL_PRECISION_FP32 = 1,
+  CL_PRECISION_FP16 = 2
+} CLPrecisionType;
+
 typedef enum { MLU_220 = 0, MLU_270 = 1 } MLUCoreVersion;
 
 enum class ActivationType : int {

--- a/lite/backends/opencl/cl_context.cc
+++ b/lite/backends/opencl/cl_context.cc
@@ -149,6 +149,20 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
   } else if (generate_lws_type == 1) {
     // 1 - Rapid
     for (auto tune_reverse : {true, false}) {
+      for (size_t divisor = 1; divisor < /*max_divisor=*/17; divisor *= 2) {
+        tmp_lws = DefaultLocalWorkSize(
+            global_work_size, max_work_size, divisor, tune_reverse);
+        if (last_lws[0] == tmp_lws[0] && last_lws[1] == tmp_lws[1] &&
+            last_lws[2] == tmp_lws[2]) {
+          // skip tuned lws
+          continue;
+        }
+        lwss.emplace_back(tmp_lws);
+      }
+    }
+  } else if (generate_lws_type == 2) {
+    // 2 - Normal
+    for (auto tune_reverse : {true, false}) {
       for (size_t divisor = 1; divisor < /*max_divisor=*/15; divisor += 2) {
         tmp_lws = DefaultLocalWorkSize(
             global_work_size, max_work_size, divisor, tune_reverse);
@@ -160,8 +174,7 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
         lwss.emplace_back(tmp_lws);
       }
     }
-  } else if (generate_lws_type == 2 || generate_lws_type == 3) {
-    // 2 - Normal
+  } else if (generate_lws_type == 3) {
     // 3 - Exhaustive
     for (auto tune_reverse : {true, false}) {
       for (size_t divisor = 1; divisor < /*max_divisor=*/15; divisor++) {
@@ -176,7 +189,6 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
       }
     }
   } else {
-    // todo
     LOG(FATAL) << "Unsupported opencl tune type:" << generate_lws_type;
   }
 

--- a/lite/backends/opencl/cl_context.cc
+++ b/lite/backends/opencl/cl_context.cc
@@ -13,6 +13,7 @@ limitations under the License. */
 #include <memory>
 #include <string>
 #include <utility>
+#include "lite/api/paddle_place.h"
 #include "lite/backends/opencl/cl_runtime.h"
 #include "lite/backends/opencl/cl_utility.h"
 #include "lite/utils/cp_logging.h"
@@ -144,9 +145,9 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
   std::vector<cl::NDRange> lwss{tmp_lws};
   VLOG(1) << "generate_lws_type:" << generate_lws_type;
   // 0 - None, 1 - Rapid, 2 - Normal, 3 - Exhaustive
-  if (generate_lws_type == 0) {
+  if (generate_lws_type == lite_api::CL_TUNE_NONE) {
     // 0 - None: nothing to do
-  } else if (generate_lws_type == 1) {
+  } else if (generate_lws_type == lite_api::CL_TUNE_RAPID) {
     // 1 - Rapid
     for (auto tune_reverse : {true, false}) {
       for (size_t divisor = 1; divisor < /*max_divisor=*/17; divisor *= 2) {
@@ -160,7 +161,7 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
         lwss.emplace_back(tmp_lws);
       }
     }
-  } else if (generate_lws_type == 2) {
+  } else if (generate_lws_type == lite_api::CL_TUNE_NORMAL) {
     // 2 - Normal
     for (auto tune_reverse : {true, false}) {
       for (size_t divisor = 1; divisor < /*max_divisor=*/15; divisor += 2) {
@@ -174,7 +175,7 @@ std::vector<cl::NDRange> CLContext::GenerateLocalWorkSizes(
         lwss.emplace_back(tmp_lws);
       }
     }
-  } else if (generate_lws_type == 3) {
+  } else if (generate_lws_type == lite_api::CL_TUNE_EXHAUSTIVE) {
     // 3 - Exhaustive
     for (auto tune_reverse : {true, false}) {
       for (size_t divisor = 1; divisor < /*max_divisor=*/15; divisor++) {

--- a/lite/backends/opencl/cl_image_converter.h
+++ b/lite/backends/opencl/cl_image_converter.h
@@ -35,7 +35,7 @@ class CLImageConverterBase {
                            const DDim &tensor_dim) = 0;
   virtual DDim InitImageDimInfoWith(const DDim &tensor_dim) = 0;
 
-  bool fp16_support_{paddle::lite::CLRuntime::Global()->support_half()};
+  bool fp16_support_{paddle::lite::CLRuntime::Global()->get_precision() == 2};
 };
 
 class CLImageConverterDefault : public CLImageConverterBase {

--- a/lite/backends/opencl/cl_image_converter.h
+++ b/lite/backends/opencl/cl_image_converter.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include "lite/api/paddle_place.h"
 #include "lite/backends/opencl/cl_half.h"
 #include "lite/backends/opencl/cl_runtime.h"
 #include "lite/core/tensor.h"
@@ -35,7 +36,8 @@ class CLImageConverterBase {
                            const DDim &tensor_dim) = 0;
   virtual DDim InitImageDimInfoWith(const DDim &tensor_dim) = 0;
 
-  bool fp16_support_{paddle::lite::CLRuntime::Global()->get_precision() == 2};
+  bool fp16_support_{paddle::lite::CLRuntime::Global()->get_precision() ==
+                     lite_api::CL_PRECISION_FP16};
 };
 
 class CLImageConverterDefault : public CLImageConverterBase {

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -93,6 +93,7 @@ bool CLRuntime::Init() {
     LOG(INFO) << "set is_cl_runtime_initialized_ = true";
 #endif
   }
+  set_precision();
   return is_cl_runtime_initialized_;
 }
 

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -149,7 +149,7 @@ bool CLRuntime::BuildProgram(cl::Program* program, const std::string& options) {
   /* -I +CLRuntime::Global()->cl_path() + "/cl_kernel"*/
   std::string build_option = options + " -cl-fast-relaxed-math -cl-mad-enable";
   if (build_option.find("CL_DTYPE_") == std::string::npos) {
-    if (2 == get_precision()) {
+    if (lite_api::CL_PRECISION_FP16 == get_precision()) {
       build_option += " -DCL_DTYPE_half ";
     } else {
       build_option += " -DCL_DTYPE_float -DCL_DTYPE_FLOAT_FORCE ";

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -148,13 +148,16 @@ bool CLRuntime::BuildProgram(cl::Program* program, const std::string& options) {
   /* -I +CLRuntime::Global()->cl_path() + "/cl_kernel"*/
   std::string build_option = options + " -cl-fast-relaxed-math -cl-mad-enable";
   if (build_option.find("CL_DTYPE_") == std::string::npos) {
-    if (support_half()) {
+    if (2 == get_precision()) {
       build_option += " -DCL_DTYPE_half ";
     } else {
       build_option += " -DCL_DTYPE_float -DCL_DTYPE_FLOAT_FORCE ";
     }
   }
+#ifdef LITE_WITH_LOG
+  VLOG(4) << "precision_:" << precision_;
   VLOG(4) << "OpenCL build_option: " << build_option;
+#endif
   status_ = program->build({*device_}, build_option.c_str());
   CL_CHECK_ERROR(status_);
 

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -16,6 +16,7 @@ limitations under the License. */
 #include <memory>
 #include <string>
 #include <vector>
+#include "lite/api/paddle_place.h"
 #include "lite/backends/opencl/cl_include.h"
 #include "lite/backends/opencl/cl_utility.h"
 #include "lite/backends/opencl/cl_wrapper.h"
@@ -84,28 +85,32 @@ class CLRuntime {
     return is_device_avaliable_for_opencl_;
   }
 
-  void set_auto_tune(size_t enable_tune) {
-    auto_tune_ = enable_tune;
+  void set_auto_tune(lite_api::CLTuneMode tune_mode) {
+    auto_tune_ = tune_mode;
     command_queue_ = CreateCommandQueue(context());
   }
 
-  size_t auto_tune() { return auto_tune_; }
+  lite_api::CLTuneMode auto_tune() { return auto_tune_; }
 
-  void set_precision(size_t p = 0) {
+  void set_precision(
+      lite_api::CLPrecisionType p = lite_api::CL_PRECISION_AUTO) {
     // CL_PRECISION_AUTO: 0
     // CL_PRECISION_FP32: 1
     // CL_PRECISION_FP16: 2
-    if ((0 == p || 2 == p) && support_half()) {
-      precision_ = 2;
-    } else if (0 == p || 1 == p) {
-      precision_ = 1;
+    if ((lite_api::CL_PRECISION_AUTO == p ||
+         lite_api::CL_PRECISION_FP16 == p) &&
+        support_half()) {
+      precision_ = lite_api::CL_PRECISION_FP16;
+    } else if (lite_api::CL_PRECISION_AUTO == p ||
+               lite_api::CL_PRECISION_FP32 == p) {
+      precision_ = lite_api::CL_PRECISION_FP32;
     } else {
       LOG(FATAL) << "unsupported precision for opencl:"
                  << static_cast<size_t>(p);
     }
   }
 
-  size_t get_precision() { return precision_; }
+  lite_api::CLPrecisionType get_precision() { return precision_; }
 
   bool Init();
 
@@ -218,9 +223,13 @@ class CLRuntime {
 
   bool is_platform_device_init_success_{false};
 
-  size_t auto_tune_{0};  // 0 - None, 1 - Rapid, 2 - Normal, 3 - Exhaustive
+  lite_api::CLTuneMode auto_tune_{lite_api::CL_TUNE_NONE};  // 0 - None, 1 -
+                                                            // Rapid, 2 -
+                                                            // Normal, 3 -
+                                                            // Exhaustive
 
-  size_t precision_{0};  // 0 - AUTO, 1 - fp32, 2 - fp16
+  lite_api::CLPrecisionType precision_{
+      lite_api::CL_PRECISION_AUTO};  // 0 - AUTO, 1 - fp32, 2 - fp16
 };
 
 }  // namespace lite

--- a/lite/core/kernel.h
+++ b/lite/core/kernel.h
@@ -212,7 +212,7 @@ class KernelBase {
 #endif
 #ifdef LITE_WITH_OPENCL
   cl::Event event_;
-  bool fp16_support_{paddle::lite::CLRuntime::Global()->support_half()};
+  bool fp16_support_{paddle::lite::CLRuntime::Global()->get_precision() == 2};
 #endif
 };
 

--- a/lite/core/kernel.h
+++ b/lite/core/kernel.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "lite/api/paddle_place.h"
 #include "lite/backends/arm/math/type_trans.h"
 #include "lite/core/context.h"
 #include "lite/core/target_wrapper.h"
@@ -212,7 +213,8 @@ class KernelBase {
 #endif
 #ifdef LITE_WITH_OPENCL
   cl::Event event_;
-  bool fp16_support_{paddle::lite::CLRuntime::Global()->get_precision() == 2};
+  bool fp16_support_{paddle::lite::CLRuntime::Global()->get_precision() ==
+                     lite_api::CL_PRECISION_FP16};
 #endif
 };
 

--- a/lite/core/profile/precision_profiler.h
+++ b/lite/core/profile/precision_profiler.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "lite/api/paddle_place.h"
 #include "lite/core/program.h"
 #include "lite/utils/io.h"
 #ifdef LITE_WITH_X86
@@ -303,7 +304,8 @@ class PrecisionProfiler {
       }
 #ifdef LITE_WITH_OPENCL
     } else if (target_type == TARGET(kOpenCL)) {
-      bool use_fp16 = paddle::lite::CLRuntime::Global()->get_precision() == 2;
+      bool use_fp16 = paddle::lite::CLRuntime::Global()->get_precision() ==
+                      lite_api::CL_PRECISION_FP16;
       CLRuntime::Global()->command_queue().finish();
       switch (layout_type) {
         case DATALAYOUT(kImageDefault): {

--- a/lite/core/profile/precision_profiler.h
+++ b/lite/core/profile/precision_profiler.h
@@ -303,7 +303,7 @@ class PrecisionProfiler {
       }
 #ifdef LITE_WITH_OPENCL
     } else if (target_type == TARGET(kOpenCL)) {
-      bool use_fp16 = paddle::lite::CLRuntime::Global()->support_half();
+      bool use_fp16 = paddle::lite::CLRuntime::Global()->get_precision() == 2;
       CLRuntime::Global()->command_queue().finish();
       switch (layout_type) {
         case DATALAYOUT(kImageDefault): {

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -159,14 +159,9 @@ RuntimeProgram::RuntimeProgram(
     int block_idx)
     : exec_scope_(exec_scope) {
 #ifdef LITE_WITH_OPENCL
-#ifdef LITE_WITH_ANDROID
   bool opencl_valid = paddle::lite::CLWrapper::Global()->OpenclLibFound() &&
                       paddle::lite::CLWrapper::Global()->DlsymSuccess() &&
                       CLRuntime::Global()->OpenCLAvaliableForDevice();
-#else
-  bool opencl_valid = paddle::lite::CLWrapper::Global()->OpenclLibFound() &&
-                      paddle::lite::CLWrapper::Global()->DlsymSuccess();
-#endif  // LITE_WITH_ANDROID
   using OpenCLContext = Context<TargetType::kOpenCL>;
   std::unique_ptr<KernelContext> unique_opencl_ctx(new KernelContext());
   if (opencl_valid) {

--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -26,7 +26,7 @@
 // avoid linking errors such as `unsupport ops or kernels`.
 /////////////////////////////////////////////////////////////////////////
 // #include "paddle_use_kernels.h"  // NOLINT
-//#include "paddle_use_ops.h"      // NOLINT
+// #include "paddle_use_ops.h"      // NOLINT
 
 using namespace paddle::lite_api;  // NOLINT
 

--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -26,7 +26,7 @@
 // avoid linking errors such as `unsupport ops or kernels`.
 /////////////////////////////////////////////////////////////////////////
 // #include "paddle_use_kernels.h"  // NOLINT
-// #include "paddle_use_ops.h"      // NOLINT
+//#include "paddle_use_ops.h"      // NOLINT
 
 using namespace paddle::lite_api;  // NOLINT
 
@@ -137,16 +137,28 @@ void RunModel(std::string model_dir,
   //    lib](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/docs/demo_guides/opencl.md);
   //  second, [convert and use opencl nb
   //    model](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/docs/user_guides/opt/opt_bin.md).
-  //
+
+  bool is_opencl_backend_valid =
+      ::IsOpenCLBackendValid(/*check_fp16_valid = false*/);
+  std::cout << "is_opencl_backend_valid:" << is_opencl_backend_valid
+            << std::endl;
   /*  Uncomment code below to enable OpenCL
-  bool is_opencl_backend_valid = ::IsOpenCLBackendValid();
-  std::cout << "is_opencl_backend_valid:" << is_opencl_backend_valid <<
-  std::endl;
   if (is_opencl_backend_valid) {
     // give opencl nb model dir
     config.set_model_from_file(model_dir);
-    // opencl tune option: 0 - None, 1 - Rapid, 2 - Normal, 3 - Exhaustive
-    config.set_opencl_tune(0);
+
+    // opencl tune option
+    // CL_TUNE_NONE: 0
+    // CL_TUNE_RAPID: 1
+    // CL_TUNE_NORMAL: 2
+    // CL_TUNE_EXHAUSTIVE: 3
+    config.set_opencl_tune(CL_TUNE_NONE);
+
+    // opencl precision option
+    // CL_PRECISION_AUTO: 0, first fp16 if valid, default
+    // CL_PRECISION_FP32: 1, force fp32
+    // CL_PRECISION_FP16: 2, force fp16
+    config.set_opencl_precision(CL_PRECISION_FP16);
   } else {
     std::cout << "Unsupport opencl nb model." << std::endl;
     exit(1);


### PR DESCRIPTION
# 状态：等待review

## 主要内容

1. 精度强化
    1. 增加opencl用户侧设置计算精度api。默认fp16，可以设置AUTO/FP32/FP16这3种计算精度，方便RD、QA验证精度，开发过程更自由；
        1. CL_PRECISION_AUTO：自动判断，优先fp16；
        2. CL_PRECISION_FP32：强制fp32，若不支持会FATAL掉；
        3. CL_PRECISION_FP16：强制fp16，若不支持会FATAL掉。
    2. 弱化opencl_valid api对fp16精度支持的检查，默认改为不做该检查，此外加入新参数让用户决定是否做该检查；
    3. cl_runtime增加set_precision和get_precision方法，便于设置和获取用户设置的精度；
    4. 其它。修改相关精度的内容，如build_options、精度Profiler等等。
2. tune强化
    1. 由原本的数字改为枚举名等，用户友好；
        1. CL_TUNE_NONE：不做TUNE；
        2. CL_TUNE_RAPID
        3. CL_TUNE_NORMAL
        4. CL_TUNE_EXHAUSTIVE
    2. 原有的cl_tune_rapid改名为cl_tune_normal；
    3. 增加cl_tune_rapid。进一步简化cl_tune_normal得到。

## 性能：主要测试FP32和CL_TUNE_RAPID（新增）

- 硬件平台：麒麟810，未root；
- 模型：caffe_mobilenetv1；
- 性能：
    - fp32性能
        1. caffe_mobilenetv1/fp32/tune(NONE): 52.1ms, 0.00197302；
        2. caffe_mobilenetv1/fp32/tune(RAPID): 47.2ms, 0.00197302；
        3. caffe_mobilenetv1/fp32/tune(NORMAL): 34.5ms, 0.00197302；
        4. caffe_mobilenetv1/fp32/tune(EXHAUSTIVE): 38.6ms, 0.00197302。
    - fp16性能
        1. caffe_mobilenetv1/fp16/tune(NONE): 37.1ms, 首次480ms，0.00186522；
        2. caffe_mobilenetv1/fp16/tune(RAPID): 35.3ms, 首次2800ms，0.00186522；
        3. caffe_mobilenetv1/fp16/tune(NORMAL): 24.3ms, 首次3500ms，0.00186522；
        4. caffe_mobilenetv1/fp16/tune(EXHAUSTIVE): 26.3ms, 首次6100ms，0.00186522。

----
- 硬件平台：骁龙855，root；
- 模型：caffe_mobilenetv1；
- 性能：
    - fp32性能
        1. caffe_mobilenetv1/fp32/tune(NONE): 11.9, 00197302；
        2. caffe_mobilenetv1/fp32/tune(RAPID): 10.1, 00197302；
        3. caffe_mobilenetv1/fp32/tune(NORMAL): 10.1, 00197302；
        4. caffe_mobilenetv1/fp32/tune(EXHAUSTIVE): 10.2, 00197302；
    - fp16性能
        1. caffe_mobilenetv1/fp16/tune(NONE): 7.7ms, 首次480ms，0.00191348；
        2. caffe_mobilenetv1/fp16/tune(RAPID): 7.8ms, 首次890ms，0.00191348；
        3. caffe_mobilenetv1/fp16/tune(NORMAL): 7.7ms, 首次1100ms，0.00191348；
        4. caffe_mobilenetv1/fp16/tune(EXHAUSTIVE): 7.8ms, 首次1700ms，10.00191348。
----
- 硬件平台：MacOS-X86，Intel(R) Iris(TM) Plus Graphics 640；
- 模型：caffe_mobilenetv1；
- 性能：
    - fp32性能
        1. caffe_mobilenetv1/fp32/tune(NONE):26.9ms，首次1120ms，0.00197302；
        2. caffe_mobilenetv1/fp32/tune(RAPID):24.1ms，首次1960ms，0.00197302；
        3. caffe_mobilenetv1/fp32/tune(NORMAL):24.1ms，首次2260ms，0.00197302；
        4. caffe_mobilenetv1/fp32/tune(EXHAUSTIVE): 24.1ms，首次3300ms，0.00197302。