### PR TITLE
[Test][InstanceNorm] Loose abs_err for ARM. test=develop

### DIFF
--- a/lite/tests/kernels/instance_norm_compute_test.cc
+++ b/lite/tests/kernels/instance_norm_compute_test.cc
@@ -170,7 +170,7 @@ void TestInstanceNorm(Place place,
 
 TEST(InstanceNorm, precision) {
   Place place;
-  float abs_error = 1e-3;
+  float abs_error = 2e-3;
   std::vector<std::string> ignored_outs = {};
 #if defined(LITE_WITH_NPU)
   place = TARGET(kNPU);


### PR DESCRIPTION
在执行ARMLinux下的 IN 单测时，有时会因 abs_err 设置偏小而 fail，具体如下图：
![image](https://user-images.githubusercontent.com/24290792/104808184-7419a400-581f-11eb-8f86-bdd4ae463cc9.png)
