### PR TITLE
[fix bug][opencl]fix ar detection concat opencl type bug 

### DIFF
--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -333,10 +333,9 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       std::shared_ptr<lite::Tensor> buf_to_img_output_t(new lite::Tensor);
       buf_to_img_output_t->Resize(concat_param_->output->dims());
 
-      std::shared_ptr<operators::LayoutParam> buf_to_img_param(
-          new operators::LayoutParam);
-      buf_to_img_param->x = concat_mul_buf_output_t.get();
-      buf_to_img_param->y = concat_param_->output;
+      operators::LayoutParam buf_to_img_param;
+      buf_to_img_param.x = concat_mul_buf_output_t.get();
+      buf_to_img_param.y = concat_param_->output;
       buf_to_img_kernel->SetParam(buf_to_img_param);
 
       std::unique_ptr<KernelContext> buf_to_img_context(new KernelContext);


### PR DESCRIPTION
【问题】当执行opencl concat kernel时，channel > 4，会报错：Check failed: ((*(type_->ptype_info) == typeid(T)) == true): 0!==1 Any struct is stored in the type NSt6__ndk110shared_ptrIN6paddle4lite9operators11LayoutParamEEE, but trying to obtain the type N6paddle4lite9operators11LayoutParamE.
【解决方法】修改原来的param定义方式