### PR TITLE
[v2.8][cherry-pick]Add precision info into persistable variable and fix crop tensor

### DIFF
--- a/lite/core/arena/framework.h
+++ b/lite/core/arena/framework.h
@@ -140,7 +140,7 @@ class TestCase {
 
     auto* base_tensor_list = base_scope_->NewTensorList(var_name);
     auto* inst_tensor_list = inst_scope_->NewTensorList(var_name);
-    for (int i = 0; i < ddims.size(); i++) {
+    for (size_t i = 0; i < ddims.size(); i++) {
       Tensor item;
       item.Resize(ddims[i]);
       memcpy(item.mutable_data<T>(),

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -416,6 +416,18 @@ void Program::PrepareWorkspace(
         }
       } else {
         if (var_name == "feed" || var_name == "fetch") continue;
+#ifndef LITE_WITH_XPU
+        // Collect precision info into var_type_map_
+        if (var_type == lite::VarDescAPI::Type::LOD_TENSOR) {
+          const auto& var_data_type =
+              VarDescType2PrecisionType(var_desc->GetDataType());
+          if (var_data_type != PRECISION(kUnk)) {
+            var_type_map_[var_name] = LiteType::GetTensorTy(
+                TARGET(kUnk), var_data_type, DATALAYOUT(kUnk));
+          }
+          VLOG(4) << " - data type " << static_cast<int>(var_data_type);
+        }
+#endif
         weights_.push_back(var_name);
         scope_->Var(var_name);
       }

--- a/lite/model_parser/compatible_pb.cc
+++ b/lite/model_parser/compatible_pb.cc
@@ -96,14 +96,6 @@ void TransformVarDescAnyToCpp<naive_buffer::VarDesc>(
   cpp_desc->SetName(any_desc.Name());
   cpp_desc->SetType(any_desc.GetType());
   cpp_desc->SetPersistable(any_desc.Persistable());
-  // todo : SetDataType function is commented out temporarily
-  // because of Compatibility issues. The Compatibility issue
-  // should be fixed later and the code below should be applied
-  // later. @DannyIsFunny
-  /*  if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
-      cpp_desc->SetDataType(any_desc.GetDataType());
-      cpp_desc->SetShape(any_desc.GetShape());
-    }*/
 }
 #endif
 /// For OpDesc transform

--- a/lite/tests/kernels/crop_tensor_compute_test.cc
+++ b/lite/tests/kernels/crop_tensor_compute_test.cc
@@ -31,10 +31,10 @@ void slice_ref(const T* input,
   std::vector<int> real_starts(in_dims.size(), 0);
   std::vector<int> real_ends(in_dims.size(), 0);
   std::vector<int> real_step(in_dims.size(), 0);
-  for (int i = 0; i < in_dims.size(); i++) {
+  for (size_t i = 0; i < in_dims.size(); i++) {
     real_ends[i] = in_dims[i];
   }
-  for (int i = 0; i < axes.size(); i++) {
+  for (size_t i = 0; i < axes.size(); i++) {
     int dim_value = in_dims[axes[i]];
     if (dim_value > 0) {
       int start = starts[i] < 0 ? (starts[i] + dim_value) : starts[i];
@@ -49,11 +49,11 @@ void slice_ref(const T* input,
   }
   const int LEN = in_dims.size();
   std::vector<int> dst_step(LEN);
-  for (int i = 0; i < in_dims.size(); ++i) {
+  for (size_t i = 0; i < in_dims.size(); ++i) {
     dst_step[i] = 1;
   }
   std::vector<int> src_step(LEN);
-  for (int i = 0; i < in_dims.size(); ++i) {
+  for (size_t i = 0; i < in_dims.size(); ++i) {
     src_step[i] = 1;
   }
   int out_num = out_dims[in_dims.size() - 1];
@@ -66,7 +66,7 @@ void slice_ref(const T* input,
   for (int dst_id = 0; dst_id < out_num; dst_id++) {
     int src_id = 0;
     int index_id = dst_id;
-    for (int j = 0; j < out_dims.size(); j++) {
+    for (size_t j = 0; j < out_dims.size(); j++) {
       int cur_id = index_id / dst_step[j];
       index_id = index_id % dst_step[j];
       src_id += (cur_id + real_starts[j]) * src_step[j];
@@ -183,17 +183,21 @@ class CropTensorComputeTester : public arena::TestCase {
 
 template <class T = float>
 void TestCropTensor(Place place, float abs_error = 1e-5) {
-  place.precision = lite_api::PrecisionTypeTrait<T>::Type();
+  place.precision = lite_api::PrecisionTypeTrait<float>::Type();
+  std::string alias = "def";
+  if (lite_api::PrecisionTypeTrait<T>::Type() == PrecisionType::kInt32) {
+    alias = "int32_precision";
+  }
 
   // test 1D
   std::unique_ptr<arena::TestCase> tester_1d(
-      new CropTensorComputeTester<T>(place, "def", {1}, {3}, DDim({4})));
+      new CropTensorComputeTester<T>(place, alias, {1}, {3}, DDim({4})));
   arena::Arena arena_1d(std::move(tester_1d), place, abs_error);
   arena_1d.TestPrecision();
 
   // test 4D
   std::unique_ptr<arena::TestCase> tester_4d(new CropTensorComputeTester<T>(
-      place, "def", {1, 1, 2, 3}, {1, 0, 2, 1}, DDim({2, 3, 4, 5})));
+      place, alias, {1, 1, 2, 3}, {1, 0, 2, 1}, DDim({2, 3, 4, 5})));
   arena::Arena arena_4d(std::move(tester_4d), place, abs_error);
   arena_4d.TestPrecision();
 }


### PR DESCRIPTION
cherry-picked from #5225 and #5227 
###  Add precision info into persistable variable（#5225）
#### 问题描述
- Paddle-Lite opt 转化模型时，会丢失 `weights` (persistable variables) 的精度信息
- 导致问题： 部分变量缺失精度信息、导致`kernel`选择错误
#### 本PR修复
- 转化模型时，保留`weights` (persistable variables) 的精度信息
- 使模型`opt`转化过程正常

###   Fix crop tensor（#5227 ）
#### 解决以下问题
- 解决 `crop_tensor`算子非float32 输入精度的kernel实现无法被选中的问题
- 解决`crop_tensor` 不支持 `shape` 参数中含有`-1`，即可变`shape` 的问题