### PR TITLE
[armlinux] set c_compile and cxx_compile by env CC and env CXX

### DIFF
--- a/cmake/cross_compiling/armlinux.cmake
+++ b/cmake/cross_compiling/armlinux.cmake
@@ -39,3 +39,17 @@ if(ARMLINUX_ARCH_ABI STREQUAL "armv7hf")
     set(CMAKE_C_COMPILER "arm-linux-gnueabihf-gcc")
     set(CMAKE_CXX_COMPILER "arm-linux-gnueabihf-g++")
 endif()
+
+set(HOST_C_COMPILER $ENV{CC})
+set(HOST_CXX_COMPILER $ENV{CXX})
+
+if(NOT ${HOST_C_COMPILER})
+    set(CMAKE_C_COMPILER ${HOST_C_COMPILER})
+endif()
+
+if(NOT ${HOST_CXX_COMPILER})
+    set(CMAKE_CXX_COMPILER ${HOST_CXX_COMPILER})
+endif()
+
+message(STATUS "armlinux CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
+message(STATUS "armlinux CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")


### PR DESCRIPTION
- armlinux编译时，默认使用交叉编译工具链（docker内编译）
- 机器上编译时，需要设置环境变量 ```CC``` 和 ```CXX``` 来分别指定c编译器和c++编译器