### PR TITLE
[Pass][OpenCL] Add fuse for conv and hard_swish

### DIFF
--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -121,6 +121,12 @@ inline CL_DTYPE activation(CL_DTYPE in
       (CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, (ushort)(isgreaterequal(in, 0)));
 #endif
 #endif
+
+#ifdef HARD_SWISH
+  output = fmin(fmax(in + ACT_OFFSET, (CL_DTYPE)0), (CL_DTYPE)ACT_THRESHOLD) *
+           in / ACT_SCALE;
+#endif
+
   return output;
 }
 
@@ -152,6 +158,12 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
 //                 in,
 //                 (ushort4)((in.x >= 0) << 15, (in.y >= 0) << 15, (in.z >= 0)
 //                 << 15, (in.w >= 0) << 15));
+#endif
+
+#ifdef HARD_SWISH
+  output = fmin(fmax(in + (CL_DTYPE4)ACT_OFFSET, (CL_DTYPE4)0),
+                (CL_DTYPE4)ACT_THRESHOLD) *
+           in / ACT_SCALE;
 #endif
 
   return output;

--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -123,8 +123,9 @@ inline CL_DTYPE activation(CL_DTYPE in
 #endif
 
 #ifdef HARD_SWISH
-  output = fmin(fmax(in + ACT_OFFSET, (CL_DTYPE)0), (CL_DTYPE)ACT_THRESHOLD) *
-           in / ACT_SCALE;
+  output = fmin(fmax(in + (CL_DTYPE)ACT_OFFSET, (CL_DTYPE)0),
+                (CL_DTYPE)ACT_THRESHOLD) *
+           in / (CL_DTYPE)ACT_SCALE;
 #endif
 
   return output;
@@ -163,7 +164,7 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
 #ifdef HARD_SWISH
   output = fmin(fmax(in + (CL_DTYPE4)ACT_OFFSET, (CL_DTYPE4)0),
                 (CL_DTYPE4)ACT_THRESHOLD) *
-           in / ACT_SCALE;
+           in / (CL_DTYPE4)ACT_SCALE;
 #endif
 
   return output;

--- a/lite/core/mir/fusion/conv_activation_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_activation_fuse_pass.cc
@@ -26,6 +26,7 @@ void ConvActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   std::vector<std::string> act_types{"relu"};
   bool has_int8 = false;
   bool has_arm = false;
+  bool has_opencl = false;
   bool has_cuda = false;
   bool has_x86 = false;
   for (auto& place : graph->valid_places()) {
@@ -34,6 +35,9 @@ void ConvActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
     }
     if (place.target == TARGET(kARM)) {
       has_arm = true;
+    }
+    if (place.target == TARGET(kOpenCL)) {
+      has_opencl = true;
     }
     if (place.target == TARGET(kCUDA)) {
       has_cuda = true;
@@ -46,6 +50,9 @@ void ConvActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   if (has_arm) {
     act_types.push_back("relu6");
     act_types.push_back("leaky_relu");
+  }
+  if (has_opencl) {
+    act_types.push_back("hard_swish");
   }
   if (!has_int8 && has_cuda) {
     act_types.push_back("leaky_relu");

--- a/lite/core/mir/fusion/conv_activation_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_activation_fuse_pass.cc
@@ -52,6 +52,8 @@ void ConvActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
     act_types.push_back("leaky_relu");
   }
   if (has_opencl) {
+    act_types.push_back("relu6");
+    act_types.push_back("leaky_relu");
     act_types.push_back("hard_swish");
   }
   if (!has_int8 && has_cuda) {

--- a/lite/core/mir/fusion/conv_activation_fuser.cc
+++ b/lite/core/mir/fusion/conv_activation_fuser.cc
@@ -85,6 +85,13 @@ cpp::OpDesc ConvActivationFuser::GenOpDesc(const key2nodes_t& matched) {
   } else if (act_type_ == "leaky_relu") {
     float alpha = act_op_desc.GetAttr<float>("alpha");
     op_desc.SetAttr("leaky_relu_alpha", alpha);
+  } else if (act_type_ == "hard_swish") {
+    float threshold = act_op_desc.GetAttr<float>("threshold");
+    float scale = act_op_desc.GetAttr<float>("scale");
+    float offset = act_op_desc.GetAttr<float>("offset");
+    op_desc.SetAttr("hard_swish_threshold", threshold);
+    op_desc.SetAttr("hard_swish_scale", scale);
+    op_desc.SetAttr("hard_swish_offset", offset);
   }
   return op_desc;
 }

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -296,6 +296,17 @@ void ConvImageCompute::PrepareForRun() {
           std::to_string(conv_param_->activation_param.Leaky_relu_alpha);
       build_options_single +=
           " -DLEAKY_RELU -DLEAKY_RELU_ALPHA=" + leaky_relu_alpha_str + "f";
+    } else if (conv_param_->activation_param.active_type ==
+               lite_api::ActivationType::kHardSwish) {
+      std::string threshold =
+          std::to_string(conv_param_->activation_param.hard_swish_threshold);
+      std::string scale =
+          std::to_string(conv_param_->activation_param.hard_swish_scale);
+      std::string offset =
+          std::to_string(conv_param_->activation_param.hard_swish_offset);
+      build_options_single += " -DHARD_SWISH -DACT_THRESHOLD=" + threshold +
+                              "f" + " -DACT_SCALE=" + scale + "f" +
+                              " -DACT_OFFSET=" + offset + "f";
     } else {
       LOG(FATAL) << "Unsupported activation type:"
                  << static_cast<int>(conv_param_->activation_param.active_type);

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -120,9 +120,18 @@ class ConvOpLite : public OpLite {
             lite_api::ActivationType::kLeakyRelu;
         param_.activation_param.Leaky_relu_alpha =
             op_desc.GetAttr<float>("leaky_relu_alpha");
+      } else if (act_type == "hard_swish") {
+        param_.activation_param.active_type =
+            lite_api::ActivationType::kHardSwish;
+        param_.activation_param.hard_swish_threshold =
+            op_desc.GetAttr<float>("hard_swish_threshold");
+        param_.activation_param.hard_swish_scale =
+            op_desc.GetAttr<float>("hard_swish_scale");
+        param_.activation_param.hard_swish_offset =
+            op_desc.GetAttr<float>("hard_swish_offset");
       } else {
-        CHECK(false)
-            << "The fused conv only supports fuse with relu and leaky relu";
+        CHECK(false) << "The fused conv only supports fuse with relu, leaky "
+                        "relu, hard_swish";
       }
     }
 

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -131,7 +131,7 @@ class ConvOpLite : public OpLite {
             op_desc.GetAttr<float>("hard_swish_offset");
       } else {
         CHECK(false) << "The fused conv only supports fuse with relu, leaky "
-                        "relu, hard_swish, while the given activation_type is "
+                        "relu, hard_swish, while the given activation type is "
                      << act_type;
       }
     }

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -130,9 +130,9 @@ class ConvOpLite : public OpLite {
         param_.activation_param.hard_swish_offset =
             op_desc.GetAttr<float>("hard_swish_offset");
       } else {
-        CHECK(false) << "The fused conv only supports fuse with relu, leaky "
-                        "relu, hard_swish, while the given activation type is "
-                     << act_type;
+        LOG(FATAL) << "The fused conv only supports fuse with relu, leaky "
+                      "relu, hard_swish, while the given activation type is "
+                   << act_type;
       }
     }
 

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -131,7 +131,8 @@ class ConvOpLite : public OpLite {
             op_desc.GetAttr<float>("hard_swish_offset");
       } else {
         CHECK(false) << "The fused conv only supports fuse with relu, leaky "
-                        "relu, hard_swish";
+                        "relu, hard_swish, while the given activation_type is "
+                     << act_type;
       }
     }
 


### PR DESCRIPTION
目前 OpenCL 后端支持 conv2d 和激活函数的融合，其中激活函数只支持 RELU, RELU6, LEAKY_RELU。
MobileNetV3 模型(2.0版本)中，有 20 个 conv2d + bn + hard_swish，本 PR 是新增支持 conv2d 和 hard_swish 的融合。

【结果】在 845 上，加入本PR后，MobileNetV3 模型速度由 27.07ms 降低至 26.19ms。
【备注】在 MobileNetV3 中，存在 3 次不必要的 IO_COPY，需要再优化。