### PR TITLE
[OpenCL] Add preconditions for set AdrenoContextProperties

### DIFF
--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -301,11 +301,14 @@ bool CLRuntime::InitializeDevice() {
     }
     return t_str;
   };
-  const std::string device_version = device_->getInfo<CL_DEVICE_VERSION>();
-  LOG(INFO) << "device_version:" << device_version;
-  opencl_version_ = ParseDeviceVersion(device_version);
-  CHECK(opencl_version_ != OpenCLVersion::CL_VER_UNKNOWN)
-      << "The device version[" << device_version << "] is illegal!";
+
+  auto device_version = device_->getInfo<CL_DEVICE_VERSION>();
+  LOG(INFO) << "CL_DEVICE_VERSION:" << device_version;
+  auto opencl_version = ParseDeviceVersion(device_version);
+  if (opencl_version == OpenCLVersion::CL_VER_UNKNOWN) {
+    LOG(ERROR) << "Parse device version[" << device_version << "] failed!";
+  }
+  device_info_["CL_DEVICE_VERSION"] = opencl_version;
 
   LOG(INFO) << "device_type:" << device_type_to_str(device_type);
   device_info_["CL_DEVICE_TYPE"] = device_type;

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -30,6 +30,15 @@ typedef enum {
 } GpuType;
 
 typedef enum {
+  CL_VER_UNKNOWN = 0,
+  CL_VER_1_0 = 1,
+  CL_VER_1_1 = 2,
+  CL_VER_1_2 = 3,
+  CL_VER_2_0 = 4,
+  CL_VER_2_1 = 5
+} OpenCLVersion;
+
+typedef enum {
   PERF_DEFAULT = 0,
   PERF_LOW = 1,
   PERF_NORMAL = 2,
@@ -181,7 +190,8 @@ class CLRuntime {
     auto perf_mode = GPUPerfMode::PERF_HIGH;
     auto priority_level = GPUPriorityLevel::PRIORITY_HIGH;
     std::vector<cl_context_properties> context_properties;
-    if (gpu_type_ == GpuType::QUALCOMM_ADRENO) {
+    if (gpu_type_ == GpuType::QUALCOMM_ADRENO &&
+        opencl_version_ >= OpenCLVersion::CL_VER_2_0) {
       GetAdrenoContextProperties(
           &context_properties, perf_mode, priority_level);
     }
@@ -214,9 +224,12 @@ class CLRuntime {
     return queue;
   }
 
+  OpenCLVersion ParseDeviceVersion(const std::string& device_version);
   GpuType ParseGpuTypeFromDeviceName(std::string device_name);
 
   std::map<std::string, size_t> device_info_;
+
+  OpenCLVersion opencl_version_;
 
   GpuType gpu_type_{GpuType::UNKNOWN};
 

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -191,7 +191,7 @@ class CLRuntime {
     auto priority_level = GPUPriorityLevel::PRIORITY_HIGH;
     std::vector<cl_context_properties> context_properties;
     if (gpu_type_ == GpuType::QUALCOMM_ADRENO &&
-        opencl_version_ >= OpenCLVersion::CL_VER_2_0) {
+        device_info_["CL_DEVICE_VERSION"] >= OpenCLVersion::CL_VER_2_0) {
       GetAdrenoContextProperties(
           &context_properties, perf_mode, priority_level);
     }
@@ -228,8 +228,6 @@ class CLRuntime {
   GpuType ParseGpuTypeFromDeviceName(std::string device_name);
 
   std::map<std::string, size_t> device_info_;
-
-  OpenCLVersion opencl_version_;
 
   GpuType gpu_type_{GpuType::UNKNOWN};
 


### PR DESCRIPTION
【问题】
在 oppo R7007 android 4.3 手机上执行预测时，在执行到设置`CL_CONTEXT_PRIORITY_HINT_QCOM`时提示`CL_INVALID_PROPERTY`，具体报错见如下截图：
![image](https://user-images.githubusercontent.com/24290792/105620728-d5063500-5e3a-11eb-98f4-5cf0ae9f1486.png)
【原因】
虽然`CL_CONTEXT_PRIORITY_HINT_QCOM`这一针对 Adreno GPU 的 OpenCL 扩展在 1.1 版本中就已经支持，但在实际测试中发现部分手机在执行设置 PRIORITY_HINT_QCOM 时会失败。因此增加了版本约束。
【备注】
MNN 中采用了更强的约束条件：在`platforms[0].getInfo<CL_PLATFORM_EXTENSIONS>()`不为空的情况下才会设置 PRIORITY_HINT_QCOM 和 PERF_HINT_QCOM。但实测发现大部分主流手机（MI9/8/7）的 platform_extensions 都是空，但可以正常设置 HINT_QCOM（虽然设置后并无性能提升😓）