### PR TITLE
[ReduceOP] all Reduce ops should apply ReduceParam

### DIFF
--- a/lite/kernels/arm/reduce_max_compute.cc
+++ b/lite/kernels/arm/reduce_max_compute.cc
@@ -22,7 +22,7 @@ namespace kernels {
 namespace arm {
 
 void ReduceMaxCompute::Run() {
-  auto& param = Param<operators::ReduceMaxParam>();
+  auto& param = Param<operators::ReduceParam>();
   const float* input = param.X->data<float>();
   auto x_dims = param.X->dims();
 

--- a/lite/kernels/arm/reduce_mean_compute.cc
+++ b/lite/kernels/arm/reduce_mean_compute.cc
@@ -22,7 +22,7 @@ namespace kernels {
 namespace arm {
 
 void ReduceMeanCompute::Run() {
-  auto& param = Param<operators::ReduceMeanParam>();
+  auto& param = Param<operators::ReduceParam>();
   const float* input = param.X->data<float>();
   auto x_dims = param.X->dims();
   int x_rank = x_dims.size();

--- a/lite/kernels/arm/reduce_prod_compute.cc
+++ b/lite/kernels/arm/reduce_prod_compute.cc
@@ -24,10 +24,10 @@ namespace arm {
 template <typename T, PrecisionType Ptype>
 void ReduceProdCompute<T, Ptype>::Run() {
   auto& param = this->template Param<operators::ReduceParam>();
-  auto* input = param.x->template data<T>();
-  auto x_dims = param.x->dims();
+  auto* input = param.X->template data<T>();
+  auto x_dims = param.X->dims();
   int x_rank = x_dims.size();
-  auto* output = param.output->template mutable_data<T>();
+  auto* Out = param.Out->template mutable_data<T>();
   std::vector<int> dim = param.dim;
   bool keep_dim = param.keep_dim;
   bool reduce_all = param.reduce_all;
@@ -41,7 +41,7 @@ void ReduceProdCompute<T, Ptype>::Run() {
   }
 
   if (reduce_all) {
-    lite::arm::math::reduce_prod_all(input, output, x_dims.production());
+    lite::arm::math::reduce_prod_all(input, Out, x_dims.production());
   } else {
     CHECK_EQ(x_rank, 4U);
     int n_in = x_dims[0];
@@ -52,27 +52,27 @@ void ReduceProdCompute<T, Ptype>::Run() {
     if (dim.size() == 1) {
       switch (dim[0]) {
         case 0:
-          lite::arm::math::reduce_prod_n(input, output, n_in, c_in, h_in, w_in);
+          lite::arm::math::reduce_prod_n(input, Out, n_in, c_in, h_in, w_in);
           break;
         case 1:
-          lite::arm::math::reduce_prod_c(input, output, n_in, c_in, h_in, w_in);
+          lite::arm::math::reduce_prod_c(input, Out, n_in, c_in, h_in, w_in);
           break;
         case 2:
-          lite::arm::math::reduce_prod_h(input, output, n_in, c_in, h_in, w_in);
+          lite::arm::math::reduce_prod_h(input, Out, n_in, c_in, h_in, w_in);
           break;
         case 3:
-          lite::arm::math::reduce_prod_w(input, output, n_in, c_in, h_in, w_in);
+          lite::arm::math::reduce_prod_w(input, Out, n_in, c_in, h_in, w_in);
           break;
         default:
           LOG(FATAL) << "dim[0] should be less than 4.";
       }
     } else if (dim.size() == 2) {
       if (dim[0] == 0 && dim[1] == 1) {
-        lite::arm::math::reduce_prod_nc(input, output, n_in, c_in, h_in, w_in);
+        lite::arm::math::reduce_prod_nc(input, Out, n_in, c_in, h_in, w_in);
       } else if (dim[0] == 1 && dim[1] == 2) {
-        lite::arm::math::reduce_prod_ch(input, output, n_in, c_in, h_in, w_in);
+        lite::arm::math::reduce_prod_ch(input, Out, n_in, c_in, h_in, w_in);
       } else if (dim[0] == 2 && dim[1] == 3) {
-        lite::arm::math::reduce_prod_hw(input, output, n_in, c_in, h_in, w_in);
+        lite::arm::math::reduce_prod_hw(input, Out, n_in, c_in, h_in, w_in);
       } else {
         LOG(FATAL)
             << "Only support the values of the dim are 0,1 1,2 or 2,3 for now.";

--- a/lite/kernels/arm/reduce_sum_compute.cc
+++ b/lite/kernels/arm/reduce_sum_compute.cc
@@ -24,10 +24,10 @@ namespace arm {
 
 void ReduceSumCompute::Run() {
   auto& param = this->template Param<operators::ReduceParam>();
-  auto* input = param.x->template data<float>();
-  auto x_dims = param.x->dims();
+  auto* input = param.X->template data<float>();
+  auto x_dims = param.X->dims();
   int x_rank = x_dims.size();
-  auto* output = param.output->template mutable_data<float>();
+  auto* Out = param.Out->template mutable_data<float>();
   std::vector<int> dim = param.dim;
   bool keep_dim = param.keep_dim;
   bool reduce_all = param.reduce_all;
@@ -41,7 +41,7 @@ void ReduceSumCompute::Run() {
   }
 
   if (reduce_all) {
-    lite::arm::math::reduce_sum_all(input, output, x_dims.production());
+    lite::arm::math::reduce_sum_all(input, Out, x_dims.production());
   } else {
     int n_in = 1;
     int c_in = 1;
@@ -65,16 +65,16 @@ void ReduceSumCompute::Run() {
     if (dim.size() == 1) {
       switch (dim[0]) {
         case 0:
-          lite::arm::math::reduce_sum_n(input, output, n_in, c_in, h_in, w_in);
+          lite::arm::math::reduce_sum_n(input, Out, n_in, c_in, h_in, w_in);
           break;
         case 1:
-          lite::arm::math::reduce_sum_c(input, output, n_in, c_in, h_in, w_in);
+          lite::arm::math::reduce_sum_c(input, Out, n_in, c_in, h_in, w_in);
           break;
         case 2:
-          lite::arm::math::reduce_sum_h(input, output, n_in, c_in, h_in, w_in);
+          lite::arm::math::reduce_sum_h(input, Out, n_in, c_in, h_in, w_in);
           break;
         case 3:
-          lite::arm::math::reduce_sum_w(input, output, n_in, c_in, h_in, w_in);
+          lite::arm::math::reduce_sum_w(input, Out, n_in, c_in, h_in, w_in);
           break;
         default:
           LOG(FATAL) << "dim[0] is " << dim[0]
@@ -82,11 +82,11 @@ void ReduceSumCompute::Run() {
       }
     } else if (dim.size() == 2) {
       if (dim[0] == 0 && dim[1] == 1) {
-        lite::arm::math::reduce_sum_nc(input, output, n_in, c_in, h_in, w_in);
+        lite::arm::math::reduce_sum_nc(input, Out, n_in, c_in, h_in, w_in);
       } else if (dim[0] == 1 && dim[1] == 2) {
-        lite::arm::math::reduce_sum_ch(input, output, n_in, c_in, h_in, w_in);
+        lite::arm::math::reduce_sum_ch(input, Out, n_in, c_in, h_in, w_in);
       } else if (dim[0] == 2 && dim[1] == 3) {
-        lite::arm::math::reduce_sum_hw(input, output, n_in, c_in, h_in, w_in);
+        lite::arm::math::reduce_sum_hw(input, Out, n_in, c_in, h_in, w_in);
       } else {
         LOG(FATAL)
             << "Only support the values of the dim are 0,1 1,2 or 2,3 for now.";

--- a/lite/kernels/opencl/reduce_mean_image_compute.cc
+++ b/lite/kernels/opencl/reduce_mean_image_compute.cc
@@ -28,7 +28,7 @@ class ReduceMeanComputeImage2D : public KernelLite<TARGET(kOpenCL),
                                                    PRECISION(kFP16),
                                                    DATALAYOUT(kImageDefault)> {
  public:
-  using param_t = operators::ReduceMeanParam;
+  using param_t = operators::ReduceParam;
 
   std::string doc() const override {
     return "Reduce_mean using cl::Image2D, kFP16";

--- a/lite/kernels/x86/reduce_compute.cc
+++ b/lite/kernels/x86/reduce_compute.cc
@@ -18,7 +18,7 @@ REGISTER_LITE_KERNEL(reduce_sum,
                      kX86,
                      kFloat,
                      kNCHW,
-                     paddle::lite::kernels::x86::ReduceSumCompute<float>,
+                     paddle::lite::kernels::x86::ReduceCompute<float>,
                      def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
@@ -28,7 +28,7 @@ REGISTER_LITE_KERNEL(reduce_mean,
                      kX86,
                      kFloat,
                      kNCHW,
-                     paddle::lite::kernels::x86::ReduceMeanCompute<float>,
+                     paddle::lite::kernels::x86::ReduceCompute<float>,
                      def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})

--- a/lite/kernels/x86/reduce_compute.cc
+++ b/lite/kernels/x86/reduce_compute.cc
@@ -18,7 +18,7 @@ REGISTER_LITE_KERNEL(reduce_sum,
                      kX86,
                      kFloat,
                      kNCHW,
-                     paddle::lite::kernels::x86::ReduceCompute<float>,
+                     paddle::lite::kernels::x86::ReduceSumCompute<float>,
                      def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})
@@ -28,7 +28,7 @@ REGISTER_LITE_KERNEL(reduce_mean,
                      kX86,
                      kFloat,
                      kNCHW,
-                     paddle::lite::kernels::x86::ReduceCompute<float>,
+                     paddle::lite::kernels::x86::ReduceMeanCompute<float>,
                      def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kX86))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86))})

--- a/lite/kernels/x86/reduce_compute.h
+++ b/lite/kernels/x86/reduce_compute.h
@@ -42,7 +42,7 @@ struct MeanFunctor {
   if (ndim == NDIM && rdim == RDIM) {                                  \
     paddle::lite::kernels::x86::                                       \
         ReduceFunctor<lite::TargetType::kX86, T, NDIM, RDIM, FUNCTOR>( \
-            *input, output, dims, keep_dim);                           \
+            *input, Out, dims, keep_dim);                              \
   }
 
 template <typename T>
@@ -54,16 +54,16 @@ class ReduceSumCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
     auto& param = *param_.get_mutable<operators::ReduceParam>();
     // auto& context = ctx_->As<X86Context>();
     bool reduce_all = param.reduce_all;
-    auto* input = param.x;
-    auto* output = param.output;
-    param.output->template mutable_data<T>();
+    auto* input = param.X;
+    auto* Out = param.Out;
+    param.Out->template mutable_data<T>();
 
     const auto& dims = param.dim;
     bool keep_dim = param.keep_dim;
     if (reduce_all) {
       // Flatten and reduce 1-D tensor
       auto x = lite::fluid::EigenVector<T>::Flatten(*input);
-      auto out = lite::fluid::EigenScalar<T>::From(output);
+      auto out = lite::fluid::EigenScalar<T>::From(Out);
       // auto& place = *platform::CPUDeviceContext().eigen_device();
       auto reduce_dim = Eigen::array<int, 1>({{0}});
       SumFunctor functor;
@@ -93,7 +93,7 @@ class ReduceMeanCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
     auto& param = *param_.get_mutable<operators::ReduceMeanParam>();
     // auto& context = ctx_->As<X86Context>();
     auto* input = param.X;
-    auto* output = param.Out;
+    auto* Out = param.Out;
     param.Out->template mutable_data<T>();
 
     const auto& dims = param.dim;
@@ -102,7 +102,7 @@ class ReduceMeanCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
     if (dims.size() == 0) {
       // Flatten and reduce 1-D tensor
       auto x = lite::fluid::EigenVector<T>::Flatten(*input);
-      auto out = lite::fluid::EigenScalar<T>::From(output);
+      auto out = lite::fluid::EigenScalar<T>::From(Out);
       // auto& place = *platform::CPUDeviceContext().eigen_device();
       auto reduce_dim = Eigen::array<int, 1>({{0}});
       MeanFunctor functor;

--- a/lite/kernels/x86/reduce_compute.h
+++ b/lite/kernels/x86/reduce_compute.h
@@ -52,7 +52,6 @@ class ReduceSumCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
 
   void Run() override {
     auto& param = *param_.get_mutable<operators::ReduceParam>();
-    // auto& context = ctx_->As<X86Context>();
     bool reduce_all = param.reduce_all;
     auto* input = param.X;
     auto* Out = param.Out;
@@ -64,7 +63,6 @@ class ReduceSumCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
       // Flatten and reduce 1-D tensor
       auto x = lite::fluid::EigenVector<T>::Flatten(*input);
       auto out = lite::fluid::EigenScalar<T>::From(Out);
-      // auto& place = *platform::CPUDeviceContext().eigen_device();
       auto reduce_dim = Eigen::array<int, 1>({{0}});
       SumFunctor functor;
       functor(&x, &out, reduce_dim);
@@ -91,7 +89,6 @@ class ReduceMeanCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
 
   void Run() override {
     auto& param = *param_.get_mutable<operators::ReduceParam>();
-    // auto& context = ctx_->As<X86Context>();
     auto* input = param.X;
     auto* Out = param.Out;
     param.Out->template mutable_data<T>();
@@ -103,7 +100,6 @@ class ReduceMeanCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
       // Flatten and reduce 1-D tensor
       auto x = lite::fluid::EigenVector<T>::Flatten(*input);
       auto out = lite::fluid::EigenScalar<T>::From(Out);
-      // auto& place = *platform::CPUDeviceContext().eigen_device();
       auto reduce_dim = Eigen::array<int, 1>({{0}});
       MeanFunctor functor;
       functor(&x, &out, reduce_dim);

--- a/lite/kernels/x86/reduce_compute.h
+++ b/lite/kernels/x86/reduce_compute.h
@@ -87,10 +87,10 @@ class ReduceSumCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
 template <typename T>
 class ReduceMeanCompute : public KernelLite<TARGET(kX86), PRECISION(kFloat)> {
  public:
-  using param_t = operators::ReduceMeanParam;
+  using param_t = operators::ReduceParam;
 
   void Run() override {
-    auto& param = *param_.get_mutable<operators::ReduceMeanParam>();
+    auto& param = *param_.get_mutable<operators::ReduceParam>();
     // auto& context = ctx_->As<X86Context>();
     auto* input = param.X;
     auto* Out = param.Out;

--- a/lite/kernels/xpu/reduce_mean_compute.cc
+++ b/lite/kernels/xpu/reduce_mean_compute.cc
@@ -22,7 +22,7 @@ namespace kernels {
 namespace xpu {
 
 void ReduceMeanCompute::Run() {
-  auto& param = Param<operators::ReduceMeanParam>();
+  auto& param = Param<operators::ReduceParam>();
   auto& ctx = this->ctx_->As<XPUContext>();
   const float* input = param.X->data<float>();
   auto x_dims = param.X->dims();

--- a/lite/kernels/xpu/reduce_sum_compute.cc
+++ b/lite/kernels/xpu/reduce_sum_compute.cc
@@ -24,16 +24,16 @@ namespace xpu {
 void ReduceSumCompute::Run() {
   auto& param = Param<operators::ReduceParam>();
   auto& ctx = this->ctx_->As<XPUContext>();
-  const float* input = param.x->data<float>();
-  float* output = param.output->mutable_data<float>(TARGET(kXPU));
+  const float* input = param.X->data<float>();
+  float* Out = param.Out->mutable_data<float>(TARGET(kXPU));
   bool reduce_all = param.reduce_all;
 
   if (reduce_all) {
-    int input_len = param.x->numel();
-    int r = xdnn::sum(ctx.GetRawContext(), input, output, input_len);
+    int input_len = param.X->numel();
+    int r = xdnn::sum(ctx.GetRawContext(), input, Out, input_len);
     CHECK_EQ(r, 0);
   } else {
-    auto x_dims = param.x->dims();
+    auto x_dims = param.X->dims();
     int x_rank = x_dims.size();
     auto reduce_dim = param.dim;
     auto rdim = reduce_dim.size();
@@ -46,7 +46,7 @@ void ReduceSumCompute::Run() {
     auto type = xdnn::ReduceOp::REDUCE_SUM;
     int r = xdnn::reduce(ctx.GetRawContext(),
                          input,
-                         output,
+                         Out,
                          idims.data(),
                          x_rank,
                          reduce_dim.data(),

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -206,15 +206,6 @@ struct MulGradParam : ParamBase {
   int y_num_col_dims{1};
 };
 
-// For ReduceMean Op
-struct ReduceMeanParam : ParamBase {
-  lite::Tensor* X{};
-  lite::Tensor* Out{};
-
-  std::vector<int> dim;
-  bool keep_dim{false};
-};
-
 // For Stack Op
 struct StackParam : ParamBase {
   std::vector<lite::Tensor*> X;
@@ -1250,13 +1241,6 @@ struct SequenceArithmeticParam : ParamBase {
   lite::Tensor* Out{};
 };
 
-struct ReduceMaxParam : ParamBase {
-  const lite::Tensor* X{};
-  lite::Tensor* Out{};
-  std::vector<int> dim{};
-  bool keep_dim{false};
-};
-
 struct LodResetParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Y{};
@@ -1271,8 +1255,8 @@ struct IsEmptyParam : ParamBase {
 };
 
 struct ReduceParam : ParamBase {
-  lite::Tensor* x{};
-  lite::Tensor* output{};
+  lite::Tensor* X{};
+  lite::Tensor* Out{};
   std::vector<int> dim{0};
   bool keep_dim{false};
   bool reduce_all{false};

--- a/lite/operators/reduce_max_op.h
+++ b/lite/operators/reduce_max_op.h
@@ -56,7 +56,7 @@ class ReduceMaxOp : public OpLite {
 #endif
 
  private:
-  mutable ReduceMaxParam param_;
+  mutable ReduceParam param_;
 };
 
 }  // namespace operators

--- a/lite/operators/reduce_mean_op.h
+++ b/lite/operators/reduce_mean_op.h
@@ -62,7 +62,7 @@ class ReduceMeanOp : public OpLite {
 #endif
 
  private:
-  mutable ReduceMeanParam param_;
+  mutable ReduceParam param_;
 };
 
 }  // namespace operators

--- a/lite/operators/reduce_ops.cc
+++ b/lite/operators/reduce_ops.cc
@@ -66,14 +66,14 @@ bool ReduceOp::InferShapeImpl() const {
     }
     param_.Out->Resize(out_dims);
     if (dims[0] != 0) {
-      param_.Out->set_lod(param_.x->lod());
+      param_.Out->set_lod(param_.X->lod());
     }
   }
   return true;
 }
 
 bool ReduceOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  param_.x =
+  param_.X =
       scope->FindVar(opdesc.Input("X").front())->GetMutable<lite::Tensor>();
   param_.Out =
       scope->FindVar(opdesc.Output("Out").front())->GetMutable<lite::Tensor>();

--- a/lite/operators/reduce_ops.cc
+++ b/lite/operators/reduce_ops.cc
@@ -20,16 +20,16 @@ namespace lite {
 namespace operators {
 
 bool ReduceOp::CheckShape() const {
-  CHECK_OR_FALSE(param_.x);
-  CHECK_OR_FALSE(param_.output);
-  auto x_dims = param_.x->dims();
+  CHECK_OR_FALSE(param_.X);
+  CHECK_OR_FALSE(param_.Out);
+  auto x_dims = param_.X->dims();
   auto x_rank = x_dims.size();
   CHECK_LE(x_rank, 6UL) << "Tensors with rank at most 6 are supported.";
   return true;
 }
 
 bool ReduceOp::InferShapeImpl() const {
-  const auto &x_dims = param_.x->dims();
+  const auto &x_dims = param_.X->dims();
   auto x_rank = x_dims.size();
   auto dims = param_.dim;
   for (size_t i = 0; i < dims.size(); ++i) {
@@ -44,9 +44,9 @@ bool ReduceOp::InferShapeImpl() const {
 
   if (reduce_all) {
     if (keep_dim)
-      param_.output->Resize(std::vector<int64_t>(x_rank, 1));
+      param_.Out->Resize(std::vector<int64_t>(x_rank, 1));
     else
-      param_.output->Resize(std::vector<int64_t>{1});
+      param_.Out->Resize(std::vector<int64_t>{1});
   } else {
     size_t out_rank = keep_dim ? x_rank : x_rank - dims.size();
     std::vector<DDim::value_type> out_dims(out_rank);
@@ -64,9 +64,9 @@ bool ReduceOp::InferShapeImpl() const {
         out_dims[out_index++] = x_dims[i];
       }
     }
-    param_.output->Resize(out_dims);
+    param_.Out->Resize(out_dims);
     if (dims[0] != 0) {
-      param_.output->set_lod(param_.x->lod());
+      param_.Out->set_lod(param_.x->lod());
     }
   }
   return true;
@@ -75,7 +75,7 @@ bool ReduceOp::InferShapeImpl() const {
 bool ReduceOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   param_.x =
       scope->FindVar(opdesc.Input("X").front())->GetMutable<lite::Tensor>();
-  param_.output =
+  param_.Out =
       scope->FindVar(opdesc.Output("Out").front())->GetMutable<lite::Tensor>();
 
   param_.dim = opdesc.GetAttr<std::vector<int>>("dim");

--- a/lite/operators/reduce_prod_op.cc
+++ b/lite/operators/reduce_prod_op.cc
@@ -23,14 +23,14 @@ namespace lite {
 namespace operators {
 
 bool ReduceProdOpLite::CheckShape() const {
-  CHECK_OR_FALSE(param_.x);
-  CHECK_OR_FALSE(param_.output);
+  CHECK_OR_FALSE(param_.X);
+  CHECK_OR_FALSE(param_.Out);
   return true;
 }
 
 bool ReduceProdOpLite::InferShapeImpl() const {
-  auto x = param_.x;
-  auto out = param_.output;
+  auto x = param_.X;
+  auto out = param_.Out;
   std::vector<int> dim = param_.dim;
   bool reduce_all = param_.reduce_all;
   bool keep_dim = param_.keep_dim;
@@ -81,10 +81,10 @@ bool ReduceProdOpLite::InferShapeImpl() const {
 bool ReduceProdOpLite::AttachImpl(const cpp::OpDesc &op_desc,
                                   lite::Scope *scope) {
   auto x = op_desc.Input("X").front();
-  param_.x = scope->FindVar(x)->GetMutable<lite::Tensor>();
+  param_.X = scope->FindVar(x)->GetMutable<lite::Tensor>();
 
-  auto output = op_desc.Output("Out").front();
-  param_.output = scope->FindVar(output)->GetMutable<lite::Tensor>();
+  auto Out = op_desc.Output("Out").front();
+  param_.Out = scope->FindVar(Out)->GetMutable<lite::Tensor>();
 
   param_.dim = op_desc.GetAttr<std::vector<int>>("dim");
   param_.keep_dim = op_desc.GetAttr<bool>("keep_dim");

--- a/lite/operators/reduce_prod_op.h
+++ b/lite/operators/reduce_prod_op.h
@@ -39,13 +39,13 @@ class ReduceProdOpLite : public OpLite {
 
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
-    ch->input_shape = ch->DimToStr(param_.x->dims());
-    ch->output_shape = ch->DimToStr(param_.output->dims());
+    ch->input_shape = ch->DimToStr(param_.X->dims());
+    ch->output_shape = ch->DimToStr(param_.Out->dims());
     ch->remark = "keep_dim" + std::to_string(param_.keep_dim) + "reduce_all" +
                  std::to_string(param_.reduce_all);
 
     auto dims = param_.dim;
-    auto in_sum = param_.x->numel();
+    auto in_sum = param_.X->numel();
     if (dims.size() == 0 || dims.size() == 1) {
       ch->macs = 1.f * in_sum;
     } else if (dims.size() == 2) {


### PR DESCRIPTION
### 问题描述
- `reduce_mean\reduce_all\reduce_max` 等算子 中param参数定义相同，可以公用一个`ReduceParam`
- 当前代码中有  `ReduceMeanParam`、`ReduceMaxParam`、`ReduceParam`，定义重复

### 本PR工作
- 将`ReduceMeanParam`、`ReduceMaxParam`、`ReduceParam`等reduce 相关算子的 param统一成`ReduceParam`