### PR TITLE
[cherry-pick2.8][OPENCL] Enhance OpenCL intialization check, AutoTune, etc. test=develop

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -266,11 +266,12 @@ ConfigBase::ConfigBase(PowerMode mode, int threads) {
 #endif
 }
 
-void ConfigBase::set_opencl_tune(CLTuneMode tune_mode) {
+void ConfigBase::set_opencl_tune(CLTuneMode tune_mode, size_t lws_repeats) {
 #ifdef LITE_WITH_OPENCL
   if (paddle::lite_api::IsOpenCLBackendValid()) {
     opencl_tune_mode_ = tune_mode;
-    paddle::lite::CLRuntime::Global()->set_auto_tune(opencl_tune_mode_);
+    paddle::lite::CLRuntime::Global()->set_auto_tune(opencl_tune_mode_,
+                                                     lws_repeats);
 #ifdef LITE_WITH_LOG
     LOG(INFO) << "opencl_tune_mode:"
               << static_cast<size_t>(

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -163,7 +163,8 @@ class LITE_API ConfigBase {
   void set_power_mode(PowerMode mode);
   PowerMode power_mode() const { return mode_; }
   // set GPU opencl tune
-  void set_opencl_tune(CLTuneMode tune_mode = CL_TUNE_NONE);
+  void set_opencl_tune(CLTuneMode tune_mode = CL_TUNE_NONE,
+                       size_t lws_repeats = 4);
   // set GPU opencl precision
   void set_opencl_precision(CLPrecisionType p = CL_PRECISION_AUTO);
   // set subgraph_model_dir

--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -121,6 +121,20 @@ inline CL_DTYPE activation(CL_DTYPE in
       (CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, (ushort)(isgreaterequal(in, 0)));
 #endif
 #endif
+
+#ifdef HARD_SWISH
+  output = fmin(fmax(in + (CL_DTYPE)ACT_OFFSET, (CL_DTYPE)0),
+                (CL_DTYPE)ACT_THRESHOLD) *
+           in / (CL_DTYPE)ACT_SCALE;
+#endif
+
+#ifdef HARD_SIGMOID
+  output =
+      clamp(in * (CL_DTYPE)HARD_SIGMOID_SLOPE + (CL_DTYPE)HARD_SIGMOID_OFFSET,
+            (CL_DTYPE)0.0,
+            (CL_DTYPE)1.0);
+#endif
+
   return output;
 }
 
@@ -152,6 +166,19 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
 //                 in,
 //                 (ushort4)((in.x >= 0) << 15, (in.y >= 0) << 15, (in.z >= 0)
 //                 << 15, (in.w >= 0) << 15));
+#endif
+
+#ifdef HARD_SWISH
+  output = fmin(fmax(in + (CL_DTYPE4)ACT_OFFSET, (CL_DTYPE4)0),
+                (CL_DTYPE4)ACT_THRESHOLD) *
+           in / (CL_DTYPE4)ACT_SCALE;
+#endif
+
+#ifdef HARD_SIGMOID
+  output =
+      clamp(in * (CL_DTYPE4)HARD_SIGMOID_SLOPE + (CL_DTYPE4)HARD_SIGMOID_OFFSET,
+            (CL_DTYPE4)0.0,
+            (CL_DTYPE4)1.0);
 #endif
 
   return output;

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -104,7 +104,8 @@ cl::Platform& CLRuntime::platform() {
 
 cl::Context& CLRuntime::context() {
   if (context_ == nullptr) {
-    LOG(FATAL) << "context_ create failed. ";
+    LOG(FATAL) << "context_ create failed, check whether context create "
+                  "successfully in CreateContext!";
   }
   return *context_;
 }
@@ -118,7 +119,8 @@ cl::Device& CLRuntime::device() {
 
 cl::CommandQueue& CLRuntime::command_queue() {
   if (command_queue_ == nullptr) {
-    LOG(FATAL) << "command_queue_ create failed. ";
+    LOG(FATAL) << "command_queue_ create failed, check whether command queue "
+                  "create successfully in CreateCommandQueue!";
   }
   return *command_queue_;
 }
@@ -180,7 +182,7 @@ bool CLRuntime::InitializePlatform() {
   // has return status do not exit here when release
   CL_CHECK_ERROR(status_);
   if (all_platforms.empty()) {
-    LOG(FATAL) << "No OpenCL platform found!";
+    LOG(ERROR) << "No OpenCL platform found!";
     return false;
   }
   platform_ = std::make_shared<cl::Platform>();
@@ -213,10 +215,12 @@ GpuType CLRuntime::ParseGpuTypeFromDeviceName(std::string device_name) {
 }
 
 bool CLRuntime::InitializeDevice() {
+#ifdef LITE_WITH_LOG
   VLOG(3) << "device_info_.size():" << device_info_.size();
   for (auto i : device_info_) {
     VLOG(3) << ">>> " << i.first << " " << i.second;
   }
+#endif
   // initialized without valid opencl device
   if (device_info_.size() > 0 && device_info_.size() <= 2) {
     return false;
@@ -357,19 +361,19 @@ bool CLRuntime::InitializeDevice() {
   if (image_support) {
     LOG(INFO) << "The chosen device supports image processing.";
     device_info_["CL_DEVICE_IMAGE_SUPPORT"] = 1;
+
+    auto image2d_max_height = device_->getInfo<CL_DEVICE_IMAGE2D_MAX_HEIGHT>();
+    LOG(INFO) << "CL_DEVICE_IMAGE2D_MAX_HEIGHT:" << image2d_max_height;
+    device_info_["CL_DEVICE_IMAGE2D_MAX_HEIGHT"] = image2d_max_height;
+
+    auto image2d_max_width = device_->getInfo<CL_DEVICE_IMAGE2D_MAX_WIDTH>();
+    LOG(INFO) << "CL_DEVICE_IMAGE2D_MAX_WIDTH:" << image2d_max_width;
+    device_info_["CL_DEVICE_IMAGE2D_MAX_WIDTH"] = image2d_max_width;
   } else {
-    LOG(INFO) << "The chosen device doesn't support image processing!";
+    LOG(ERROR) << "The chosen device doesn't support image processing!";
     device_info_["CL_DEVICE_IMAGE_SUPPORT"] = 0;
     return false;
   }
-
-  auto image2d_max_height = device_->getInfo<CL_DEVICE_IMAGE2D_MAX_HEIGHT>();
-  LOG(INFO) << "CL_DEVICE_IMAGE2D_MAX_HEIGHT:" << image2d_max_height;
-  device_info_["CL_DEVICE_IMAGE2D_MAX_HEIGHT"] = image2d_max_height;
-
-  auto image2d_max_width = device_->getInfo<CL_DEVICE_IMAGE2D_MAX_WIDTH>();
-  LOG(INFO) << "CL_DEVICE_IMAGE2D_MAX_WIDTH:" << image2d_max_width;
-  device_info_["CL_DEVICE_IMAGE2D_MAX_WIDTH"] = image2d_max_width;
 
   // ===================== OTHERS / EXTENSION / VERSION =====================
   // CL_DEVICE_EXTENSIONS
@@ -405,7 +409,10 @@ void CLRuntime::GetAdrenoContextProperties(
     std::vector<cl_context_properties>* properties,
     GPUPerfMode gpu_perf_mode,
     GPUPriorityLevel gpu_priority_level) {
-  CHECK(properties) << "cl_context_properties is nullptr";
+  if (properties == nullptr) {
+    LOG(ERROR) << "cl_context_properties is nullptr";
+    return;
+  }
   properties->reserve(5);
   switch (gpu_perf_mode) {
     case GPUPerfMode::PERF_LOW:

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -86,7 +86,11 @@ class CLRuntime {
                  << paddle::lite::CLWrapper::Global()->DlsymSuccess();
       return false;
     }
-
+    // for sepcial case: gionee M6, with invalid opencl device type
+    if (device_info_.count("CL_DEVICE_TYPE") == 0) {
+      LOG(ERROR) << "Invalid opencl device, CL_DEVICE_TYPE is None.";
+      return false;
+    }
     bool support_fp16 = support_half();
     is_device_avaliable_for_opencl_ =
         check_fp16_valid ? support_fp16 : is_device_avaliable_for_opencl_;

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -78,6 +78,14 @@ class CLRuntime {
     // note(ysh329): entered this func means:
     //  1. opencl_lib_found must be true
     //  2. dlsym_success must be true
+    if (!paddle::lite::CLWrapper::Global()->OpenclLibFound() ||
+        !paddle::lite::CLWrapper::Global()->DlsymSuccess()) {
+      LOG(ERROR) << "Invalid opencl device, OpenclLibFound:"
+                 << paddle::lite::CLWrapper::Global()->OpenclLibFound()
+                 << ", DlsymSuccess:"
+                 << paddle::lite::CLWrapper::Global()->DlsymSuccess();
+      return false;
+    }
 
     bool support_fp16 = support_half();
     is_device_avaliable_for_opencl_ =
@@ -180,7 +188,7 @@ class CLRuntime {
                                       nullptr,
                                       &status_);
     // use in is opencl valid check, do not exit here when release.
-    CL_CHECK_FATAL(status_);
+    CL_CHECK_ERROR(status_);
     return context;
   }
 
@@ -198,7 +206,7 @@ class CLRuntime {
     auto queue = std::make_shared<cl::CommandQueue>(
         context, device(), properties, &status_);
     // use in is opencl valid check, do not exit here when release.
-    CL_CHECK_FATAL(status_);
+    CL_CHECK_ERROR(status_);
     return queue;
   }
 

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -85,12 +85,15 @@ class CLRuntime {
     return is_device_avaliable_for_opencl_;
   }
 
-  void set_auto_tune(lite_api::CLTuneMode tune_mode) {
+  void set_auto_tune(lite_api::CLTuneMode tune_mode, size_t lws_repeats = 4) {
     auto_tune_ = tune_mode;
+    lws_repeats_ = lws_repeats;
     command_queue_ = CreateCommandQueue(context());
   }
 
   lite_api::CLTuneMode auto_tune() { return auto_tune_; }
+
+  size_t lws_repeats() { return lws_repeats_; }
 
   void set_precision(
       lite_api::CLPrecisionType p = lite_api::CL_PRECISION_AUTO) {
@@ -227,6 +230,7 @@ class CLRuntime {
                                                             // Rapid, 2 -
                                                             // Normal, 3 -
                                                             // Exhaustive
+  size_t lws_repeats_{0};
 
   lite_api::CLPrecisionType precision_{
       lite_api::CL_PRECISION_AUTO};  // 0 - AUTO, 1 - fp32, 2 - fp16

--- a/lite/backends/opencl/cl_wrapper.cc
+++ b/lite/backends/opencl/cl_wrapper.cc
@@ -31,8 +31,17 @@ CLWrapper *CLWrapper::Global() {
 }
 
 CLWrapper::CLWrapper() {
+  if (!is_first_init_ && !opencl_lib_found_) {
+    LOG(INFO) << "This isn't first init for CLWrapper, opencl library not "
+                 "found previously";
+    return;
+  }
   opencl_lib_found_ = InitHandle();
-  CHECK(opencl_lib_found_) << "Fail to initialize the OpenCL library!";
+  if (!opencl_lib_found_) {
+    LOG(INFO) << "Failed to find and initialize Opencl library";
+    return;
+  }
+  is_first_init_ = false;
   dlsym_success_ = InitFunctions();
 }
 
@@ -91,7 +100,10 @@ bool CLWrapper::InitHandle() {
 }
 
 bool CLWrapper::InitFunctions() {
-  CHECK(handle_ != nullptr) << "The library handle can't be null!";
+  if (handle_ == nullptr) {
+    LOG(ERROR) << "The library handle can't be null!";
+    return false;
+  }
   bool dlsym_success = true;
 
 #define PADDLE_DLSYM(cl_func)                                        \

--- a/lite/backends/opencl/cl_wrapper.h
+++ b/lite/backends/opencl/cl_wrapper.h
@@ -257,296 +257,385 @@ class CLWrapper final {
                                             cl_event *);
 
   clGetPlatformIDsType clGetPlatformIDs() {
-    CHECK(clGetPlatformIDs_ != nullptr) << "Cannot load clGetPlatformIDs!";
+    if (clGetPlatformIDs_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetPlatformIDs!";
+    }
     return clGetPlatformIDs_;
   }
 
   clGetPlatformInfoType clGetPlatformInfo() {
-    CHECK(clGetPlatformInfo_ != nullptr) << "Cannot load clGetPlatformInfo!";
+    if (clGetPlatformInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetPlatformInfo!";
+    }
     return clGetPlatformInfo_;
   }
 
   clBuildProgramType clBuildProgram() {
-    CHECK(clBuildProgram_ != nullptr) << "Cannot load clBuildProgram!";
+    if (clBuildProgram_ == nullptr) {
+      LOG(ERROR) << "Cannot load clBuildProgram!";
+    }
     return clBuildProgram_;
   }
 
   clEnqueueNDRangeKernelType clEnqueueNDRangeKernel() {
-    CHECK(clEnqueueNDRangeKernel_ != nullptr)
-        << "Cannot load clEnqueueNDRangeKernel!";
+    if (clEnqueueNDRangeKernel_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueNDRangeKernel!";
+    }
     return clEnqueueNDRangeKernel_;
   }
 
   clSetKernelArgType clSetKernelArg() {
-    CHECK(clSetKernelArg_ != nullptr) << "Cannot load clSetKernelArg!";
+    if (clSetKernelArg_ == nullptr) {
+      LOG(ERROR) << "Cannot load clSetKernelArg!";
+    }
     return clSetKernelArg_;
   }
 
   clRetainMemObjectType clRetainMemObject() {
-    CHECK(clRetainMemObject_ != nullptr) << "Cannot load clRetainMemObject!";
+    if (clRetainMemObject_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainMemObject!";
+    }
     return clRetainMemObject_;
   }
 
   clReleaseMemObjectType clReleaseMemObject() {
-    CHECK(clReleaseMemObject_ != nullptr) << "Cannot load clReleaseMemObject!";
+    if (clReleaseMemObject_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseMemObject!";
+    }
     return clReleaseMemObject_;
   }
 
   clEnqueueUnmapMemObjectType clEnqueueUnmapMemObject() {
-    CHECK(clEnqueueUnmapMemObject_ != nullptr)
-        << "Cannot load clEnqueueUnmapMemObject!";
+    if (clEnqueueUnmapMemObject_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueUnmapMemObject!";
+    }
     return clEnqueueUnmapMemObject_;
   }
 
   clRetainCommandQueueType clRetainCommandQueue() {
-    CHECK(clRetainCommandQueue_ != nullptr)
-        << "Cannot load clRetainCommandQueue!";
+    if (clRetainCommandQueue_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainCommandQueue!";
+    }
     return clRetainCommandQueue_;
   }
 
   clCreateContextType clCreateContext() {
-    CHECK(clCreateContext_ != nullptr) << "Cannot load clCreateContext!";
+    if (clCreateContext_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateContext!";
+    }
     return clCreateContext_;
   }
 
   clCreateContextFromTypeType clCreateContextFromType() {
-    CHECK(clCreateContextFromType_ != nullptr)
-        << "Cannot load clCreateContextFromType!";
+    if (clCreateContextFromType_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateContextFromType!";
+    }
     return clCreateContextFromType_;
   }
 
   clReleaseContextType clReleaseContext() {
-    CHECK(clReleaseContext_ != nullptr) << "Cannot load clReleaseContext!";
+    if (clReleaseContext_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseContext!";
+    }
     return clReleaseContext_;
   }
 
   clWaitForEventsType clWaitForEvents() {
-    CHECK(clWaitForEvents_ != nullptr) << "Cannot load clWaitForEvents!";
+    if (clWaitForEvents_ == nullptr) {
+      LOG(ERROR) << "Cannot load clWaitForEvents!";
+    }
     return clWaitForEvents_;
   }
 
   clReleaseEventType clReleaseEvent() {
-    CHECK(clReleaseEvent_ != nullptr) << "Cannot load clReleaseEvent!";
+    if (clReleaseEvent_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseEvent!";
+    }
     return clReleaseEvent_;
   }
 
   clEnqueueWriteBufferType clEnqueueWriteBuffer() {
-    CHECK(clEnqueueWriteBuffer_ != nullptr)
-        << "Cannot loadcl clEnqueueWriteBuffer!";
+    if (clEnqueueWriteBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot loadcl clEnqueueWriteBuffer!";
+    }
     return clEnqueueWriteBuffer_;
   }
 
   clEnqueueReadBufferType clEnqueueReadBuffer() {
-    CHECK(clEnqueueReadBuffer_ != nullptr)
-        << "Cannot load clEnqueueReadBuffer!";
+    if (clEnqueueReadBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueReadBuffer!";
+    }
     return clEnqueueReadBuffer_;
   }
 
   clEnqueueReadImageType clEnqueueReadImage() {
-    CHECK(clEnqueueReadImage_ != nullptr) << "Cannot load clEnqueueReadImage!";
+    if (clEnqueueReadImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueReadImage!";
+    }
     return clEnqueueReadImage_;
   }
 
   clGetProgramBuildInfoType clGetProgramBuildInfo() {
-    CHECK(clGetProgramBuildInfo_ != nullptr)
-        << "Cannot load clGetProgramBuildInfo!";
+    if (clGetProgramBuildInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetProgramBuildInfo!";
+    }
     return clGetProgramBuildInfo_;
   }
 
   clRetainProgramType clRetainProgram() {
-    CHECK(clRetainProgram_ != nullptr) << "Cannot load clRetainProgram!";
+    if (clRetainProgram_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainProgram!";
+    }
     return clRetainProgram_;
   }
 
   clEnqueueMapBufferType clEnqueueMapBuffer() {
-    CHECK(clEnqueueMapBuffer_ != nullptr) << "Cannot load clEnqueueMapBuffer!";
+    if (clEnqueueMapBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueMapBuffer!";
+    }
     return clEnqueueMapBuffer_;
   }
 
   clEnqueueMapImageType clEnqueueMapImage() {
-    CHECK(clEnqueueMapImage_ != nullptr) << "Cannot load clEnqueueMapImage!";
+    if (clEnqueueMapImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueMapImage!";
+    }
     return clEnqueueMapImage_;
   }
 
   clCreateCommandQueueType clCreateCommandQueue() {
-    CHECK(clCreateCommandQueue_ != nullptr)
-        << "Cannot load clCreateCommandQueue!";
+    if (clCreateCommandQueue_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateCommandQueue!";
+    }
     return clCreateCommandQueue_;
   }
 
   clGetCommandQueueInfoType clGetCommandQueueInfo() {
-    CHECK(clGetCommandQueueInfo_ != nullptr)
-        << "Cannot load clGetCommandQueueInfo!";
+    if (clGetCommandQueueInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetCommandQueueInfo!";
+    }
     return clGetCommandQueueInfo_;
   }
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 200
 
   clCreateCommandQueueWithPropertiesType clCreateCommandQueueWithProperties() {
-    CHECK(clCreateCommandQueueWithProperties_ != nullptr)
-        << "Cannot load clCreateCommandQueueWithProperties!";
+    if (clCreateCommandQueueWithProperties_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateCommandQueueWithProperties!";
+    }
     return clCreateCommandQueueWithProperties_;
   }
 
 #endif
 
   clReleaseCommandQueueType clReleaseCommandQueue() {
-    CHECK(clReleaseCommandQueue_ != nullptr)
-        << "Cannot load clReleaseCommandQueue!";
+    if (clReleaseCommandQueue_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseCommandQueue!";
+    }
     return clReleaseCommandQueue_;
   }
 
   clCreateProgramWithBinaryType clCreateProgramWithBinary() {
-    CHECK(clCreateProgramWithBinary_ != nullptr)
-        << "Cannot load clCreateProgramWithBinary!";
+    if (clCreateProgramWithBinary_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateProgramWithBinary!";
+    }
     return clCreateProgramWithBinary_;
   }
 
   clRetainContextType clRetainContext() {
-    CHECK(clRetainContext_ != nullptr) << "Cannot load clRetainContext!";
+    if (clRetainContext_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainContext!";
+    }
     return clRetainContext_;
   }
 
   clGetContextInfoType clGetContextInfo() {
-    CHECK(clGetContextInfo_ != nullptr) << "Cannot load clGetContextInfo!";
+    if (clGetContextInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetContextInfo!";
+    }
     return clGetContextInfo_;
   }
 
   clReleaseProgramType clReleaseProgram() {
-    CHECK(clReleaseProgram_ != nullptr) << "Cannot load clReleaseProgram!";
+    if (clReleaseProgram_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseProgram!";
+    }
     return clReleaseProgram_;
   }
 
   clFlushType clFlush() {
-    CHECK(clFlush_ != nullptr) << "Cannot load clFlush!";
+    if (clFlush_ == nullptr) {
+      LOG(ERROR) << "Cannot load clFlush!";
+    }
     return clFlush_;
   }
 
   clFinishType clFinish() {
-    CHECK(clFinish_ != nullptr) << "Cannot load clFinish!";
+    if (clFinish_ == nullptr) {
+      LOG(ERROR) << "Cannot load clFinish!";
+    }
     return clFinish_;
   }
 
   clGetProgramInfoType clGetProgramInfo() {
-    CHECK(clGetProgramInfo_ != nullptr) << "Cannot load clGetProgramInfo!";
+    if (clGetProgramInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetProgramInfo!";
+    }
     return clGetProgramInfo_;
   }
 
   clCreateKernelType clCreateKernel() {
-    CHECK(clCreateKernel_ != nullptr) << "Cannot load clCreateKernel!";
+    if (clCreateKernel_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateKernel!";
+    }
     return clCreateKernel_;
   }
 
   clRetainKernelType clRetainKernel() {
-    CHECK(clRetainKernel_ != nullptr) << "Cannot load clRetainKernel!";
+    if (clRetainKernel_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainKernel!";
+    }
     return clRetainKernel_;
   }
 
   clCreateBufferType clCreateBuffer() {
-    CHECK(clCreateBuffer_ != nullptr) << "Cannot load clCreateBuffer!";
+    if (clCreateBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateBuffer!";
+    }
     return clCreateBuffer_;
   }
 
   clCreateImage2DType clCreateImage2D() {
-    CHECK(clCreateImage2D_ != nullptr) << "Cannot load clCreateImage2D!";
+    if (clCreateImage2D_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateImage2D!";
+    }
     return clCreateImage2D_;
   }
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
 
   clCreateImageType clCreateImage() {
-    CHECK(clCreateImage_ != nullptr) << "Cannot load clCreateImage!";
+    if (clCreateImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateImage!";
+    }
     return clCreateImage_;
   }
 
 #endif
 
   clCreateUserEventType clCreateUserEvent() {
-    CHECK(clCreateUserEvent_ != nullptr) << "Cannot load clCreateUserEvent!";
+    if (clCreateUserEvent_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateUserEvent!";
+    }
     return clCreateUserEvent_;
   }
 
   clCreateProgramWithSourceType clCreateProgramWithSource() {
-    CHECK(clCreateProgramWithSource_ != nullptr)
-        << "Cannot load clCreateProgramWithSource!";
+    if (clCreateProgramWithSource_ == nullptr) {
+      LOG(ERROR) << "Cannot load clCreateProgramWithSource!";
+    }
     return clCreateProgramWithSource_;
   }
 
   clReleaseKernelType clReleaseKernel() {
-    CHECK(clReleaseKernel_ != nullptr) << "Cannot load clReleaseKernel!";
+    if (clReleaseKernel_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseKernel!";
+    }
     return clReleaseKernel_;
   }
 
   clGetDeviceInfoType clGetDeviceInfo() {
-    CHECK(clGetDeviceInfo_ != nullptr) << "Cannot load clGetDeviceInfo!";
+    if (clGetDeviceInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetDeviceInfo!";
+    }
     return clGetDeviceInfo_;
   }
 
   clGetDeviceIDsType clGetDeviceIDs() {
-    CHECK(clGetDeviceIDs_ != nullptr) << "Cannot load clGetDeviceIDs!";
+    if (clGetDeviceIDs_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetDeviceIDs!";
+    }
     return clGetDeviceIDs_;
   }
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
 
   clRetainDeviceType clRetainDevice() {
-    CHECK(clRetainDevice_ != nullptr) << "Cannot load clRetainDevice!";
+    if (clRetainDevice_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainDevice!";
+    }
     return clRetainDevice_;
   }
 
   clReleaseDeviceType clReleaseDevice() {
-    CHECK(clReleaseDevice_ != nullptr) << "Cannot load clReleaseDevice!";
+    if (clReleaseDevice_ == nullptr) {
+      LOG(ERROR) << "Cannot load clReleaseDevice!";
+    }
     return clReleaseDevice_;
   }
 
 #endif
 
   clRetainEventType clRetainEvent() {
-    CHECK(clRetainEvent_ != nullptr) << "Cannot load clRetainEvent!";
+    if (clRetainEvent_ == nullptr) {
+      LOG(ERROR) << "Cannot load clRetainEvent!";
+    }
     return clRetainEvent_;
   }
 
   clGetKernelWorkGroupInfoType clGetKernelWorkGroupInfo() {
-    CHECK(clGetKernelWorkGroupInfo_ != nullptr)
-        << "Cannot load clGetKernelWorkGroupInfo!";
+    if (clGetKernelWorkGroupInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetKernelWorkGroupInfo!";
+    }
     return clGetKernelWorkGroupInfo_;
   }
 
   clGetEventInfoType clGetEventInfo() {
-    CHECK(clGetEventInfo_ != nullptr) << "Cannot load clGetEventInfo!";
+    if (clGetEventInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetEventInfo!";
+    }
     return clGetEventInfo_;
   }
 
   clGetEventProfilingInfoType clGetEventProfilingInfo() {
-    CHECK(clGetEventProfilingInfo_ != nullptr)
-        << "Cannot load clGetEventProfilingInfo!";
+    if (clGetEventProfilingInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetEventProfilingInfo!";
+    }
     return clGetEventProfilingInfo_;
   }
 
   clGetImageInfoType clGetImageInfo() {
-    CHECK(clGetImageInfo_ != nullptr) << "Cannot load clGetImageInfo!";
+    if (clGetImageInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetImageInfo!";
+    }
     return clGetImageInfo_;
   }
 
   clGetMemObjectInfoType clGetMemObjectInfo() {
-    CHECK(clGetMemObjectInfo_ != nullptr) << "Cannot load clGetMemObjectInfo!";
+    if (clGetMemObjectInfo_ == nullptr) {
+      LOG(ERROR) << "Cannot load clGetMemObjectInfo!";
+    }
     return clGetMemObjectInfo_;
   }
 
   clEnqueueCopyBufferType clEnqueueCopyBuffer() {
-    CHECK(clEnqueueCopyBuffer_ != nullptr)
-        << "Cannot load clEnqueueCopyBuffer!";
+    if (clEnqueueCopyBuffer_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueCopyBuffer!";
+    }
     return clEnqueueCopyBuffer_;
   }
 
   clEnqueueWriteImageType clEnqueueWriteImage() {
-    CHECK(clEnqueueWriteImage_ != nullptr)
-        << "Cannot load clEnqueueWriteImage!";
+    if (clEnqueueWriteImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueWriteImage!";
+    }
     return clEnqueueWriteImage_;
   }
 
   clEnqueueCopyImageType clEnqueueCopyImage() {
-    CHECK(clEnqueueCopyImage_ != nullptr) << "Cannot load clEnqueueCopyImage!";
+    if (clEnqueueCopyImage_ == nullptr) {
+      LOG(ERROR) << "Cannot load clEnqueueCopyImage!";
+    }
     return clEnqueueCopyImage_;
   }
 
@@ -561,6 +650,7 @@ class CLWrapper final {
   bool InitHandle();
   bool InitFunctions();
   bool opencl_lib_found_{true};
+  bool is_first_init_{true};
   bool dlsym_success_{true};
   void *handle_{nullptr};
 

--- a/lite/core/mir/fusion/conv_activation_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_activation_fuse_pass.cc
@@ -47,6 +47,12 @@ void ConvActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
     act_types.push_back("relu6");
     act_types.push_back("leaky_relu");
   }
+  if (has_opencl) {
+    act_types.push_back("relu6");
+    act_types.push_back("leaky_relu");
+    act_types.push_back("hard_swish");
+    act_types.push_back("hard_sigmoid");
+  }
   if (!has_int8 && has_cuda) {
     act_types.push_back("leaky_relu");
   }

--- a/lite/core/mir/fusion/conv_activation_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_activation_fuse_pass.cc
@@ -26,6 +26,7 @@ void ConvActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   std::vector<std::string> act_types{"relu"};
   bool has_int8 = false;
   bool has_arm = false;
+  bool has_opencl = false;
   bool has_cuda = false;
   bool has_x86 = false;
   for (auto& place : graph->valid_places()) {
@@ -34,6 +35,9 @@ void ConvActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
     }
     if (place.target == TARGET(kARM)) {
       has_arm = true;
+    }
+    if (place.target == TARGET(kOpenCL)) {
+      has_opencl = true;
     }
     if (place.target == TARGET(kCUDA)) {
       has_cuda = true;

--- a/lite/core/mir/fusion/conv_activation_fuser.cc
+++ b/lite/core/mir/fusion/conv_activation_fuser.cc
@@ -85,6 +85,18 @@ cpp::OpDesc ConvActivationFuser::GenOpDesc(const key2nodes_t& matched) {
   } else if (act_type_ == "leaky_relu") {
     float alpha = act_op_desc.GetAttr<float>("alpha");
     op_desc.SetAttr("leaky_relu_alpha", alpha);
+  } else if (act_type_ == "hard_swish") {
+    float threshold = act_op_desc.GetAttr<float>("threshold");
+    float scale = act_op_desc.GetAttr<float>("scale");
+    float offset = act_op_desc.GetAttr<float>("offset");
+    op_desc.SetAttr("hard_swish_threshold", threshold);
+    op_desc.SetAttr("hard_swish_scale", scale);
+    op_desc.SetAttr("hard_swish_offset", offset);
+  } else if (act_type_ == "hard_sigmoid") {
+    float slope = act_op_desc.GetAttr<float>("slope");
+    float offset = act_op_desc.GetAttr<float>("offset");
+    op_desc.SetAttr("slope", slope);
+    op_desc.SetAttr("offset", offset);
   }
   return op_desc;
 }

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -316,6 +316,25 @@ void ConvImageCompute::PrepareForRun() {
           std::to_string(conv_param_->activation_param.Leaky_relu_alpha);
       build_options_single +=
           " -DLEAKY_RELU -DLEAKY_RELU_ALPHA=" + leaky_relu_alpha_str + "f";
+    } else if (conv_param_->activation_param.active_type ==
+               lite_api::ActivationType::kHardSwish) {
+      std::string threshold =
+          std::to_string(conv_param_->activation_param.hard_swish_threshold);
+      std::string scale =
+          std::to_string(conv_param_->activation_param.hard_swish_scale);
+      std::string offset =
+          std::to_string(conv_param_->activation_param.hard_swish_offset);
+      build_options_single += " -DHARD_SWISH -DACT_THRESHOLD=" + threshold +
+                              "f" + " -DACT_SCALE=" + scale + "f" +
+                              " -DACT_OFFSET=" + offset + "f";
+    } else if (conv_param_->activation_param.active_type ==
+               lite_api::ActivationType::kHardSigmoid) {
+      std::string slope =
+          std::to_string(conv_param_->activation_param.hard_sigmoid_slope);
+      std::string offset =
+          std::to_string(conv_param_->activation_param.hard_sigmoid_offset);
+      build_options_single += " -DHARD_SIGMOID -DHARD_SIGMOID_SLOPE=" + slope +
+                              "f" + " -DHARD_SIGMOID_OFFSET=" + offset + "f";
     } else {
       LOG(FATAL) << "Unsupported activation type:"
                  << static_cast<int>(conv_param_->activation_param.active_type);

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -391,7 +391,7 @@ void ConvImageCompute::PrepareForRun() {
                                     build_options_[i],
                                     time_stamp_);
   }
-  SetLocalWorkSize();
+  SetLocalWorkSize(CLRuntime::Global()->lws_repeats());
 }
 
 void ConvImageCompute::SetLocalWorkSize(size_t repeats /*=4*/) {

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -120,6 +120,22 @@ class ConvOpLite : public OpLite {
             lite_api::ActivationType::kLeakyRelu;
         param_.activation_param.Leaky_relu_alpha =
             op_desc.GetAttr<float>("leaky_relu_alpha");
+      } else if (act_type == "hard_swish") {
+        param_.activation_param.active_type =
+            lite_api::ActivationType::kHardSwish;
+        param_.activation_param.hard_swish_threshold =
+            op_desc.GetAttr<float>("hard_swish_threshold");
+        param_.activation_param.hard_swish_scale =
+            op_desc.GetAttr<float>("hard_swish_scale");
+        param_.activation_param.hard_swish_offset =
+            op_desc.GetAttr<float>("hard_swish_offset");
+      } else if (act_type == "hard_sigmoid") {
+        param_.activation_param.active_type =
+            lite_api::ActivationType::kHardSigmoid;
+        param_.activation_param.hard_sigmoid_slope =
+            op_desc.GetAttr<float>("slope");
+        param_.activation_param.hard_sigmoid_offset =
+            op_desc.GetAttr<float>("offset");
       } else {
         CHECK(false)
             << "The fused conv only supports fuse with relu and leaky relu";


### PR DESCRIPTION
# 状态：等待review

## 主要内容

cherry-pick from

1. 对无效opencl设备的valid预判：https://github.com/PaddlePaddle/Paddle-Lite/pull/5354 ；
2. 对Android7.0以上限制系统库加载的处理容错机制（cpu模型跑gpu库，库找不到）：https://github.com/PaddlePaddle/Paddle-Lite/pull/5334 ；
3. AutoTune增加灵活性，可以平衡因为绑定大小核或者不绑定带来的tune性能波动，交由用户可以调整（参数非必须）：https://github.com/PaddlePaddle/Paddle-Lite/pull/5254 ；
4. conv-hard_sigmoid融合pass：https://github.com/PaddlePaddle/Paddle-Lite/pull/5303 。

详细说明：见各独立PR内「主要内容」。