### PR TITLE
[opencl]fix opencl iocopy precision bug

### DIFF
--- a/lite/kernels/opencl/io_copy_buffer_compute.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute.cc
@@ -143,8 +143,10 @@ class IoCopykOpenCLToHostCompute
     const cl::Buffer* x_ptr;
     if (param.process_type == 1) {
       x_ptr = param.x->data<uint8_t, cl::Buffer>();
+      param.y->set_precision(PRECISION(kUInt8));
     } else {
       x_ptr = param.x->data<float, cl::Buffer>();
+      param.y->set_precision(PRECISION(kFloat));
     }
 
     auto& context = ctx_->As<OpenCLContext>();


### PR DESCRIPTION
增加Iocopy时输出结果的precision类型设置，因为有些kernel会check precision类型，避免check通不过。