### PR TITLE
[OpenCL] Fix concat memory leak bug when inputs.size() > 4

### DIFF
--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -119,6 +119,14 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
         }
       }
     }
+    // create kernels of img2buf and buf2img
+    auto img_to_buf_kernels = KernelRegistry::Global().Create(
+        "layout", TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW));
+    auto buf_to_img_kernels = KernelRegistry::Global().Create(
+        "layout", TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kImageDefault));
+
+    img_to_buf_kernel = std::move(img_to_buf_kernels.front());
+    buf_to_img_kernel = std::move(buf_to_img_kernels.front());
   }
 
   void Run() override {
@@ -279,35 +287,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
         inputs_image_shapes[i] = InitImageDimInfoWith(input->dims());
         inputs_image_pointers[i] = GET_DATA_GPU(input);
       }
-      // step1. create kernels
-      // 1.1 img_to_buf
-      std::vector<std::list<std::unique_ptr<KernelBase>>>
-          img_to_buf_kernels_vec(inputs_num);
-      for (size_t i = 0; i < inputs_num; ++i) {
-        auto img_to_buf_kernels = KernelRegistry::Global().Create(
-            "layout", TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW));
-        img_to_buf_kernels_vec[i] = std::move(img_to_buf_kernels);
-      }
-      // 1.2 buf_to_img
-      std::list<std::unique_ptr<KernelBase>> buf_to_img_kernels =
-          KernelRegistry::Global().Create("layout",
-                                          TARGET(kOpenCL),
-                                          PRECISION(kAny),
-                                          DATALAYOUT(kImageDefault));
-
-      // step2. get real kernel
-      // 2.1 img_to_buf
-      std::vector<std::unique_ptr<KernelBase>> img_to_buf_kernel_vec(
-          inputs_num);
-      for (size_t i = 0; i < inputs_num; ++i) {
-        img_to_buf_kernel_vec[i] = std::move(img_to_buf_kernels_vec[i].front());
-      }
-      // 2.2 buf_to_img
-      std::unique_ptr<KernelBase> buf_to_img_kernel =
-          std::move(buf_to_img_kernels.front());
-
-      // step3. create and set param, context to kernel
-      // 3.1 img_to_buf
+      // create and set param, context to kernel img_to_buf
       std::vector<operators::LayoutParam> img_to_buf_params(inputs_num);
       std::vector<lite::Tensor> outputs_vec(inputs_num);
       std::vector<cl::Buffer*> outputs_buffer_pointers(inputs_num);
@@ -317,38 +297,28 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
         outputs_vec[i].Resize(inputs_dims[i]);
         outputs_buffer_pointers[i] =
             outputs_vec[i].mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
-        img_to_buf_kernel_vec[i]->SetParam(img_to_buf_params[i]);
+        img_to_buf_kernel->SetParam(img_to_buf_params[i]);
 
         std::unique_ptr<KernelContext> img_to_buf_context(new KernelContext);
         context.CopySharedTo(&(img_to_buf_context->As<OpenCLContext>()));
-        img_to_buf_kernel_vec[i]->SetContext(std::move(img_to_buf_context));
+        img_to_buf_kernel->SetContext(std::move(img_to_buf_context));
+        img_to_buf_kernel->Launch();
       }
-      // 3.2 concat_mul_buf
+      // create and set param, context to kernel buf_to_img
       std::shared_ptr<lite::Tensor> concat_mul_buf_output_t(new lite::Tensor);
       concat_mul_buf_output_t->Resize(concat_param_->output->dims());
       auto conat_mul_buf_output_data =
           concat_mul_buf_output_t->mutable_data<float, cl::Buffer>(
               TARGET(kOpenCL));
-      // 3.3 buf_to_img
-      std::shared_ptr<lite::Tensor> buf_to_img_output_t(new lite::Tensor);
-      buf_to_img_output_t->Resize(concat_param_->output->dims());
-
-      std::shared_ptr<operators::LayoutParam> buf_to_img_param(
-          new operators::LayoutParam);
-      buf_to_img_param->x = concat_mul_buf_output_t.get();
-      buf_to_img_param->y = concat_param_->output;
+      operators::LayoutParam buf_to_img_param;
+      buf_to_img_param.x = concat_mul_buf_output_t.get();
+      buf_to_img_param.y = concat_param_->output;
       buf_to_img_kernel->SetParam(buf_to_img_param);
 
       std::unique_ptr<KernelContext> buf_to_img_context(new KernelContext);
       context.CopySharedTo(&(buf_to_img_context->As<OpenCLContext>()));
       buf_to_img_kernel->SetContext(std::move(buf_to_img_context));
 
-      // step4. run kernels
-      // 4.1 run kernel: image->buffer
-      for (size_t i = 0; i < inputs_num; ++i) {
-        img_to_buf_kernel_vec[i]->Launch();
-      }
-      // 4.2 run kernel: concat_mul_buffer
       int cur_axis_start_idx = 0;
       int total = output_tensor_dims[axis_] * post_size_;
       for (size_t i = 0; i < inputs_num; ++i) {
@@ -389,7 +359,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
         CL_CHECK_FATAL(status);
         cur_axis_start_idx += axis_dim_size;
       }
-      // 4.3 run kernel: buffer->image
+      // run kernel: buffer->image
       buf_to_img_kernel->Launch();
     }
   }
@@ -414,6 +384,8 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
   std::string kernel_func_name_{};
   std::string build_options_{""};
   std::string time_stamp_{GetTimeStamp()};
+  std::unique_ptr<KernelBase> img_to_buf_kernel;
+  std::unique_ptr<KernelBase> buf_to_img_kernel;
 };
 
 }  // namespace opencl


### PR DESCRIPTION
【问题描述】3万测试集在高通手机上结果正常，mali手机上结果不对。排查后发现是因为opencl concat inputs.size() > 4时在run()函数内使用 KernelRegistry::Global().Create( )函数导致。由于该函数在run()函数中,导致每次运行都会创建KernelBase,从而导致is_first_epoch_每次都为true,从而导致每次都会AddKernel时创建opencl kernel。因为创建的kernel会通过kernels_.emplace_back(std::move(kernel))存储起来不会被释放，所以照成内存泄漏。
【解决方法】将 KernelRegistry::Global().Create( )方法放在preparerun()函数内，并且不管input size大小，都只使用一个img_to_buf的kernel。
【备注】3万张测试集为什么高通手机上不会暴露问题？应该是高通手机对该内存泄漏的容忍度更高。