### PR TITLE
[Ops] ReConstruct activation ops

### DIFF
--- a/lite/backends/arm/math/activation.cc
+++ b/lite/backends/arm/math/activation.cc
@@ -702,6 +702,17 @@ void act_rsqrt<float>(const float* din, float* dout, int size, int threads) {
 }
 
 template <>
+void act_sqrt<float>(const float* din, float* dout, int size, int threads) {
+  const float* ptr_in = din;
+  float* ptr_out = dout;
+  for (int i = 0; i < size; ++i) {
+    ptr_out[0] = sqrtf(ptr_in[0]);
+    ptr_in++;
+    ptr_out++;
+  }
+}
+
+template <>
 void act_square<float>(const float* din, float* dout, int size, int threads) {
   const float* ptr_in = din;
   float* ptr_out = dout;

--- a/lite/backends/arm/math/activation.h
+++ b/lite/backends/arm/math/activation.h
@@ -70,6 +70,9 @@ template <typename T>
 void act_rsqrt(const T* din, T* dout, int size, int threads);
 
 template <typename T>
+void act_sqrt(const T* din, T* dout, int size, int threads);
+
+template <typename T>
 void act_square(const T* din, T* dout, int size, int threads);
 
 template <typename T>

--- a/lite/kernels/arm/CMakeLists.txt
+++ b/lite/kernels/arm/CMakeLists.txt
@@ -50,6 +50,7 @@ add_kernel(instance_norm_compute_arm ARM basic SRCS instance_norm_compute.cc DEP
 add_kernel(grid_sampler_compute_arm ARM basic SRCS grid_sampler_compute.cc DEPS ${lite_kernel_deps} math_arm)
 
 ## 2.other basic kernels: basic kernels that not used in basic models
+add_kernel(activation_extra_compute_arm ARM extrta SRCS activation_extra_compute.cc DEPS ${lite_kernel_deps} math_arm)
 add_kernel(negative_compute_arm ARM extra SRCS negative_compute.cc DEPS ${lite_kernel_deps} math_arm)
 add_kernel(crop_compute_arm ARM extra SRCS crop_compute.cc DEPS ${lite_kernel_deps} crop_compute_host)
 add_kernel(pow_compute_arm ARM extra SRCS pow_compute.cc DEPS ${lite_kernel_deps} math_arm)

--- a/lite/kernels/arm/activation_compute.cc
+++ b/lite/kernels/arm/activation_compute.cc
@@ -41,17 +41,6 @@ void LeakyReluCompute::Run() {
       x_data, output_data, x_dims.production(), alpha, ctx.threads());
 }
 
-void ReluClippedCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto coef = param.Relu_clipped_coef;
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_clipped_relu<float>(
-      x_data, output_data, x_dims.production(), coef, ctx.threads());
-}
-
 void PReluCompute::Run() {
   auto& param = this->Param<param_t>();
   auto& ctx = this->ctx_->template As<ARMContext>();
@@ -95,17 +84,6 @@ void TanhCompute::Run() {
       x_data, output_data, x_dims.production(), ctx.threads());
 }
 
-void SwishCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto beta = param.Swish_beta;
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_swish<float>(
-      x_data, output_data, x_dims.production(), beta, ctx.threads());
-}
-
 void Relu6Compute::Run() {
   auto& param = this->Param<param_t>();
   auto& ctx = this->ctx_->template As<ARMContext>();
@@ -115,106 +93,6 @@ void Relu6Compute::Run() {
   auto output_data = param.Out->mutable_data<float>();
   lite::arm::math::act_clipped_relu<float>(
       x_data, output_data, x_dims.production(), coef, ctx.threads());
-}
-
-void LogCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_log<float>(
-      x_data, output_data, x_dims.production(), ctx.threads());
-}
-
-void ExpCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_exp<float>(
-      x_data, output_data, x_dims.production(), ctx.threads());
-}
-
-void FloorCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_floor<float>(
-      x_data, output_data, x_dims.production(), ctx.threads());
-}
-
-void HardSigmoidCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  float slope = param.hard_sigmoid_slope;
-  float offset = param.hard_sigmoid_offset;
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_hard_sigmoid<float>(
-      x_data, output_data, x_dims.production(), slope, offset, ctx.threads());
-}
-
-void RsqrtCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_rsqrt<float>(
-      x_data, output_data, x_dims.production(), ctx.threads());
-}
-
-void SquareCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_square<float>(
-      x_data, output_data, x_dims.production(), ctx.threads());
-}
-
-void HardSwishCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto output_data = param.Out->mutable_data<float>();
-  float threshold = param.hard_swish_threshold;
-  float scale = param.hard_swish_scale;
-  float offset = param.hard_swish_offset;
-  lite::arm::math::act_hard_swish<float>(x_data,
-                                         output_data,
-                                         x_dims.production(),
-                                         threshold,
-                                         scale,
-                                         offset,
-                                         ctx.threads());
-}
-
-void ReciprocalCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_reciprocal<float>(
-      x_data, output_data, x_dims.production(), ctx.threads());
-}
-
-void AbsCompute::Run() {
-  auto& param = this->Param<param_t>();
-  auto& ctx = this->ctx_->template As<ARMContext>();
-  auto x_dims = param.X->dims();
-  auto x_data = param.X->data<float>();
-  auto output_data = param.Out->mutable_data<float>();
-  lite::arm::math::act_abs<float>(
-      x_data, output_data, x_dims.production(), ctx.threads());
 }
 
 void ThresholdedReluCompute::Run() {
@@ -260,16 +138,6 @@ REGISTER_LITE_KERNEL(leaky_relu,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindPaddleOpVersion("leaky_relu", 1)
     .Finalize();
-REGISTER_LITE_KERNEL(relu_clipped,
-                     kARM,
-                     kFloat,
-                     kNCHW,
-                     paddle::lite::kernels::arm::ReluClippedCompute,
-                     def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindInput("Relu_clipped_coef", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
 REGISTER_LITE_KERNEL(
     prelu, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::PReluCompute, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
@@ -292,70 +160,7 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 REGISTER_LITE_KERNEL(
-    swish, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::SwishCompute, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindInput("beta", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(
     relu6, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::Relu6Compute, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(
-    log, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::LogCompute, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(
-    exp, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::ExpCompute, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(
-    floor, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::FloorCompute, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(hard_sigmoid,
-                     kARM,
-                     kFloat,
-                     kNCHW,
-                     paddle::lite::kernels::arm::HardSigmoidCompute,
-                     def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(
-    rsqrt, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::RsqrtCompute, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(
-    square, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::SquareCompute, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(hard_swish,
-                     kARM,
-                     kFloat,
-                     kNCHW,
-                     paddle::lite::kernels::arm::HardSwishCompute,
-                     def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(reciprocal,
-                     kARM,
-                     kFloat,
-                     kNCHW,
-                     paddle::lite::kernels::arm::ReciprocalCompute,
-                     def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
-    .Finalize();
-REGISTER_LITE_KERNEL(
-    abs, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::AbsCompute, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();

--- a/lite/kernels/arm/activation_extra_compute.cc
+++ b/lite/kernels/arm/activation_extra_compute.cc
@@ -84,6 +84,16 @@ void HardSigmoidCompute::Run() {
       x_data, output_data, x_dims.production(), slope, offset, ctx.threads());
 }
 
+void SqrtCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_sqrt<float>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+
 void RsqrtCompute::Run() {
   auto& param = this->Param<param_t>();
   auto& ctx = this->ctx_->template As<ARMContext>();
@@ -185,6 +195,11 @@ REGISTER_LITE_KERNEL(hard_sigmoid,
                      kNCHW,
                      paddle::lite::kernels::arm::HardSigmoidCompute,
                      def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(
+    sqrt, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::SqrtCompute, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();

--- a/lite/kernels/arm/activation_extra_compute.cc
+++ b/lite/kernels/arm/activation_extra_compute.cc
@@ -1,0 +1,223 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/arm/activation_extra_compute.h"
+#include "lite/backends/arm/math/funcs.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace arm {
+
+void ReluClippedCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto coef = param.Relu_clipped_coef;
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_clipped_relu<float>(
+      x_data, output_data, x_dims.production(), coef, ctx.threads());
+}
+
+void SwishCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto beta = param.Swish_beta;
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_swish<float>(
+      x_data, output_data, x_dims.production(), beta, ctx.threads());
+}
+
+void LogCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_log<float>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+
+void ExpCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_exp<float>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+
+void FloorCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_floor<float>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+
+void HardSigmoidCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  float slope = param.hard_sigmoid_slope;
+  float offset = param.hard_sigmoid_offset;
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_hard_sigmoid<float>(
+      x_data, output_data, x_dims.production(), slope, offset, ctx.threads());
+}
+
+void RsqrtCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_rsqrt<float>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+
+void SquareCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_square<float>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+
+void HardSwishCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto output_data = param.Out->mutable_data<float>();
+  float threshold = param.hard_swish_threshold;
+  float scale = param.hard_swish_scale;
+  float offset = param.hard_swish_offset;
+  lite::arm::math::act_hard_swish<float>(x_data,
+                                         output_data,
+                                         x_dims.production(),
+                                         threshold,
+                                         scale,
+                                         offset,
+                                         ctx.threads());
+}
+
+void ReciprocalCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_reciprocal<float>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+
+void AbsCompute::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->data<float>();
+  auto output_data = param.Out->mutable_data<float>();
+  lite::arm::math::act_abs<float>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+
+}  // namespace arm
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(relu_clipped,
+                     kARM,
+                     kFloat,
+                     kNCHW,
+                     paddle::lite::kernels::arm::ReluClippedCompute,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("Relu_clipped_coef", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    swish, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::SwishCompute, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("beta", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(
+    log, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::LogCompute, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(
+    exp, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::ExpCompute, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(
+    floor, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::FloorCompute, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(hard_sigmoid,
+                     kARM,
+                     kFloat,
+                     kNCHW,
+                     paddle::lite::kernels::arm::HardSigmoidCompute,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(
+    rsqrt, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::RsqrtCompute, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(
+    square, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::SquareCompute, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(hard_swish,
+                     kARM,
+                     kFloat,
+                     kNCHW,
+                     paddle::lite::kernels::arm::HardSwishCompute,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(reciprocal,
+                     kARM,
+                     kFloat,
+                     kNCHW,
+                     paddle::lite::kernels::arm::ReciprocalCompute,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+REGISTER_LITE_KERNEL(
+    abs, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::AbsCompute, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();

--- a/lite/kernels/arm/activation_extra_compute.h
+++ b/lite/kernels/arm/activation_extra_compute.h
@@ -76,6 +76,15 @@ class HardSigmoidCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
   virtual ~HardSigmoidCompute() = default;
 };
 
+class SqrtCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+ public:
+  using param_t = operators::ActivationParam;
+
+  void Run() override;
+
+  virtual ~SqrtCompute() = default;
+};
+
 class RsqrtCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
  public:
   using param_t = operators::ActivationParam;

--- a/lite/kernels/arm/activation_extra_compute.h
+++ b/lite/kernels/arm/activation_extra_compute.h
@@ -22,77 +22,103 @@ namespace lite {
 namespace kernels {
 namespace arm {
 
-class ReluCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class ReluClippedCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
  public:
   using param_t = operators::ActivationParam;
 
   void Run() override;
 
-  virtual ~ReluCompute() = default;
+  virtual ~ReluClippedCompute() = default;
 };
 
-class LeakyReluCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class SwishCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
  public:
   using param_t = operators::ActivationParam;
 
   void Run() override;
 
-  virtual ~LeakyReluCompute() = default;
+  virtual ~SwishCompute() = default;
 };
 
-class PReluCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class LogCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
  public:
   using param_t = operators::ActivationParam;
 
   void Run() override;
 
-  virtual ~PReluCompute() = default;
+  virtual ~LogCompute() = default;
 };
 
-class SigmoidCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class ExpCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
  public:
   using param_t = operators::ActivationParam;
 
   void Run() override;
 
-  virtual ~SigmoidCompute() = default;
+  virtual ~ExpCompute() = default;
 };
 
-class TanhCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class FloorCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
  public:
   using param_t = operators::ActivationParam;
 
   void Run() override;
 
-  virtual ~TanhCompute() = default;
+  virtual ~FloorCompute() = default;
 };
 
-class Relu6Compute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class HardSigmoidCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
  public:
   using param_t = operators::ActivationParam;
 
   void Run() override;
 
-  virtual ~Relu6Compute() = default;
+  virtual ~HardSigmoidCompute() = default;
 };
 
-class ThresholdedReluCompute
-    : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class RsqrtCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
  public:
   using param_t = operators::ActivationParam;
 
   void Run() override;
 
-  virtual ~ThresholdedReluCompute() = default;
+  virtual ~RsqrtCompute() = default;
 };
 
-class EluCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class SquareCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
  public:
   using param_t = operators::ActivationParam;
 
   void Run() override;
 
-  virtual ~EluCompute() = default;
+  virtual ~SquareCompute() = default;
+};
+
+class HardSwishCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+ public:
+  using param_t = operators::ActivationParam;
+
+  void Run() override;
+
+  virtual ~HardSwishCompute() = default;
+};
+
+class ReciprocalCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+ public:
+  using param_t = operators::ActivationParam;
+
+  void Run() override;
+
+  virtual ~ReciprocalCompute() = default;
+};
+
+class AbsCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+ public:
+  using param_t = operators::ActivationParam;
+
+  void Run() override;
+
+  virtual ~AbsCompute() = default;
 };
 
 }  // namespace arm

--- a/lite/tests/benchmark/src/get_activation_latency.cc
+++ b/lite/tests/benchmark/src/get_activation_latency.cc
@@ -19,6 +19,7 @@
 #include "lite/core/profile/timer.h"
 #include "lite/core/tensor.h"
 #include "lite/kernels/arm/activation_compute.h"
+#include "lite/kernels/arm/activation_extra_compute.h"
 #include "lite/operators/op_params.h"
 #include "lite/tests/utils/tensor_utils.h"
 

--- a/lite/tests/kernels/activation_compute_test.cc
+++ b/lite/tests/kernels/activation_compute_test.cc
@@ -34,6 +34,7 @@ enum activation_type_test {
   LOG,
   EXP,
   FLOOR,
+  SQRT,
   RSQRT,
   GELU,
   SQUARE,
@@ -194,6 +195,12 @@ class ActivationComputeTester : public arena::TestCase {
         }
         break;
       }
+      case SQRT: {
+        for (int i = 0; i < dims_.production(); i++) {
+          output_data[i] = std::sqrt(x_data[i]);
+        }
+        break;
+      }
       case RSQRT: {
         for (int i = 0; i < dims_.production(); i++) {
           output_data[i] = 1.0 / std::sqrt(x_data[i]);
@@ -290,7 +297,7 @@ class ActivationComputeTester : public arena::TestCase {
     std::vector<float> data(dims_.production());
     for (int i = 0; i < dims_.production(); i++) {
       float sign = i % 3 == 0 ? -1.0f : 1.0f;
-      sign = (type_ == "log" || type_ == "rsqrt") ? 1 : sign;
+      sign = (type_ == "log" || type_ == "rsqrt" || type_ == "sqrt") ? 1 : sign;
       data[i] = sign * static_cast<float>(i % 128) * 0.013f + 0.001;
     }
     SetCommonTensor(input_, dims_, data.data());
@@ -603,6 +610,19 @@ TEST(Activation_rsqrt, precision) {
            {1, 3, 2, 4}, {2, 3, 4}, {5, 4}, {8}}) {
     std::unique_ptr<arena::TestCase> tester(new ActivationComputeTester(
         place, "def", 0.01, 6., "all", 0., 1.0, DDim(dims), "rsqrt", RSQRT));
+    arena::Arena arena(std::move(tester), place, 2e-5);
+    arena.TestPrecision();
+  }
+#endif
+}
+
+TEST(Activation_sqrt, precision) {
+#ifdef LITE_WITH_ARM
+  Place place(TARGET(kARM));
+  for (auto dims : std::vector<std::vector<int64_t>>{
+           {1, 3, 2, 4}, {2, 3, 4}, {5, 4}, {8}}) {
+    std::unique_ptr<arena::TestCase> tester(new ActivationComputeTester(
+        place, "def", 0.01, 6., "all", 0., 1.0, DDim(dims), "sqrt", SQRT));
     arena::Arena arena(std::move(tester), place, 2e-5);
     arena.TestPrecision();
   }

--- a/lite/tests/kernels/activation_grad_compute_test.cc
+++ b/lite/tests/kernels/activation_grad_compute_test.cc
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include "lite/core/op_registry.h"
 #include "lite/kernels/arm/activation_compute.h"
+#include "lite/kernels/arm/activation_extra_compute.h"
 
 namespace paddle {
 namespace lite {


### PR DESCRIPTION
### 问题描述
- Paddle-Lite 中部分激活函数 op和kernel的属性不一致
  - Paddle-Lite 中激活函数(activation) op 分为 extra 和basic
  - 但是 其中所有的激活（activation) kernel 都被注册成了 basic 
### 本PR工作
- 对齐activation kernel和op
- 注册arm kernel `sqrt` （求取平方根）