### PR TITLE
[Host][Kernel] Add argmax

### DIFF
--- a/lite/backends/host/math/CMakeLists.txt
+++ b/lite/backends/host/math/CMakeLists.txt
@@ -5,4 +5,5 @@ lite_cc_library(math_host SRCS
     concat.cc
     stack.cc
     reduce_all.cc
+    argmax.cc
     DEPS context)

--- a/lite/backends/host/math/argmax.cc
+++ b/lite/backends/host/math/argmax.cc
@@ -1,0 +1,103 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/backends/host/math/argmax.h"
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace paddle {
+namespace lite {
+namespace host {
+namespace math {
+
+template <typename InType, typename OutType>
+void argmax_func(const lite::Tensor *input,
+                 const int axis,
+                 lite::Tensor *output) {
+  auto input_ddim = input->dims();
+  auto output_ddim = output->dims();
+
+  const int size = input_ddim[axis];
+  const int in_channel = input_ddim.count(axis, input_ddim.size());
+  const int out_channel = output_ddim.count(axis, output_ddim.size());
+  const int in_stride = input_ddim.count(axis + 1, input_ddim.size());
+  const int out_stride = input_ddim.count(0, axis);
+
+  for (int n = 0; n < out_stride; n++) {
+    for (int k = 0; k < in_stride; k++) {
+      const InType *in_ptr = input->data<InType>() + n * in_channel + k;
+      std::vector<std::pair<InType, OutType>> vec;
+      vec.resize(size);
+      for (int i = 0; i < size; i++) {
+        vec[i] = std::make_pair(in_ptr[i * in_stride], i);
+      }
+      // sort
+      std::partial_sort(vec.begin(),
+                        vec.begin() + 1,
+                        vec.end(),
+                        std::greater<std::pair<InType, OutType>>());
+
+      // out
+      OutType *out_ptr = output->mutable_data<OutType>() + n * out_channel + k;
+      *out_ptr = vec[0].second;
+    }
+  }
+}
+
+template void argmax_func<float, int32_t>(const lite::Tensor *input,
+                                          const int axis,
+                                          lite::Tensor *output);
+template void argmax_func<float, int64_t>(const lite::Tensor *input,
+                                          const int axis,
+                                          lite::Tensor *output);
+#ifdef LITE_BUILD_EXTRA
+template void argmax_func<double, int32_t>(const lite::Tensor *input,
+                                           const int axis,
+                                           lite::Tensor *output);
+template void argmax_func<double, int64_t>(const lite::Tensor *input,
+                                           const int axis,
+                                           lite::Tensor *output);
+template void argmax_func<int64_t, int32_t>(const lite::Tensor *input,
+                                            const int axis,
+                                            lite::Tensor *output);
+template void argmax_func<int64_t, int64_t>(const lite::Tensor *input,
+                                            const int axis,
+                                            lite::Tensor *output);
+template void argmax_func<int32_t, int32_t>(const lite::Tensor *input,
+                                            const int axis,
+                                            lite::Tensor *output);
+template void argmax_func<int32_t, int64_t>(const lite::Tensor *input,
+                                            const int axis,
+                                            lite::Tensor *output);
+template void argmax_func<int16_t, int32_t>(const lite::Tensor *input,
+                                            const int axis,
+                                            lite::Tensor *output);
+template void argmax_func<int16_t, int64_t>(const lite::Tensor *input,
+                                            const int axis,
+                                            lite::Tensor *output);
+template void argmax_func<uint8_t, int32_t>(const lite::Tensor *input,
+                                            const int axis,
+                                            lite::Tensor *output);
+template void argmax_func<uint8_t, int64_t>(const lite::Tensor *input,
+                                            const int axis,
+                                            lite::Tensor *output);
+#endif
+}  // namespace math
+}  // namespace host
+}  // namespace lite
+}  // namespace paddle

--- a/lite/backends/host/math/argmax.h
+++ b/lite/backends/host/math/argmax.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <vector>
+#include "lite/operators/op_params.h"
+#include "lite/utils/cp_logging.h"
+
+namespace paddle {
+namespace lite {
+namespace host {
+namespace math {
+
+template <typename InType, typename OutType>
+void argmax_func(const lite::Tensor* input,
+                 const int axis,
+                 lite::Tensor* output);
+
+}  // namespace math
+}  // namespace host
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/host/CMakeLists.txt
+++ b/lite/kernels/host/CMakeLists.txt
@@ -15,6 +15,7 @@ add_kernel(fill_constant_batch_size_like_compute_host Host basic SRCS fill_const
 add_kernel(deformable_conv_compute_host Host basic SRCS deformable_conv_compute.cc DEPS ${lite_kernel_deps})
 add_kernel(stack_compute_host Host basic SRCS stack_compute.cc DEPS ${lite_kernel_deps})
 add_kernel(unbind_compute_host Host basic SRCS unbind_compute.cc DEPS ${lite_kernel_deps})
+add_kernel(argmax_compute_host Host basic SRCS argmax_compute.cc DEPS ${lite_kernel_deps} math_host)
 
 # extra kernels
 add_kernel(reduce_all_compute_host Host extra SRCS reduce_all_compute.cc DEPS ${lite_kernel_deps} math_host)

--- a/lite/kernels/host/argmax_compute.cc
+++ b/lite/kernels/host/argmax_compute.cc
@@ -1,0 +1,128 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/host/argmax_compute.h"
+#include <string>
+#include <vector>
+#include "lite/backends/host/math/argmax.h"
+#include "lite/core/op_registry.h"
+#include "lite/core/tensor.h"
+#include "lite/core/type_system.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <typename T>
+void ArgmaxCompute<T>::Run() {
+  auto& param = Param<operators::ArgmaxParam>();
+  lite::Tensor* input = param.X;
+  lite::Tensor* output = param.Out;
+  int axis = param.Axis;
+  if (axis < 0) {
+    axis += input->dims().size();
+  }
+
+  switch (param.dtype) {
+    // default indices type: int64_t
+    case -1: {
+      lite::host::math::argmax_func<T, int64_t>(input, axis, output);
+      break;
+    }
+    // static_cast<int>(lite::core::FluidType::INT32) == 2
+    case 2: {
+      lite::host::math::argmax_func<T, int32_t>(input, axis, output);
+      break;
+    }
+    // static_cast<int>(lite::core::FluidType::INT64) == 3
+    case 3: {
+      lite::host::math::argmax_func<T, int64_t>(input, axis, output);
+      break;
+    }
+    default: {
+      LOG(FATAL) << "Attribute `dtype` in arg_max op must be 2 or 3, which "
+                    "indicates that indices dtype must be int32 or int64, "
+                    "default dtype is int64.";
+      break;
+    }
+  }
+#ifdef LITE_WITH_PROFILE
+  kernel_func_name_ = "argmax_func";
+#endif
+  return;
+}
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(arg_max,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::ArgmaxCompute<float>,
+                     fp32)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFloat))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
+    .Finalize();
+
+#ifdef LITE_BUILD_EXTRA
+// arg_max only supports float input except that LITE_WITH_EXTRA=ON
+REGISTER_LITE_KERNEL(arg_max,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::ArgmaxCompute<int64_t>,
+                     int64)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt64))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
+    .Finalize();
+
+REGISTER_LITE_KERNEL(arg_max,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::ArgmaxCompute<int32_t>,
+                     int32)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
+    .Finalize();
+
+REGISTER_LITE_KERNEL(arg_max,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::ArgmaxCompute<int16_t>,
+                     int16)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
+    .Finalize();
+
+REGISTER_LITE_KERNEL(arg_max,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::ArgmaxCompute<uint8_t>,
+                     uint8)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kUInt8))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindPaddleOpVersion("arg_max", 1)
+    .Finalize();
+#endif  // LITE_BUILD_EXTRA

--- a/lite/kernels/host/argmax_compute.h
+++ b/lite/kernels/host/argmax_compute.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <algorithm>
+#include "lite/core/kernel.h"
+#include "lite/operators/argmax_op.h"
+#ifdef LITE_WITH_PROFILE
+#include <string>
+#include "lite/core/profile/profiler.h"
+#endif
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <typename T>
+class ArgmaxCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
+ public:
+  using param_t = operators::ArgmaxParam;
+
+  void Run() override;
+
+  virtual ~ArgmaxCompute() = default;
+
+#ifdef LITE_WITH_PROFILE
+  virtual void SetProfileRuntimeKernelInfo(
+      paddle::lite::profile::OpCharacter* ch) {
+    ch->kernel_func_name = kernel_func_name_;
+  }
+  std::string kernel_func_name_{"NotImplForArgmax"};
+#endif
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/tests/kernels/argmax_compute_test.cc
+++ b/lite/tests/kernels/argmax_compute_test.cc
@@ -171,7 +171,6 @@ class ArgmaxComputeTester : public arena::TestCase {
 };
 
 void TestArgmax(const Place& place) {
-  std::unique_ptr<arena::TestCase> tester(
   for (int axis : {0, 1, 2, 3}) {
     // attribute: keepdims
     for (bool keepdims : {false, true}) {
@@ -199,7 +198,7 @@ void TestArgmax(const Place& place) {
   }
 }
 
-TEST(Assign, precision) {
+TEST(Argmax, precision) {
   Place place;
 #if defined(LITE_WITH_ARM)
   place = TARGET(kARM);

--- a/lite/tests/kernels/argmax_compute_test.cc
+++ b/lite/tests/kernels/argmax_compute_test.cc
@@ -170,15 +170,8 @@ class ArgmaxComputeTester : public arena::TestCase {
   }
 };
 
-TEST(Argmax, precision) {
-  // #ifdef LITE_WITH_X86
-  //  Place place(TARGET(kX86));
-  // #endif
-  LOG(INFO) << "test argmax op";
-#ifdef LITE_WITH_ARM
-  LOG(INFO) << "test argmax arm";
-  Place place(TARGET(kARM));
-
+void TestArgmax(const Place& place) {
+  std::unique_ptr<arena::TestCase> tester(
   for (int axis : {0, 1, 2, 3}) {
     // attribute: keepdims
     for (bool keepdims : {false, true}) {
@@ -204,7 +197,19 @@ TEST(Argmax, precision) {
       }
     }
   }
+}
+
+TEST(Assign, precision) {
+  Place place;
+#if defined(LITE_WITH_ARM)
+  place = TARGET(kARM);
+#elif defined(LITE_WITH_X86)
+  place = TARGET(kHost);
+#else
+  return;
 #endif
+
+  TestArgmax(place);
 }
 
 }  // namespace lite


### PR DESCRIPTION
当前只有 ARM backend 有`argmax`kernel 实现，但其实现无特殊计算，具有平台无关性。因此为了支持 x86 平台，在 host 端新增该 kernel。