### PR TITLE
[Framework] Host memcpy 

### DIFF
--- a/lite/backends/arm/math/concat.h
+++ b/lite/backends/arm/math/concat.h
@@ -51,7 +51,7 @@ void concat_func(const std::vector<lite::Tensor*>& input,
     auto* dout_ptr = dst_ptr + offset_concat_axis * concat_input_size;
     int64_t in_sum = in_concat_axis * concat_input_size;
     for (int i = 0; i < num_cancats; i++) {
-      std::memcpy(dout_ptr, src_ptr, sizeof(T) * in_sum);
+      host::memcpy(dout_ptr, src_ptr, sizeof(T) * in_sum);
       dout_ptr += out_sum;
       src_ptr += in_sum;
     }

--- a/lite/backends/arm/math/conv3x3_winograd_fp32_c4.cc
+++ b/lite/backends/arm/math/conv3x3_winograd_fp32_c4.cc
@@ -220,7 +220,7 @@ void conv_compute_6x6_3x3(const float* input,
               for (int yi = 0; yi < ey; ++yi) {
                 float* dst_yi = trans_remain_tmp_data + yi * 32;
                 const float* src_yi = src_ci + w_pad * yi * 4;
-                memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
+                host::memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
               }
             }
             // trans
@@ -341,9 +341,9 @@ void conv_compute_6x6_3x3(const float* input,
             // copy to dest
             memset(trans_tmp_data, 0, 144 * sizeof(float));
             for (int i = 0; i < ey; ++i) {
-              memcpy(trans_tmp_data + i * ex * 4,
-                     trans_remain_tmp_data + i * 24,
-                     ex * sizeof(float) * 4);
+              host::memcpy(trans_tmp_data + i * ex * 4,
+                           trans_remain_tmp_data + i * 24,
+                           ex * sizeof(float) * 4);
             }
             write_to_output_c4_fp32(trans_tmp_data,
                                     output_ptr,
@@ -503,7 +503,7 @@ void conv_compute_4x4_3x3(const float* input,
               for (int yi = 0; yi < ey; ++yi) {
                 float* dst_yi = trans_remain_tmp_data + yi * 24;
                 const float* src_yi = src_ci + w_pad * yi * 4;
-                memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
+                host::memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
               }
             }
             // trans
@@ -625,9 +625,9 @@ void conv_compute_4x4_3x3(const float* input,
             // copy to dest
             memset(trans_tmp_data, 0, 64 * sizeof(float));
             for (int i = 0; i < ey; ++i) {
-              memcpy(trans_tmp_data + i * ex * 4,
-                     trans_remain_tmp_data + i * 16,
-                     ex * sizeof(float) * 4);
+              host::memcpy(trans_tmp_data + i * ex * 4,
+                           trans_remain_tmp_data + i * 16,
+                           ex * sizeof(float) * 4);
             }
             write_to_output_c4_fp32(trans_tmp_data,
                                     output_ptr,
@@ -782,7 +782,7 @@ void conv_compute_2x2_3x3(const float* input,
               for (int yi = 0; yi < ey; ++yi) {
                 float* dst_yi = trans_remain_tmp_data + yi * 16;
                 const float* src_yi = src_ci + w_pad * yi * 4;
-                memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
+                host::memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
               }
             }
 
@@ -890,9 +890,9 @@ void conv_compute_2x2_3x3(const float* input,
             // copy to dest
             memset(trans_tmp_data, 0, 16 * sizeof(float));
             for (int i = 0; i < ey; ++i) {
-              memcpy(trans_tmp_data + i * ex * 4,
-                     trans_remain_tmp_data + i * 8,
-                     ex * sizeof(float) * 4);
+              host::memcpy(trans_tmp_data + i * ex * 4,
+                           trans_remain_tmp_data + i * 8,
+                           ex * sizeof(float) * 4);
             }
             write_to_output_c4_fp32(trans_tmp_data,
                                     output_ptr,
@@ -1038,7 +1038,7 @@ void conv_compute_2x2_3x3_small(const float* input,
               for (int yi = 0; yi < ey; ++yi) {
                 float* dst_yi = trans_remain_tmp_data + yi * 16;
                 const float* src_yi = src_ci + w_pad * yi * 4;
-                memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
+                host::memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
               }
             }
 
@@ -1147,9 +1147,9 @@ void conv_compute_2x2_3x3_small(const float* input,
             // copy to dest
             memset(trans_tmp_data, 0, 16 * sizeof(float));
             for (int i = 0; i < ey; ++i) {
-              memcpy(trans_tmp_data + i * ex * 4,
-                     trans_remain_tmp_data + i * 8,
-                     ex * sizeof(float) * 4);
+              host::memcpy(trans_tmp_data + i * ex * 4,
+                           trans_remain_tmp_data + i * 8,
+                           ex * sizeof(float) * 4);
             }
             write_to_output_c4_fp32(trans_tmp_data,
                                     output_ptr,

--- a/lite/backends/arm/math/conv3x3_winograd_fp32_c4.cc
+++ b/lite/backends/arm/math/conv3x3_winograd_fp32_c4.cc
@@ -220,7 +220,7 @@ void conv_compute_6x6_3x3(const float* input,
               for (int yi = 0; yi < ey; ++yi) {
                 float* dst_yi = trans_remain_tmp_data + yi * 32;
                 const float* src_yi = src_ci + w_pad * yi * 4;
-                host::memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
+                memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
               }
             }
             // trans
@@ -341,9 +341,9 @@ void conv_compute_6x6_3x3(const float* input,
             // copy to dest
             memset(trans_tmp_data, 0, 144 * sizeof(float));
             for (int i = 0; i < ey; ++i) {
-              host::memcpy(trans_tmp_data + i * ex * 4,
-                           trans_remain_tmp_data + i * 24,
-                           ex * sizeof(float) * 4);
+              memcpy(trans_tmp_data + i * ex * 4,
+                     trans_remain_tmp_data + i * 24,
+                     ex * sizeof(float) * 4);
             }
             write_to_output_c4_fp32(trans_tmp_data,
                                     output_ptr,
@@ -503,7 +503,7 @@ void conv_compute_4x4_3x3(const float* input,
               for (int yi = 0; yi < ey; ++yi) {
                 float* dst_yi = trans_remain_tmp_data + yi * 24;
                 const float* src_yi = src_ci + w_pad * yi * 4;
-                host::memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
+                memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
               }
             }
             // trans
@@ -625,9 +625,9 @@ void conv_compute_4x4_3x3(const float* input,
             // copy to dest
             memset(trans_tmp_data, 0, 64 * sizeof(float));
             for (int i = 0; i < ey; ++i) {
-              host::memcpy(trans_tmp_data + i * ex * 4,
-                           trans_remain_tmp_data + i * 16,
-                           ex * sizeof(float) * 4);
+              memcpy(trans_tmp_data + i * ex * 4,
+                     trans_remain_tmp_data + i * 16,
+                     ex * sizeof(float) * 4);
             }
             write_to_output_c4_fp32(trans_tmp_data,
                                     output_ptr,
@@ -782,7 +782,7 @@ void conv_compute_2x2_3x3(const float* input,
               for (int yi = 0; yi < ey; ++yi) {
                 float* dst_yi = trans_remain_tmp_data + yi * 16;
                 const float* src_yi = src_ci + w_pad * yi * 4;
-                host::memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
+                memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
               }
             }
 
@@ -890,9 +890,9 @@ void conv_compute_2x2_3x3(const float* input,
             // copy to dest
             memset(trans_tmp_data, 0, 16 * sizeof(float));
             for (int i = 0; i < ey; ++i) {
-              host::memcpy(trans_tmp_data + i * ex * 4,
-                           trans_remain_tmp_data + i * 8,
-                           ex * sizeof(float) * 4);
+              memcpy(trans_tmp_data + i * ex * 4,
+                     trans_remain_tmp_data + i * 8,
+                     ex * sizeof(float) * 4);
             }
             write_to_output_c4_fp32(trans_tmp_data,
                                     output_ptr,
@@ -1038,7 +1038,7 @@ void conv_compute_2x2_3x3_small(const float* input,
               for (int yi = 0; yi < ey; ++yi) {
                 float* dst_yi = trans_remain_tmp_data + yi * 16;
                 const float* src_yi = src_ci + w_pad * yi * 4;
-                host::memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
+                memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
               }
             }
 
@@ -1147,9 +1147,9 @@ void conv_compute_2x2_3x3_small(const float* input,
             // copy to dest
             memset(trans_tmp_data, 0, 16 * sizeof(float));
             for (int i = 0; i < ey; ++i) {
-              host::memcpy(trans_tmp_data + i * ex * 4,
-                           trans_remain_tmp_data + i * 8,
-                           ex * sizeof(float) * 4);
+              memcpy(trans_tmp_data + i * ex * 4,
+                     trans_remain_tmp_data + i * 8,
+                     ex * sizeof(float) * 4);
             }
             write_to_output_c4_fp32(trans_tmp_data,
                                     output_ptr,

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -39,6 +39,43 @@ using lite_api::TargetRepr;
 using lite_api::PrecisionRepr;
 using lite_api::DataLayoutRepr;
 
+namespace host {
+const int MALLOC_ALIGN = 64;
+
+// Allocate the requested memory and return a pointer to it.
+// Byte alignment and memory checking are performed.
+inline void* malloc(size_t size) {
+  size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;
+  char* p = static_cast<char*>(malloc(offset + size));
+  // Memory checking
+  CHECK(p) << "Error occurred in malloc period: available space is not enough "
+              "for mallocing "
+           << size << " bytes.";
+  // Byte alignment
+  void* r = reinterpret_cast<void*>(reinterpret_cast<size_t>(p + offset) &
+                                    (~(MALLOC_ALIGN - 1)));
+  static_cast<void**>(r)[-1] = p;
+  return r;
+}
+
+// Deallocate the memory.
+inline void free(void* ptr) {
+  if (ptr) {
+    free(static_cast<void**>(ptr)[-1]);
+  }
+}
+
+// Copy size characters from memory area src to memory area dst.
+// Memory checking is performed.
+inline void memcpy(void* dst, const void* src, size_t size) {
+  if (size > 0) {
+    CHECK(dst) << "Error: the destination of memcpy can not be nullptr.";
+    CHECK(src) << "Error: the source of memcpy can not be nullptr.";
+    memcpy(dst, src, size);
+  }
+}
+}  // namespace host
+
 // Memory copy directions.
 enum class IoDirection {
   HtoH = 0,  // Host to host

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <string>

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -46,7 +46,7 @@ const int MALLOC_ALIGN = 64;
 // Byte alignment and memory checking are performed.
 inline void* malloc(size_t size) {
   size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;
-  char* p = static_cast<char*>(malloc(offset + size));
+  char* p = static_cast<char*>(std::malloc(offset + size));
   // Memory checking
   CHECK(p) << "Error occurred in malloc period: available space is not enough "
               "for mallocing "
@@ -61,7 +61,7 @@ inline void* malloc(size_t size) {
 // Deallocate the memory.
 inline void free(void* ptr) {
   if (ptr) {
-    free(static_cast<void**>(ptr)[-1]);
+    std::free(static_cast<void**>(ptr)[-1]);
   }
 }
 
@@ -71,7 +71,7 @@ inline void memcpy(void* dst, const void* src, size_t size) {
   if (size > 0) {
     CHECK(dst) << "Error: the destination of memcpy can not be nullptr.";
     CHECK(src) << "Error: the source of memcpy can not be nullptr.";
-    memcpy(dst, src, size);
+    std::memcpy(dst, src, size);
   }
 }
 }  // namespace host


### PR DESCRIPTION
### 问题描述
- Lite 代码中有直接调用 malloc、memcpy、free等内存函数，但不添加指针检查的操作。 可能导致 Lite 程序异常退出，影响业务线稳定性
### 本PR工作
- lite中实现带有指针检查功能的 malloc 、memcpy、free 方法
  - lite::host::malloc
  - lite::host::memcpy
  - lite::host::free
- 函数定义为inline类型，避免可能的函数堆栈耗时

### 后续工作
- 需要批量替换 `arm\host\x86` 平台下的内存操作代码
  - `std::malloc` ----> `host::malloc`
  - `std::memcpy` ----> `host::memcpy`
  - `std::free` ----> `host::free`