### PR TITLE
[cherry-pick] add 2.0 api pad3d bilinear_interp_v2 and sync_batchnorm

### DIFF
--- a/lite/backends/arm/math/conv_impl.cc
+++ b/lite/backends/arm/math/conv_impl.cc
@@ -735,7 +735,9 @@ void conv1x1s1_gemm_int8(const int8_t* i_data,
             bias_ptr[i] = bias_group[0];
           }
         }
-        memset(scale_ptr, scale_group[0], sizeof(float) * n);
+        for (int i = 0; i < n; i++) {
+          scale_ptr[i] = scale_group[0];
+        }
         gemv_int8(din_group,
                   weights_group,
                   dout_group,

--- a/lite/backends/host/math/CMakeLists.txt
+++ b/lite/backends/host/math/CMakeLists.txt
@@ -1,4 +1,5 @@
 lite_cc_library(math_host SRCS
     sequence_padding.cc
     slice.cc
+    pad3d.cc
     DEPS ${lite_kernel_deps})

--- a/lite/backends/host/math/pad3d.cc
+++ b/lite/backends/host/math/pad3d.cc
@@ -1,0 +1,584 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/backends/host/math/pad3d.h"
+#include <algorithm>
+#include <limits>
+#include <memory>
+
+namespace paddle {
+namespace lite {
+namespace host {
+namespace math {
+
+void pad_ncdhw_constant(const float* din,
+                        float* dout,
+                        int n,
+                        int c,
+                        int in_d,
+                        int in_h,
+                        int in_w,
+                        int out_d,
+                        int out_h,
+                        int out_w,
+                        const int pad_top,
+                        const int pad_bottom,
+                        const int pad_left,
+                        const int pad_right,
+                        const int pad_front,
+                        const int pad_back,
+                        const float pad_value) {
+  int num = n * c;
+  int size_in_hw = in_h * in_w;
+  int size_out_hw = out_h * out_w;
+  int spatial_size_out = size_out_hw * out_d;
+  int spatial_size_in = size_in_hw * in_d;
+#pragma omp parallel for
+  for (int i = 0; i < num; i++) {
+    const float* din_num = din + i * spatial_size_in;
+    float* dout_num = dout + i * spatial_size_out;
+    for (int d = -pad_front; d < in_d + pad_back; d++) {
+      if (d < 0 || d >= in_d) {
+        memset(dout_num, pad_value, sizeof(float) * size_out_hw);
+        dout_num += size_out_hw;
+      } else {
+        for (int h = -pad_top; h < in_h + pad_bottom; h++) {
+          if (h < 0 || h >= in_h) {
+            memset(dout_num, pad_value, sizeof(float) * out_w);
+            dout_num += out_w;
+          } else {
+            if (pad_left) {
+              memset(dout_num, pad_value, sizeof(float) * pad_left);
+              dout_num += pad_left;
+            }
+            memcpy(dout_num, din_num, sizeof(float) * in_w);
+            dout_num += in_w;
+            din_num += in_w;
+            if (pad_right) {
+              memset(dout_num, pad_value, sizeof(float) * pad_right);
+              dout_num += pad_right;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+void pad_ndhwc_constant(const float* din,
+                        float* dout,
+                        int n,
+                        int c,
+                        int in_d,
+                        int in_h,
+                        int in_w,
+                        int out_d,
+                        int out_h,
+                        int out_w,
+                        const int pad_top,
+                        const int pad_bottom,
+                        const int pad_left,
+                        const int pad_right,
+                        const int pad_front,
+                        const int pad_back,
+                        const float pad_value) {
+  int in_wc = in_w * c;
+  int out_wc = out_w * c;
+  int size_in_hw = in_h * in_wc;
+  int size_out_hw = out_h * out_wc;
+  int spatial_size_out = size_out_hw * out_d;
+  int spatial_size_in = size_in_hw * in_d;
+  int pad_leftc = pad_left * c;
+  int pad_rightc = pad_right * c;
+#pragma omp parallel for
+  for (int i = 0; i < n; i++) {
+    const float* din_num = din + i * spatial_size_in;
+    float* dout_num = dout + i * spatial_size_out;
+    for (int d = -pad_front; d < in_d + pad_back; d++) {
+      if (d < 0 || d >= in_d) {
+        memset(dout_num, pad_value, sizeof(float) * size_out_hw);
+        dout_num += size_out_hw;
+      } else {
+        for (int h = -pad_top; h < in_h + pad_bottom; h++) {
+          if (h < 0 || h >= in_h) {
+            memset(dout_num, pad_value, sizeof(float) * out_wc);
+            dout_num += out_wc;
+          } else {
+            if (pad_left) {
+              memset(dout_num, pad_value, sizeof(float) * pad_leftc);
+              dout_num += pad_leftc;
+            }
+            memcpy(dout_num, din_num, sizeof(float) * in_wc);
+            dout_num += in_wc;
+            din_num += in_wc;
+            if (pad_right) {
+              memset(dout_num, pad_value, sizeof(float) * pad_rightc);
+              dout_num += pad_rightc;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+void pad_ncdhw_reflect(const float* din,
+                       float* dout,
+                       int n,
+                       int c,
+                       int in_d,
+                       int in_h,
+                       int in_w,
+                       int out_d,
+                       int out_h,
+                       int out_w,
+                       const int pad_top,
+                       const int pad_bottom,
+                       const int pad_left,
+                       const int pad_right,
+                       const int pad_front,
+                       const int pad_back) {
+  int num = n * c;
+  int size_in_hw = in_h * in_w;
+  int size_out_hw = out_h * out_w;
+  int spatial_size_out = size_out_hw * out_d;
+  int spatial_size_in = size_in_hw * in_d;
+#pragma omp parallel for
+  for (int i = 0; i < num; i++) {
+    const float* din_num = din + i * spatial_size_in;
+    float* dout_num = dout + i * spatial_size_out;
+    for (int od = 0; od < out_d; od++) {
+      for (int oh = 0; oh < out_h; oh++) {
+        for (int ow = 0; ow < out_w; ow++) {
+          int in_depth = od - pad_front;
+          int in_height = oh - pad_top;
+          int in_width = ow - pad_left;
+          in_depth = std::max(in_depth, -in_depth);
+          in_depth = std::min(in_depth, 2 * in_d - in_depth - 2);
+          in_height = std::max(in_height, -in_height);
+          in_height = std::min(in_height, 2 * in_h - in_height - 2);
+          in_width = std::max(in_width, -in_width);
+          in_width = std::min(in_width, 2 * in_w - in_width - 2);
+          dout_num[od * size_out_hw + oh * out_w + ow] =
+              din_num[in_depth * size_in_hw + in_height * in_w + in_width];
+        }
+      }
+    }
+  }
+}
+
+void pad_ndhwc_reflect(const float* din,
+                       float* dout,
+                       int n,
+                       int c,
+                       int in_d,
+                       int in_h,
+                       int in_w,
+                       int out_d,
+                       int out_h,
+                       int out_w,
+                       const int pad_top,
+                       const int pad_bottom,
+                       const int pad_left,
+                       const int pad_right,
+                       const int pad_front,
+                       const int pad_back) {
+  int in_wc = in_w * c;
+  int out_wc = out_w * c;
+  int size_in_hw = in_h * in_wc;
+  int size_out_hw = out_h * out_wc;
+  int spatial_size_out = size_out_hw * out_d;
+  int spatial_size_in = size_in_hw * in_d;
+#pragma omp parallel for
+  for (int i = 0; i < n; i++) {
+    const float* din_num = din + i * spatial_size_in;
+    float* dout_num = dout + i * spatial_size_out;
+    for (int od = 0; od < out_d; od++) {
+      for (int oh = 0; oh < out_h; oh++) {
+        for (int ow = 0; ow < out_w; ow++) {
+          int in_depth = od - pad_front;
+          int in_height = oh - pad_top;
+          int in_width = ow - pad_left;
+          in_depth = std::max(in_depth, -in_depth);
+          in_depth = std::min(in_depth, 2 * in_d - in_depth - 2);
+          in_height = std::max(in_height, -in_height);
+          in_height = std::min(in_height, 2 * in_h - in_height - 2);
+          in_width = std::max(in_width, -in_width);
+          in_width = std::min(in_width, 2 * in_w - in_width - 2);
+          int out_idx = od * size_out_hw + oh * out_wc + ow * c;
+          int in_idx = in_depth * size_in_hw + in_height * in_wc + in_width * c;
+          for (int j = 0; j < c; j++) {
+            dout_num[out_idx + j] = din_num[in_idx + j];
+          }
+        }
+      }
+    }
+  }
+}
+
+void pad_ncdhw_replicate(const float* din,
+                         float* dout,
+                         int n,
+                         int c,
+                         int in_d,
+                         int in_h,
+                         int in_w,
+                         int out_d,
+                         int out_h,
+                         int out_w,
+                         const int pad_top,
+                         const int pad_bottom,
+                         const int pad_left,
+                         const int pad_right,
+                         const int pad_front,
+                         const int pad_back) {
+  int num = n * c;
+  int size_in_hw = in_h * in_w;
+  int size_out_hw = out_h * out_w;
+  int spatial_size_out = size_out_hw * out_d;
+  int spatial_size_in = size_in_hw * in_d;
+#pragma omp parallel for
+  for (int i = 0; i < num; i++) {
+    const float* din_num = din + i * spatial_size_in;
+    float* dout_num = dout + i * spatial_size_out;
+    for (int od = 0; od < out_d; od++) {
+      for (int oh = 0; oh < out_h; oh++) {
+        for (int ow = 0; ow < out_w; ow++) {
+          int in_depth = std::min(in_d - 1, std::max(od - pad_front, 0));
+          int in_height = std::min(in_h - 1, std::max(oh - pad_top, 0));
+          int in_width = std::min(in_w - 1, std::max(ow - pad_left, 0));
+          dout_num[od * size_out_hw + oh * out_w + ow] =
+              din_num[in_depth * size_in_hw + in_height * in_w + in_width];
+        }
+      }
+    }
+  }
+}
+
+void pad_ndhwc_replicate(const float* din,
+                         float* dout,
+                         int n,
+                         int c,
+                         int in_d,
+                         int in_h,
+                         int in_w,
+                         int out_d,
+                         int out_h,
+                         int out_w,
+                         const int pad_top,
+                         const int pad_bottom,
+                         const int pad_left,
+                         const int pad_right,
+                         const int pad_front,
+                         const int pad_back) {
+  int in_wc = in_w * c;
+  int out_wc = out_w * c;
+  int size_in_hw = in_h * in_wc;
+  int size_out_hw = out_h * out_wc;
+  int spatial_size_out = size_out_hw * out_d;
+  int spatial_size_in = size_in_hw * in_d;
+#pragma omp parallel for
+  for (int i = 0; i < n; i++) {
+    const float* din_num = din + i * spatial_size_in;
+    float* dout_num = dout + i * spatial_size_out;
+    for (int od = 0; od < out_d; od++) {
+      for (int oh = 0; oh < out_h; oh++) {
+        for (int ow = 0; ow < out_w; ow++) {
+          int in_depth = std::min(in_d - 1, std::max(od - pad_front, 0));
+          int in_height = std::min(in_h - 1, std::max(oh - pad_top, 0));
+          int in_width = std::min(in_w - 1, std::max(ow - pad_left, 0));
+          int out_idx = od * size_out_hw + oh * out_wc + ow * c;
+          int in_idx = in_depth * size_in_hw + in_height * in_wc + in_width * c;
+          for (int j = 0; j < c; j++) {
+            dout_num[out_idx + j] = din_num[in_idx + j];
+          }
+        }
+      }
+    }
+  }
+}
+
+void pad_ncdhw_circular(const float* din,
+                        float* dout,
+                        int n,
+                        int c,
+                        int in_d,
+                        int in_h,
+                        int in_w,
+                        int out_d,
+                        int out_h,
+                        int out_w,
+                        const int pad_top,
+                        const int pad_bottom,
+                        const int pad_left,
+                        const int pad_right,
+                        const int pad_front,
+                        const int pad_back) {
+  int num = n * c;
+  int size_in_hw = in_h * in_w;
+  int size_out_hw = out_h * out_w;
+  int spatial_size_out = size_out_hw * out_d;
+  int spatial_size_in = size_in_hw * in_d;
+#pragma omp parallel for
+  for (int i = 0; i < num; i++) {
+    const float* din_num = din + i * spatial_size_in;
+    float* dout_num = dout + i * spatial_size_out;
+    for (int od = 0; od < out_d; od++) {
+      for (int oh = 0; oh < out_h; oh++) {
+        for (int ow = 0; ow < out_w; ow++) {
+          int in_depth = ((od - pad_front) % in_d + in_d) % in_d;
+          int in_height = ((oh - pad_top) % in_h + in_h) % in_h;
+          int in_width = ((ow - pad_left) % in_w + in_w) % in_w;
+          dout_num[od * size_out_hw + oh * out_w + ow] =
+              din_num[in_depth * size_in_hw + in_height * in_w + in_width];
+        }
+      }
+    }
+  }
+}
+
+void pad_ndhwc_circular(const float* din,
+                        float* dout,
+                        int n,
+                        int c,
+                        int in_d,
+                        int in_h,
+                        int in_w,
+                        int out_d,
+                        int out_h,
+                        int out_w,
+                        const int pad_top,
+                        const int pad_bottom,
+                        const int pad_left,
+                        const int pad_right,
+                        const int pad_front,
+                        const int pad_back) {
+  int in_wc = in_w * c;
+  int out_wc = out_w * c;
+  int size_in_hw = in_h * in_wc;
+  int size_out_hw = out_h * out_wc;
+  int spatial_size_out = size_out_hw * out_d;
+  int spatial_size_in = size_in_hw * in_d;
+#pragma omp parallel for
+  for (int i = 0; i < n; i++) {
+    const float* din_num = din + i * spatial_size_in;
+    float* dout_num = dout + i * spatial_size_out;
+    for (int od = 0; od < out_d; od++) {
+      for (int oh = 0; oh < out_h; oh++) {
+        for (int ow = 0; ow < out_w; ow++) {
+          int in_depth = ((od - pad_front) % in_d + in_d) % in_d;
+          int in_height = ((oh - pad_top) % in_h + in_h) % in_h;
+          int in_width = ((ow - pad_left) % in_w + in_w) % in_w;
+          int out_idx = od * size_out_hw + oh * out_wc + ow * c;
+          int in_idx = in_depth * size_in_hw + in_height * in_wc + in_width * c;
+          for (int j = 0; j < c; j++) {
+            dout_num[out_idx + j] = din_num[in_idx + j];
+          }
+        }
+      }
+    }
+  }
+}
+
+void pad3d_ncdhw_func(const lite::Tensor* input,
+                      lite::Tensor* output,
+                      int n,
+                      int c,
+                      int in_d,
+                      int in_h,
+                      int in_w,
+                      int out_d,
+                      int out_h,
+                      int out_w,
+                      int mode,
+                      std::vector<int> pad_h,
+                      std::vector<int> pad_w,
+                      std::vector<int> pad_d,
+                      float pad_value) {
+  float* dout = output->mutable_data<float>();
+  const float* din = input->data<float>();
+
+  auto output_dims = output->dims();
+
+  if (mode == 0) {
+    pad_ncdhw_constant(din,
+                       dout,
+                       n,
+                       c,
+                       in_d,
+                       in_h,
+                       in_w,
+                       out_d,
+                       out_h,
+                       out_w,
+                       pad_h[0],
+                       pad_h[1],
+                       pad_w[0],
+                       pad_w[1],
+                       pad_d[0],
+                       pad_d[1],
+                       pad_value);
+  } else if (mode == 1) {
+    pad_ncdhw_reflect(din,
+                      dout,
+                      n,
+                      c,
+                      in_d,
+                      in_h,
+                      in_w,
+                      out_d,
+                      out_h,
+                      out_w,
+                      pad_h[0],
+                      pad_h[1],
+                      pad_w[0],
+                      pad_w[1],
+                      pad_d[0],
+                      pad_d[1]);
+  } else if (mode == 2) {
+    pad_ncdhw_replicate(din,
+                        dout,
+                        n,
+                        c,
+                        in_d,
+                        in_h,
+                        in_w,
+                        out_d,
+                        out_h,
+                        out_w,
+                        pad_h[0],
+                        pad_h[1],
+                        pad_w[0],
+                        pad_w[1],
+                        pad_d[0],
+                        pad_d[1]);
+  } else if (mode == 3) {
+    pad_ncdhw_circular(din,
+                       dout,
+                       n,
+                       c,
+                       in_d,
+                       in_h,
+                       in_w,
+                       out_d,
+                       out_h,
+                       out_w,
+                       pad_h[0],
+                       pad_h[1],
+                       pad_w[0],
+                       pad_w[1],
+                       pad_d[0],
+                       pad_d[1]);
+  } else {
+    LOG(ERROR) << "ERROR: unknown pad mode " << mode;
+  }
+}
+
+void pad3d_ndhwc_func(const lite::Tensor* input,
+                      lite::Tensor* output,
+                      int n,
+                      int c,
+                      int in_d,
+                      int in_h,
+                      int in_w,
+                      int out_d,
+                      int out_h,
+                      int out_w,
+                      int mode,
+                      std::vector<int> pad_h,
+                      std::vector<int> pad_w,
+                      std::vector<int> pad_d,
+                      float pad_value) {
+  float* dout = output->mutable_data<float>();
+  const float* din = input->data<float>();
+
+  auto output_dims = output->dims();
+
+  if (mode == 0) {
+    pad_ndhwc_constant(din,
+                       dout,
+                       n,
+                       c,
+                       in_d,
+                       in_h,
+                       in_w,
+                       out_d,
+                       out_h,
+                       out_w,
+                       pad_h[0],
+                       pad_h[1],
+                       pad_w[0],
+                       pad_w[1],
+                       pad_d[0],
+                       pad_d[1],
+                       pad_value);
+  } else if (mode == 1) {
+    pad_ndhwc_reflect(din,
+                      dout,
+                      n,
+                      c,
+                      in_d,
+                      in_h,
+                      in_w,
+                      out_d,
+                      out_h,
+                      out_w,
+                      pad_h[0],
+                      pad_h[1],
+                      pad_w[0],
+                      pad_w[1],
+                      pad_d[0],
+                      pad_d[1]);
+  } else if (mode == 2) {
+    pad_ndhwc_replicate(din,
+                        dout,
+                        n,
+                        c,
+                        in_d,
+                        in_h,
+                        in_w,
+                        out_d,
+                        out_h,
+                        out_w,
+                        pad_h[0],
+                        pad_h[1],
+                        pad_w[0],
+                        pad_w[1],
+                        pad_d[0],
+                        pad_d[1]);
+  } else if (mode == 3) {
+    pad_ndhwc_circular(din,
+                       dout,
+                       n,
+                       c,
+                       in_d,
+                       in_h,
+                       in_w,
+                       out_d,
+                       out_h,
+                       out_w,
+                       pad_h[0],
+                       pad_h[1],
+                       pad_w[0],
+                       pad_w[1],
+                       pad_d[0],
+                       pad_d[1]);
+  } else {
+    LOG(ERROR) << "ERROR: unknown pad mode " << mode;
+  }
+}
+}  // namespace math
+}  // namespace host
+}  // namespace lite
+}  // namespace paddle

--- a/lite/backends/host/math/pad3d.h
+++ b/lite/backends/host/math/pad3d.h
@@ -1,0 +1,195 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <vector>
+#include "lite/operators/op_params.h"
+#include "lite/utils/cp_logging.h"
+
+namespace paddle {
+namespace lite {
+namespace host {
+namespace math {
+
+void pad_ncdhw_constant(const float* din,
+                        float* dout,
+                        int n,
+                        int c,
+                        int in_d,
+                        int in_h,
+                        int in_w,
+                        int out_d,
+                        int out_h,
+                        int out_w,
+                        const int pad_top,
+                        const int pad_bottom,
+                        const int pad_left,
+                        const int pad_right,
+                        const int pad_front,
+                        const int pad_back,
+                        const float pad_value);
+void pad_ndhwc_constant(const float* din,
+                        float* dout,
+                        int n,
+                        int c,
+                        int in_d,
+                        int in_h,
+                        int in_w,
+                        int out_d,
+                        int out_h,
+                        int out_w,
+                        const int pad_top,
+                        const int pad_bottom,
+                        const int pad_left,
+                        const int pad_right,
+                        const int pad_front,
+                        const int pad_back,
+                        const float pad_value);
+
+void pad_ncdhw_reflect(const float* din,
+                       float* dout,
+                       int n,
+                       int c,
+                       int in_d,
+                       int in_h,
+                       int in_w,
+                       int out_d,
+                       int out_h,
+                       int out_w,
+                       const int pad_top,
+                       const int pad_bottom,
+                       const int pad_left,
+                       const int pad_right,
+                       const int pad_front,
+                       const int pad_back);
+void pad_ndhwc_reflect(const float* din,
+                       float* dout,
+                       int n,
+                       int c,
+                       int in_d,
+                       int in_h,
+                       int in_w,
+                       int out_d,
+                       int out_h,
+                       int out_w,
+                       const int pad_top,
+                       const int pad_bottom,
+                       const int pad_left,
+                       const int pad_right,
+                       const int pad_front,
+                       const int pad_back);
+void pad_ncdhw_replicate(const float* din,
+                         float* dout,
+                         int n,
+                         int c,
+                         int in_d,
+                         int in_h,
+                         int in_w,
+                         int out_d,
+                         int out_h,
+                         int out_w,
+                         const int pad_top,
+                         const int pad_bottom,
+                         const int pad_left,
+                         const int pad_right,
+                         const int pad_front,
+                         const int pad_back);
+void pad_ndhwc_replicate(const float* din,
+                         float* dout,
+                         int n,
+                         int c,
+                         int in_d,
+                         int in_h,
+                         int in_w,
+                         int out_d,
+                         int out_h,
+                         int out_w,
+                         const int pad_top,
+                         const int pad_bottom,
+                         const int pad_left,
+                         const int pad_right,
+                         const int pad_front,
+                         const int pad_back);
+
+void pad_ncdhw_circular(const float* din,
+                        float* dout,
+                        int n,
+                        int c,
+                        int in_d,
+                        int in_h,
+                        int in_w,
+                        int out_d,
+                        int out_h,
+                        int out_w,
+                        const int pad_top,
+                        const int pad_bottom,
+                        const int pad_left,
+                        const int pad_right,
+                        const int pad_front,
+                        const int pad_back);
+void pad_ndhwc_circular(const float* din,
+                        float* dout,
+                        int n,
+                        int c,
+                        int in_d,
+                        int in_h,
+                        int in_w,
+                        int out_d,
+                        int out_h,
+                        int out_w,
+                        const int pad_top,
+                        const int pad_bottom,
+                        const int pad_left,
+                        const int pad_right,
+                        const int pad_front,
+                        const int pad_back);
+
+void pad3d_ncdhw_func(const lite::Tensor* input,
+                      lite::Tensor* output,
+                      int n,
+                      int c,
+                      int in_d,
+                      int in_h,
+                      int in_w,
+                      int out_d,
+                      int out_h,
+                      int out_w,
+                      int mode,
+                      std::vector<int> pad_h,
+                      std::vector<int> pad_w,
+                      std::vector<int> pad_d,
+                      float pad_value);
+
+void pad3d_ndhwc_func(const lite::Tensor* input,
+                      lite::Tensor* output,
+                      int n,
+                      int c,
+                      int in_d,
+                      int in_h,
+                      int in_w,
+                      int out_d,
+                      int out_h,
+                      int out_w,
+                      int mode,
+                      std::vector<int> pad_h,
+                      std::vector<int> pad_w,
+                      std::vector<int> pad_d,
+                      float pad_value);
+}  // namespace math
+}  // namespace host
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/mir/fusion/conv_bn_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_bn_fuse_pass.cc
@@ -28,13 +28,16 @@ void ConvBNFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   std::vector<bool> conv_has_bias_cases{true, false};
   std::vector<std::string> conv_type_cases{
       "conv2d", "depthwise_conv2d", "conv2d_transpose"};
+  std::vector<std::string> bn_type_cases{"batch_norm", "sync_batch_norm"};
   // start fuse using params
   for (auto conv_has_bias : conv_has_bias_cases) {
     for (auto conv_type : conv_type_cases) {
-      VLOG(4) << "conv_has_bias:" << conv_has_bias
-              << " conv_type:" << conv_type;
-      fusion::ConvBNFuser fuser(conv_type, conv_has_bias);
-      fuser(graph.get());
+      for (auto bn_type : bn_type_cases) {
+        VLOG(4) << "conv_has_bias:" << conv_has_bias
+                << " conv_type:" << conv_type;
+        fusion::ConvBNFuser fuser(conv_type, bn_type, conv_has_bias);
+        fuser(graph.get());
+      }
     }
   }
 }

--- a/lite/core/mir/fusion/conv_bn_fuser.cc
+++ b/lite/core/mir/fusion/conv_bn_fuser.cc
@@ -31,36 +31,35 @@ void ConvBNFuser::BuildPattern() {
   auto* conv = OpNode("conv2d", conv_type_)->assert_is_op(conv_type_);
   auto* conv_out = VarNode("conv_out")
                        ->assert_is_op_output(conv_type_, "Output")
-                       ->assert_is_op_input("batch_norm", "X")
+                       ->assert_is_op_input(bn_type_, "X")
                        ->AsIntermediate();
 
   auto* bn_scale = VarNode("bn_scale")
-                       ->assert_is_op_input("batch_norm", "Scale")
+                       ->assert_is_op_input(bn_type_, "Scale")
                        ->AsIntermediate();
   auto* bn_bias =
-      VarNode("bn_bias")->assert_is_op_input("batch_norm", "Bias")->AsInput();
+      VarNode("bn_bias")->assert_is_op_input(bn_type_, "Bias")->AsInput();
   auto* bn_mean = VarNode("bn_mean")
-                      ->assert_is_op_input("batch_norm", "Mean")
+                      ->assert_is_op_input(bn_type_, "Mean")
                       ->AsIntermediate();
   auto* bn_var = VarNode("bn_variance")
-                     ->assert_is_op_input("batch_norm", "Variance")
+                     ->assert_is_op_input(bn_type_, "Variance")
                      ->AsIntermediate();
-  auto* bn =
-      OpNode("bn", "batch_norm")->assert_is_op("batch_norm")->AsIntermediate();
+  auto* bn = OpNode("bn", bn_type_)->assert_is_op(bn_type_)->AsIntermediate();
 
   auto* bn_out =
-      VarNode("bn_out")->assert_is_op_output("batch_norm", "Y")->AsOutput();
+      VarNode("bn_out")->assert_is_op_output(bn_type_, "Y")->AsOutput();
   auto* bn_mean_out = VarNode("bn_mean_out")
-                          ->assert_is_op_output("batch_norm", "MeanOut")
+                          ->assert_is_op_output(bn_type_, "MeanOut")
                           ->AsIntermediate();
   auto* bn_var_out = VarNode("bn_var_out")
-                         ->assert_is_op_output("batch_norm", "VarianceOut")
+                         ->assert_is_op_output(bn_type_, "VarianceOut")
                          ->AsIntermediate();
   auto* bn_saved_mean = VarNode("bn_saved_mean")
-                            ->assert_is_op_output("batch_norm", "SavedMean")
+                            ->assert_is_op_output(bn_type_, "SavedMean")
                             ->AsIntermediate();
   auto* bn_saved_var = VarNode("bn_saved_var")
-                           ->assert_is_op_output("batch_norm", "SavedVariance")
+                           ->assert_is_op_output(bn_type_, "SavedVariance")
                            ->AsIntermediate();
 
   if (conv_has_bias_) {

--- a/lite/core/mir/fusion/conv_bn_fuser.h
+++ b/lite/core/mir/fusion/conv_bn_fuser.h
@@ -27,8 +27,12 @@ namespace fusion {
 
 class ConvBNFuser : public FuseBase {
  public:
-  explicit ConvBNFuser(const std::string& conv_type, const bool conv_has_bias)
-      : conv_type_(conv_type), conv_has_bias_(conv_has_bias) {}
+  explicit ConvBNFuser(const std::string& conv_type,
+                       const std::string& bn_type,
+                       const bool conv_has_bias)
+      : conv_type_(conv_type),
+        bn_type_{bn_type},
+        conv_has_bias_(conv_has_bias) {}
   void BuildPattern() override;
   void InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) override;
 
@@ -51,6 +55,7 @@ class ConvBNFuser : public FuseBase {
 
  private:
   std::string conv_type_{"conv2d"};
+  std::string bn_type_{"batch_norm"};
   bool conv_has_bias_{false};
 };
 

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -369,6 +369,8 @@ void Program::PrepareWorkspace(
         return PRECISION(kInt32);
       case lite::VarDescAPI::Type::INT64:
         return PRECISION(kInt64);
+      case lite::VarDescAPI::Type::UINT8:
+        return PRECISION(kUInt8);
       default:
         LOG(WARNING) << "Unable to convert var desc type("
                      << static_cast<int>(type) << ") to precision type!";

--- a/lite/kernels/arm/batch_norm_compute.cc
+++ b/lite/kernels/arm/batch_norm_compute.cc
@@ -121,3 +121,21 @@ REGISTER_LITE_KERNEL(batch_norm,
     .BindOutput("SavedMean", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("SavedVariance", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
+
+REGISTER_LITE_KERNEL(sync_batch_norm,
+                     kARM,
+                     kFloat,
+                     kNCHW,
+                     paddle::lite::kernels::arm::BatchNormCompute,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("Scale", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("Bias", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("Mean", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("Variance", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("MeanOut", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("VarianceOut", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("SavedMean", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("SavedVariance", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();

--- a/lite/kernels/arm/interpolate_compute.cc
+++ b/lite/kernels/arm/interpolate_compute.cc
@@ -106,3 +106,18 @@ REGISTER_LITE_KERNEL(nearest_interp,
     .BindInput("Scale", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
+
+REGISTER_LITE_KERNEL(bilinear_interp_v2,
+                     kARM,
+                     kFloat,
+                     kNCHW,
+                     paddle::lite::kernels::arm::BilinearInterpCompute,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("OutSize",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("SizeTensor",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("Scale", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();

--- a/lite/kernels/host/CMakeLists.txt
+++ b/lite/kernels/host/CMakeLists.txt
@@ -46,6 +46,7 @@ add_kernel(flatten_contiguous_range_compute_host Host extra SRCS flatten_compute
 add_kernel(shuffle_channel_compute_host Host extra SRCS shuffle_channel_compute.cc DEPS ${lite_kernel_deps} math_host)
 add_kernel(activation_compute_host Host train SRCS activation_compute.cc DEPS ${lite_kernel_deps} math_host)
 add_kernel(box_coder_compute_host Host basic SRCS box_coder_compute.cc DEPS ${lite_kernel_deps} math_host)
+add_kernel(pad3d_compute_host Host extra SRCS pad3d_compute.cc DEPS ${lite_kernel_deps} math_host)
 
 if(LITE_BUILD_EXTRA AND LITE_WITH_x86)
   lite_cc_test(test_where_index_compute_host SRCS where_index_compute.cc DEPS where_index_compute_host)

--- a/lite/kernels/host/pad3d_compute.cc
+++ b/lite/kernels/host/pad3d_compute.cc
@@ -1,0 +1,129 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/host/pad3d_compute.h"
+#include <string>
+#include <vector>
+#include "lite/backends/host/math/pad3d.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+void Pad3dCompute::Run() {
+  auto& param = Param<operators::Pad2dParam>();
+  const lite::Tensor* inputs = param.X;
+  auto* out = param.Out;
+
+  if (param.mode == "constant") {
+    mode_ = 0;
+  } else if (param.mode == "reflect") {
+    mode_ = 1;
+  } else if (param.mode == "replicate") {
+    mode_ = 2;
+  } else if (param.mode == "circular") {
+    mode_ = 3;
+  } else {
+    LOG(FATAL) << "Unknown mode type";
+  }
+
+  pad_w_ = {param.paddings[0], param.paddings[1]};
+  pad_h_ = {param.paddings[2], param.paddings[3]};
+  pad_depth_ = {param.paddings[4], param.paddings[5]};
+  pad_value_ = param.pad_value;
+  data_format_ = param.data_format;
+  auto x_dims = inputs->dims();
+  auto out_dims = out->dims();
+  // default is NCDHW
+  int batch = x_dims[0];
+  int channels = x_dims[1];
+  int in_depth = x_dims[2];
+  int in_height = x_dims[3];
+  int in_width = x_dims[4];
+  int out_depth = out_dims[2];
+  int out_height = out_dims[3];
+  int out_width = out_dims[4];
+  if (data_format_ == "NDHWC") {
+    channels = x_dims[4];
+    in_depth = x_dims[1];
+    in_height = x_dims[2];
+    in_width = x_dims[3];
+    out_depth = out_dims[1];
+    out_height = out_dims[2];
+    out_width = out_dims[3];
+  }
+
+  if (mode_ == 2) {
+    CHECK_LE(pad_depth_[0], in_depth - 1)
+        << "pad front size must <= inputs depth - 1";
+    CHECK_LE(pad_depth_[1], in_depth - 1)
+        << "pad back size must <= inputs depth - 1";
+    CHECK_LE(pad_h_[0], in_height - 1)
+        << "pad bottom size must <= inputs height - 1";
+    CHECK_LE(pad_h_[1], in_height - 1)
+        << "pad bottom size must <= inputs height - 1";
+    CHECK_LE(pad_w_[0], in_width - 1)
+        << "pad left size must <= inputs width - 1";
+    CHECK_LE(pad_w_[1], in_width - 1)
+        << "pad right size must  <= inputs width - 1";
+  }
+  if (data_format_ == "NCDHW") {
+    lite::host::math::pad3d_ncdhw_func(inputs,
+                                       out,
+                                       batch,
+                                       channels,
+                                       in_depth,
+                                       in_height,
+                                       in_width,
+                                       out_depth,
+                                       out_height,
+                                       out_width,
+                                       mode_,
+                                       pad_h_,
+                                       pad_w_,
+                                       pad_depth_,
+                                       pad_value_);
+  } else if (data_format_ == "NDHWC") {
+    lite::host::math::pad3d_ndhwc_func(inputs,
+                                       out,
+                                       batch,
+                                       channels,
+                                       in_depth,
+                                       in_height,
+                                       in_width,
+                                       out_depth,
+                                       out_height,
+                                       out_width,
+                                       mode_,
+                                       pad_h_,
+                                       pad_w_,
+                                       pad_depth_,
+                                       pad_value_);
+  } else {
+    LOG(FATAL) << "This dataformat:" << data_format_ << " doesn't support!";
+  }
+  return;
+}
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(
+    pad3d, kHost, kFloat, kNCHW, paddle::lite::kernels::host::Pad3dCompute, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost))})
+    .Finalize();

--- a/lite/kernels/host/pad3d_compute.h
+++ b/lite/kernels/host/pad3d_compute.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <algorithm>
+#include <string>
+#include <vector>
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+class Pad3dCompute : public KernelLite<TARGET(kHost), PRECISION(kFloat)> {
+ public:
+  using param_t = operators::Pad2dParam;
+
+  void Run() override;
+
+  virtual ~Pad3dCompute() = default;
+
+ private:
+  int mode_;
+  std::vector<int> pad_h_{0, 0};
+  std::vector<int> pad_w_{0, 0};
+  std::vector<int> pad_depth_{0, 0};
+  float pad_value_ = 0.f;
+  std::string data_format_{"NCDHW"};
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/operators/CMakeLists.txt
+++ b/lite/operators/CMakeLists.txt
@@ -127,6 +127,7 @@ add_operator(matrix_nms_op_lite extra SRCS matrix_nms_op.cc DEPS ${op_DEPS})
 add_operator(sin_op extra SRCS sin_op.cc DEPS ${op_DEPS})
 add_operator(cos_op extra SRCS cos_op.cc DEPS ${op_DEPS})
 add_operator(unstack_op extra SRCS unstack_op.cc DEPS ${op_DEPS})
+add_operator(pad3d_op extra SRCS pad3d_op.cc DEPS ${op_DEPS})
 
 # for OCR specific
 add_operator(while_op extra SRCS while_op.cc DEPS ${op_DEPS})

--- a/lite/operators/CMakeLists.txt
+++ b/lite/operators/CMakeLists.txt
@@ -23,6 +23,7 @@ add_operator(fill_constant_batch_size_like_op basic SRCS fill_constant_batch_siz
 add_operator(shuffle_channel_op basic SRCS shuffle_channel_op.cc DEPS ${op_DEPS})
 add_operator(yolo_box_op basic SRCS yolo_box_op.cc DEPS ${op_DEPS})
 add_operator(interpolate_op basic SRCS interpolate_op.cc DEPS ${op_DEPS})
+add_operator(interpolate_v2_op basic SRCS interpolate_v2_op.cc DEPS ${op_DEPS})
 add_operator(argmax_op basic SRCS argmax_op.cc DEPS ${op_DEPS})
 add_operator(prior_box_op basic SRCS prior_box_op.cc DEPS ${op_DEPS})
 add_operator(concat_op basic SRCS concat_op.cc DEPS ${op_DEPS})

--- a/lite/operators/batch_norm_op.cc
+++ b/lite/operators/batch_norm_op.cc
@@ -125,3 +125,4 @@ bool BatchNormOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
 }  // namespace paddle
 
 REGISTER_LITE_OP(batch_norm, paddle::lite::operators::BatchNormOp);
+REGISTER_LITE_OP(sync_batch_norm, paddle::lite::operators::BatchNormOp);

--- a/lite/operators/interpolate_v2_op.cc
+++ b/lite/operators/interpolate_v2_op.cc
@@ -1,0 +1,154 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/interpolate_v2_op.h"
+#include <string>
+#include <vector>
+#include "lite/core/op_lite.h"
+#include "lite/core/op_registry.h"
+#include "lite/core/tensor.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+bool InterpolateV2Op::CheckShape() const {
+  auto* X = param_.X;
+  auto* OutSize = param_.OutSize;
+  CHECK_OR_FALSE(X);
+  if (OutSize != nullptr) {
+    CHECK_OR_FALSE(OutSize);
+  }
+  CHECK_OR_FALSE(param_.Out);
+  return true;
+}
+
+bool InterpolateV2Op::InferShapeImpl() const {
+  auto X = param_.X;
+
+  int n = X->dims()[0];
+  int c = X->dims()[1];
+  int h = X->dims()[2];
+  int w = X->dims()[3];
+  int out_h;
+  int out_w;
+
+  auto SizeTensor = param_.SizeTensor;
+  auto OutSize = param_.OutSize;
+  auto Scale = param_.Scale;
+  if (!SizeTensor.empty()) {
+    CHECK_EQ(SizeTensor.size(), 2u)
+        << "Input(SizeTensor)'size of Op(interpolate) must be 2. "
+           "Attr(out_shape)'s length must be 2 for 4-D input tensor.";
+    out_h = SizeTensor[0]->data<int>()[0];
+    out_w = SizeTensor[1]->data<int>()[0];
+  } else if (OutSize) {
+    auto OutSize_dims = OutSize->dims();
+    CHECK_EQ(OutSize_dims.size(), 1u) << "Input(OutSize)'s dims size must be 1";
+    CHECK_EQ(OutSize_dims[0], 2) << "OutSize's dim[0] must be 2";
+    auto OutSize_data = OutSize->data<int>();
+    out_h = OutSize_data[0];
+    out_w = OutSize_data[1];
+  } else if (param_.out_h > 0 && param_.out_w > 0) {
+    out_h = param_.out_h;
+    out_w = param_.out_w;
+  } else {
+    float scale_w = -1.f;
+    float scale_h = -1.f;
+    if (Scale) {
+      auto Scale_dims = Scale->dims();
+      CHECK_EQ(Scale_dims.size(), 1) << "Scale's dimension size must be 1.";
+      out_h = -1;
+      out_w = -1;
+    } else {
+      if (param_.scale_v.size() > 0) {
+        scale_h = param_.scale_v[0];
+        scale_w = param_.scale_v[1];
+        CHECK_GT(scale_h, 0) << "scale_h must be greaten 0.";
+        CHECK_GT(scale_w, 0) << "scale_w must be greaten 0.";
+        out_h = static_cast<int>(h * scale_h);
+        out_w = static_cast<int>(w * scale_w);
+      } else {
+        out_h = param_.out_h;
+        out_w = param_.out_w;
+      }
+    }
+  }
+
+  auto out_lod = param_.Out->mutable_lod();
+  *out_lod = param_.X->lod();
+  param_.Out->Resize({n, c, out_h, out_w});
+
+  return true;
+}
+
+bool InterpolateV2Op::AttachImpl(const cpp::OpDesc& op_desc,
+                                 lite::Scope* scope) {
+  auto X = op_desc.Input("X").front();
+  if (op_desc.HasInput("OutSize")) {
+    auto out_size_var_names = op_desc.Input("OutSize");
+    if (out_size_var_names.size() > 0) {
+      param_.OutSize = scope->FindVar(out_size_var_names.front())
+                           ->GetMutable<lite::Tensor>();
+    }
+  } else {
+    param_.OutSize = nullptr;
+  }
+
+  if (op_desc.HasInput("SizeTensor")) {
+    auto size_tensor = op_desc.Input("SizeTensor");
+    for (auto var : size_tensor) {
+      param_.SizeTensor.push_back(
+          scope->FindVar(var)->GetMutable<lite::Tensor>());
+    }
+  }
+
+  if (op_desc.HasInput("Scale")) {
+    auto scale_var_names = op_desc.Input("Scale");
+    if (scale_var_names.size() > 0) {
+      param_.Scale =
+          scope->FindVar(scale_var_names.front())->GetMutable<lite::Tensor>();
+    }
+  } else {
+    param_.Scale = nullptr;
+  }
+  auto Out = op_desc.Output("Out").front();
+  param_.X = scope->FindVar(X)->GetMutable<lite::Tensor>();
+  param_.Out = scope->FindVar(Out)->GetMutable<lite::Tensor>();
+  if (op_desc.HasAttr("scale")) {
+    auto vs = op_desc.GetAttr<std::vector<float>>("scale");
+    if (vs.size() > 0) {
+      param_.scale_v = vs;
+      param_.scale = vs[0];
+    }
+  }
+  if (op_desc.HasAttr("out_w")) {
+    param_.out_w = op_desc.GetAttr<int>("out_w");
+  }
+  if (op_desc.HasAttr("out_h")) {
+    param_.out_h = op_desc.GetAttr<int>("out_h");
+  }
+  if (op_desc.HasAttr("align_mode")) {
+    param_.align_mode = op_desc.GetAttr<int>("align_mode");
+  }
+  param_.align_corners = op_desc.GetAttr<bool>("align_corners");
+  param_.interp_method = op_desc.GetAttr<std::string>("interp_method");
+  return true;
+}
+
+} /* namespace operators */
+} /* namespace lite */
+} /* namespace paddle */
+
+REGISTER_LITE_OP(bilinear_interp_v2, paddle::lite::operators::InterpolateV2Op);

--- a/lite/operators/interpolate_v2_op.h
+++ b/lite/operators/interpolate_v2_op.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+#include "lite/core/op_lite.h"
+#include "lite/core/scope.h"
+#include "lite/utils/all.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+class InterpolateV2Op : public OpLite {
+ public:
+  InterpolateV2Op() {}
+
+  explicit InterpolateV2Op(const std::string &op_type) : OpLite(op_type) {}
+
+  bool CheckShape() const override;
+
+  bool InferShapeImpl() const override;
+
+  bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+
+  std::string DebugString() const override { return "interpolate"; }
+
+#ifdef LITE_WITH_PROFILE
+  void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
+    ch->input_shape = ch->DimToStr(param_.X->dims());
+    ch->output_shape = ch->DimToStr(param_.Out->dims());
+    ch->remark = param_.interp_method;
+    ch->macs = param_.Out->numel() * 14.f;
+  }
+#endif
+
+ private:
+  mutable InterpolateParam param_;
+};
+
+} /* namespace operators */
+} /* namespace lite */
+} /* namespace paddle */

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -159,6 +159,7 @@ struct InterpolateParam : ParamBase {
   lite::Tensor* Scale{};
 
   float scale{0.f};
+  std::vector<float> scale_v{};
   int out_h{-1};
   int out_w{-1};
   bool align_corners{true};

--- a/lite/operators/pad3d_op.cc
+++ b/lite/operators/pad3d_op.cc
@@ -1,0 +1,85 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/pad3d_op.h"
+#include "lite/core/op_lite.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+bool Pad3dOpLite::CheckShape() const {
+  CHECK_EQ(param_.X->dims().size(), 5UL);
+  CHECK_OR_FALSE(param_.Out);
+  CHECK(param_.mode == "constant" || param_.mode == "reflect" ||
+        param_.mode == "replicate" || param_.mode == "circular")
+      << "Invilid mode.";
+  CHECK_EQ(param_.paddings.size(), 6UL);
+  CHECK(param_.data_format == "NCDHW" || param_.data_format == "NDHWC")
+      << "Invilid data_format.";
+  return true;
+}
+
+bool Pad3dOpLite::InferShapeImpl() const {
+  // NCDHW
+  auto x_dims = param_.X->dims();
+  int out_d = x_dims[2] + param_.paddings[4] + param_.paddings[5];
+  int out_h = x_dims[3] + param_.paddings[2] + param_.paddings[3];
+  int out_w = x_dims[4] + param_.paddings[0] + param_.paddings[1];
+  if (param_.data_format == "NDHWC") {
+    out_d = x_dims[1] + param_.paddings[4] + param_.paddings[5];
+    out_h = x_dims[2] + param_.paddings[2] + param_.paddings[3];
+    out_w = x_dims[3] + param_.paddings[0] + param_.paddings[1];
+    param_.Out->Resize(lite::DDim({x_dims[0], out_d, out_h, out_w, x_dims[1]}));
+  } else {
+    param_.Out->Resize(lite::DDim({x_dims[0], x_dims[1], out_d, out_h, out_w}));
+  }
+  return true;
+}
+
+// TODO(Superjomn) replace framework::OpDesc with a lite one.
+bool Pad3dOpLite::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
+  param_.X = scope->FindVar(op_desc.Input("X").front())->GetMutable<Tensor>();
+  param_.Out =
+      scope->FindVar(op_desc.Output("Out").front())->GetMutable<Tensor>();
+  param_.mode = op_desc.GetAttr<std::string>("mode");
+  param_.pad_value = op_desc.GetAttr<float>("value");
+  if (op_desc.HasAttr("Paddings") && op_desc.GetAttr<bool>("Paddings")) {
+    auto Paddings =
+        scope->FindVar(op_desc.Input("Paddings").front())->GetMutable<Tensor>();
+
+    if (Paddings->dims().size() != 1) {
+      printf("Paddings size must be one: %d \n",
+             static_cast<int>(Paddings->dims().size()));
+      return false;
+    }
+    if (Paddings->dims()[0] != 6) {
+      printf("Paddings->dims()[0] must be six: %d \n",
+             static_cast<int>(Paddings->dims()[0]));
+      return false;
+    }
+    param_.paddings = {0, 0, 0, 0, 0, 0};
+  } else {
+    param_.paddings = op_desc.GetAttr<std::vector<int>>("paddings");
+  }
+  param_.data_format = op_desc.GetAttr<std::string>("data_format");
+  return true;
+}
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_OP(pad3d, paddle::lite::operators::Pad3dOpLite);

--- a/lite/operators/pad3d_op.h
+++ b/lite/operators/pad3d_op.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+#include "lite/core/op_lite.h"
+#include "lite/core/scope.h"
+#include "lite/utils/all.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+class Pad3dOpLite : public OpLite {
+ public:
+  Pad3dOpLite() {}
+  explicit Pad3dOpLite(const std::string &op_type) : OpLite(op_type) {}
+
+  bool CheckShape() const override;
+
+  bool InferShapeImpl() const override;
+
+  bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+  std::string DebugString() const override { return "pad3d"; }
+
+ private:
+  mutable Pad2dParam param_;
+};
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle

--- a/lite/tests/kernels/CMakeLists.txt
+++ b/lite/tests/kernels/CMakeLists.txt
@@ -93,6 +93,7 @@ if(LITE_BUILD_EXTRA)
     lite_cc_test(test_kernel_sequence_expand_as_compute SRCS sequence_expand_as_compute_test.cc DEPS ${test_kernel_deps})
     lite_cc_test(test_kernel_sin_compute SRCS sin_compute_test.cc DEPS arena_framework ${test_kernel_deps})
     lite_cc_test(test_kernel_cos_compute SRCS cos_compute_test.cc DEPS arena_framework ${test_kernel_deps})
+    lite_cc_test(test_kernel_pad3d_compute SRCS  pad3d_compute_test.cc DEPS arena_framework ${test_kernel_deps})
     
     # for training kernel
     if (LITE_WITH_TRAIN)

--- a/lite/tests/kernels/gather_compute_test.cc
+++ b/lite/tests/kernels/gather_compute_test.cc
@@ -55,9 +55,9 @@ class GatherComputeTest : public arena::TestCase {
           (index_dims.size() == 2 && index_dims[1] == 1));
     CHECK_EQ(index_dims.size(), 1);
     if (axis_dims_.production() == 1) {
-      auto* axis_data = axis->data<A>();
-      auto* index_data = index->data<R>();
-      auto* input_data = x->data<T>();
+      auto* axis_data = axis->template data<A>();
+      auto* index_data = index->template data<R>();
+      auto* input_data = x->template data<T>();
 
       int index_size = index->numel();
       int input_size = x->numel();
@@ -78,7 +78,7 @@ class GatherComputeTest : public arena::TestCase {
       auto out = scope->NewTensor(out_);
       CHECK(out);
       out->Resize(out_dim_vec);
-      auto* out_data = out->mutable_data<T>();
+      auto* out_data = out->template mutable_data<T>();
 
       int out_index = 0;
       for (int i = 0; i < inner_dim_size; i++) {

--- a/lite/tests/kernels/pad3d_compute_test.cc
+++ b/lite/tests/kernels/pad3d_compute_test.cc
@@ -1,0 +1,302 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "lite/api/paddle_use_kernels.h"
+#include "lite/api/paddle_use_ops.h"
+#include "lite/core/arena/framework.h"
+#include "lite/tests/utils/fill_data.h"
+
+namespace paddle {
+namespace lite {
+
+class Pad3dComputeTester : public arena::TestCase {
+ protected:
+  // common attributes for this op.
+  std::string x_ = "X";
+  std::string out_ = "Out";
+  DDim dims_{{1, 1, 14, 14, 14}};
+  std::string mode_{"constant"};
+  std::vector<int> paddings_;
+  float pad_value_ = 0.f;
+  std::string data_format_{"NCDHW"};
+
+ public:
+  Pad3dComputeTester(const Place& place,
+                     const std::string& alias,
+                     std::string mode,
+                     std::vector<int> paddings,
+                     float pad_value,
+                     std::string data_format)
+      : TestCase(place, alias),
+        mode_(mode),
+        paddings_(paddings),
+        pad_value_(pad_value),
+        data_format_(data_format) {}
+
+  void RunBaseline(Scope* scope) override {
+    auto* out = scope->NewTensor(out_);
+    CHECK(out);
+    int out_d = dims_[2] + paddings_[4] + paddings_[5];
+    int out_h = dims_[3] + paddings_[2] + paddings_[3];
+    int out_w = dims_[4] + paddings_[0] + paddings_[1];
+    if (data_format_ == "NDHWC") {
+      out_d = dims_[1] + paddings_[4] + paddings_[5];
+      out_h = dims_[2] + paddings_[2] + paddings_[3];
+      out_w = dims_[3] + paddings_[0] + paddings_[1];
+      out->Resize(lite::DDim({dims_[0], out_d, out_h, out_w, dims_[1]}));
+    } else {
+      out->Resize(lite::DDim({dims_[0], dims_[1], out_d, out_h, out_w}));
+    }
+    auto* out_data = out->mutable_data<float>();
+    auto* x = scope->FindTensor(x_);
+    const auto* x_data = x->data<float>();
+
+    auto output_dims = out->dims();
+    int n = output_dims[0];
+    int c = output_dims[1];
+    int d = output_dims[2];
+    int h = output_dims[3];
+    int w = output_dims[4];
+    if (data_format_ == "NDHWC") {
+      d = output_dims[1];
+      h = output_dims[2];
+      w = output_dims[3];
+      c = output_dims[4];
+    }
+
+    int pad_front = paddings_[4];
+    int pad_back = paddings_[5];
+    int pad_top = paddings_[2];
+    int pad_bottom = paddings_[3];
+    int pad_left = paddings_[0];
+    int pad_right = paddings_[1];
+    int pad_mode;
+    if (mode_ == "constant") {
+      pad_mode = 0;
+    } else if (mode_ == "reflect") {
+      pad_mode = 1;
+    } else if (mode_ == "replicate") {
+      pad_mode = 2;
+    } else if (mode_ == "circular") {
+      pad_mode = 3;
+    } else {
+      LOG(FATAL) << "Unknown mode type: " << mode_;
+    }
+    float pad_value = pad_value_;
+
+    int in_w = w - pad_left - pad_right;
+    int in_h = h - pad_bottom - pad_top;
+    int in_d = d - pad_front - pad_back;
+    int in_size = in_w * in_h;
+    int out_size = w * h;
+    int spatial_size_out = out_size * d;
+    int spatial_size_in = in_size * in_d;
+    if (data_format_ == "NCDHW") {
+      for (int i = 0; i < n * c; ++i) {
+        const float* din_batch = x_data + i * spatial_size_in;
+        float* dout_batch = out_data + i * spatial_size_out;
+        int in_z = 0;
+        int in_x = 0;
+        int in_y = 0;
+        for (int z = 0; z < d; z++) {
+          for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+              switch (pad_mode) {
+                case 0:
+                  in_z = z - pad_front;
+                  in_y = y - pad_top;
+                  in_x = x - pad_left;
+                  dout_batch[z * out_size + y * w + x] =
+                      (in_x >= 0 && in_x < in_w) &&
+                              (in_y >= 0 && in_y < in_h) &&
+                              (in_z >= 0 && in_z < in_d)
+                          ? din_batch[in_z * in_size + in_y * in_w + in_x]
+                          : pad_value;
+                  break;
+                case 1:
+                  in_z = z - pad_front;
+                  in_y = y - pad_top;
+                  in_x = x - pad_left;
+                  in_z = std::max(in_z, -in_z);
+                  in_z = std::min(in_z, 2 * in_d - in_z - 2);
+                  in_y = std::max(in_y, -in_y);
+                  in_y = std::min(in_y, 2 * in_h - in_y - 2);
+                  in_x = std::max(in_x, -in_x);
+                  in_x = std::min(in_x, 2 * in_w - in_x - 2);
+                  dout_batch[z * out_size + y * w + x] =
+                      din_batch[in_z * in_size + in_y * in_w + in_x];
+                  break;
+                case 2:
+                  in_z = std::min(in_d - 1, std::max(z - pad_front, 0));
+                  in_y = std::min(in_h - 1, std::max(y - pad_top, 0));
+                  in_x = std::min(in_w - 1, std::max(x - pad_left, 0));
+                  dout_batch[z * out_size + y * w + x] =
+                      din_batch[in_z * in_size + in_y * in_w + in_x];
+                  break;
+                case 3:
+                  in_z = ((z - pad_front) % in_d + in_d) % in_d;
+                  in_y = ((y - pad_top) % in_h + in_h) % in_h;
+                  in_x = ((x - pad_left) % in_w + in_w) % in_w;
+                  dout_batch[z * out_size + y * w + x] =
+                      din_batch[in_z * in_size + in_y * in_w + in_x];
+                  break;
+                default:
+                  LOG(ERROR) << "ERROR: unknown pad mode:" << pad_mode;
+              }
+            }
+          }
+        }
+      }
+    } else {  // NDHWC
+      int c_in_size = spatial_size_in * c;
+      int c_out_size = spatial_size_out * c;
+      for (int i = 0; i < n; ++i) {
+        const float* din_batch = x_data + i * c_in_size;
+        float* dout_batch = out_data + i * c_out_size;
+        int in_z = 0;
+        int in_x = 0;
+        int in_y = 0;
+        int in_index = 0;
+        int out_index = 0;
+        for (int z = 0; z < d; z++) {
+          for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+              switch (pad_mode) {
+                case 0:
+                  in_z = z - pad_front;
+                  in_y = y - pad_top;
+                  in_x = x - pad_left;
+                  in_index = (in_z * in_size + in_y * in_w + in_x) * c;
+                  out_index = (z * out_size + y * w + x) * c;
+                  if ((in_x >= 0 && in_x < in_w) &&
+                      (in_y >= 0 && in_y < in_h) &&
+                      (in_z >= 0 && in_z < in_d)) {
+                    for (int j = 0; j < c; j++) {
+                      dout_batch[out_index + j] = din_batch[in_index + j];
+                    }
+                  } else {
+                    for (int j = 0; j < c; j++) {
+                      dout_batch[out_index + j] = pad_value;
+                    }
+                  }
+                  break;
+                case 1:
+                  in_z = z - pad_front;
+                  in_y = y - pad_top;
+                  in_x = x - pad_left;
+                  in_z = std::max(in_z, -in_z);
+                  in_z = std::min(in_z, 2 * in_d - in_z - 2);
+                  in_y = std::max(in_y, -in_y);
+                  in_y = std::min(in_y, 2 * in_h - in_y - 2);
+                  in_x = std::max(in_x, -in_x);
+                  in_x = std::min(in_x, 2 * in_w - in_x - 2);
+                  in_index = (in_z * in_size + in_y * in_w + in_x) * c;
+                  out_index = (z * out_size + y * w + x) * c;
+                  for (int j = 0; j < c; j++) {
+                    dout_batch[out_index + j] = din_batch[in_index + j];
+                  }
+                  break;
+                case 2:
+                  in_z = std::min(in_d - 1, std::max(z - pad_front, 0));
+                  in_y = std::min(in_h - 1, std::max(y - pad_top, 0));
+                  in_x = std::min(in_w - 1, std::max(x - pad_left, 0));
+                  in_index = (in_z * in_size + in_y * in_w + in_x) * c;
+                  out_index = (z * out_size + y * w + x) * c;
+                  for (int j = 0; j < c; j++) {
+                    dout_batch[out_index + j] = din_batch[in_index + j];
+                  }
+                  break;
+                case 3:
+                  in_z = ((z - pad_front) % in_d + in_d) % in_d;
+                  in_y = ((y - pad_top) % in_h + in_h) % in_h;
+                  in_x = ((x - pad_left) % in_w + in_w) % in_w;
+                  in_index = (in_z * in_size + in_y * in_w + in_x) * c;
+                  out_index = (z * out_size + y * w + x) * c;
+                  for (int j = 0; j < c; j++) {
+                    dout_batch[out_index + j] = din_batch[in_index + j];
+                  }
+                  break;
+                default:
+                  LOG(ERROR) << "ERROR: unknown pad mode:" << pad_mode;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void PrepareOpDesc(cpp::OpDesc* op_desc) {
+    op_desc->SetType("pad3d");
+    op_desc->SetInput("X", {x_});
+    op_desc->SetOutput("Out", {out_});
+    op_desc->SetAttr("mode", mode_);
+    op_desc->SetAttr("value", pad_value_);
+    op_desc->SetAttr("paddings", paddings_);
+    op_desc->SetAttr("data_format", data_format_);
+  }
+
+  void PrepareData() override {
+    std::vector<float> x(dims_.production());
+    fill_data_rand(x.data(), -1.f, 1.f, dims_.production());
+    SetCommonTensor(x_, dims_, x.data());
+  }
+};
+
+void TestPad3d(const Place& place, float abs_error = 2e-5) {
+  std::string data_format = "NCDHW";
+  const float pad_value = 0.f;
+  for (int pad_top : {0, 1}) {
+    for (int pad_bottom : {0, 1}) {
+      for (int pad_left : {0, 1}) {
+        for (int pad_right : {0, 1}) {
+          for (int pad_front : {0, 1}) {
+            for (int pad_back : {0, 1}) {
+              std::vector<int> paddings{pad_left,
+                                        pad_right,
+                                        pad_top,
+                                        pad_bottom,
+                                        pad_front,
+                                        pad_back};
+              for (std::string pad_mode :
+                   {"constant", "reflect", "replicate", "circular"}) {
+                VLOG(4) << "pad3d pad_mode: " << pad_mode
+                        << ", pad_val: " << pad_value
+                        << ", padding: " << paddings[0] << ", " << paddings[1]
+                        << ", " << paddings[2] << ", " << paddings[3] << ", "
+                        << paddings[4] << ", " << paddings[5];
+                std::unique_ptr<arena::TestCase> tester(new Pad3dComputeTester(
+                    place, "def", pad_mode, paddings, pad_value, data_format));
+                arena::Arena arena(std::move(tester), place, abs_error);
+                arena.TestPrecision();
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(pad3d, precision) {
+  Place place;
+#ifdef LITE_WITH_ARM
+  place = TARGET(kHost);
+  TestPad3d(place, 2e-5);
+#endif
+}
+
+}  // namespace lite
+}  // namespace paddle


### PR DESCRIPTION
cherry-pick [PR5041](https://github.com/PaddlePaddle/Paddle-Lite/pull/5041) add pad3d
cherry-pick [PR50446](https://github.com/PaddlePaddle/Paddle-Lite/pull/5046) add 2.0 bilinear_interp_v2 adn sync_batch_norm OP, add conv+sync_bn fusion