### PR TITLE
[OpenCL] Add func wrapper: clGetMemObjectInfo

### DIFF
--- a/lite/backends/opencl/cl_wrapper.cc
+++ b/lite/backends/opencl/cl_wrapper.cc
@@ -159,6 +159,7 @@ bool CLWrapper::InitFunctions() {
   PADDLE_DLSYM(clGetEventInfo);
   PADDLE_DLSYM(clGetEventProfilingInfo);
   PADDLE_DLSYM(clGetImageInfo);
+  PADDLE_DLSYM(clGetMemObjectInfo);
   PADDLE_DLSYM(clEnqueueCopyBuffer);
   PADDLE_DLSYM(clEnqueueWriteImage);
   PADDLE_DLSYM(clEnqueueCopyImage);
@@ -715,6 +716,16 @@ CL_API_ENTRY cl_int CL_API_CALL clGetImageInfo(cl_mem image,
     CL_API_SUFFIX__VERSION_1_0 {
   return paddle::lite::CLWrapper::Global()->clGetImageInfo()(
       image, param_name, param_value_size, param_value, param_value_size_ret);
+}
+
+CL_API_ENTRY cl_int CL_API_CALL clGetMemObjectInfo(cl_mem memobj,
+                                                   cl_mem_info param_name,
+                                                   size_t param_value_size,
+                                                   void *param_value,
+                                                   size_t *param_value_size_ret)
+    CL_API_SUFFIX__VERSION_1_0 {
+  return paddle::lite::CLWrapper::Global()->clGetMemObjectInfo()(
+      memobj, param_name, param_value_size, param_value, param_value_size_ret);
 }
 
 CL_API_ENTRY cl_int CL_API_CALL

--- a/lite/backends/opencl/cl_wrapper.h
+++ b/lite/backends/opencl/cl_wrapper.h
@@ -223,6 +223,9 @@ class CLWrapper final {
   using clGetImageInfoType =
       cl_int (*)(cl_mem, cl_image_info, size_t, void *, size_t *);
 
+  using clGetMemObjectInfoType =
+      cl_int (*)(cl_mem, cl_mem_info, size_t, void *, size_t *);
+
   using clEnqueueCopyBufferType = cl_int (*)(cl_command_queue,
                                              cl_mem,
                                              cl_mem,
@@ -525,6 +528,11 @@ class CLWrapper final {
     return clGetImageInfo_;
   }
 
+  clGetMemObjectInfoType clGetMemObjectInfo() {
+    CHECK(clGetMemObjectInfo_ != nullptr) << "Cannot load clGetMemObjectInfo!";
+    return clGetMemObjectInfo_;
+  }
+
   clEnqueueCopyBufferType clEnqueueCopyBuffer() {
     CHECK(clEnqueueCopyBuffer_ != nullptr)
         << "Cannot load clEnqueueCopyBuffer!";
@@ -610,6 +618,7 @@ class CLWrapper final {
   clGetEventInfoType clGetEventInfo_{nullptr};
   clGetEventProfilingInfoType clGetEventProfilingInfo_{nullptr};
   clGetImageInfoType clGetImageInfo_{nullptr};
+  clGetMemObjectInfoType clGetMemObjectInfo_{nullptr};
   clEnqueueCopyBufferType clEnqueueCopyBuffer_{nullptr};
   clEnqueueWriteImageType clEnqueueWriteImage_{nullptr};
   clEnqueueCopyImageType clEnqueueCopyImage_{nullptr};


### PR DESCRIPTION
增加`clGetMemObjectInfo`函数的 wrapper，便于 debug buffer 实现的 kernel。改函数自 OpenCL 1.0 就支持了，因此不用担心版本问题。