### PR TITLE
[opencl][inceptionv4]add common conv for opencl

### DIFF
--- a/lite/backends/opencl/cl_image_converter.h
+++ b/lite/backends/opencl/cl_image_converter.h
@@ -133,5 +133,15 @@ class CLImageConverterWinoTransWeight : public CLImageConverterBase {
                    const DDim &tensor_dim) override;
 };
 
+class CLImageConverterNBlock : public CLImageConverterBase {
+ public:
+  DDim InitImageDimInfoWith(const DDim &tensor_dim) override;
+  void NCHWToImage(float *tensor, void *image, const DDim &tensor_dim) override;
+  void ImageToNCHW(void *image,
+                   float *tensor,
+                   const DDim &image_dim,
+                   const DDim &tensor_dim) override;
+};
+
 }  // namespace lite
 }  // namespace paddle

--- a/lite/backends/opencl/cl_kernel/image/conv2d_common_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_common_kernel.cl
@@ -1,0 +1,181 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cl_common.h>
+
+__kernel void conv2d_common(__private const int global_size_dim0,
+                            __private const int global_size_dim1,
+                            __private const int global_size_dim2,
+                            __read_only image2d_t input,
+                            __read_only image2d_t filter, 
+                            __read_only image2d_t bias,
+                            __write_only image2d_t output,
+                            __private const int input_width,
+                            __private const int input_height,
+                            __private const int in_channel_block_length, 
+                            __private const int output_width,
+                            __private const int output_height,
+                            __private const int kernel_width,
+                            __private const int kernel_height,  
+                            __private const int stride_width,
+                            __private const int stride_height,
+                            __private const int padding_width,
+                            __private const int padding_height, 
+                            __private const int dilation_width,
+                            __private const int dilation_height) {
+    const int out_channel_block_idx = get_global_id(0);
+    const int out_width_block_idx   = get_global_id(1);
+    const int output_bh_idx         = get_global_id(2);
+
+    if (out_channel_block_idx >= global_size_dim0 || out_width_block_idx >= global_size_dim1 ||
+        output_bh_idx >= global_size_dim2) {
+        return;
+    }
+
+    int out_w_base_id = out_channel_block_idx * output_width;
+    int out_w_id0 = out_width_block_idx;
+    int out_w_id1 = out_w_id0 + global_size_dim1;
+    int out_w_id2 = out_w_id1 + global_size_dim1;
+    int out_w_id3 = out_w_id2 + global_size_dim1;
+#ifdef BIASE_CH
+    CL_DTYPE4 out_base = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, SAMPLER, (int2)(out_channel_block_idx, 0));
+    CL_DTYPE4 out0 = out_base;
+    CL_DTYPE4 out1 = out0;
+    CL_DTYPE4 out2 = out0;
+    CL_DTYPE4 out3 = out0;
+#elif defined(BIASE_ELE)
+    CL_DTYPE4 out0, out1, out2, out3;
+    out0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
+                                bias,
+                                SAMPLER,
+                                (int2)(out_w_base_id + out_w_id0, output_bh_idx));
+    if (out_w_id1 < output_width) {
+        out1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
+                                bias,
+                                SAMPLER,
+                                (int2)(out_w_base_id + out_w_id1, output_bh_idx));
+    }
+    if (out_w_id2 < output_width) {
+        out2 = READ_IMG_TYPE(CL_DTYPE_CHAR,
+                                bias,
+                                SAMPLER,
+                                (int2)(out_w_base_id + out_w_id2, output_bh_idx));
+    }
+    if (out_w_id3 < output_width) {
+        out3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
+                                bias,
+                                SAMPLER,
+                                (int2)(out_w_base_id + out_w_id3, output_bh_idx));
+    }
+#else
+  CL_DTYPE4 out_base = (CL_DTYPE4)(0.0f, 0.0f, 0.0f, 0.0f);
+  CL_DTYPE4 out0 = out_base;
+  CL_DTYPE4 out1 = out0;
+  CL_DTYPE4 out2 = out0;
+  CL_DTYPE4 out3 = out0;
+#endif
+
+
+    int in_width0 = mad24(out_width_block_idx, stride_width << 2, -padding_width);
+    int in_width1 = in_width0 + stride_width;
+    int in_width2 = in_width0 + stride_width * 2;
+    int in_width3 = in_width0 + stride_width * 3;
+
+    const int height_start = mad24((output_bh_idx % output_height), stride_height, -padding_height);
+    int in_height_start = mad24(select(0, (-height_start + dilation_height - 1) / dilation_height, height_start < 0), dilation_height, height_start);
+    int in_height_end = min(mad24(kernel_height, dilation_height, height_start), input_height);
+
+    const int batch_idx = mul24((output_bh_idx / output_height), input_height);
+    const int filter_h_idx = mul24(out_channel_block_idx, mul24(kernel_width, kernel_height)) + mul24(select(0, (-height_start + dilation_height - 1) / dilation_height, height_start < 0), kernel_width);
+    CL_DTYPE4 in0, in1, in2, in3;
+    CL_DTYPE4 filter0, filter1, filter2, filter3;
+    for (int input_c_block_idx = 0; input_c_block_idx < in_channel_block_length; ++input_c_block_idx) {
+        const int in_idx  = mul24(input_c_block_idx, input_width);
+        int filter_x_idx = input_c_block_idx << 2;
+        int filter_y_idx = filter_h_idx;
+        for (int iy = in_height_start; iy < in_height_end; iy += dilation_height) {
+            int in_hb_value = iy + batch_idx;
+            for (int w = 0; w < kernel_width; w++) {
+                int input_w_base = mul24(w, dilation_width);
+
+                int in_width_value0 = in_width0 + input_w_base; 
+                in_width_value0 = select(in_idx + in_width_value0, -1, (in_width_value0 < 0 || in_width_value0 >= input_width)); 
+                in0 = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(in_width_value0, in_hb_value));
+
+                int in_width_value1 = in_width1 + input_w_base; 
+                in_width_value1 = select(in_idx + in_width_value1, -1, (in_width_value1 < 0 || in_width_value1 >= input_width)); 
+                in1 = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(in_width_value1, in_hb_value));
+
+                int in_width_value2 = in_width2 + input_w_base; 
+                in_width_value2 = select(in_idx + in_width_value2, -1, (in_width_value2 < 0 || in_width_value2 >= input_width)); 
+                in2 = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(in_width_value2, in_hb_value));
+
+                int in_width_value3 = in_width3 + input_w_base; 
+                in_width_value3 = select(in_idx + in_width_value3, -1, (in_width_value3 < 0 || in_width_value3 >= input_width)); 
+                in3 = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(in_width_value3, in_hb_value));
+
+                filter0 = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, SAMPLER, (int2)(filter_x_idx, filter_y_idx));
+                filter1 = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, SAMPLER, (int2)(filter_x_idx + 1, filter_y_idx));
+                filter2 = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, SAMPLER, (int2)(filter_x_idx + 2, filter_y_idx));
+                filter3 = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, SAMPLER, (int2)(filter_x_idx + 3, filter_y_idx++));
+
+                out0 = mad(in0.x, filter0, out0); 
+                out0 = mad(in0.y, filter1, out0); 
+                out0 = mad(in0.z, filter2, out0); 
+                out0 = mad(in0.w, filter3, out0);
+
+                out1 = mad(in1.x, filter0, out1); 
+                out1 = mad(in1.y, filter1, out1); 
+                out1 = mad(in1.z, filter2, out1); 
+                out1 = mad(in1.w, filter3, out1);
+
+                out2 = mad(in2.x, filter0, out2); 
+                out2 = mad(in2.y, filter1, out2); 
+                out2 = mad(in2.z, filter2, out2); 
+                out2 = mad(in2.w, filter3, out2);
+
+                out3 = mad(in3.x, filter0, out3); 
+                out3 = mad(in3.y, filter1, out3); 
+                out3 = mad(in3.z, filter2, out3); 
+                out3 = mad(in3.w, filter3, out3);                
+            }
+        }
+    }
+    out0 = activation_type4(out0);
+    out1 = activation_type4(out1);
+    out2 = activation_type4(out2);
+    out3 = activation_type4(out3);
+
+    const int out_x_base = mul24(out_channel_block_idx, output_width);
+    int out_x_idx        = out_width_block_idx << 2;
+
+    const int remain = output_width - out_x_idx;
+    int output_w_idx = out_x_base + out_x_idx;
+    
+    if (remain >= 4) {
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx, output_bh_idx), out0);
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx + 1, output_bh_idx), out1);
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx + 2, output_bh_idx), out2);
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx + 3, output_bh_idx), out3);
+    } else if (remain == 3) {
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx, output_bh_idx), out0);
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx + 1, output_bh_idx), out1);
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx + 2, output_bh_idx), out2);
+    } else if (remain == 2) {
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx, output_bh_idx), out0);
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx + 1, output_bh_idx), out1);
+    } else if (remain == 1) {
+        WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(output_w_idx, output_bh_idx), out0);
+    }    
+}

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -84,13 +84,9 @@ void ConvImageCompute::PrepareForRun() {
       stride_h_ > 1) {
     pad_equal = (pad_left_ == pad_up_);
   }
-  CHECK(pad_equal && stride_equal && dilation_equal);
   CHECK_GE(conv_param_->dilations->size(), 2);
-  CHECK(dilation_h_ == dilation_w_);
   CHECK_GE(conv_param_->paddings->size(), 2);
-  CHECK(pad_left_ == pad_up_);
   CHECK_GE(conv_param_->strides.size(), 2);
-  CHECK(stride_h_ == stride_w_);
 
   /*********************************************
    * Upload filter, bias to opencl device
@@ -100,7 +96,8 @@ void ConvImageCompute::PrepareForRun() {
   tensor_hold_filter_image_ = std::unique_ptr<Tensor>(new Tensor);
   tensor_hold_bias_image_ = std::unique_ptr<Tensor>(new Tensor);
 
-  if (filter_tensor_h_ == 1 && filter_tensor_h_ == 1) {
+  if (filter_tensor_h_ == 1 && filter_tensor_w_ == 1) {
+    CHECK(pad_equal && stride_equal && dilation_equal);
     if (input_tensor_c_ % 4 == 0) {
       kernel_func_names_.push_back("conv2d_1x1_simple");
     } else {
@@ -125,6 +122,7 @@ void ConvImageCompute::PrepareForRun() {
   } else if (filter_tensor_c_ == 1 && input_tensor_c_ == output_tensor_c_ &&
              filter_tensor_h_ == 3 && filter_tensor_w_ == 3 && groups_ > 1) {
     // depth_conv2d_3x3s1, depth_conv2d_3x3
+    CHECK(pad_equal && stride_equal && dilation_equal);
     if (stride_h_ == 1 && dilation_h_ == 1) {
       kernel_func_names_.push_back("depth_conv2d_3x3s1");
       impl_ = &ConvImageCompute::DepthwiseConv2d3x3s1;
@@ -153,6 +151,7 @@ void ConvImageCompute::PrepareForRun() {
 #undef DEPTH_CONV_USE_SPL
              ) {
     // depth_conv2d
+    CHECK(pad_equal && stride_equal && dilation_equal);
     kernel_func_names_.push_back("depth_conv2d");
     kernel_func_paths_.push_back("image/depthwise_conv2d_basic_kernel.cl");
 
@@ -170,6 +169,7 @@ void ConvImageCompute::PrepareForRun() {
     impl_ = &ConvImageCompute::DepthwiseConv2d;
   } else if (filter_tensor_h_ == 3 && filter_tensor_w_ == 3) {
     // conv2d_3x3
+    CHECK(pad_equal && stride_equal && dilation_equal);
     if (groups_ == 1) {
       kernel_func_names_.push_back(
           input_tensor_n_ > 1 ? "conv2d_3x3_multi_batch" : "conv2d_3x3_opt");
@@ -192,6 +192,7 @@ void ConvImageCompute::PrepareForRun() {
     MUTABLE_DATA_GPU(
         filter_gpu_image_, filter_image_w_, filter_image_h_, filter_image_data);
   } else if (filter_tensor_h_ == 5 && filter_tensor_w_ == 5) {
+    CHECK(pad_equal && stride_equal && dilation_equal);
 #define CONV_5x5_OPT
 #ifndef CONV_5x5_OPT
     // conv2d_5x5
@@ -233,6 +234,7 @@ void ConvImageCompute::PrepareForRun() {
 #endif
 #undef CONV_5x5_OPT
   } else if (filter_tensor_h_ == 7 && filter_tensor_w_ == 7) {
+    CHECK(pad_equal && stride_equal && dilation_equal);
 #define CONV_7x7_OPT
 #ifndef CONV_7x7_OPT
     // conv2d_7x7
@@ -271,6 +273,23 @@ void ConvImageCompute::PrepareForRun() {
     impl_ = &ConvImageCompute::Conv2d7x7opt;
 #endif
 #undef CONV_7x7_OPT
+  } else if (groups_ == 1) {
+    // conv2d_common
+    kernel_func_names_.push_back("conv2d_common");
+    kernel_func_paths_.push_back("image/conv2d_common_kernel.cl");
+    impl_ = &ConvImageCompute::Conv2dCommon;
+
+    CLImageConverterNBlock converter;
+    const DDim& filter_image_dims = converter.InitImageDimInfoWith(filter_dims);
+    filter_image_h_ = filter_image_dims[1];
+    filter_image_w_ = filter_image_dims[0];
+    tensor_hold_filter_image_->Resize({1, filter_image_w_, filter_image_h_, 4});
+    auto* filter_image_data = MUTABLE_DATA_CPU(tensor_hold_filter_image_);
+
+    converter.NCHWToImage(filter_cpu, filter_image_data, filter_dims);
+    MUTABLE_DATA_GPU(
+        filter_gpu_image_, filter_image_w_, filter_image_h_, filter_image_data);
+
   } else {
     LOG(FATAL) << "conv image compute not support this condition yet! ";
   }
@@ -592,6 +611,14 @@ void ConvImageCompute::SetGlobalWorkSize() {
     global_work_size_ = cl::NDRange{static_cast<size_t>(c_blk_),
                                     static_cast<size_t>(w_blk_),
                                     static_cast<size_t>(nh_blk_)};
+  } else if (kernel_func_names_[0] == "conv2d_common") {
+    c_blk_ = (output_tensor_c_ + 3) / 4;
+    w_blk_ = maptofactor(default_w_blk_, 4);
+    nh_blk_ = default_nh_blk_;
+    global_work_size_ = cl::NDRange{static_cast<size_t>(c_blk_),
+                                    static_cast<size_t>(w_blk_),
+                                    static_cast<size_t>(nh_blk_)};
+    input_c_block_ = static_cast<const int>((input_tensor_c_ + 3) / 4);
   }
   VLOG(4) << "global_work_size_[3D]: {" << global_work_size_[0] << ","
           << global_work_size_[1] << "," << global_work_size_[2] << "}";
@@ -955,6 +982,50 @@ void ConvImageCompute::DepthwiseConv2d() {
   status_ = kernel_.setArg(15, filter_tensor_w_);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(16, filter_tensor_h_);
+  CL_CHECK_FATAL(status_);
+}
+
+void ConvImageCompute::Conv2dCommon() {
+  use_lws_ = false;
+  status_ = kernel_.setArg(0, c_blk_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(1, w_blk_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(2, nh_blk_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(3, *input_image_p_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(4, *filter_image_p_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(5, *bias_image_p_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(6, *output_image_p_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(7, input_tensor_w_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(8, input_tensor_h_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(9, input_c_block_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(10, output_tensor_w_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(11, output_tensor_h_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(12, filter_tensor_w_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(13, filter_tensor_h_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(14, stride_w_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(15, stride_h_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(16, pad_left_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(17, pad_up_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(18, dilation_w_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(19, dilation_h_);
   CL_CHECK_FATAL(status_);
 }
 

--- a/lite/kernels/opencl/conv_image_compute.h
+++ b/lite/kernels/opencl/conv_image_compute.h
@@ -73,6 +73,7 @@ class ConvImageCompute : public KernelLite<TARGET(kOpenCL),
   void DepthwiseConv2d3x3s1();
   void DepthwiseConv2d3x3();
   void DepthwiseConv2d();
+  void Conv2dCommon();
 
   param_t* conv_param_{nullptr};
 

--- a/lite/kernels/opencl/conv_image_compute_test.cc
+++ b/lite/kernels/opencl/conv_image_compute_test.cc
@@ -1514,6 +1514,368 @@ TEST(conv2d, compute_image2d_7x7) {
 #undef LOOP_TEST
 #undef PRINT_RESULT
 #endif
+#define TEST_CONV_IMAGE_COMMON
+#ifdef TEST_CONV_IMAGE_COMMON
+// #define PRINT_RESULT
+// #define LOOP_TEST
+TEST(conv2d, compute_image2d_common) {
+  // conv infos
+  const int ksize_x = 7;
+  const int ksize_y = 1;
+  int loop_cnt = 0;
+
+#ifdef LOOP_TEST
+  const int pad_left = 1;
+  const int pad_up = 1;
+  const int dilation = 1;
+  const int stride = 2;
+  const int group = 1;
+  for (int batch_size = 1; batch_size < 4; ++batch_size) {
+    for (int oc = 1; oc < 10; oc += 1) {   // oc
+      for (int ih = 5; ih < 9; ih += 1) {  // ih
+        int iw = ih;
+        for (int ic = 1; ic < 10; ic += 1) {  // ic
+          for (bool bias_flag : {true, false}) {
+            for (std::string relu_flag : {"", "relu"}) {
+#else
+  const int pad_left = 3;
+  const int pad_up = 0;
+  const int dilation = 1;
+
+#if 0  // small scale with group, but result of cpu reference is wrong
+const int stride = 2;
+                const int group = 2;
+                const int batch_size = 1;
+                const int ic = 1;
+                const int ih = 3;
+                const int iw = 3;
+                const int oc = 2;
+#else  // big scale with group
+  const int stride = 1;
+  const int group = 1;
+  const int batch_size = 1;
+  const int ic = 64 / 1;
+  const int ih = 54 / 1;
+  const int iw = 54 / 1;
+  const int oc = 64 / 1;
+#endif
+
+  const bool bias_flag = false;
+  const std::string relu_flag = "";
+#endif
+              int filter_channel = ic;
+              if (group > 1) {
+                filter_channel = 1;
+              }
+
+              const int oh =
+                  ConvOutputSize(ih, ksize_y, dilation, pad_up, pad_up, stride);
+              const int ow = ConvOutputSize(
+                  iw, ksize_x, dilation, pad_left, pad_left, stride);
+              SHADOW_LOG << "to get kernel ...";
+              auto kernels =
+                  KernelRegistry::Global().Create("conv2d",
+                                                  TARGET(kOpenCL),
+                                                  PRECISION(kFP16),
+                                                  DATALAYOUT(kImageDefault));
+              ASSERT_FALSE(kernels.empty());
+              auto kernel = std::move(kernels.front());
+              SHADOW_LOG << "created conv2d kernel";
+
+              SHADOW_LOG << "prepare kernel ------";
+
+              lite::Tensor input, filter, bias, output;
+              operators::ConvParam param;
+              param.x = &input;
+              param.filter = &filter;
+              param.output = &output;
+              param.groups = group;
+              if (bias_flag) {
+                param.bias = &bias;
+              }
+
+              if (relu_flag == "relu") {
+                param.fuse_relu = true;  // relu only
+                param.activation_param.has_active = true;
+                param.activation_param.active_type =
+                    lite_api::ActivationType::kRelu;
+              } else if (relu_flag == "relu6") {
+                param.activation_param.Relu_clipped_coef = 6.f;
+                param.activation_param.has_active = true;
+                param.activation_param.active_type =
+                    lite_api::ActivationType::kRelu6;
+              } else if (relu_flag == "leaky_relu") {
+                param.activation_param.active_type =
+                    lite_api::ActivationType::kLeakyRelu;
+                param.activation_param.has_active = true;
+                param.activation_param.Leaky_relu_alpha = LEAKY_RELU_ALPHA;
+              } else {
+                param.fuse_relu = false;  // relu only
+                param.activation_param.has_active = false;
+              }
+
+              std::vector<int> paddings = {pad_up, pad_up, pad_left, pad_left};
+              std::vector<int> dilations = {dilation, dilation};
+
+              param.paddings = std::make_shared<std::vector<int>>(paddings);
+              param.dilations = std::make_shared<std::vector<int>>(dilations);
+              param.strides = std::vector<int>{stride, stride};
+
+              std::unique_ptr<KernelContext> context(new KernelContext);
+              context->As<OpenCLContext>().InitOnce();
+
+              std::unique_ptr<KernelContext> conv_1x1_context(
+                  new KernelContext);
+              context->As<OpenCLContext>().CopySharedTo(
+                  &(conv_1x1_context->As<OpenCLContext>()));
+              kernel->SetContext(std::move(conv_1x1_context));
+
+              const DDim& input_dim =
+                  lite::DDim{std::vector<int64_t>({batch_size, ic, ih, iw})};
+
+              const DDim& filter_dim = lite::DDim{
+                  std::vector<int64_t>({oc, filter_channel, ksize_y, ksize_x})};
+              const DDim& out_dim =
+                  lite::DDim{std::vector<int64_t>({batch_size, oc, oh, ow})};
+              // element wise bias
+              const DDim& bias_dim = lite::DDim{std::vector<int64_t>({oc})};
+
+              VLOG(2) << "input_dim:" << input_dim
+                      << " filter_dim:" << filter_dim << " out_dim:" << out_dim
+                      << " bias_flag:" << bias_flag << " bias_dim:" << bias_dim
+                      << " group:" << group << " stride:" << stride
+                      << " pad:" << pad_left << " dilation:" << dilation;
+
+              param.x->Resize(input_dim);
+              param.filter->Resize(filter_dim);
+              param.output->Resize(out_dim);
+              if (bias_flag) {
+                param.bias->Resize(bias_dim);
+              }
+
+              kernel->SetParam(param);
+
+              size_t input_image_width = iw * ((ic + 3) / 4);
+              size_t input_image_height = ih * batch_size;
+
+              size_t out_image_width = ow * ((oc + 3) / 4);
+              size_t out_image_height = oh * batch_size;
+
+              size_t bias_image_width = ow * ((oc + 3) / 4);
+              size_t bias_image_height = oh * batch_size;
+
+              size_t filter_image_width = filter_channel;
+              size_t filter_image_height = ((oc + 3) / 4) * ksize_x * ksize_y;
+
+              const size_t cl_image2d_row_pitch{0};
+              const size_t cl_image2d_slice_pitch{0};
+
+              std::default_random_engine engine;
+              std::uniform_real_distribution<float> gen(-1, 1);
+
+              std::vector<float> input_v(batch_size * ic * ih * iw);
+              std::vector<float> filter_v(oc * filter_channel * ksize_x *
+                                          ksize_y);
+              std::vector<float> output_v(batch_size * oc * oh * ow);
+              std::vector<float> bias_v(oc);
+
+              SHADOW_LOG << "gen input and filter ...";
+              for (int i = 0; i < input_v.size(); ++i) {
+                input_v[i] = gen(engine);
+              }
+              for (int i = 0; i < filter_v.size(); ++i) {
+                filter_v[i] = gen(engine);
+              }
+
+              SHADOW_LOG << "after gen input and filter ...";
+              SHADOW_LOG << "input_v.size(): " << input_v.size();
+              SHADOW_LOG << "filter_v.size(): " << filter_v.size();
+              SHADOW_LOG << "output_v.size(): " << output_v.size();
+              SHADOW_LOG << "bias_v.size(): " << bias_v.size();
+              SHADOW_LOG << "input_dim.production(): "
+                         << input_dim.production();
+              SHADOW_LOG << "filter_dim.production(): "
+                         << filter_dim.production();
+              SHADOW_LOG << "out_dim.production(): " << out_dim.production();
+              SHADOW_LOG << "bias_dim.production(): " << bias_dim.production();
+              SHADOW_LOG << "input_image_height:" << input_image_height
+                         << " input_image_width:" << input_image_width;
+              SHADOW_LOG << "filter_image_height:" << filter_image_height
+                         << " filter_image_width:" << filter_image_width;
+              SHADOW_LOG << "4 * input_image_height *input_image_width: "
+                         << 4 * input_image_height * input_image_width;
+              SHADOW_LOG << "4 * filter_image_width * filter_image_height: "
+                         << 4 * filter_image_width * filter_image_height;
+
+              CHECK(input_dim.production() == input_v.size());
+              CHECK_LE(input_dim.production(),
+                       4 * input_image_height * input_image_width);
+              CHECK(filter_dim.production() == filter_v.size());
+              CHECK_LE(filter_dim.production(),
+                       4 * filter_image_width * filter_image_height);
+
+              paddle::lite::CLImageConverterDefault default_convertor;
+              SHADOW_LOG << "set mapped input  ...";
+              std::vector<half_t> x_image_v(input_image_width *
+                                            input_image_height * 4);  // 4 :RGBA
+              std::vector<half_t> filter_image_v(
+                  filter_image_width * filter_image_height * 4);  // 4 : RGBA
+              std::vector<half_t> bias_image_v(
+                  bias_image_width * bias_image_height * 4);  // 4 : RGBA
+              std::vector<half_t> out_image_v(out_image_width *
+                                              out_image_height * 4);  // 4 :RGBA
+
+              default_convertor.NCHWToImage(
+                  input_v.data(), x_image_v.data(), input_dim);
+              SHADOW_LOG << "输入: ----  ";
+              for (int i = 0; i < input_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << input_v[i];
+              }
+              SHADOW_LOG << "输入image : ----  ";
+              for (int i = 0; i < x_image_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << Half2Float(x_image_v[i]);
+              }
+              SHADOW_LOG << "set mapped filter  ...";
+              CLImageConverterNBlock folder_convertor;
+
+              folder_convertor.NCHWToImage(
+                  filter_v.data(), filter_image_v.data(), filter_dim);
+              SHADOW_LOG << "卷积核: ----  ";
+              for (int i = 0; i < filter_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << filter_v[i];
+              }
+              SHADOW_LOG << "卷积核image: ----  ";
+              for (int i = 0; i < filter_image_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << Half2Float(filter_image_v[i]);
+              }
+              auto* input_image2d = input.mutable_data<half_t, cl::Image2D>(
+                  input_image_width, input_image_height, x_image_v.data());
+              // assign filter as target arm
+              filter.Assign<float, lite::DDim, TARGET(kARM)>(filter_v.data(),
+                                                             filter_dim);
+              if (bias_flag) {
+                for (int i = 0; i < bias_dim.production(); ++i) {
+                  bias_v[i] = static_cast<int>(gen(engine));
+                }
+                bias.Assign<float, lite::DDim, TARGET(kARM)>(bias_v.data(),
+                                                             bias_dim);
+              }
+
+              SHADOW_LOG << "resize output  ...";
+              output.Resize(out_dim);
+
+              // cpu conv basic calc
+              lite::Tensor out_ref;
+              out_ref.Resize(out_dim);
+
+              SHADOW_LOG << "prepare kernel ready";
+
+              SHADOW_LOG << "kernel launch ...";
+              kernel->Launch();
+              SHADOW_LOG << "mutable output ...";
+              auto* output_image2d = output.mutable_data<half_t, cl::Image2D>(
+                  out_image_width, out_image_height);
+
+              CLRuntime::Global()->command_queue().finish();
+              TargetWrapperCL::ImgcpySync(out_image_v.data(),
+                                          output.data<half_t, cl::Image2D>(),
+                                          out_image_width,
+                                          out_image_height,
+                                          cl_image2d_row_pitch,
+                                          cl_image2d_slice_pitch,
+                                          IoDirection::DtoH);
+
+              DDim out_image_shape =
+                  default_convertor.InitImageDimInfoWith(output.dims());
+
+              default_convertor.ImageToNCHW(out_image_v.data(),
+                                            output_v.data(),
+                                            out_image_shape,
+                                            output.dims());
+
+              SHADOW_LOG << "输出: ----  ";
+              for (int i = 0; i < output_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << output_v[i];
+              }
+
+              SHADOW_LOG << "输出image: ----  ";
+              for (int i = 0; i < out_image_v.size(); i++) {
+                SHADOW_LOG << "(" << i << ")" << out_image_v[i];
+              }
+              SHADOW_LOG << "mutable_data out_ref_data: ";
+
+              // run cpu ref
+              auto* out_ref_data = out_ref.mutable_data<float>(TARGET(kARM));
+
+              SHADOW_LOG << " conv_basic beigin ..... ";
+
+              conv_basic<float, float>(input_v.data(),
+                                       out_ref_data,
+                                       batch_size,
+                                       oc,
+                                       oh,
+                                       ow,
+                                       ic,
+                                       ih,
+                                       iw,
+                                       filter_v.data(),
+                                       bias_v.data(),  // mapped_bias,
+                                       group,
+                                       ksize_x,
+                                       ksize_y,
+                                       stride,
+                                       stride,
+                                       dilation,
+                                       dilation,
+                                       pad_left,
+                                       pad_up,
+                                       bias_flag,
+                                       relu_flag);
+              SHADOW_LOG << " conv_basic end ..... ";
+
+              SHADOW_LOG << " out_dim: " << out_dim;
+              const DDim& out_image_dims = lite::DDim{std::vector<int64_t>(
+                  {static_cast<int64_t>(out_image_width),
+                   static_cast<int64_t>(out_image_height)})};
+
+              for (int i = 0; i < 100; i++) {
+                LOG(INFO) << "output_v[" << i << "]:" << output_v[i]
+                          << " out_ref_data[" << i << "]:" << out_ref_data[i];
+              }
+#ifdef PRINT_RESULT
+              for (int i = 0; i < out_dim.production(); i++) {
+                VLOG(4) << "output_v[" << i << "]:" << output_v[i]
+                        << " out_ref_data[" << i << "]:" << out_ref_data[i];
+              }
+#endif
+              for (int i = 0; i < out_dim.production(); i++) {
+                auto relative_diff =
+                    COMPUTE_RELATIVE_DIFF(output_v[i], out_ref_data[i]);
+                auto abs_diff = COMPUTE_ABS_DIFF(output_v[i], out_ref_data[i]);
+                EXPECT_FALSE(relative_diff > FP16_MAX_DIFF &&
+                             abs_diff > FP16_ABS_DIFF);
+                if (relative_diff > FP16_MAX_DIFF && abs_diff > FP16_ABS_DIFF) {
+                  LOG(FATAL) << "error idx:" << i << "output_v[" << i
+                             << "]:" << output_v[i] << " "
+                                                       "out_ref_data["
+                             << i << "]:" << out_ref_data[i];
+                }
+              }
+
+#ifdef LOOP_TEST
+            }
+          }
+        }
+      }
+    }
+  }
+#else
+// nothing to do.
+#endif
+}
+#undef LOOP_TEST
+#undef PRINT_RESULT
+#endif
 
 #undef SHADOW_LOG
 #undef TEST_CONV_IMAGE_1x1


### PR DESCRIPTION
【问题】opencl目前实现中不支持inceptionv4中1x7 7x1 1x3 3x1这样的kernel size的conv。
【解决】添加Opencl的通用版本的卷积实现，测试1x7 7x1 3x1 1x3这样的卷积结果对齐，支持pad_left != pad_up。
【备注】目前版本针对inceptionv4卷积结果正确，其他模型还未验证。暂时只支持conv group =1的情况。