### PR TITLE
[OpenCL] Fix paddle::lite::replace_stl::ostream::operator<< error

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -273,7 +273,8 @@ void ConfigBase::set_opencl_tune(CLTuneMode tune_mode) {
     paddle::lite::CLRuntime::Global()->set_auto_tune(opencl_tune_mode_);
 #ifdef LITE_WITH_LOG
     LOG(INFO) << "opencl_tune_mode:"
-              << paddle::lite::CLRuntime::Global()->auto_tune();
+              << static_cast<size_t>(
+                     paddle::lite::CLRuntime::Global()->auto_tune());
 #endif
   }
 #endif
@@ -285,9 +286,9 @@ void ConfigBase::set_opencl_precision(CLPrecisionType p) {
     opencl_precision_ = p;
     paddle::lite::CLRuntime::Global()->set_precision(p);
 #ifdef LITE_WITH_LOG
-    LOG(INFO) << "set opencl precision:" << static_cast<size_t>(p);
     LOG(INFO) << "get opencl precision:"
-              << paddle::lite::CLRuntime::Global()->get_precision();
+              << static_cast<size_t>(
+                     paddle::lite::CLRuntime::Global()->get_precision());
 #endif
   }
 #endif

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -156,7 +156,7 @@ bool CLRuntime::BuildProgram(cl::Program* program, const std::string& options) {
     }
   }
 #ifdef LITE_WITH_LOG
-  VLOG(4) << "precision_:" << precision_;
+  VLOG(4) << "precision_:" << static_cast<size_t>(precision_);
   VLOG(4) << "OpenCL build_option: " << build_option;
 #endif
   status_ = program->build({*device_}, build_option.c_str());

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -46,7 +46,7 @@ CLRuntime::~CLRuntime() {
 
 bool CLRuntime::Init() {
 #ifdef LITE_WITH_LOG
-  VLOG(3) << "is_cl_runtime_initialized_:" << is_cl_runtime_initialized_;
+  VLOG(6) << "is_cl_runtime_initialized_:" << is_cl_runtime_initialized_;
 #endif
   if (is_cl_runtime_initialized_) {
     return true;


### PR DESCRIPTION
【问题】在 tiny_publish 下编译 mobile_light 报错：
```
../../..//cxx/lib//libpaddle_light_api_shared.so: error: undefined reference to 'paddle::lite::replace_stl::ostream& paddle::lite::replace_stl::ostream::operator<< <paddle::lite_api::CLPrecisionType>(paddle::lite_api::CLPrecisionType const&)'
../../..//cxx/lib//libpaddle_light_api_shared.so: error: undefined reference to 'paddle::lite::replace_stl::ostream& paddle::lite::replace_stl::ostream::operator<< <paddle::lite_api::CLTuneMode>(paddle::lite_api::CLTuneMode const&)'
collect2: error: ld returned 1 exit status
Makefile:25: recipe for target 'mobilenetv1_light_api' failed
```
【原因】在 tiny_pubish 编译下，`LOG`和`VLOG`的底层实现均无法处理枚举类型变量，然而`paddle::lite_api::CLPrecisionType`和`paddle::lite_api::CLTuneMode`均为枚举变量，因此在打 log 时需要执行显式类型转换。
【本 PR 内容】修复 #4959 引入的 bug；提高打印 init 的 LOG level，避免开启 LOG 时刷屏。