### PR TITLE
[BUG FIX] Remove empty symbol in Python lib

### DIFF
--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -112,6 +112,15 @@ void LoadCombinedParamsPb(const std::string &path,
                             << " LoadCombinedParamsPb, use LoadParam instead.";
 }
 
+void TensorToStream(std::ostream &os, const lite::Tensor &tensor) {
+  LITE_MODEL_INTERFACE_NOT_IMPLEMENTED
+}
+void TensorFromStream(std::istream &is, lite::Tensor *tensor) {
+  LITE_MODEL_INTERFACE_NOT_IMPLEMENTED
+}
+void ReadBinaryFile(const std::string &filename, std::string *contents) {
+  LITE_MODEL_INTERFACE_NOT_IMPLEMENTED
+}
 void LoadModelPb(const std::string &model_dir,
                  const std::string &model_file,
                  const std::string &param_file,

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -113,13 +113,13 @@ void LoadCombinedParamsPb(const std::string &path,
 }
 
 void TensorToStream(std::ostream &os, const lite::Tensor &tensor) {
-  LITE_MODEL_INTERFACE_NOT_IMPLEMENTED
+  LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
 }
 void TensorFromStream(std::istream &is, lite::Tensor *tensor) {
-  LITE_MODEL_INTERFACE_NOT_IMPLEMENTED
+  LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
 }
 void ReadBinaryFile(const std::string &filename, std::string *contents) {
-  LITE_MODEL_INTERFACE_NOT_IMPLEMENTED
+  LITE_MODEL_INTERFACE_NOT_IMPLEMENTED;
 }
 void LoadModelPb(const std::string &model_dir,
                  const std::string &model_file,


### PR DESCRIPTION
### 问题描述
- Paddle-Lite 代码中有只有声明没有实现的函数，导致预测库中出现 空的函数符号
### 本PR工作
- 为函数声明补充默认实现

### Todo
- 需要补充下列函数的实现
  - TensorToStream
  - TensorFromStream
  - ReadFromBinaryFile