### PR TITLE
[Core][OpenCL] Fix DataLayoutCompatible & io_copy register

### DIFF
--- a/lite/core/type_system.h
+++ b/lite/core/type_system.h
@@ -189,15 +189,18 @@ static bool TargetCompatibleTo(const Type& a, const Type& b) {
 }
 
 static bool DataLayoutCompatibleTo(const Type& a, const Type& b) {
-  return a.IsVoid() ||                  //
-         ((a.layout() == b.layout() ||  //
-           b.layout() == DATALAYOUT(kAny)));
+  return a.IsVoid() ||                 //
+         (a.layout() == b.layout() ||  //
+          ((b.layout() == DATALAYOUT(kAny)) &&
+           (a.layout() != DATALAYOUT(kImageDefault))));
 }
 static bool DataLayoutCompatible(const Type& a, const Type& b) {
-  return a.IsVoid() || b.IsVoid() ||    //
-         ((a.layout() == b.layout() ||  //
-           b.layout() == DATALAYOUT(kAny) ||
-           a.layout() == DATALAYOUT(kAny)));
+  return a.IsVoid() || b.IsVoid() ||   //
+         (a.layout() == b.layout() ||  //
+          ((b.layout() == DATALAYOUT(kAny)) &&
+           (a.layout() != DATALAYOUT(kImageDefault))) ||
+          ((a.layout() == DATALAYOUT(kAny)) &&
+           (b.layout() != DATALAYOUT(kImageDefault))));
 }
 
 static bool PrecisionCompatibleTo(const Type& a, const Type& b) {

--- a/lite/kernels/opencl/io_copy_buffer_compute.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute.cc
@@ -171,8 +171,9 @@ REGISTER_LITE_KERNEL(io_copy,
                      kAny,
                      paddle::lite::kernels::opencl::IoCopyHostToOpenCLCompute,
                      host_to_device)
-    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kHost))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kOpenCL))})
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL), PRECISION(kAny))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(io_copy,
@@ -181,8 +182,9 @@ REGISTER_LITE_KERNEL(io_copy,
                      kAny,
                      paddle::lite::kernels::opencl::IoCopykOpenCLToHostCompute,
                      device_to_host)
-    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kOpenCL))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kOpenCL), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(io_copy_once,
@@ -191,8 +193,9 @@ REGISTER_LITE_KERNEL(io_copy_once,
                      kAny,
                      paddle::lite::kernels::opencl::IoCopyHostToOpenCLCompute,
                      host_to_device)
-    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kHost))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kOpenCL))})
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL), PRECISION(kAny))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(io_copy_once,
@@ -201,8 +204,9 @@ REGISTER_LITE_KERNEL(io_copy_once,
                      kAny,
                      paddle::lite::kernels::opencl::IoCopykOpenCLToHostCompute,
                      device_to_host)
-    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kOpenCL))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kOpenCL), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
     .Finalize();
 
 #define LITE_WITH_LOG


### PR DESCRIPTION
【问题1】
 type_target_pass 无法处理 <host, int32_t, any, 0> 到 <opencl, float16, ImageDefault, 0> 的转换，模型转换时提示：
```
Check failed: is_found: Can't find a io_copy  kernel for io_copy op: Tensor<host,int32_t,any,0>:shape_2.tmp_0 -> Tensor<opencl,float16,ImageDefault,0>:slice
```
【分析】
当前的`io_copy`的 kernel 注册的 Input type 是`io_copy/host_to_device:Input:in:opencl/any/any Tensor<host,float,NCHW,0>`，Out type 是`io_copy/host_to_device:Out:out:opencl/any/any Tensor<opencl,float,NCHW,0>`。
type_target_pass 的加入必须在满足 io_copy 的输入 tensor 精度（`float`）与当前tensor的精度（`int32_t`）兼容的前提下才能进行。
然而，`float`和`int32_t`显然不兼容，因此报了开头的错误提示。因此，通过修复 io_copy register 可以解决这个报错。

【问题2】
加入这个修改后，模型转换通过，但查看转换后的模型结构图，发现在 <host, int32_t, any, 0> 到 <opencl, float16, ImageDefault, 0> 的转换过程种，仅加入了`io_copy`，漏掉了`layout_cast`，见下图：
![image](https://user-images.githubusercontent.com/24290792/102839511-aa8c1b00-443b-11eb-9379-00f494ed8826.png)
【分析】
由于经过`io_copy`后的 tensor layout是`Any`，与当前 tensor 的 layout`Image2d`是兼容的，因此不需要加入`layout_cast`。具体见下图：
![image](https://user-images.githubusercontent.com/24290792/102842974-348bb200-4443-11eb-8cda-06e793fa5eaa.png)

layout 类型`ImageDefault`与`Any`其实是不兼容的，当遇到这种 case 时需要插入`layout_cast`。转换正确的模型结构图如下：
![image](https://user-images.githubusercontent.com/24290792/102843347-f9d64980-4443-11eb-8f6d-05a525af90c9.png)
