### PR TITLE
[v2.8][Cherry-pick] Fix some kernels and update memory operation method

### DIFF
--- a/lite/backends/arm/math/concat.h
+++ b/lite/backends/arm/math/concat.h
@@ -51,7 +51,7 @@ void concat_func(const std::vector<lite::Tensor*>& input,
     auto* dout_ptr = dst_ptr + offset_concat_axis * concat_input_size;
     int64_t in_sum = in_concat_axis * concat_input_size;
     for (int i = 0; i < num_cancats; i++) {
-      std::memcpy(dout_ptr, src_ptr, sizeof(T) * in_sum);
+      host::memcpy(dout_ptr, src_ptr, sizeof(T) * in_sum);
       dout_ptr += out_sum;
       src_ptr += in_sum;
     }

--- a/lite/backends/arm/math/slice.cc
+++ b/lite/backends/arm/math/slice.cc
@@ -100,6 +100,13 @@ template void slice(const int64_t* input,
                     std::vector<int> ends,
                     int64_t* out,
                     Context<TARGET(kARM)>* ctx);
+template void slice(const bool* input,
+                    std::vector<int64_t> dims,
+                    std::vector<int> axes,
+                    std::vector<int> starts,
+                    std::vector<int> ends,
+                    bool* out,
+                    Context<TARGET(kARM)>* ctx);
 
 }  // namespace math
 }  // namespace arm

--- a/lite/core/arena/framework.h
+++ b/lite/core/arena/framework.h
@@ -140,7 +140,7 @@ class TestCase {
 
     auto* base_tensor_list = base_scope_->NewTensorList(var_name);
     auto* inst_tensor_list = inst_scope_->NewTensorList(var_name);
-    for (int i = 0; i < ddims.size(); i++) {
+    for (size_t i = 0; i < ddims.size(); i++) {
       Tensor item;
       item.Resize(ddims[i]);
       memcpy(item.mutable_data<T>(),

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -38,6 +39,43 @@ using lite_api::DataLayoutToStr;
 using lite_api::TargetRepr;
 using lite_api::PrecisionRepr;
 using lite_api::DataLayoutRepr;
+
+namespace host {
+const int MALLOC_ALIGN = 64;
+
+// Allocate the requested memory and return a pointer to it.
+// Byte alignment and memory checking are performed.
+inline void* malloc(size_t size) {
+  size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;
+  char* p = static_cast<char*>(std::malloc(offset + size));
+  // Memory checking
+  CHECK(p) << "Error occurred in malloc period: available space is not enough "
+              "for mallocing "
+           << size << " bytes.";
+  // Byte alignment
+  void* r = reinterpret_cast<void*>(reinterpret_cast<size_t>(p + offset) &
+                                    (~(MALLOC_ALIGN - 1)));
+  static_cast<void**>(r)[-1] = p;
+  return r;
+}
+
+// Deallocate the memory.
+inline void free(void* ptr) {
+  if (ptr) {
+    std::free(static_cast<void**>(ptr)[-1]);
+  }
+}
+
+// Copy size characters from memory area src to memory area dst.
+// Memory checking is performed.
+inline void memcpy(void* dst, const void* src, size_t size) {
+  if (size > 0) {
+    CHECK(dst) << "Error: the destination of memcpy can not be nullptr.";
+    CHECK(src) << "Error: the source of memcpy can not be nullptr.";
+    std::memcpy(dst, src, size);
+  }
+}
+}  // namespace host
 
 // Memory copy directions.
 enum class IoDirection {

--- a/lite/kernels/arm/cast_compute.cc
+++ b/lite/kernels/arm/cast_compute.cc
@@ -84,6 +84,11 @@ void CastCompute::Run() {
     int64_t* out_data = param.Out->mutable_data<int64_t>();
     std::transform(
         x_data_begin, x_data_end, out_data, TransOp<int32_t, int64_t>);
+  } else if (param.in_dtype == 5 && param.out_dtype == 2) {  // float32 -> INT32
+    const float* x_data_begin = param.X->data<float>();
+    const float* x_data_end = x_data_begin + param.X->numel();
+    int32_t* out_data = param.Out->mutable_data<int32_t>();
+    std::transform(x_data_begin, x_data_end, out_data, TransOp<float, int32_t>);
   } else if (param.in_dtype == 5 &&
              param.out_dtype == 20) {  // float32 -> uint8
     const float* x_data_begin = param.X->data<float>();
@@ -91,6 +96,16 @@ void CastCompute::Run() {
     unsigned char* out_data = param.Out->mutable_data<unsigned char>();
     std::transform(
         x_data_begin, x_data_end, out_data, TransOp<float, unsigned char>);
+  } else if (param.in_dtype == 0 && param.out_dtype == 2) {  // bool -> INT32
+    const bool* x_data_begin = param.X->data<bool>();
+    const bool* x_data_end = x_data_begin + param.X->numel();
+    int32_t* out_data = param.Out->mutable_data<int32_t>();
+    std::transform(x_data_begin, x_data_end, out_data, TransOp<bool, int32_t>);
+  } else if (param.in_dtype == 2 && param.out_dtype == 0) {  // INT32 -> bool
+    const int32_t* x_data_begin = param.X->data<int32_t>();
+    const int32_t* x_data_end = x_data_begin + param.X->numel();
+    bool* out_data = param.Out->mutable_data<bool>();
+    std::transform(x_data_begin, x_data_end, out_data, TransOp<int32_t, bool>);
   } else {
     LOG(FATAL) << "other has not been implemented transform with dtype"
                << param.in_dtype << " X, dtype" << param.out_dtype << " Out";

--- a/lite/kernels/arm/slice_compute.cc
+++ b/lite/kernels/arm/slice_compute.cc
@@ -182,6 +182,21 @@ REGISTER_LITE_KERNEL(slice, kARM, kFloat, kNCHW, slice_float, def)
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
     .Finalize();
 
+using slice_boolean =
+    paddle::lite::kernels::arm::SliceCompute<bool, PRECISION(kFloat)>;
+REGISTER_LITE_KERNEL(slice, kARM, kFloat, kNCHW, slice_boolean, bool_slice)
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kBool))})
+    .BindInput("StartsTensor",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("EndsTensor",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorListTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorListTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kBool))})
+    .Finalize();
+
 using slice_int32 =
     paddle::lite::kernels::arm::SliceCompute<int, PRECISION(kInt32)>;
 REGISTER_LITE_KERNEL(slice, kARM, kInt32, kNCHW, slice_int32, def)

--- a/lite/kernels/host/fill_constant_compute.cc
+++ b/lite/kernels/host/fill_constant_compute.cc
@@ -44,6 +44,8 @@ void FillConstantCompute::Run() {
   } else if (param.dtype ==
              static_cast<int32_t>(lite::core::FluidType::INT64)) {
     FillConstData<int64_t>();
+  } else if (param.dtype == static_cast<int32_t>(lite::core::FluidType::BOOL)) {
+    FillConstData<bool>();
   } else {
     LOG(FATAL) << "not supported dtype " << param.dtype;
   }

--- a/lite/kernels/host/unstack_compute.cc
+++ b/lite/kernels/host/unstack_compute.cc
@@ -66,3 +66,14 @@ REGISTER_LITE_KERNEL(unstack, kHost, kFloat, kAny, unstack_float, def)
                 {LiteType::GetTensorTy(
                     TARGET(kHost), PRECISION(kFloat), DATALAYOUT(kAny), -1)})
     .Finalize();
+
+using unstack_int32 =
+    paddle::lite::kernels::host::UnstackCompute<int32_t, PRECISION(kFloat)>;
+REGISTER_LITE_KERNEL(unstack, kHost, kFloat, kAny, unstack_int32, unstack_int32)
+    .BindInput("X",
+               {LiteType::GetTensorTy(
+                   TARGET(kHost), PRECISION(kInt32), DATALAYOUT(kAny), -1)})
+    .BindOutput("Y",
+                {LiteType::GetTensorTy(
+                    TARGET(kHost), PRECISION(kInt32), DATALAYOUT(kAny), -1)})
+    .Finalize();

--- a/lite/model_parser/compatible_pb.cc
+++ b/lite/model_parser/compatible_pb.cc
@@ -96,14 +96,6 @@ void TransformVarDescAnyToCpp<naive_buffer::VarDesc>(
   cpp_desc->SetName(any_desc.Name());
   cpp_desc->SetType(any_desc.GetType());
   cpp_desc->SetPersistable(any_desc.Persistable());
-  // todo : SetDataType function is commented out temporarily
-  // because of Compatibility issues. The Compatibility issue
-  // should be fixed later and the code below should be applied
-  // later. @DannyIsFunny
-  /*  if (any_desc.Name() != "feed" && any_desc.Name() != "fetch") {
-      cpp_desc->SetDataType(any_desc.GetDataType());
-      cpp_desc->SetShape(any_desc.GetShape());
-    }*/
 }
 #endif
 /// For OpDesc transform

--- a/lite/tests/kernels/crop_tensor_compute_test.cc
+++ b/lite/tests/kernels/crop_tensor_compute_test.cc
@@ -31,10 +31,10 @@ void slice_ref(const T* input,
   std::vector<int> real_starts(in_dims.size(), 0);
   std::vector<int> real_ends(in_dims.size(), 0);
   std::vector<int> real_step(in_dims.size(), 0);
-  for (int i = 0; i < in_dims.size(); i++) {
+  for (size_t i = 0; i < in_dims.size(); i++) {
     real_ends[i] = in_dims[i];
   }
-  for (int i = 0; i < axes.size(); i++) {
+  for (size_t i = 0; i < axes.size(); i++) {
     int dim_value = in_dims[axes[i]];
     if (dim_value > 0) {
       int start = starts[i] < 0 ? (starts[i] + dim_value) : starts[i];
@@ -49,11 +49,11 @@ void slice_ref(const T* input,
   }
   const int LEN = in_dims.size();
   std::vector<int> dst_step(LEN);
-  for (int i = 0; i < in_dims.size(); ++i) {
+  for (size_t i = 0; i < in_dims.size(); ++i) {
     dst_step[i] = 1;
   }
   std::vector<int> src_step(LEN);
-  for (int i = 0; i < in_dims.size(); ++i) {
+  for (size_t i = 0; i < in_dims.size(); ++i) {
     src_step[i] = 1;
   }
   int out_num = out_dims[in_dims.size() - 1];
@@ -66,7 +66,7 @@ void slice_ref(const T* input,
   for (int dst_id = 0; dst_id < out_num; dst_id++) {
     int src_id = 0;
     int index_id = dst_id;
-    for (int j = 0; j < out_dims.size(); j++) {
+    for (size_t j = 0; j < out_dims.size(); j++) {
       int cur_id = index_id / dst_step[j];
       index_id = index_id % dst_step[j];
       src_id += (cur_id + real_starts[j]) * src_step[j];
@@ -183,17 +183,21 @@ class CropTensorComputeTester : public arena::TestCase {
 
 template <class T = float>
 void TestCropTensor(Place place, float abs_error = 1e-5) {
-  place.precision = lite_api::PrecisionTypeTrait<T>::Type();
+  place.precision = lite_api::PrecisionTypeTrait<float>::Type();
+  std::string alias = "def";
+  if (lite_api::PrecisionTypeTrait<T>::Type() == PrecisionType::kInt32) {
+    alias = "int32_precision";
+  }
 
   // test 1D
   std::unique_ptr<arena::TestCase> tester_1d(
-      new CropTensorComputeTester<T>(place, "def", {1}, {3}, DDim({4})));
+      new CropTensorComputeTester<T>(place, alias, {1}, {3}, DDim({4})));
   arena::Arena arena_1d(std::move(tester_1d), place, abs_error);
   arena_1d.TestPrecision();
 
   // test 4D
   std::unique_ptr<arena::TestCase> tester_4d(new CropTensorComputeTester<T>(
-      place, "def", {1, 1, 2, 3}, {1, 0, 2, 1}, DDim({2, 3, 4, 5})));
+      place, alias, {1, 1, 2, 3}, {1, 0, 2, 1}, DDim({2, 3, 4, 5})));
   arena::Arena arena_4d(std::move(tester_4d), place, abs_error);
   arena_4d.TestPrecision();
 }

--- a/lite/utils/cp_logging.h
+++ b/lite/utils/cp_logging.h
@@ -29,3 +29,10 @@
 #include <glog/logging.h>
 #endif
 #endif
+
+// On windows environment, min and max will be undefined to
+// avoid compiling error.
+#if defined(_MSC_VER)
+#undef min
+#undef max
+#endif


### PR DESCRIPTION
cherry-picked from: #5272 #5191 #5221 #5283 

### PR #5272 
- `unstack`算子补充输入精度为`int32`的实现
- `slice`算子补充输入精度为`bool`的实现
- `fill_const` 算子补充输入精度为`bool`的实现
- `cast` 算子补充三种实现： `float--->int32_t`、`bool--->int32_t`、`int32_t--->bool`

### PR #5227 
- 解决 `crop_tensor`算子非float32 输入精度的kernel实现无法被选中的问题
- 解决`crop_tensor` 不支持 `shape` 参数中含有`-1`，即可变`shape` 的问题

### PR #5191 
- lite中实现带有指针检查功能的 malloc 、memcpy、free 方法
  - lite::host::malloc
  - lite::host::memcpy
  - lite::host::free
- 函数定义为inline类型，避免可能的函数堆栈耗时

### PR #5283 
- Fix compiling error on windows environment
