### PR TITLE
[OpenCL][Kernel] Fix depthwise_conv2d_3x3 stride equal err

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
@@ -25,7 +25,8 @@ __kernel void depth_conv2d(__private const int global_size_dim0,
                            __read_only image2d_t new_biase,
 #endif
                            __write_only image2d_t output_image,
-                           __private const int stride,
+                           __private const int stride_h,
+                           __private const int stride_w,
                            __private const int offset,
                            __private const int input_c,
                            __private const int dilation,
@@ -45,7 +46,7 @@ __kernel void depth_conv2d(__private const int global_size_dim0,
   const int batch_index = out_nh / output_height;
   const int out_nh_in_one_batch = out_nh % output_height;
 
-  int2 stride_xy = (int2)(stride, stride);
+  int2 stride_xy = (int2)(stride_w, stride_h);
   int2 ouput_pos_in_one_block = (int2)(out_w, out_nh_in_one_batch);
   int2 in_pos_in_one_block =
       ouput_pos_in_one_block * stride_xy + (int2)(offset, offset);

--- a/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_kernel.cl
@@ -22,7 +22,8 @@ __kernel void depth_conv2d_3x3(
     __read_only image2d_t filter,
     __read_only image2d_t bias,
     __write_only image2d_t output_image,
-    __private const int stride,
+    __private const int stride_h,
+    __private const int stride_w,
     __private const int offset,
     __private const int dilation,
     __private const int input_c,
@@ -39,7 +40,7 @@ __kernel void depth_conv2d_3x3(
   const int batch_index = out_nh / output_height;
   const int out_nh_in_one_batch = out_nh % output_height;
 
-  int2 stride_xy = (int2)(stride, stride);
+  int2 stride_xy = (int2)(stride_w, stride_h);
   int2 ouput_pos_in_one_block = (int2)(out_w, out_nh_in_one_batch);
 
   int2 in_pos_in_one_block =

--- a/lite/core/mir/memory_optimize_pass.cc
+++ b/lite/core/mir/memory_optimize_pass.cc
@@ -74,7 +74,7 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
   auto insert_invalid_op_nodes_for_specific_target = [&](
       std::set<std::string> op_node_set, TargetType specific_target) {
     std::set<std::string> invalid_op_nodes_opencl = {
-        "layout", "fc", "yolo_box", "shape"};
+        "layout", "fc", "yolo_box", "shape", "slice"};
     for (auto& op_node : graph->StmtTopologicalOrder()) {
       if (!op_node->IsStmt()) continue;
       TargetType op_target_type = op_node->AsStmt().place().target;

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -119,8 +119,8 @@ void ConvImageCompute::PrepareForRun() {
   } else if (filter_tensor_c_ == 1 && input_tensor_c_ == output_tensor_c_ &&
              filter_tensor_h_ == 3 && filter_tensor_w_ == 3 && groups_ > 1) {
     // depth_conv2d_3x3s1, depth_conv2d_3x3
-    CHECK(pad_equal && stride_equal && dilation_equal);
-    if (stride_h_ == 1 && dilation_h_ == 1) {
+    CHECK(pad_equal && dilation_equal);
+    if (stride_equal && stride_h_ == 1 && dilation_h_ == 1) {
       kernel_func_names_.push_back("depth_conv2d_3x3s1");
       impl_ = &ConvImageCompute::DepthwiseConv2d3x3s1;
     } else {
@@ -148,7 +148,7 @@ void ConvImageCompute::PrepareForRun() {
 #undef DEPTH_CONV_USE_SPL
              ) {
     // depth_conv2d
-    CHECK(pad_equal && stride_equal && dilation_equal);
+    CHECK(pad_equal && dilation_equal);
     kernel_func_names_.push_back("depth_conv2d");
     kernel_func_paths_.push_back("image/depthwise_conv2d_basic_kernel.cl");
 
@@ -919,19 +919,21 @@ void ConvImageCompute::DepthwiseConv2d3x3() {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(7, stride_h_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(8, offset_);
+  status_ = kernel_.setArg(8, stride_w_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(9, dilation_h_);
+  status_ = kernel_.setArg(9, offset_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(10, input_c_block_);
+  status_ = kernel_.setArg(10, dilation_h_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(11, input_tensor_w_);
+  status_ = kernel_.setArg(11, input_c_block_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(12, input_tensor_h_);
+  status_ = kernel_.setArg(12, input_tensor_w_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(13, output_tensor_w_);
+  status_ = kernel_.setArg(13, input_tensor_h_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(14, output_tensor_h_);
+  status_ = kernel_.setArg(14, output_tensor_w_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(15, output_tensor_h_);
   CL_CHECK_FATAL(status_);
 }
 
@@ -953,23 +955,25 @@ void ConvImageCompute::DepthwiseConv2d() {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(7, stride_h_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(8, offset_);
+  status_ = kernel_.setArg(8, stride_w_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(9, input_c_block_);
+  status_ = kernel_.setArg(9, offset_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(10, dilation_h_);
+  status_ = kernel_.setArg(10, input_c_block_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(11, input_tensor_w_);
+  status_ = kernel_.setArg(11, dilation_h_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(12, input_tensor_h_);
+  status_ = kernel_.setArg(12, input_tensor_w_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(13, output_tensor_w_);
+  status_ = kernel_.setArg(13, input_tensor_h_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(14, output_tensor_h_);
+  status_ = kernel_.setArg(14, output_tensor_w_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(15, filter_tensor_w_);
+  status_ = kernel_.setArg(15, output_tensor_h_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(16, filter_tensor_h_);
+  status_ = kernel_.setArg(16, filter_tensor_w_);
+  CL_CHECK_FATAL(status_);
+  status_ = kernel_.setArg(17, filter_tensor_h_);
   CL_CHECK_FATAL(status_);
 }
 

--- a/lite/kernels/opencl/slice_buffer_compute.cc
+++ b/lite/kernels/opencl/slice_buffer_compute.cc
@@ -174,14 +174,6 @@ void SliceCompute<T, PType>::Run() {
   CL_CHECK_FATAL(status);
 }
 
-#ifdef LITE_WITH_PROFILE
-void SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
-  ch->kernel_func_name = kernel_func_name_;
-  ch->cl_event =
-      this->event_;  // `event_` defined in `kernel.h`, valid after kernel::Run
-}
-#endif
-
 }  // namespace opencl
 }  // namespace kernels
 }  // namespace lite

--- a/lite/kernels/opencl/slice_buffer_compute.cc
+++ b/lite/kernels/opencl/slice_buffer_compute.cc
@@ -66,113 +66,6 @@ void SliceCompute<T, PType>::PrepareForRun() {
   VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
   context.cl_context()->AddKernel(
       kernel_func_name_, "buffer/slice_kernel.cl", build_options_, time_stamp_);
-
-  auto in = param.X;
-  auto in_dims = in->dims();
-  auto out = param.Out;
-  auto out_dims = out->dims();
-
-  std::vector<int> axes = param.axes;
-  std::vector<int32_t> starts = param.starts;
-  std::vector<int32_t> ends = param.ends;
-  std::vector<int> decrease_axis = param.decrease_axis;
-  std::vector<int> infer_flags = param.infer_flags;
-
-  auto list_new_ends_tensor = param.EndsTensorList;
-  auto list_new_starts_tensor = param.StartsTensorList;
-
-  bool need_infer = false;
-  if (param.StartsTensor || param.EndsTensor) {
-    need_infer = true;
-  }
-  if (list_new_starts_tensor.size() > 0 || list_new_ends_tensor.size() > 0) {
-    need_infer = true;
-  }
-  if (need_infer) {
-    if (param.StartsTensor) {
-      starts = get_new_data_from_tensor(param.StartsTensor);
-    } else if (list_new_starts_tensor.size() > 0) {
-      starts = get_new_data_from_tensorlist(list_new_starts_tensor);
-    }
-    CHECK_EQ(starts.size(), axes.size())
-        << "The size of starts must be equal to the size of axes.";
-    if (param.EndsTensor) {
-      ends = get_new_data_from_tensor(param.EndsTensor);
-    } else if (list_new_ends_tensor.size() > 0) {
-      ends = get_new_data_from_tensorlist(list_new_ends_tensor);
-    }
-    CHECK_EQ(ends.size(), axes.size())
-        << "The size of ends must be equal to the size of axes.";
-    out_dims = in_dims;
-    int dim_value, start, end;
-    for (size_t i = 0; i < axes.size(); ++i) {
-      dim_value = out_dims[axes[i]];
-      if (dim_value > 0) {
-        // when end = start+1 and start == -1
-        if (starts[i] == -1 && ends[i] == 0 && infer_flags[i] == -1) {
-          auto ret =
-              std::find(decrease_axis.begin(), decrease_axis.end(), axes[i]);
-          if (ret != decrease_axis.end()) {
-            ends[i] = 10000000;
-          }
-        }
-
-        start = starts[i] < 0 ? (starts[i] + dim_value) : starts[i];
-        end = ends[i] < 0 ? (ends[i] + dim_value) : ends[i];
-        start = std::max(start, 0);
-        end = std::max(end, 0);
-        end = std::min(end, dim_value);
-        CHECK_GT(end, start) << "end should greater than start";
-        out_dims[axes[i]] = end - start;
-      }
-    }
-    out->Resize(out_dims);
-    // generate new shape
-    if (decrease_axis.size() > 0) {
-      std::vector<int64_t> new_out_shape;
-      for (size_t i = 0; i < decrease_axis.size(); ++i) {
-        CHECK_EQ(out_dims[decrease_axis[i]], 1) << "decrease dim should be 1";
-        out_dims[decrease_axis[i]] = 0;
-      }
-
-      for (int i = 0; i < out_dims.size(); ++i) {
-        if (out_dims[i] != 0) {
-          new_out_shape.push_back(out_dims[i]);
-        }
-      }
-      if (new_out_shape.size() == 0) {
-        new_out_shape.push_back(1);
-      }
-      DDim new_dims;
-      new_dims.ConstructFrom(new_out_shape);
-      out_dims = new_dims;
-    }
-  }
-
-  // resize out dims
-  if (decrease_axis.size() > 0) {
-    if (decrease_axis.size() == static_cast<size_t>(in_dims.size())) {
-      std::vector<int64_t> vec_origin_out_shape(decrease_axis.size(), 1);
-      out->Resize(DDim(vec_origin_out_shape));
-    } else {
-      std::vector<int64_t> vec_origin_out_shape(
-          out_dims.size() + decrease_axis.size(), -1);
-
-      for (size_t i = 0; i < decrease_axis.size(); ++i) {
-        vec_origin_out_shape[decrease_axis[i]] = 1;
-      }
-
-      int index = 0;
-      for (size_t i = 0; i < vec_origin_out_shape.size(); ++i) {
-        if (vec_origin_out_shape[i] == -1) {
-          vec_origin_out_shape[i] = out_dims[index];
-          ++index;
-        }
-      }
-
-      out->Resize(DDim(vec_origin_out_shape));
-    }
-  }
 }
 
 template <typename T, PrecisionType PType>
@@ -256,7 +149,6 @@ void SliceCompute<T, PType>::Run() {
   cl_int status;
   int arg_idx = 0;
   auto kernel = kernel_;
-  CHECK(src_step_buf_ != nullptr);
   status = kernel.setArg(arg_idx++, *x_buf);
   CL_CHECK_FATAL(status);
   status = kernel.setArg(arg_idx++, *out_buf);

--- a/lite/kernels/opencl/slice_buffer_compute.h
+++ b/lite/kernels/opencl/slice_buffer_compute.h
@@ -43,6 +43,14 @@ class SliceCompute
     TargetWrapperCL::Free(real_starts_buf_);
   }
 
+#ifdef LITE_WITH_PROFILE
+  void SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
+    ch->kernel_func_name = kernel_func_name_;
+    ch->cl_event = this->event_;  // `event_` defined in `kernel.h`, valid after
+                                  // kernel::Run
+  }
+#endif
+
  protected:
   param_t* slice_param_{nullptr};
   bool first_epoch_for_reinit_{true};

--- a/lite/operators/slice_op.h
+++ b/lite/operators/slice_op.h
@@ -38,6 +38,21 @@ class SliceOp : public OpLite {
 
   std::string DebugString() const override { return "slice"; }
 
+#ifdef LITE_WITH_PROFILE
+  void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
+    auto input_dims = param_.X->dims();
+    auto output_dims = param_.Out->dims();
+    ch->input_shape = ch->DimToStr(input_dims);
+    ch->output_shape = ch->DimToStr(output_dims);
+    std::string axes = "";
+    for (size_t i = 0; i < param_.axes.size(); ++i) {
+      axes += std::to_string(param_.axes[i]);
+      if (i != param_.axes.size() - 1) axes += "/";
+    }
+    ch->remark = "axes" + axes;
+  }
+#endif
+
  private:
   mutable SliceParam param_;
 };


### PR DESCRIPTION
支持 PaddleOCR_2.0/angleCls/ch_ppocr_mobile_v2.0_cls_infer 模型：该模型中有 2 个 shape -> slice 结构。

1. 支持 stride_w 不等于 stride_h 时的 depthwise_conv2d_3x3
2. 删除 slice buffer 中的冗余代码
3. 修复开启 profile 后 slice 编译报错问题

TODO: 当前 cl::Image 与 cl::Buffer 间不进行内存复用，是通过将 cl::Buffer 的 tensor 不参与内存复用实现的；后续需让其参与到内存复用中。