### PR TITLE
[Compiling] Fix the issue that iOS compiling may fail

### DIFF
--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -6,6 +6,7 @@ TESTS_FILE="./lite_tests.txt"
 LIBS_FILE="./lite_libs.txt"
 CUDNN_ROOT="/usr/local/cudnn"
 LITE_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../../" && pwd )"
+NUM_PROC=4
 
 readonly ADB_WORK_DIR="/data/local/tmp"
 readonly common_flags="-DWITH_LITE=ON -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=OFF -DWITH_PYTHON=OFF -DWITH_TESTING=ON -DLITE_WITH_ARM=OFF"


### PR DESCRIPTION
- 修复iOS编译失败问题
  - 方法：指定iOS编译的线程数为4 （之前是全线程编译，当机器资源不足时，可能会发生内存不足导致的编译失败）