### PR TITLE
[Memory Check] Add memory checking in TargetWrapper::MemcpySync

### DIFF
--- a/lite/backends/arm/math/conv_block_utils.h
+++ b/lite/backends/arm/math/conv_block_utils.h
@@ -337,7 +337,7 @@ static bool prepack_input_nxw(const dtype* din,
       for (int w = ws; w < w0; ++w) {
         *(out_array[j]++) = 0.f;
       }
-      memcpy(out_array[j], in_array, valid_w_byte);
+      lite::TargetWrapperHost::MemcpySync(out_array[j], in_array, valid_w_byte);
       out_array[j] += valid_w;
       for (int w = w1; w < we; ++w) {
         *(out_array[j]++) = 0.f;
@@ -4073,7 +4073,7 @@ static bool write_to_output_numc(const dtype* din,
       const dtype* din_ptr = din + h * size_c_in;
       for (int i = 0; i < ch_n; i++) {
         dtype* dout_ptr = out_array[i] + h * width;
-        memcpy(dout_ptr, din_ptr, valid_w_byte);
+        lite::TargetWrapperHost::MemcpySync(dout_ptr, din_ptr, valid_w_byte);
         din_ptr += size_w;
       }
     }

--- a/lite/backends/arm/math/packed_sgemm_c4.cc
+++ b/lite/backends/arm/math/packed_sgemm_c4.cc
@@ -152,7 +152,7 @@ void sgemm_prepack_c4_common(int M,
   const int lda = k_round * 4;
   float bias_buf[m_round];  // NOLINT
   if (has_bias) {
-    memcpy(bias_buf, bias, M * sizeof(float));
+    lite::TargetWrapperHost::MemcpySync(bias_buf, bias, M * sizeof(float));
     memset(bias_buf + M, 0, (m_round - M) * sizeof(float));
   } else {
     memset(bias_buf, 0, m_round * sizeof(float));
@@ -713,7 +713,7 @@ void sgemm_prepack_c4_small(int M,
   const int kcnt = k_round >> 2;
   float bias_buf[m_round];  // NOLINT
   if (has_bias) {
-    memcpy(bias_buf, bias, M * sizeof(float));
+    lite::TargetWrapperHost::MemcpySync(bias_buf, bias, M * sizeof(float));
     memset(bias_buf + M, 0, (m_round - M) * sizeof(float));
   } else {
     memset(bias_buf, 0, m_round * sizeof(float));

--- a/lite/backends/host/target_wrapper.cc
+++ b/lite/backends/host/target_wrapper.cc
@@ -24,7 +24,9 @@ const int MALLOC_ALIGN = 64;
 void* TargetWrapper<TARGET(kHost)>::Malloc(size_t size) {
   size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;
   char* p = static_cast<char*>(malloc(offset + size));
-  CHECK(p);
+  CHECK(p) << "Error occurred in TargetWrapper::Malloc period: no enough for "
+              "mallocing "
+           << size << " bytes.";
   void* r = reinterpret_cast<void*>(reinterpret_cast<size_t>(p + offset) &
                                     (~(MALLOC_ALIGN - 1)));
   static_cast<void**>(r)[-1] = p;
@@ -39,7 +41,11 @@ void TargetWrapper<TARGET(kHost)>::MemcpySync(void* dst,
                                               const void* src,
                                               size_t size,
                                               IoDirection dir) {
-  memcpy(dst, src, size);
+  if (size > 0) {
+    CHECK(dst) << "Error: the destination of MemcpySync can not be nullptr.";
+    CHECK(src) << "Error: the source of MemcpySync can not be nullptr.";
+    memcpy(dst, src, size);
+  }
 }
 
 }  // namespace lite

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -118,7 +118,7 @@ class TargetWrapper<TARGET(kHost)> {
   static void MemcpySync(void* dst,
                          const void* src,
                          size_t size,
-                         IoDirection dir);
+                         IoDirection dir = lite::IoDirection::HtoH);
   static void MemcpyAsync(void* dst,
                           const void* src,
                           size_t size,


### PR DESCRIPTION
cherry-picked from #4986 
【本PR作用】
- 为内存拷贝函数`lite::TargetWrapperHost::MemcpySync` 添加内存检查
  - 内存拷贝时，会检查 拷贝过程`source` 和`destination`指针是否为空
- kernel 内部的数据拷贝过程：应该使用`lite::TargetWrapperHost::MemcpySync`接口，而不是直接调用 `std::memcpy`