### PR TITLE
change the byte type of opencl cache, test=develop

### DIFF
--- a/lite/backends/opencl/utils/cache.cc
+++ b/lite/backends/opencl/utils/cache.cc
@@ -21,7 +21,7 @@ namespace lite {
 namespace fbs {
 namespace opencl {
 
-Cache::Cache(const std::vector<int8_t>& buffer) {
+Cache::Cache(const std::vector<uint8_t>& buffer) {
   flatbuffers::Verifier verifier(
       reinterpret_cast<const uint8_t*>(buffer.data()), buffer.size());
   CHECK(verifier.VerifyBuffer<paddle::lite::fbs::opencl::proto::Cache>(nullptr))
@@ -29,7 +29,7 @@ Cache::Cache(const std::vector<int8_t>& buffer) {
   SyncFromFbs(proto::GetCache(buffer.data()));
 }
 
-void Cache::CopyDataToBuffer(std::vector<int8_t>* buffer) const {
+void Cache::CopyDataToBuffer(std::vector<uint8_t>* buffer) const {
   CHECK(buffer);
   flatbuffers::DetachedBuffer buf{SyncToFbs()};
   buffer->resize(buf.size());
@@ -43,10 +43,10 @@ void Cache::SyncFromFbs(const paddle::lite::fbs::opencl::proto::Cache* desc) {
   const auto* binary_map_desc = desc->binary_map();
   CHECK(binary_map_desc);
   for (const auto& pair : *binary_map_desc) {
-    std::vector<std::vector<int8_t>> binary_paths;
+    std::vector<std::vector<uint8_t>> binary_paths;
     for (const auto& value : *(pair->value())) {
       const size_t size = value->data()->size();
-      binary_paths.emplace_back(std::vector<int8_t>(size));
+      binary_paths.emplace_back(std::vector<uint8_t>(size));
       // To avoid additional dependencies, standard library components are used
       // here.
       std::memcpy(binary_paths.back().data(), value->data()->data(), size);

--- a/lite/backends/opencl/utils/cache.fbs
+++ b/lite/backends/opencl/utils/cache.fbs
@@ -1,7 +1,7 @@
 namespace paddle.lite.fbs.opencl.proto.Cache_;
 
 table BinaryVector {
-  data:[byte];
+  data:[ubyte];
 }
 
 table BinaryPair {

--- a/lite/backends/opencl/utils/cache.h
+++ b/lite/backends/opencl/utils/cache.h
@@ -27,11 +27,11 @@ namespace opencl {
 class Cache {
  public:
   explicit Cache(
-      const std::map<std::string, std::vector<std::vector<int8_t>>>& map)
+      const std::map<std::string, std::vector<std::vector<uint8_t>>>& map)
       : binary_map_{map} {}
-  explicit Cache(const std::vector<int8_t>& buffer);
-  void CopyDataToBuffer(std::vector<int8_t>* buffer) const;
-  const std::map<std::string, std::vector<std::vector<int8_t>>>& GetBinaryMap()
+  explicit Cache(const std::vector<uint8_t>& buffer);
+  void CopyDataToBuffer(std::vector<uint8_t>* buffer) const;
+  const std::map<std::string, std::vector<std::vector<uint8_t>>>& GetBinaryMap()
       const {
     return binary_map_;
   }
@@ -39,7 +39,7 @@ class Cache {
  private:
   void SyncFromFbs(const paddle::lite::fbs::opencl::proto::Cache* desc);
   flatbuffers::DetachedBuffer SyncToFbs() const;
-  std::map<std::string, std::vector<std::vector<int8_t>>> binary_map_;
+  std::map<std::string, std::vector<std::vector<uint8_t>>> binary_map_;
 };
 
 }  // namespace opencl

--- a/lite/backends/opencl/utils/test_cache.cc
+++ b/lite/backends/opencl/utils/test_cache.cc
@@ -23,11 +23,11 @@ namespace fbs {
 namespace opencl {
 
 TEST(OpenCLCache, cache) {
-  const std::map<std::string, std::vector<std::vector<int8_t>>> map{
+  const std::map<std::string, std::vector<std::vector<uint8_t>>> map{
       {"a", {{1, 2}, {3, 4}}}, {"b", {{5, 6}, {7, 8}}},
   };
   Cache cache_0{map};
-  std::vector<int8_t> buffer;
+  std::vector<uint8_t> buffer;
   cache_0.CopyDataToBuffer(&buffer);
 
   Cache cache_1{buffer};


### PR DESCRIPTION
为避免数据转型带来的风险，朴素字节使用 `uint8_t` 来表示。