### PR TITLE
[CI Scripts] Add CI task for Android publish examining

### DIFF
--- a/tools/ci_tools/README.md
+++ b/tools/ci_tools/README.md
@@ -1,0 +1,2 @@
+# Paddle-Lite Continuous Integration scripts
+- 

--- a/tools/ci_tools/README.md
+++ b/tools/ci_tools/README.md
@@ -1,2 +1,2 @@
-# Paddle-Lite Continuous Integration scripts
-- 
+# Paddle-Lite Continuous Integration scripts:
+- `ci_android_publish.sh`: checking publish period on android platform.

--- a/tools/ci_tools/ci_android_publish.sh
+++ b/tools/ci_tools/ci_android_publish.sh
@@ -1,5 +1,8 @@
-#! /bin/bash
+#!/bin/bash
+#
+# Start the CI task of examining Android inference lib compiling.
 set +x
+set -e
 
 #####################################################################################################
 # Usage: test the publish period on Android platform.
@@ -10,17 +13,25 @@ set +x
 #####################################################################################################
 # 1. global variables, you can change them according to your requirements
 #####################################################################################################
-# armv7 or armv8, default armv8.
+# Architecture: armv7 or armv8, default armv8.
 ARCH=(armv8 armv7)
-# gcc or clang, default gcc.
+# Toolchain: gcc or clang, default gcc.
 TOOLCHAIN=(gcc clang)
-# absolute path of Paddle-Lite source code.
+# Absolute path of Paddle-Lite source code.
 SHELL_FOLDER=$(cd "$(dirname "$0")";pwd)
 WORKSPACE=${SHELL_FOLDER%tools/ci_tools*}
 #####################################################################################################
 
 ####################################################################################################
-# Functions of compiling test.
+# Functions of Android compiling test.
+# Globals:
+#   WORKSPACE
+# Arguments:
+#   1. architecture
+#   2. toolchain
+#   3. with extra or not
+# Returns:
+#   None
 ####################################################################################################
 function publish_inference_lib {
     local arch=$1

--- a/tools/ci_tools/ci_android_publish.sh
+++ b/tools/ci_tools/ci_android_publish.sh
@@ -1,0 +1,62 @@
+#! /bin/bash
+set +x
+
+#####################################################################################################
+# Usage: test the publish period on Android platform.
+# Data: 20210104
+# Author: DannyIsFunny
+#####################################################################################################
+
+#####################################################################################################
+# 1. global variables, you can change them according to your requirements
+#####################################################################################################
+# armv7 or armv8, default armv8.
+ARCH=(armv8 armv7)
+# gcc or clang, default gcc.
+TOOLCHAIN=(gcc clang)
+# absolute path of Paddle-Lite source code.
+SHELL_FOLDER=$(cd "$(dirname "$0")";pwd)
+WORKSPACE=${SHELL_FOLDER%tools/ci_tools*}
+#####################################################################################################
+
+####################################################################################################
+# Functions of compiling test.
+####################################################################################################
+function publish_inference_lib {
+    local arch=$1
+    local toolchain=$2
+    local with_extra=$3
+    cd $WORKSPACE
+    # Remove Compiling Cache
+    rm -rf build*
+    # Compiling inference library
+    ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=$with_extra
+    # Checking results: cplus and java inference lib.
+    if [ -d build*/inference*/cxx/lib ] && [ -d build*/inference*/java/so ]; then
+      cxx_results=$(ls build*/inference*/cxx/lib | wc -l)
+      java_results=$(ls build*/inference*/java/so | wc -l)
+          if [ $cxx_results -ge 2 ] && [ $java_results -ge 1 ]; then
+              return 0
+          fi
+    fi
+    # Error message.
+    echo "**************************************************************************************"
+    echo -e "*\033[1;31m Android compiling task failed on the following instruction: \033[0m"
+    echo -e "*     \033[1;34m ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=ON \033[0m"
+    echo "**************************************************************************************"
+   
+    echo "Error: Compiling Failed."
+    exit 1
+}
+
+
+# Compiling test
+for arch in ${ARCH[@]}
+do
+    for toolchain in ${TOOLCHAIN[@]}
+    do
+        cd $WORKSPACE
+        publish_inference_lib $arch $toolchain ON
+    done
+done    
+              

--- a/tools/ci_tools/ci_android_publish.sh
+++ b/tools/ci_tools/ci_android_publish.sh
@@ -41,11 +41,9 @@ function publish_inference_lib {
     fi
     # Error message.
     echo "**************************************************************************************"
-    echo -e "*\033[1;31m Android compiling task failed on the following instruction: \033[0m"
-    echo -e "*     \033[1;34m ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=ON \033[0m"
+    echo -e "* Android compiling task failed on the following instruction:"
+    echo -e "*     ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=ON"
     echo "**************************************************************************************"
-   
-    echo "Error: Compiling Failed."
     exit 1
 }
 

--- a/tools/ci_tools/ci_android_publish.sh
+++ b/tools/ci_tools/ci_android_publish.sh
@@ -34,38 +34,35 @@ WORKSPACE=${SHELL_FOLDER%tools/ci_tools*}
 #   None
 ####################################################################################################
 function publish_inference_lib {
-    local arch=$1
-    local toolchain=$2
-    local with_extra=$3
-    cd $WORKSPACE
-    # Remove Compiling Cache
-    rm -rf build*
-    # Compiling inference library
-    ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=$with_extra
-    # Checking results: cplus and java inference lib.
-    if [ -d build*/inference*/cxx/lib ] && [ -d build*/inference*/java/so ]; then
-      cxx_results=$(ls build*/inference*/cxx/lib | wc -l)
-      java_results=$(ls build*/inference*/java/so | wc -l)
-          if [ $cxx_results -ge 2 ] && [ $java_results -ge 1 ]; then
-              return 0
-          fi
-    fi
-    # Error message.
-    echo "**************************************************************************************"
-    echo -e "* Android compiling task failed on the following instruction:"
-    echo -e "*     ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=ON"
-    echo "**************************************************************************************"
-    exit 1
+  local arch=$1
+  local toolchain=$2
+  local with_extra=$3
+  cd $WORKSPACE
+  # Remove Compiling Cache
+  rm -rf build*
+  # Compiling inference library
+  ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=$with_extra
+  # Checking results: cplus and java inference lib.
+  if [ -d build*/inference*/cxx/lib ] && [ -d build*/inference*/java/so ]; then
+    cxx_results=$(ls build*/inference*/cxx/lib | wc -l)
+    java_results=$(ls build*/inference*/java/so | wc -l)
+      if [ $cxx_results -ge 2 ] && [ $java_results -ge 1 ]; then
+          return 0
+      fi
+  fi
+  # Error message.
+  echo "**************************************************************************************"
+  echo -e "* Android compiling task failed on the following instruction:"
+  echo -e "*     ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=ON"
+  echo "**************************************************************************************"
+  exit 1
 }
 
 
 # Compiling test
-for arch in ${ARCH[@]}
-do
-    for toolchain in ${TOOLCHAIN[@]}
-    do
-        cd $WORKSPACE
-        publish_inference_lib $arch $toolchain ON
-    done
+for arch in ${ARCH[@]}; do
+  for toolchain in ${TOOLCHAIN[@]}; do
+    cd $WORKSPACE
+    publish_inference_lib $arch $toolchain ON
+  done
 done    
-              


### PR DESCRIPTION
### CI 任务触发方法：
```
./tools/ci_tools/ci_android_publish.sh
```
### 任务失败时提示信息：
![image](https://user-images.githubusercontent.com/45189361/103533489-2c625680-4ec8-11eb-819d-ff54bfe72c74.png)

### 新的CI 脚本管理方法
- shell 脚本风格：  [google shell code style](https://zh-google-styleguide.readthedocs.io/en/latest/google-shell-styleguide/contents/) 
- CI任务的脚本需要在 `tools/ci_tools` 目录下
- CI 任务和脚本需要在 `tools/ci_tools/README.md`中注册并说明
![image](https://user-images.githubusercontent.com/45189361/103533649-721f1f00-4ec8-11eb-969b-926cfc8685b0.png)
