### PR TITLE
add opencl binary cache fbs interfaces, test=develop

### DIFF
--- a/cmake/external/flatbuffers.cmake
+++ b/cmake/external/flatbuffers.cmake
@@ -71,6 +71,8 @@ ADD_DEPENDENCIES(flatbuffers extern_flatbuffers)
 
 SET(FLATBUFFERS_FLATC_EXECUTABLE ${FLATBUFFERS_INSTALL_DIR}/bin/flatc)
 
+include_directories(${FLATBUFFERS_INCLUDE_DIR})
+
 function(register_generated_output file_name)
   get_property(tmp GLOBAL PROPERTY FBS_GENERATED_OUTPUTS)
   list(APPEND tmp ${file_name})
@@ -98,14 +100,15 @@ function(compile_flatbuffers_schema_to_cpp_opt TARGET SRC_FBS OPT)
     COMMENT "Run generation: '${GEN_HEADER}'")
   register_generated_output(${GEN_HEADER})
   add_custom_target(${TARGET} ALL DEPENDS ${GEN_HEADER})
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/${SRC_FBS_DIR})
 endfunction()
 
 set(FRAMEWORK_FBS_DIR "lite/model_parser/flatbuffers")
 set(FRAMEWORK_SCHEMA_PATH "${FRAMEWORK_FBS_DIR}/framework.fbs")
 set(PARAM_SCHEMA_PATH "${FRAMEWORK_FBS_DIR}/param.fbs")
+set(CL_CACHE_SCHEMA_PATH "${FRAMEWORK_FBS_DIR}/opencl/cache.fbs")
 compile_flatbuffers_schema_to_cpp_opt(framework_fbs_header ${FRAMEWORK_SCHEMA_PATH} "--no-includes;--gen-compare;--force-empty")
 compile_flatbuffers_schema_to_cpp_opt(param_fbs_header ${PARAM_SCHEMA_PATH} "--no-includes;--gen-compare;--force-empty")
-include_directories(${FLATBUFFERS_INCLUDE_DIR})
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/${SRC_FBS_DIR})
+compile_flatbuffers_schema_to_cpp_opt(cl_cache_fbs_header ${CL_CACHE_SCHEMA_PATH} "--no-includes;--gen-compare;--force-empty")
 
 add_custom_target(fbs_headers ALL DEPENDS framework_fbs_header param_fbs_header)

--- a/lite/model_parser/flatbuffers/CMakeLists.txt
+++ b/lite/model_parser/flatbuffers/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(opencl)
+
 function(lite_fbs_library TARGET)
   set(multiValueArgs SRCS FBS_DEPS)
   cmake_parse_arguments(args "" "" "${multiValueArgs}" ${ARGN})

--- a/lite/model_parser/flatbuffers/opencl/CMakeLists.txt
+++ b/lite/model_parser/flatbuffers/opencl/CMakeLists.txt
@@ -1,0 +1,3 @@
+lite_cc_library(cl_cache SRCS cache.cc DEPS model_base_io)
+add_dependencies(cl_cache cl_cache_fbs_header)
+lite_cc_test(test_cl_cache SRCS test_cache.cc DEPS cl_cache)

--- a/lite/model_parser/flatbuffers/opencl/cache.cc
+++ b/lite/model_parser/flatbuffers/opencl/cache.cc
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/model_parser/flatbuffers/opencl/cache.h"
+#include <utility>
+
+namespace paddle {
+namespace lite {
+namespace fbs {
+namespace opencl {
+
+Cache::Cache(const model_parser::Buffer& buf) {
+  flatbuffers::Verifier verifier(static_cast<const uint8_t*>(buf.data()),
+                                 buf.size());
+  CHECK(verifier.VerifyBuffer<paddle::lite::fbs::opencl::proto::Cache>(nullptr))
+      << "OpenCL Cache verification failed.";
+  SyncFromFbs(proto::GetCache(buf.data()));
+}
+
+void Cache::CopyDataToBuffer(model_parser::Buffer* buffer) const {
+  CHECK(buffer);
+  flatbuffers::DetachedBuffer buf{SyncToFbs()};
+  buffer->ResetLazy(buf.size());
+  model_parser::memcpy(buffer->data(), buf.data(), buf.size());
+}
+
+void Cache::SyncFromFbs(const paddle::lite::fbs::opencl::proto::Cache* desc) {
+  CHECK(desc);
+  const auto* binary_map_desc = desc->binary_map();
+  CHECK(binary_map_desc);
+  for (const auto& pair : *binary_map_desc) {
+    std::vector<std::vector<int8_t>> binary_paths;
+    for (const auto& value : *(pair->value())) {
+      const size_t size = value->data()->size();
+      binary_paths.emplace_back(std::vector<int8_t>(size));
+      model_parser::memcpy(
+          binary_paths.back().data(), value->data()->data(), size);
+    }
+    binary_map_.insert({pair->key()->str(), std::move(binary_paths)});
+  }
+}
+
+flatbuffers::DetachedBuffer Cache::SyncToFbs() const {
+  flatbuffers::FlatBufferBuilder fbb;
+  std::vector<flatbuffers::Offset<proto::Cache_::BinaryPair>> binary_map;
+  for (const auto& pair : binary_map_) {
+    std::vector<flatbuffers::Offset<proto::Cache_::BinaryVector>> value;
+    for (const auto& data : pair.second) {
+      value.emplace_back(proto::Cache_::CreateBinaryVectorDirect(fbb, &data));
+    }
+    binary_map.emplace_back(
+        proto::Cache_::CreateBinaryPairDirect(fbb, pair.first.c_str(), &value));
+  }
+  fbb.Finish(proto::CreateCacheDirect(fbb, &binary_map));
+  return fbb.Release();
+}
+
+}  // namespace opencl
+}  // namespace fbs
+}  // namespace lite
+}  // namespace paddle

--- a/lite/model_parser/flatbuffers/opencl/cache.fbs
+++ b/lite/model_parser/flatbuffers/opencl/cache.fbs
@@ -1,0 +1,18 @@
+namespace paddle.lite.fbs.opencl.proto.Cache_;
+
+table BinaryVector {
+  data:[byte];
+}
+
+table BinaryPair {
+  key:string (required, key);
+  value:[paddle.lite.fbs.opencl.proto.Cache_.BinaryVector];
+}
+
+namespace paddle.lite.fbs.opencl.proto;
+
+table Cache {
+  binary_map:[paddle.lite.fbs.opencl.proto.Cache_.BinaryPair] (required);
+}
+
+root_type paddle.lite.fbs.opencl.proto.Cache;

--- a/lite/model_parser/flatbuffers/opencl/cache.h
+++ b/lite/model_parser/flatbuffers/opencl/cache.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+#include "lite/model_parser/base/io.h"
+#include "lite/model_parser/flatbuffers/opencl/cache_generated.h"
+
+namespace paddle {
+namespace lite {
+namespace fbs {
+namespace opencl {
+
+class Cache {
+ public:
+  explicit Cache(
+      const std::map<std::string, std::vector<std::vector<int8_t>>>& map)
+      : binary_map_{map} {}
+  explicit Cache(const model_parser::Buffer& buf);
+  void CopyDataToBuffer(model_parser::Buffer* buffer) const;
+  const std::map<std::string, std::vector<std::vector<int8_t>>>& GetBinaryMap()
+      const {
+    return binary_map_;
+  }
+
+ private:
+  void SyncFromFbs(const paddle::lite::fbs::opencl::proto::Cache* desc);
+  flatbuffers::DetachedBuffer SyncToFbs() const;
+  std::map<std::string, std::vector<std::vector<int8_t>>> binary_map_;
+};
+
+}  // namespace opencl
+}  // namespace fbs
+}  // namespace lite
+}  // namespace paddle

--- a/lite/model_parser/flatbuffers/opencl/test_cache.cc
+++ b/lite/model_parser/flatbuffers/opencl/test_cache.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
 #include "lite/model_parser/flatbuffers/opencl/cache.h"
 
 namespace paddle {

--- a/lite/model_parser/flatbuffers/opencl/test_cache.cc
+++ b/lite/model_parser/flatbuffers/opencl/test_cache.cc
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/model_parser/flatbuffers/opencl/cache.h"
+
+namespace paddle {
+namespace lite {
+namespace fbs {
+namespace opencl {
+
+TEST(OpenCLCache, cache) {
+  const std::map<std::string, std::vector<std::vector<int8_t>>> map{
+      {"a", {{1, 2}, {3, 4}}}, {"b", {{5, 6}, {7, 8}}},
+  };
+  Cache cache_0{map};
+  paddle::lite::model_parser::Buffer buffer;
+  cache_0.CopyDataToBuffer(&buffer);
+
+  Cache cache_1{buffer};
+  CHECK(map == cache_1.GetBinaryMap());
+}
+
+}  // namespace opencl
+}  // namespace fbs
+}  // namespace lite
+}  // namespace paddle


### PR DESCRIPTION
为满足 OpenCL 序列化需求，添加了一组 Flatbuffers 数据结构及接口。