### PR TITLE
[OpenCL]fix droupout io_copy_buffer layout bug 

### DIFF
--- a/lite/kernels/opencl/dropout_image_compute.cc
+++ b/lite/kernels/opencl/dropout_image_compute.cc
@@ -55,7 +55,12 @@ class DropoutComputeImage2D : public KernelLite<TARGET(kOpenCL),
     const auto& in_dims = param.x->dims();
     const auto& out_dims = param.output->dims();
     auto* x_img = GET_DATA_GPU(param.x);
-    const float dropout_prob = param.dropout_prob;
+    float dropout_prob;
+    if (param.dropout_implementation == "upscale_in_train") {
+      dropout_prob = 0.0f;
+    } else {
+      dropout_prob = param.dropout_prob;
+    }
 
     int input_dims[4] = {1, 1, 1, 1};
     for (int i = 0; i < in_dims.size(); i++) {

--- a/lite/kernels/opencl/io_copy_buffer_compute.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute.cc
@@ -138,8 +138,10 @@ class IoCopykOpenCLToHostCompute
     const cl::Buffer* x_ptr;
     if (param.process_type == 1) {
       x_ptr = param.x->data<uint8_t, cl::Buffer>();
+      param.y->set_precision(PRECISION(kUInt8));
     } else {
       x_ptr = param.x->data<float, cl::Buffer>();
+      param.y->set_precision(PRECISION(kFloat));
     }
 
 #ifdef LITE_WITH_LOG

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -446,6 +446,23 @@ REGISTER_LITE_KERNEL(
     .Finalize();
 
 REGISTER_LITE_KERNEL(
+    layout,
+    kOpenCL,
+    kAny,
+    kNCHW,
+    paddle::lite::kernels::opencl::LayoutComputeImageDefaultToBufferChw,
+    def)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kImageDefault))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
     layout_once,
     kOpenCL,
     kAny,


### PR DESCRIPTION
1、opencl支持dropout_implementation属性。
2、添加opencl io_copy_buffer中的precision传递，防止一些type检查不通过。
3、添加layout_image中新的place支持。