### PR TITLE
[OPENCL] Enhance initialization check for OpenCL when restricted permission in APP env.

### DIFF
--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -104,7 +104,8 @@ cl::Platform& CLRuntime::platform() {
 
 cl::Context& CLRuntime::context() {
   if (context_ == nullptr) {
-    LOG(FATAL) << "context_ create failed. ";
+    LOG(FATAL) << "context_ create failed, check whether context create "
+                  "successfully in CreateContext!";
   }
   return *context_;
 }
@@ -118,7 +119,8 @@ cl::Device& CLRuntime::device() {
 
 cl::CommandQueue& CLRuntime::command_queue() {
   if (command_queue_ == nullptr) {
-    LOG(FATAL) << "command_queue_ create failed. ";
+    LOG(FATAL) << "command_queue_ create failed, check whether command queue "
+                  "create successfully in CreateCommandQueue!";
   }
   return *command_queue_;
 }
@@ -180,7 +182,7 @@ bool CLRuntime::InitializePlatform() {
   // has return status do not exit here when release
   CL_CHECK_ERROR(status_);
   if (all_platforms.empty()) {
-    LOG(FATAL) << "No OpenCL platform found!";
+    LOG(ERROR) << "No OpenCL platform found!";
     return false;
   }
   platform_ = std::make_shared<cl::Platform>();
@@ -213,10 +215,12 @@ GpuType CLRuntime::ParseGpuTypeFromDeviceName(std::string device_name) {
 }
 
 bool CLRuntime::InitializeDevice() {
+#ifdef LITE_WITH_LOG
   VLOG(3) << "device_info_.size():" << device_info_.size();
   for (auto i : device_info_) {
     VLOG(3) << ">>> " << i.first << " " << i.second;
   }
+#endif
   // initialized without valid opencl device
   if (device_info_.size() > 0 && device_info_.size() <= 2) {
     return false;
@@ -357,19 +361,19 @@ bool CLRuntime::InitializeDevice() {
   if (image_support) {
     LOG(INFO) << "The chosen device supports image processing.";
     device_info_["CL_DEVICE_IMAGE_SUPPORT"] = 1;
+
+    auto image2d_max_height = device_->getInfo<CL_DEVICE_IMAGE2D_MAX_HEIGHT>();
+    LOG(INFO) << "CL_DEVICE_IMAGE2D_MAX_HEIGHT:" << image2d_max_height;
+    device_info_["CL_DEVICE_IMAGE2D_MAX_HEIGHT"] = image2d_max_height;
+
+    auto image2d_max_width = device_->getInfo<CL_DEVICE_IMAGE2D_MAX_WIDTH>();
+    LOG(INFO) << "CL_DEVICE_IMAGE2D_MAX_WIDTH:" << image2d_max_width;
+    device_info_["CL_DEVICE_IMAGE2D_MAX_WIDTH"] = image2d_max_width;
   } else {
-    LOG(INFO) << "The chosen device doesn't support image processing!";
+    LOG(ERROR) << "The chosen device doesn't support image processing!";
     device_info_["CL_DEVICE_IMAGE_SUPPORT"] = 0;
     return false;
   }
-
-  auto image2d_max_height = device_->getInfo<CL_DEVICE_IMAGE2D_MAX_HEIGHT>();
-  LOG(INFO) << "CL_DEVICE_IMAGE2D_MAX_HEIGHT:" << image2d_max_height;
-  device_info_["CL_DEVICE_IMAGE2D_MAX_HEIGHT"] = image2d_max_height;
-
-  auto image2d_max_width = device_->getInfo<CL_DEVICE_IMAGE2D_MAX_WIDTH>();
-  LOG(INFO) << "CL_DEVICE_IMAGE2D_MAX_WIDTH:" << image2d_max_width;
-  device_info_["CL_DEVICE_IMAGE2D_MAX_WIDTH"] = image2d_max_width;
 
   // ===================== OTHERS / EXTENSION / VERSION =====================
   // CL_DEVICE_EXTENSIONS
@@ -405,7 +409,10 @@ void CLRuntime::GetAdrenoContextProperties(
     std::vector<cl_context_properties>* properties,
     GPUPerfMode gpu_perf_mode,
     GPUPriorityLevel gpu_priority_level) {
-  CHECK(properties) << "cl_context_properties is nullptr";
+  if (properties == nullptr) {
+    LOG(ERROR) << "cl_context_properties is nullptr";
+    return;
+  }
   properties->reserve(5);
   switch (gpu_perf_mode) {
     case GPUPerfMode::PERF_LOW:

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -78,6 +78,14 @@ class CLRuntime {
     // note(ysh329): entered this func means:
     //  1. opencl_lib_found must be true
     //  2. dlsym_success must be true
+    if (!paddle::lite::CLWrapper::Global()->OpenclLibFound() ||
+        !paddle::lite::CLWrapper::Global()->DlsymSuccess()) {
+      LOG(ERROR) << "Invalid opencl device, OpenclLibFound:"
+                 << paddle::lite::CLWrapper::Global()->OpenclLibFound()
+                 << ", DlsymSuccess:"
+                 << paddle::lite::CLWrapper::Global()->DlsymSuccess();
+      return false;
+    }
 
     bool support_fp16 = support_half();
     is_device_avaliable_for_opencl_ =
@@ -177,7 +185,7 @@ class CLRuntime {
                                       nullptr,
                                       &status_);
     // use in is opencl valid check, do not exit here when release.
-    CL_CHECK_FATAL(status_);
+    CL_CHECK_ERROR(status_);
     return context;
   }
 
@@ -195,7 +203,7 @@ class CLRuntime {
     auto queue = std::make_shared<cl::CommandQueue>(
         context, device(), properties, &status_);
     // use in is opencl valid check, do not exit here when release.
-    CL_CHECK_FATAL(status_);
+    CL_CHECK_ERROR(status_);
     return queue;
   }
 

--- a/lite/backends/opencl/cl_wrapper.cc
+++ b/lite/backends/opencl/cl_wrapper.cc
@@ -31,8 +31,17 @@ CLWrapper *CLWrapper::Global() {
 }
 
 CLWrapper::CLWrapper() {
+  if (!is_first_init_ && !opencl_lib_found_) {
+    LOG(INFO) << "This isn't first init for CLWrapper, opencl library not "
+                 "found previously";
+    return;
+  }
   opencl_lib_found_ = InitHandle();
-  CHECK(opencl_lib_found_) << "Fail to initialize the OpenCL library!";
+  if (!opencl_lib_found_) {
+    LOG(INFO) << "Failed to find and initialize Opencl library";
+    return;
+  }
+  is_first_init_ = false;
   dlsym_success_ = InitFunctions();
 }
 
@@ -91,7 +100,10 @@ bool CLWrapper::InitHandle() {
 }
 
 bool CLWrapper::InitFunctions() {
-  CHECK(handle_ != nullptr) << "The library handle can't be null!";
+  if (handle_ == nullptr) {
+    LOG(ERROR) << "The library handle can't be null!";
+    return false;
+  }
   bool dlsym_success = true;
 
 #define PADDLE_DLSYM(cl_func)                                        \

--- a/lite/backends/opencl/cl_wrapper.h
+++ b/lite/backends/opencl/cl_wrapper.h
@@ -257,296 +257,385 @@ class CLWrapper final {
                                             cl_event *);
 
   clGetPlatformIDsType clGetPlatformIDs() {
-    CHECK(clGetPlatformIDs_ != nullptr) << "Cannot load clGetPlatformIDs!";
+    if (clGetPlatformIDs_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetPlatformIDs!";
+    }
     return clGetPlatformIDs_;
   }
 
   clGetPlatformInfoType clGetPlatformInfo() {
-    CHECK(clGetPlatformInfo_ != nullptr) << "Cannot load clGetPlatformInfo!";
+    if (clGetPlatformInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetPlatformInfo!";
+    }
     return clGetPlatformInfo_;
   }
 
   clBuildProgramType clBuildProgram() {
-    CHECK(clBuildProgram_ != nullptr) << "Cannot load clBuildProgram!";
+    if (clBuildProgram_ == nullptr) {
+      LOG(ERROR) << "Cannot load clBuildProgram!";
+    }
     return clBuildProgram_;
   }
 
   clEnqueueNDRangeKernelType clEnqueueNDRangeKernel() {
-    CHECK(clEnqueueNDRangeKernel_ != nullptr)
-        << "Cannot load clEnqueueNDRangeKernel!";
+    if (clEnqueueNDRangeKernel_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueNDRangeKernel!";
+    }
     return clEnqueueNDRangeKernel_;
   }
 
   clSetKernelArgType clSetKernelArg() {
-    CHECK(clSetKernelArg_ != nullptr) << "Cannot load clSetKernelArg!";
+    if (clSetKernelArg_ == nullptr) {
+      LOG(ERROR) << "Cannot load clSetKernelArg!";
+    }
     return clSetKernelArg_;
   }
 
   clRetainMemObjectType clRetainMemObject() {
-    CHECK(clRetainMemObject_ != nullptr) << "Cannot load clRetainMemObject!";
+    if (clRetainMemObject_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainMemObject!";
+    }
     return clRetainMemObject_;
   }
 
   clReleaseMemObjectType clReleaseMemObject() {
-    CHECK(clReleaseMemObject_ != nullptr) << "Cannot load clReleaseMemObject!";
+    if (clReleaseMemObject_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseMemObject!";
+    }
     return clReleaseMemObject_;
   }
 
   clEnqueueUnmapMemObjectType clEnqueueUnmapMemObject() {
-    CHECK(clEnqueueUnmapMemObject_ != nullptr)
-        << "Cannot load clEnqueueUnmapMemObject!";
+    if (clEnqueueUnmapMemObject_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueUnmapMemObject!";
+    }
     return clEnqueueUnmapMemObject_;
   }
 
   clRetainCommandQueueType clRetainCommandQueue() {
-    CHECK(clRetainCommandQueue_ != nullptr)
-        << "Cannot load clRetainCommandQueue!";
+    if (clRetainCommandQueue_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainCommandQueue!";
+    }
     return clRetainCommandQueue_;
   }
 
   clCreateContextType clCreateContext() {
-    CHECK(clCreateContext_ != nullptr) << "Cannot load clCreateContext!";
+    if (clCreateContext_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateContext!";
+    }
     return clCreateContext_;
   }
 
   clCreateContextFromTypeType clCreateContextFromType() {
-    CHECK(clCreateContextFromType_ != nullptr)
-        << "Cannot load clCreateContextFromType!";
+    if (clCreateContextFromType_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateContextFromType!";
+    }
     return clCreateContextFromType_;
   }
 
   clReleaseContextType clReleaseContext() {
-    CHECK(clReleaseContext_ != nullptr) << "Cannot load clReleaseContext!";
+    if (clReleaseContext_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseContext!";
+    }
     return clReleaseContext_;
   }
 
   clWaitForEventsType clWaitForEvents() {
-    CHECK(clWaitForEvents_ != nullptr) << "Cannot load clWaitForEvents!";
+    if (clWaitForEvents_ == nullptr) {
+      LOG(ERROR) << "Cannot load clWaitForEvents!";
+    }
     return clWaitForEvents_;
   }
 
   clReleaseEventType clReleaseEvent() {
-    CHECK(clReleaseEvent_ != nullptr) << "Cannot load clReleaseEvent!";
+    if (clReleaseEvent_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseEvent!";
+    }
     return clReleaseEvent_;
   }
 
   clEnqueueWriteBufferType clEnqueueWriteBuffer() {
-    CHECK(clEnqueueWriteBuffer_ != nullptr)
-        << "Cannot loadcl clEnqueueWriteBuffer!";
+    if (clEnqueueWriteBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot loadcl clEnqueueWriteBuffer!";
+    }
     return clEnqueueWriteBuffer_;
   }
 
   clEnqueueReadBufferType clEnqueueReadBuffer() {
-    CHECK(clEnqueueReadBuffer_ != nullptr)
-        << "Cannot load clEnqueueReadBuffer!";
+    if (clEnqueueReadBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueReadBuffer!";
+    }
     return clEnqueueReadBuffer_;
   }
 
   clEnqueueReadImageType clEnqueueReadImage() {
-    CHECK(clEnqueueReadImage_ != nullptr) << "Cannot load clEnqueueReadImage!";
+    if (clEnqueueReadImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueReadImage!";
+    }
     return clEnqueueReadImage_;
   }
 
   clGetProgramBuildInfoType clGetProgramBuildInfo() {
-    CHECK(clGetProgramBuildInfo_ != nullptr)
-        << "Cannot load clGetProgramBuildInfo!";
+    if (clGetProgramBuildInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetProgramBuildInfo!";
+    }
     return clGetProgramBuildInfo_;
   }
 
   clRetainProgramType clRetainProgram() {
-    CHECK(clRetainProgram_ != nullptr) << "Cannot load clRetainProgram!";
+    if (clRetainProgram_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainProgram!";
+    }
     return clRetainProgram_;
   }
 
   clEnqueueMapBufferType clEnqueueMapBuffer() {
-    CHECK(clEnqueueMapBuffer_ != nullptr) << "Cannot load clEnqueueMapBuffer!";
+    if (clEnqueueMapBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueMapBuffer!";
+    }
     return clEnqueueMapBuffer_;
   }
 
   clEnqueueMapImageType clEnqueueMapImage() {
-    CHECK(clEnqueueMapImage_ != nullptr) << "Cannot load clEnqueueMapImage!";
+    if (clEnqueueMapImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueMapImage!";
+    }
     return clEnqueueMapImage_;
   }
 
   clCreateCommandQueueType clCreateCommandQueue() {
-    CHECK(clCreateCommandQueue_ != nullptr)
-        << "Cannot load clCreateCommandQueue!";
+    if (clCreateCommandQueue_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateCommandQueue!";
+    }
     return clCreateCommandQueue_;
   }
 
   clGetCommandQueueInfoType clGetCommandQueueInfo() {
-    CHECK(clGetCommandQueueInfo_ != nullptr)
-        << "Cannot load clGetCommandQueueInfo!";
+    if (clGetCommandQueueInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetCommandQueueInfo!";
+    }
     return clGetCommandQueueInfo_;
   }
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
   clCreateCommandQueueWithPropertiesType clCreateCommandQueueWithProperties() {
-    CHECK(clCreateCommandQueueWithProperties_ != nullptr)
-        << "Cannot load clCreateCommandQueueWithProperties!";
+    if (clCreateCommandQueueWithProperties_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateCommandQueueWithProperties!";
+    }
     return clCreateCommandQueueWithProperties_;
   }
 
 #endif
 
   clReleaseCommandQueueType clReleaseCommandQueue() {
-    CHECK(clReleaseCommandQueue_ != nullptr)
-        << "Cannot load clReleaseCommandQueue!";
+    if (clReleaseCommandQueue_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseCommandQueue!";
+    }
     return clReleaseCommandQueue_;
   }
 
   clCreateProgramWithBinaryType clCreateProgramWithBinary() {
-    CHECK(clCreateProgramWithBinary_ != nullptr)
-        << "Cannot load clCreateProgramWithBinary!";
+    if (clCreateProgramWithBinary_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateProgramWithBinary!";
+    }
     return clCreateProgramWithBinary_;
   }
 
   clRetainContextType clRetainContext() {
-    CHECK(clRetainContext_ != nullptr) << "Cannot load clRetainContext!";
+    if (clRetainContext_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainContext!";
+    }
     return clRetainContext_;
   }
 
   clGetContextInfoType clGetContextInfo() {
-    CHECK(clGetContextInfo_ != nullptr) << "Cannot load clGetContextInfo!";
+    if (clGetContextInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetContextInfo!";
+    }
     return clGetContextInfo_;
   }
 
   clReleaseProgramType clReleaseProgram() {
-    CHECK(clReleaseProgram_ != nullptr) << "Cannot load clReleaseProgram!";
+    if (clReleaseProgram_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseProgram!";
+    }
     return clReleaseProgram_;
   }
 
   clFlushType clFlush() {
-    CHECK(clFlush_ != nullptr) << "Cannot load clFlush!";
+    if (clFlush_ == nullptr) {
+      LOG(ERROR) << "Cannot load clFlush!";
+    }
     return clFlush_;
   }
 
   clFinishType clFinish() {
-    CHECK(clFinish_ != nullptr) << "Cannot load clFinish!";
+    if (clFinish_ == nullptr) {
+      LOG(ERROR) << "Cannot load clFinish!";
+    }
     return clFinish_;
   }
 
   clGetProgramInfoType clGetProgramInfo() {
-    CHECK(clGetProgramInfo_ != nullptr) << "Cannot load clGetProgramInfo!";
+    if (clGetProgramInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetProgramInfo!";
+    }
     return clGetProgramInfo_;
   }
 
   clCreateKernelType clCreateKernel() {
-    CHECK(clCreateKernel_ != nullptr) << "Cannot load clCreateKernel!";
+    if (clCreateKernel_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateKernel!";
+    }
     return clCreateKernel_;
   }
 
   clRetainKernelType clRetainKernel() {
-    CHECK(clRetainKernel_ != nullptr) << "Cannot load clRetainKernel!";
+    if (clRetainKernel_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainKernel!";
+    }
     return clRetainKernel_;
   }
 
   clCreateBufferType clCreateBuffer() {
-    CHECK(clCreateBuffer_ != nullptr) << "Cannot load clCreateBuffer!";
+    if (clCreateBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateBuffer!";
+    }
     return clCreateBuffer_;
   }
 
   clCreateImage2DType clCreateImage2D() {
-    CHECK(clCreateImage2D_ != nullptr) << "Cannot load clCreateImage2D!";
+    if (clCreateImage2D_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateImage2D!";
+    }
     return clCreateImage2D_;
   }
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
 
   clCreateImageType clCreateImage() {
-    CHECK(clCreateImage_ != nullptr) << "Cannot load clCreateImage!";
+    if (clCreateImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateImage!";
+    }
     return clCreateImage_;
   }
 
 #endif
 
   clCreateUserEventType clCreateUserEvent() {
-    CHECK(clCreateUserEvent_ != nullptr) << "Cannot load clCreateUserEvent!";
+    if (clCreateUserEvent_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateUserEvent!";
+    }
     return clCreateUserEvent_;
   }
 
   clCreateProgramWithSourceType clCreateProgramWithSource() {
-    CHECK(clCreateProgramWithSource_ != nullptr)
-        << "Cannot load clCreateProgramWithSource!";
+    if (clCreateProgramWithSource_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateProgramWithSource!";
+    }
     return clCreateProgramWithSource_;
   }
 
   clReleaseKernelType clReleaseKernel() {
-    CHECK(clReleaseKernel_ != nullptr) << "Cannot load clReleaseKernel!";
+    if (clReleaseKernel_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseKernel!";
+    }
     return clReleaseKernel_;
   }
 
   clGetDeviceInfoType clGetDeviceInfo() {
-    CHECK(clGetDeviceInfo_ != nullptr) << "Cannot load clGetDeviceInfo!";
+    if (clGetDeviceInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetDeviceInfo!";
+    }
     return clGetDeviceInfo_;
   }
 
   clGetDeviceIDsType clGetDeviceIDs() {
-    CHECK(clGetDeviceIDs_ != nullptr) << "Cannot load clGetDeviceIDs!";
+    if (clGetDeviceIDs_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetDeviceIDs!";
+    }
     return clGetDeviceIDs_;
   }
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
 
   clRetainDeviceType clRetainDevice() {
-    CHECK(clRetainDevice_ != nullptr) << "Cannot load clRetainDevice!";
+    if (clRetainDevice_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainDevice!";
+    }
     return clRetainDevice_;
   }
 
   clReleaseDeviceType clReleaseDevice() {
-    CHECK(clReleaseDevice_ != nullptr) << "Cannot load clReleaseDevice!";
+    if (clReleaseDevice_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseDevice!";
+    }
     return clReleaseDevice_;
   }
 
 #endif
 
   clRetainEventType clRetainEvent() {
-    CHECK(clRetainEvent_ != nullptr) << "Cannot load clRetainEvent!";
+    if (clRetainEvent_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainEvent!";
+    }
     return clRetainEvent_;
   }
 
   clGetKernelWorkGroupInfoType clGetKernelWorkGroupInfo() {
-    CHECK(clGetKernelWorkGroupInfo_ != nullptr)
-        << "Cannot load clGetKernelWorkGroupInfo!";
+    if (clGetKernelWorkGroupInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetKernelWorkGroupInfo!";
+    }
     return clGetKernelWorkGroupInfo_;
   }
 
   clGetEventInfoType clGetEventInfo() {
-    CHECK(clGetEventInfo_ != nullptr) << "Cannot load clGetEventInfo!";
+    if (clGetEventInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetEventInfo!";
+    }
     return clGetEventInfo_;
   }
 
   clGetEventProfilingInfoType clGetEventProfilingInfo() {
-    CHECK(clGetEventProfilingInfo_ != nullptr)
-        << "Cannot load clGetEventProfilingInfo!";
+    if (clGetEventProfilingInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetEventProfilingInfo!";
+    }
     return clGetEventProfilingInfo_;
   }
 
   clGetImageInfoType clGetImageInfo() {
-    CHECK(clGetImageInfo_ != nullptr) << "Cannot load clGetImageInfo!";
+    if (clGetImageInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetImageInfo!";
+    }
     return clGetImageInfo_;
   }
 
   clGetMemObjectInfoType clGetMemObjectInfo() {
-    CHECK(clGetMemObjectInfo_ != nullptr) << "Cannot load clGetMemObjectInfo!";
+    if (clGetMemObjectInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetMemObjectInfo!";
+    }
     return clGetMemObjectInfo_;
   }
 
   clEnqueueCopyBufferType clEnqueueCopyBuffer() {
-    CHECK(clEnqueueCopyBuffer_ != nullptr)
-        << "Cannot load clEnqueueCopyBuffer!";
+    if (clEnqueueCopyBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueCopyBuffer!";
+    }
     return clEnqueueCopyBuffer_;
   }
 
   clEnqueueWriteImageType clEnqueueWriteImage() {
-    CHECK(clEnqueueWriteImage_ != nullptr)
-        << "Cannot load clEnqueueWriteImage!";
+    if (clEnqueueWriteImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueWriteImage!";
+    }
     return clEnqueueWriteImage_;
   }
 
   clEnqueueCopyImageType clEnqueueCopyImage() {
-    CHECK(clEnqueueCopyImage_ != nullptr) << "Cannot load clEnqueueCopyImage!";
+    if (clEnqueueCopyImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueCopyImage!";
+    }
     return clEnqueueCopyImage_;
   }
 
@@ -561,6 +650,7 @@ class CLWrapper final {
   bool InitHandle();
   bool InitFunctions();
   bool opencl_lib_found_{true};
+  bool is_first_init_{true};
   bool dlsym_success_{true};
   void *handle_{nullptr};
 


### PR DESCRIPTION
# 状态：等待review，照搬2.7的提交类似cherry-pick，https://github.com/PaddlePaddle/Paddle-Lite/pull/5311


## 主要内容

### 1. OpenCL初始化检查增强

修复APP环境获取不到libOpenCL.so（但adb shell情况下可以获取到）的情况下CHECK失败，导致arm cpu predictor挂掉的情况。

1. 增强检查：如若获取libopencl.so失败，该情况不做CHECK，改为直接return，避免直接abort挂掉；
2. 增强检查：如若获取符号失败，情况下不做CHECK，改为直接return，避免直接abort挂掉；
2. 增加检查：如若获取函数指针失败（获取符号阶段），情况下由CHECK改为LOG(ERROR)。

### 2. 其它修复

1. 不支持打印cl::Image2D，注释掉conv中对input/output/filter/bias的image2d打印。

## opencl初始化说明

opencl初始化涉及唯二的两个单例调用，**即使是ARM CPU也会不可避免执行**：

1. cl_wrapper：**这里CPU初始化会顺带执行**
    1. 寻找手机上的opencl库；
    2. 检查该opencl库里的符号是否完全。其中该类持有所有OPENCL C API的函数指针，检查过程会做检查找不到会给出提示；
2. cl_runtime::**Init这里CPU也会在初始化时候执行**：
    1. Init过程：检查cl_wrapper时的libFound，dlSymbol：失败则return false，不会挂掉；
    2. Init过程：初始化平台，失败return false；
    3. Init过程：初始化设备，失败return false；
    4. Init过程：初始化上下文，失败LOG(ERROR)，增强context()方法的LOG提示（gpu模型情况：若失败检查CreateContext会FATAL）；
    5. Init过程：初始化CommandQueue，失败LOG(ERROR)，增强command_queue()方法的LOG提示（gpu模型情况：若失败检查CreateComandQueue会FATAL）。
3. 关于IsOpenCLBackendValid：这里会先调用CLWrapper的`OpenclLibFound`和`DlsymSuccess`，然后是CLRuntime的`OpenCLAvaliableForDevice()`，这三个方法也都在上面1，2步骤里面；
4. 关于RuntimeProgram：先调用CLWrapper的`OpenclLibFound`和`DlsymSuccess`，然后是CLRuntime的`OpenCLAvaliableForDevice()`，这三个方法也都在上面1，2步骤里面，此外，会调用Context里的`class Context<TargetType::kOpenCL>`，其中的InitOnce方法只有`LOG(ERROR)`；
5. RuntimeAssignPass：无。


## RD自测验证

_release/2.7beta：

修复后，尝试：

限制手机上，cpu+gpu库，跑gpu模型，APP环境，会挂掉符合预期，若先走isOpenclBackendValid方法，可以规避。符合预期；
限制手机上，cpu+gpu库，跑cpu模型，APP环境，找不到库不会影响创建Predictor。符合预期；
正常手机上，cpu+gpu库，跑gpu模型，APP环境，正常；
正常手机上，cpu+gpu库，跑cpu模型，APP环境，正常。

特殊手机：金立、摩托罗拉。

- 金立，cpu+gpu库，gpu模型，is_opencl_valid(【不检查fp16】)，挂在Run，catch能抓到异常，但是APP也“很抱歉，lens已停止运行”；
- 金立，cpu+gpu库，gpu模型，is_opencl_valid(【检查fp16】)，挂在createPredictor创建，catch能抓到异常；
- 金立，cpu+gpu库，cpu模型，正常预测。

