### PR TITLE
[opencl][kernel]fix avg pool2d opencl bug

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/pool_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/pool_kernel.cl
@@ -73,11 +73,13 @@ __kernel void pool_avg(__read_only image2d_t input,
   const int out_n = out_nh / out_height;
   const int out_h = out_nh % out_height;
 
-  int start_h = max(out_h * stride_h - pad_top, 0);
+  int start_h = out_h * stride_h - pad_top;
   int end_h = min(start_h + ksize_h, in_height);
+  start_h = max(start_h, 0);
 
-  int start_w = max(out_w * stride_w - pad_left, 0);
+  int start_w = out_w * stride_w - pad_left;
   int end_w = min(start_w + ksize_w, in_width);
+  start_w = max(start_w, 0);
 
   const int pos_in_x = out_c * in_width;
   const int pos_in_y = out_n * in_height;
@@ -89,7 +91,7 @@ __kernel void pool_avg(__read_only image2d_t input,
           CL_DTYPE_CHAR, input, SAMPLER, (int2)(pos_in_x + x, pos_in_y + y));
     }
   }
-  CL_DTYPE4 avg = sum / (ksize_h * ksize_w);
+  CL_DTYPE4 avg = sum / ((end_h - start_h)*(end_w - start_w));
   const int pos_out_x = mad24(out_c, out_width, out_w);
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(pos_out_x, out_nh), avg);
 }

--- a/lite/kernels/opencl/pool_image_compute_test.cc
+++ b/lite/kernels/opencl/pool_image_compute_test.cc
@@ -112,7 +112,7 @@ TEST(pool2d_image2d, compute) {
   out.Resize(out_dim);
 
   std::default_random_engine engine;
-  std::uniform_real_distribution<float> dist(1, 1);
+  std::uniform_real_distribution<float> dist(-5, 5);
   std::vector<float> input_v(4 * 11 * 107 * 107);
   for (auto& i : input_v) {
     i = dist(engine);

--- a/lite/kernels/opencl/pool_image_compute_test.cc
+++ b/lite/kernels/opencl/pool_image_compute_test.cc
@@ -92,9 +92,9 @@ TEST(pool2d_image2d, compute) {
   param.output = &out;
   param.global_pooling = false;
   param.pooling_type = "avg";
-  std::vector<int> paddings = {0, 0, 0, 0};
+  std::vector<int> paddings = {1, 1, 1, 1};
   param.strides = std::vector<int>{1, 1};
-  param.ksize = std::vector<int>{7, 7};
+  param.ksize = std::vector<int>{3, 3};
   param.paddings = std::make_shared<std::vector<int>>(paddings);
 
   std::unique_ptr<KernelContext> context(new KernelContext);
@@ -106,13 +106,13 @@ TEST(pool2d_image2d, compute) {
       &(pool_context->As<OpenCLContext>()));
   kernel->SetContext(std::move(pool_context));
 
-  const DDim in_dim = DDim(std::vector<DDim::value_type>{4, 11, 107, 107});
-  const DDim out_dim = DDim(std::vector<DDim::value_type>{4, 11, 101, 101});
+  const DDim in_dim = DDim(std::vector<DDim::value_type>{1, 384, 25, 25});
+  const DDim out_dim = DDim(std::vector<DDim::value_type>{1, 384, 25, 25});
   x.Resize(in_dim);
   out.Resize(out_dim);
 
   std::default_random_engine engine;
-  std::uniform_real_distribution<float> dist(-5, 5);
+  std::uniform_real_distribution<float> dist(1, 1);
   std::vector<float> input_v(4 * 11 * 107 * 107);
   for (auto& i : input_v) {
     i = dist(engine);
@@ -140,7 +140,7 @@ TEST(pool2d_image2d, compute) {
   CLRuntime::Global()->command_queue().finish();
 
   std::unique_ptr<float[]> out_ref(new float[out_dim.production()]);
-  pool_avg(0, 0, 1, 1, 7, 7, input_v.data(), in_dim, out_ref.get(), out_dim);
+  pool_avg(1, 1, 1, 1, 3, 3, input_v.data(), in_dim, out_ref.get(), out_dim);
 
   const size_t cl_image2d_row_pitch{0};
   const size_t cl_image2d_slice_pitch{0};


### PR DESCRIPTION
opencl中实现的avg pool2d kernel逻辑本身是错的，修复其逻辑错误。