### PR TITLE
[Cherry-pick][CI] Remove 'unit_test_skip_list' from ci_test.sh, use 'unit_test_check_list' and 'unit_test_filter_type' instead (#4981)

### DIFF
--- a/lite/tools/ci_test.sh
+++ b/lite/tools/ci_test.sh
@@ -782,10 +782,6 @@ function main() {
             TOOLCHAIN_LIST="${i#*=}"
             shift
             ;;
-        --unit_test_skip_list=*)
-            UNIT_TEST_CHECK_LIST="${i#*=}"
-            shift
-            ;;
         --unit_test_check_list=*)
             UNIT_TEST_CHECK_LIST="${i#*=}"
             shift


### PR DESCRIPTION
test=develop