### PR TITLE
[Cherry-pick][Arm] Fix compare op

### DIFF
--- a/lite/core/mir/variable_place_inference_pass.h
+++ b/lite/core/mir/variable_place_inference_pass.h
@@ -169,7 +169,7 @@ class VariablePlaceInferencePass : public DebugPass {
         VLOG(4) << " - output arg name:" << arg_name
                 << " var name:" << var_name;
         const auto* decl_type = kernel.GetOutputDeclType(arg_name);
-        if (!(*var_type)) {
+        if (!(*var_type) || var.is_weight) {
           VLOG(4) << "set type " << *decl_type << " " << var_name;
           if (var.is_weight) {
             SetWeightType(out_node, *decl_type, with_targets);

--- a/lite/kernels/host/compare_compute.cc
+++ b/lite/kernels/host/compare_compute.cc
@@ -91,6 +91,11 @@ void CompareCompute<PType, CompareFunctor>::Run() {
     }
   } else {
     int axis = (param.axis == -1 ? x_dims.size() - y_dims.size() : param.axis);
+    // If Y contains only one data, all_broad_cast mode will be applied.
+    // In this mode, each member in X will compare to the only var in Y.
+    if (param.Y->numel() == 1) {
+      axis = x_dims.size();
+    }
     int outer_num, mid_num, inner_num;
     get_mid_dims(x_dims, y_dims, axis, &outer_num, &mid_num, &inner_num);
     for (int outer_id = 0; outer_id < outer_num; ++outer_id) {


### PR DESCRIPTION
cherry-picked from #5327 
- Fix the issue: compare op failed when input Y's shape is `1`

``` shell
# eg
input_x_dims: {1, 510, 510, 16}
input_y_dims: {1}
axis: -1
------> 
# Compare will only operate on:
axis = input_x_dims.size()- input_y_dims.size() =3;
output_data[1, 510, 510,1]
```