### PR TITLE
Change the android level from 16 to 21 for paddlelite demo, test=develop

### DIFF
--- a/lite/demo/cxx/Makefile.def
+++ b/lite/demo/cxx/Makefile.def
@@ -33,9 +33,9 @@ ifeq ($(NDK_VERSION), 17)
             CC = $(NDK_ROOT)/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/bin/arm-linux-androideabi-g++
         endif
         CXX_FLAGS = -march=armv7-a -mthumb -mfpu=neon -mfloat-abi=softfp -funwind-tables -no-canonical-prefixes \
-                   -D__ANDROID_API__=16 -fexceptions -frtti  -std=c++11 -fopenmp -O3 -DNDEBUG -fPIE
+                   -D__ANDROID_API__=21 -fexceptions -frtti  -std=c++11 -fopenmp -O3 -DNDEBUG -fPIE
         CXXFLAGS_LINK = $(CXX_FLAGS) -pie -Wl,--fix-cortex-a8 -Wl,--gc-sections -Wl,-z,nocopyreloc
-        SYSROOT_LINK = --sysroot=$(NDK_ROOT)/platforms/android-16/arch-arm
+        SYSROOT_LINK = --sysroot=$(NDK_ROOT)/platforms/android-21/arch-arm
         SYSTEM_LIBS = $(NDK_ROOT)/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_static.a \
                       $(NDK_ROOT)/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++abi.a \
                       $(NDK_ROOT)/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libandroid_support.a \


### PR DESCRIPTION
这个pr改了demo的makefile，支持安卓最低版本是16：https://github.com/PaddlePaddle/Paddle-Lite/pull/5275/files#diff-8ded598e7fa21eb6d987e7d35f9077114fc4edca0108a53dca9f338e80d8453dR36

qa同学测试时发现demo/cxx/test_libs这个在armv7下编译错误，问题如：https://github.com/opencv/opencv/issues/14419

如果opencv4.1.0，要求是安卓版本最低是21。如果opencv4.0.1，则没有这个限制。后续可以考虑替换opencv版本。