### PR TITLE
[CI] return error if compile failed

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set +ex
+set -e
 
 readonly CMAKE_COMMON_OPTIONS="-DWITH_GPU=OFF \
                                -DWITH_MKL=OFF \
@@ -599,7 +599,7 @@ function main {
                 shift
                 ;;
             --xpu_sdk_root=*)
-                XPU_SDK_ROOT="${i#*=}"
+                XPU_SDK_ROOT=$(readlink -f ${i#*=})
                 shift
                 ;;
             --python_executable=*)


### PR DESCRIPTION
- CI在测试XPU编译预测库的时候，在编译失败时CI无法正确获得失败信息。
- 需要在编译失败时shell能返回错误。