### PR TITLE
[BUGFIX] Fix the issue of compiling error when build_python=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,10 @@ include_directories("${LITE_GENERATED_INCLUDE_DIR}")
 if (LITE_WITH_PYTHON)
     include(external/python)    # download, build, install python
     include(external/pybind11)    # download, build, install pybind11
+    set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG} -mfma" )
+    set(CMAKE_C_FLAGS_RELEASE  "${CMAKE_C_FLAGS_RELEASE} -mfma")
+    set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -mfma")
+    set(CMAKE_CXX_FLAGS_RELEASE   "${CMAKE_CXX_FLAGS_RELEASE} -mfma")
 endif()
 
 if(LITE_WITH_RKNPU)


### PR DESCRIPTION
### 问题描述
- `x86`环境下编译`python`预测库失败 ： `./lite/tools/build.sh --with_python=ON x86`
### 问题定位
#4941 引入，已经合入到`develop`， `release/v2.7`, `release/v2.8`分支
### 本修复内容
补充编译选项，使python预测库正常编译