### PR TITLE
[PASS] Add adaptive 1x1 pool2d convert global pass. test=develop

### DIFF
--- a/lite/api/paddle_use_passes.h
+++ b/lite/api/paddle_use_passes.h
@@ -26,6 +26,7 @@ USE_MIR_PASS(argument_type_display_pass);
 USE_MIR_PASS(runtime_context_assign_pass);
 USE_MIR_PASS(graph_visualize_pass);
 
+USE_MIR_PASS(adaptive_1x1_pool2d_convert_global_pass);
 USE_MIR_PASS(remove_tf_redundant_ops_pass);
 USE_MIR_PASS(lite_conv_bn_fuse_pass);
 USE_MIR_PASS(lite_conv_conv_fuse_pass);

--- a/lite/core/mir/CMakeLists.txt
+++ b/lite/core/mir/CMakeLists.txt
@@ -42,6 +42,7 @@ lite_cc_library(mir_passes
       elimination/identity_dropout_eliminate_pass.cc
       elimination/elementwise_mul_constant_eliminate_pass.cc
       elimination/remove_tf_redundant_ops_pass.cc
+      adaptive_1x1_pool2d_convert_global_pass.cc
       elimination/control_flow_op_unused_inputs_and_outputs_eliminate_pass.cc
       static_kernel_pick_pass.cc
       variable_place_inference_pass.cc

--- a/lite/core/mir/adaptive_1x1_pool2d_convert_global_pass.cc
+++ b/lite/core/mir/adaptive_1x1_pool2d_convert_global_pass.cc
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/mir/adaptive_1x1_pool2d_convert_global_pass.h"
+#include <set>
+#include "lite/core/mir/graph_visualize_pass.h"
+#include "lite/core/mir/pass.h"
+#include "lite/core/mir/pass_registry.h"
+#include "lite/core/mir/pattern_matcher.h"
+#include "lite/model_parser/cpp_desc.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+void Adaptive1x1Pool2dConvertGlobalPass::Apply(
+    const std::unique_ptr<SSAGraph>& graph) {
+  auto check_adaptive_1x1 = [](Node* p) -> bool {
+    auto op_desc = p->stmt()->mutable_op_info();
+    auto ksize = op_desc->GetAttr<std::vector<int>>("ksize");
+    auto ksize_one = ksize[0] == ksize[1] && ksize[0] == 1;
+    auto global_pooling = op_desc->GetAttr<bool>("global_pooling");
+    auto adaptive = op_desc->GetAttr<bool>("adaptive");
+    VLOG(1) << "check adaptive:" << adaptive;
+    VLOG(1) << "check global_pooling:" << global_pooling;
+    VLOG(1) << "check ksize:" << ksize[0] << "," << ksize[1]
+            << " | ksize_one:" << ksize_one;
+    if (adaptive && ksize_one) {
+      return true;
+    }
+    return false;
+  };
+
+  for (auto& op_node : graph->StmtTopologicalOrder()) {
+    if (op_node->AsStmt().picked_kernel().op_type() == "pool2d") {
+      Node* pool = op_node;
+      bool is_adaptive_1x1 = check_adaptive_1x1(pool);
+      if (is_adaptive_1x1) {
+        // modify its `global pooling` attribute
+        auto op_desc = pool->stmt()->mutable_op_info();
+        op_desc->SetAttr<bool>("global_pooling", true);
+        op_desc->SetAttr<bool>("adaptive", false);
+        // read && check
+        VLOG(1) << "check adaptive:" << op_desc->GetAttr<bool>("adaptive");
+        VLOG(1) << "check global_pooling:"
+                << op_desc->GetAttr<bool>("global_pooling");
+        VLOG(1) << "check ksize:"
+                << op_desc->GetAttr<std::vector<int>>("ksize")[0] << ","
+                << op_desc->GetAttr<std::vector<int>>("ksize")[1];
+      }
+    }
+  }
+}
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_MIR_PASS(adaptive_1x1_pool2d_convert_global_pass,
+                  paddle::lite::mir::Adaptive1x1Pool2dConvertGlobalPass)
+    .BindTargets({TARGET(kOpenCL)});

--- a/lite/core/mir/adaptive_1x1_pool2d_convert_global_pass.cc
+++ b/lite/core/mir/adaptive_1x1_pool2d_convert_global_pass.cc
@@ -74,4 +74,4 @@ void Adaptive1x1Pool2dConvertGlobalPass::Apply(
 
 REGISTER_MIR_PASS(adaptive_1x1_pool2d_convert_global_pass,
                   paddle::lite::mir::Adaptive1x1Pool2dConvertGlobalPass)
-    .BindTargets({TARGET(kOpenCL)});
+    .BindTargets({TARGET(kOpenCL), TARGET(kARM)});

--- a/lite/core/mir/adaptive_1x1_pool2d_convert_global_pass.cc
+++ b/lite/core/mir/adaptive_1x1_pool2d_convert_global_pass.cc
@@ -28,6 +28,11 @@ void Adaptive1x1Pool2dConvertGlobalPass::Apply(
     const std::unique_ptr<SSAGraph>& graph) {
   auto check_adaptive_1x1 = [](Node* p) -> bool {
     auto op_desc = p->stmt()->mutable_op_info();
+    if (!op_desc->HasAttr("adaptive")) {
+      VLOG(1) << "skip. Pool has no attribute named adaptive.";
+      return false;
+    }
+
     auto ksize = op_desc->GetAttr<std::vector<int>>("ksize");
     auto ksize_one = ksize[0] == ksize[1] && ksize[0] == 1;
     auto global_pooling = op_desc->GetAttr<bool>("global_pooling");

--- a/lite/core/mir/adaptive_1x1_pool2d_convert_global_pass.h
+++ b/lite/core/mir/adaptive_1x1_pool2d_convert_global_pass.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "lite/core/mir/pass.h"
+#include "lite/core/tensor.h"
+#include "lite/core/types.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+/*
+ * mir::Adaptive1x1Pool2dConvertGlobalPass
+ * convert pool2d when kernel size attribute `ksize` = 1x1 &&
+ * attribute `adaptive` = true to global pooling,
+ * thus is set its `global_pooling` = true.
+ */
+class Adaptive1x1Pool2dConvertGlobalPass : public mir::StmtPass {
+ public:
+  void Apply(const std::unique_ptr<SSAGraph>& graph) override;
+};
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -81,12 +81,13 @@ class Optimizer {
     InitControlFlowOpUnusedInputsAndOutputsEliminatePass();
 
     std::vector<std::string> passes_local{
-        {"lite_quant_dequant_fuse_pass",         //
-         "weight_quantization_preprocess_pass",  //
-         "lite_conv_elementwise_fuse_pass",      // conv-elemwise-bn
-         "lite_conv_bn_fuse_pass",               //
-         "lite_conv_elementwise_fuse_pass",      // conv-bn-elemwise
-         "lite_conv_conv_fuse_pass",             //
+        {"lite_quant_dequant_fuse_pass",             //
+         "weight_quantization_preprocess_pass",      //
+         "adaptive_1x1_pool2d_convert_global_pass",  //
+         "lite_conv_elementwise_fuse_pass",          // conv-elemwise-bn
+         "lite_conv_bn_fuse_pass",                   //
+         "lite_conv_elementwise_fuse_pass",          // conv-bn-elemwise
+         "lite_conv_conv_fuse_pass",                 //
          // TODO(Superjomn) Refine the fusion related design to select fusion
          // kernels for devices automatically.
          "lite_conv_activation_fuse_pass",              //


### PR DESCRIPTION
# 状态：等待review

## 主要内容

- 增加pass，判断是否是adaptive=true，ksize=1x1的pool2d，若是则设置为global_pooling = True；
- 原因： adaptive=true，ksize=1x1
  1. 对arm cpu来说，性能不好，arm cpu在squeezenet上pool性能退化因为会走到通用basic实现，2.x ms->5.x ms）
  2. 对opencl来说，计算存在bug，先规避（单测无法复现，模型可复现），后续对opencl加入通用buffer实现的pool2d。

目前对opencl/karm taget开放此pass。

## 精度（opencl就算对了，下面以arm cpu为例）

- 机型：kirin820
- 模型：squeezenet/resnet50/resnet50_vd/mobilenetv1/mobilenetv2
- 增加该pass前后，对精度几乎没影响，小数点后第8到第9位个别不同：

![image](https://user-images.githubusercontent.com/7320657/103146890-9a9d6f80-478a-11eb-9403-dbb9d330f34d.png)

## 性能（以arm cpu为例）

- 机型：kirin820
- 模型：squeezenet
- 增加该pass前，pool2d性能profiler显示为5.5ms，加入该pass后，pool2d性能2.6ms；

----


- 机型：kirin810
- 模型：squeezenet
- 增加该pass前，pool2d性能profiler显示为1.59ms，加入该pass后，pool2d性能0.044ms。
