### PR TITLE
[utils][x86]Use higher precision(ms->us) method to measure elapsed time

### DIFF
--- a/lite/backends/x86/port.h
+++ b/lite/backends/x86/port.h
@@ -71,21 +71,12 @@ static void *dlopen(const char *filename, int flag) {
 #ifdef LITE_WITH_LOG
 extern struct timeval;
 static int gettimeofday(struct timeval *tp, void *tzp) {
-  time_t clock;
-  struct tm tm;
-  SYSTEMTIME wtm;
-
-  GetLocalTime(&wtm);
-  tm.tm_year = wtm.wYear - 1900;
-  tm.tm_mon = wtm.wMonth - 1;
-  tm.tm_mday = wtm.wDay;
-  tm.tm_hour = wtm.wHour;
-  tm.tm_min = wtm.wMinute;
-  tm.tm_sec = wtm.wSecond;
-  tm.tm_isdst = -1;
-  clock = mktime(&tm);
-  tp->tv_sec = clock;
-  tp->tv_usec = wtm.wMilliseconds * 1000;
+  LARGE_INTEGER now, freq;
+  QueryPerformanceCounter(&now);
+  QueryPerformanceFrequency(&freq);
+  tp->tv_sec = now.QuadPart / freq.QuadPart;
+  tp->tv_usec = (now.QuadPart % freq.QuadPart) * 1000000 / freq.QuadPart;
+  // uint64_t elapsed_time = sec * 1000000 + usec;
 
   return (0);
 }

--- a/lite/demo/cxx/x86_mobilenetv1_full_demo/mobilenet_full_api.cc
+++ b/lite/demo/cxx/x86_mobilenetv1_full_demo/mobilenet_full_api.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>  // NOLINT(build/c++11)
+#include <cmath>
 #include <iostream>
 #include <vector>
 #include "paddle_api.h"  // NOLINT
@@ -27,15 +29,114 @@
 
 using namespace paddle::lite_api;  // NOLINT
 
+class Timer {
+ private:
+  std::chrono::high_resolution_clock::time_point inTime, outTime;
+
+ public:
+  void startTimer() { inTime = std::chrono::high_resolution_clock::now(); }
+
+  // unit millisecond
+  float getCostTimer() {
+    outTime = std::chrono::high_resolution_clock::now();
+    return static_cast<float>(
+        std::chrono::duration_cast<std::chrono::microseconds>(outTime - inTime)
+            .count() /
+        1e+3);
+  }
+};
+
 int64_t ShapeProduction(const shape_t& shape) {
   int64_t res = 1;
   for (auto i : shape) res *= i;
   return res;
 }
 
-// Enable `DEMO_WITH_OPENCL` macro below, if user need use gpu(opencl)
-// #define DEMO_WITH_OPENCL
-void RunModel(std::string model_dir) {
+std::string ShapePrint(const std::vector<shape_t>& shapes) {
+  std::string shapes_str{""};
+  for (size_t shape_idx = 0; shape_idx < shapes.size(); ++shape_idx) {
+    auto shape = shapes[shape_idx];
+    std::string shape_str;
+    for (auto i : shape) {
+      shape_str += std::to_string(i) + ",";
+    }
+    shapes_str += shape_str;
+    shapes_str +=
+        (shape_idx != 0 && shape_idx == shapes.size() - 1) ? "" : " : ";
+  }
+  return shapes_str;
+}
+
+std::string ShapePrint(const shape_t& shape) {
+  std::string shape_str{""};
+  for (auto i : shape) {
+    shape_str += std::to_string(i) + " ";
+  }
+  return shape_str;
+}
+
+std::vector<std::string> split_string(const std::string& str_in) {
+  std::vector<std::string> str_out;
+  std::string tmp_str = str_in;
+  while (!tmp_str.empty()) {
+    size_t next_offset = tmp_str.find(":");
+    str_out.push_back(tmp_str.substr(0, next_offset));
+    if (next_offset == std::string::npos) {
+      break;
+    } else {
+      tmp_str = tmp_str.substr(next_offset + 1);
+    }
+  }
+  return str_out;
+}
+
+std::vector<int64_t> get_shape(const std::string& str_shape) {
+  std::vector<int64_t> shape;
+  std::string tmp_str = str_shape;
+  while (!tmp_str.empty()) {
+    int dim = atoi(tmp_str.data());
+    shape.push_back(dim);
+    size_t next_offset = tmp_str.find(",");
+    if (next_offset == std::string::npos) {
+      break;
+    } else {
+      tmp_str = tmp_str.substr(next_offset + 1);
+    }
+  }
+  return shape;
+}
+
+template <typename T>
+double compute_mean(const T* in, const size_t length) {
+  double sum = 0.;
+  for (size_t i = 0; i < length; ++i) {
+    sum += in[i];
+  }
+  return sum / length;
+}
+
+template <typename T>
+double compute_standard_deviation(const T* in,
+                                  const size_t length,
+                                  bool has_mean = false,
+                                  double mean = 10000) {
+  if (!has_mean) {
+    mean = compute_mean<T>(in, length);
+  }
+
+  double variance = 0.;
+  for (size_t i = 0; i < length; ++i) {
+    variance += pow((in[i] - mean), 2);
+  }
+  variance /= length;
+  return sqrt(variance);
+}
+
+void RunModel(std::string model_dir,
+              const std::vector<shape_t>& input_shapes,
+              size_t repeats,
+              size_t warmup,
+              size_t print_output_elem) {
   // 1. Create CxxConfig
   CxxConfig config;
   config.set_model_dir(model_dir);
@@ -45,43 +146,171 @@ void RunModel(std::string model_dir) {
        Place{TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNCHW)},
        Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kImageDefault)},
        Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW)},
+       Place{TARGET(kOpenCL), PRECISION(kInt32), DATALAYOUT(kNCHW)},
        Place{TARGET(kX86), PRECISION(kFloat)},
        Place{TARGET(kHost), PRECISION(kFloat)}});
+
+  bool is_opencl_backend_valid =
+      ::IsOpenCLBackendValid(false /*check_fp16_valid = false*/);
+  std::cout << "is_opencl_backend_valid:" << is_opencl_backend_valid
+            << std::endl;
+  if (!is_opencl_backend_valid) {
+    config.set_valid_places({Place{TARGET(kX86), PRECISION(kFloat)},
+                             Place{TARGET(kHost), PRECISION(kFloat)}});
+    std::cout << "OpenCL is not valid on your device. Fallback to cpu."
+  } else {
+    // opencl tune option
+    // CL_TUNE_NONE: 0
+    // CL_TUNE_RAPID: 1
+    // CL_TUNE_NORMAL: 2
+    // CL_TUNE_EXHAUSTIVE: 3
+    config.set_opencl_tune(CL_TUNE_NONE);
+
+    // opencl precision option. Most x86 devices only support fp32, so set
+    // CL_PRECISION_FP32 as default.
+    // CL_PRECISION_AUTO: 0, first fp16 if valid, default
+    // CL_PRECISION_FP32: 1, force fp32
+    // CL_PRECISION_FP16: 2, force fp16
+    config.set_opencl_precision(CL_PRECISION_FP32);
+  }
 #else
   config.set_valid_places({Place{TARGET(kX86), PRECISION(kFloat)},
                            Place{TARGET(kHost), PRECISION(kFloat)}});
 #endif
+
   // 2. Create PaddlePredictor by CxxConfig
   std::shared_ptr<PaddlePredictor> predictor =
       CreatePaddlePredictor<CxxConfig>(config);
 
   // 3. Prepare input data
-  std::unique_ptr<Tensor> input_tensor(std::move(predictor->GetInput(0)));
-  input_tensor->Resize({1, 3, 224, 224});
-  auto* data = input_tensor->mutable_data<float>();
-  for (int i = 0; i < ShapeProduction(input_tensor->shape()); ++i) {
-    data[i] = 1;
+  for (int j = 0; j < input_shapes.size(); ++j) {
+    auto input_tensor = predictor->GetInput(j);
+    input_tensor->Resize(input_shapes[j]);
+    auto input_data = input_tensor->mutable_data<float>();
+    int input_num = 1;
+    for (int i = 0; i < input_shapes[j].size(); ++i) {
+      input_num *= input_shapes[j][i];
+    }
+
+    for (int i = 0; i < input_num; ++i) {
+      input_data[i] = 1.f;
+    }
   }
 
   // 4. Run predictor
-  predictor->Run();
+  Timer timeInstance;
+  double first_duration{-1};
+  for (size_t widx = 0; widx < warmup; ++widx) {
+    if (widx == 0) {
+      timeInstance.startTimer();
+      predictor->Run();
+      first_duration = timeInstance.getCostTimer();
+    } else {
+      predictor->Run();
+    }
+  }
+
+  double sum_duration = 0.0;
+  double max_duration = 1e-5;
+  double min_duration = 1e5;
+  double avg_duration = -1;
+  for (size_t ridx = 0; ridx < repeats; ++ridx) {
+    timeInstance.startTimer();
+
+    predictor->Run();
+
+    double duration = timeInstance.getCostTimer();
+    sum_duration += duration;
+    max_duration = duration > max_duration ? duration : max_duration;
+    min_duration = duration < min_duration ? duration : min_duration;
+    std::cout << "run_idx:" << ridx + 1 << " / " << repeats << ": " << duration
+              << " ms" << std::endl;
+    if (first_duration < 0) {
+      first_duration = duration;
+    }
+  }
+  avg_duration = sum_duration / static_cast<float>(repeats);
+  std::cout << "\n======= benchmark summary =======\n"
+            << "input_shape(s) (NCHW):" << ShapePrint(input_shapes) << "\n"
+            << "model_dir:" << model_dir << "\n"
+            << "warmup:" << warmup << "\n"
+            << "repeats:" << repeats << "\n"
+            << "*** time info(ms) ***\n"
+            << "1st_duration:" << first_duration << "\n"
+            << "max_duration:" << max_duration << "\n"
+            << "min_duration:" << min_duration << "\n"
+            << "avg_duration:" << avg_duration << "\n";
 
   // 5. Get output
-  std::unique_ptr<const Tensor> output_tensor(
-      std::move(predictor->GetOutput(0)));
-  std::cout << "Output shape " << output_tensor->shape()[1] << std::endl;
-  for (int i = 0; i < ShapeProduction(output_tensor->shape()); i += 100) {
-    std::cout << "Output[" << i << "]: " << output_tensor->data<float>()[i]
+  std::cout << "\n====== output summary ====== " << std::endl;
+  size_t output_tensor_num = predictor->GetOutputNames().size();
+  std::cout << "output tensor num:" << output_tensor_num << std::endl;
+
+  for (size_t tidx = 0; tidx < output_tensor_num; ++tidx) {
+    std::unique_ptr<const paddle::lite_api::Tensor> output_tensor =
+        predictor->GetOutput(tidx);
+    std::cout << "\n--- output tensor " << tidx << " ---" << std::endl;
+    auto out_shape = output_tensor->shape();
+    auto out_data = output_tensor->data<float>();
+    auto out_mean = compute_mean<float>(out_data, ShapeProduction(out_shape));
+    auto out_std_dev = compute_standard_deviation<float>(
+        out_data, ShapeProduction(out_shape), true, out_mean);
+
+    std::cout << "output shape(NCHW):" << ShapePrint(out_shape) << std::endl;
+    std::cout << "output tensor " << tidx
+              << " elem num:" << ShapeProduction(out_shape) << std::endl;
+    std::cout << "output tensor " << tidx
+              << " standard deviation:" << out_std_dev << std::endl;
+    std::cout << "output tensor " << tidx << " mean value:" << out_mean
               << std::endl;
+
+    // print output
+    if (print_output_elem) {
+      for (int i = 0; i < ShapeProduction(out_shape); ++i) {
+        std::cout << "out[" << tidx << "][" << i
+                  << "]:" << output_tensor->data<float>()[i] << std::endl;
+      }
+    }
   }
 }
 
 int main(int argc, char** argv) {
-  if (argc < 2) {
-    std::cerr << "[ERROR] usage: ./" << argv[0] << " naive_buffer_model_dir\n";
-    exit(1);
+  std::vector<std::string> str_input_shapes;
+  std::vector<shape_t> input_shapes{
+      {1, 3, 224, 224}};  // shape_t ==> std::vector<int64_t>
+
+  int repeats = 10;
+  int warmup = 10;
+  int print_output_elem = 0;
+
+  if (argc > 2 && argc < 6) {
+    std::cerr << "usage: ./" << argv[0] << "\n"
+              << "  <paddle_uncombined_model_dir>\n"
+              << "  <raw_input_shapes>, eg: 1,3,224,224 for 1 input; "
+                 "1,3,224,224:1,5 for 2 inputs\n"
+              << "  <repeats>\n"
+              << "  <warmup>\n"
+              << "  <print_output>" << std::endl;
+    return 0;
   }
+
   std::string model_dir = argv[1];
-  RunModel(model_dir);
+  if (argc >= 6) {
+    input_shapes.clear();
+    std::string raw_input_shapes = argv[2];
+    std::cout << "raw_input_shapes: " << raw_input_shapes << std::endl;
+    str_input_shapes = split_string(raw_input_shapes);
+    for (size_t i = 0; i < str_input_shapes.size(); ++i) {
+      std::cout << "input shape: " << str_input_shapes[i] << std::endl;
+      input_shapes.push_back(get_shape(str_input_shapes[i]));
+    }
+
+    repeats = atoi(argv[3]);
+    warmup = atoi(argv[4]);
+    print_output_elem = atoi(argv[5]);
+  }
+
+  RunModel(model_dir, input_shapes, repeats, warmup, print_output_elem);
+
   return 0;
 }

--- a/lite/demo/cxx/x86_mobilenetv1_light_demo/mobilenet_light_api.cc
+++ b/lite/demo/cxx/x86_mobilenetv1_light_demo/mobilenet_light_api.cc
@@ -37,7 +37,7 @@ class Timer {
   // unit millisecond
   float getCostTimer() {
     outTime = std::chrono::high_resolution_clock::now();
-    return std::static_cast<float>(
+    return static_cast<float>(
         std::chrono::duration_cast<std::chrono::microseconds>(outTime - inTime)
             .count() /
         1e+3);

--- a/lite/utils/logging.h
+++ b/lite/utils/logging.h
@@ -33,21 +33,12 @@
 #undef max
 extern struct timeval;
 static int gettimeofday(struct timeval* tp, void* tzp) {
-  time_t clock;
-  struct tm tm;
-  SYSTEMTIME wtm;
-
-  GetLocalTime(&wtm);
-  tm.tm_year = wtm.wYear - 1900;
-  tm.tm_mon = wtm.wMonth - 1;
-  tm.tm_mday = wtm.wDay;
-  tm.tm_hour = wtm.wHour;
-  tm.tm_min = wtm.wMinute;
-  tm.tm_sec = wtm.wSecond;
-  tm.tm_isdst = -1;
-  clock = mktime(&tm);
-  tp->tv_sec = clock;
-  tp->tv_usec = wtm.wMilliseconds * 1000;
+  LARGE_INTEGER now, freq;
+  QueryPerformanceCounter(&now);
+  QueryPerformanceFrequency(&freq);
+  tp->tv_sec = now.QuadPart / freq.QuadPart;
+  tp->tv_usec = (now.QuadPart % freq.QuadPart) * 1000000 / freq.QuadPart;
+  // uint64_t elapsed_time = sec * 1000000 + usec;
 
   return (0);
 }


### PR DESCRIPTION
【问题】
Windows 平台下的计时函数`GetLocalTime`，精度为 ms，且在实际使用时发现存在时间波动范围特别大的情况（使用该计时函数运行模型发现存在较大时间波动，见下）。
使用原计时函数放在 light_demo 中的效果：
```
run_idx:946 / 1000: 0 ms
run_idx:947 / 1000: 0 ms
run_idx:948 / 1000: 0 ms
run_idx:949 / 1000: 0 ms
run_idx:950 / 1000: 0 ms
run_idx:951 / 1000: 16 ms
run_idx:952 / 1000: 0 ms
run_idx:953 / 1000: 0 ms
run_idx:954 / 1000: 0 ms
run_idx:955 / 1000: 0 ms
run_idx:956 / 1000: 0 ms
run_idx:957 / 1000: 15 ms
run_idx:958 / 1000: 0 ms
run_idx:959 / 1000: 0 ms
run_idx:960 / 1000: 0 ms
run_idx:961 / 1000: 0 ms
run_idx:962 / 1000: 0 ms
run_idx:963 / 1000: 0 ms
run_idx:964 / 1000: 0 ms
run_idx:965 / 1000: 0 ms
run_idx:966 / 1000: 0 ms
run_idx:967 / 1000: 0 ms
run_idx:968 / 1000: 15 ms
run_idx:969 / 1000: 0 ms
run_idx:970 / 1000: 0 ms
run_idx:971 / 1000: 0 ms
run_idx:972 / 1000: 0 ms
run_idx:973 / 1000: 0 ms
run_idx:974 / 1000: 16 ms
run_idx:975 / 1000: 0 ms
run_idx:976 / 1000: 0 ms
run_idx:977 / 1000: 0 ms
run_idx:978 / 1000: 0 ms
run_idx:979 / 1000: 16 ms
run_idx:980 / 1000: 0 ms
run_idx:981 / 1000: 0 ms
run_idx:982 / 1000: 0 ms
run_idx:983 / 1000: 0 ms
run_idx:984 / 1000: 0 ms
run_idx:985 / 1000: 15 ms
run_idx:986 / 1000: 0 ms
run_idx:987 / 1000: 0 ms
run_idx:988 / 1000: 0 ms
run_idx:989 / 1000: 0 ms
run_idx:990 / 1000: 0 ms
run_idx:991 / 1000: 16 ms
run_idx:992 / 1000: 0 ms
run_idx:993 / 1000: 0 ms
run_idx:994 / 1000: 0 ms
run_idx:995 / 1000: 0 ms
run_idx:996 / 1000: 0 ms
run_idx:997 / 1000: 16 ms
run_idx:998 / 1000: 0 ms
run_idx:999 / 1000: 0 ms
run_idx:1000 / 1000: 0 ms

======= benchmark summary =======
input_shape(s) (NCHW):84,400, :
output_shape(s)      :84
model_file :.\opt_x86.nb
input_file :.\40_input_data.txt
output_file:.\out.txt
warmup :10
repeats:1000
max_duration:16 ms
min_duration:0 ms
avg_duration:2.314 ms
```

【解决方法】
使用Windows 平台下更高精度的计时函数`QueryPerformanceCounter`，精度为 us。
使用新计时函数放在 light_demo 中的效果：
```

run_idx:967 / 1000: 2.369 ms
run_idx:968 / 1000: 2.365 ms
run_idx:969 / 1000: 2.543 ms
run_idx:970 / 1000: 2.53 ms
run_idx:971 / 1000: 2.46 ms
run_idx:972 / 1000: 2.409 ms
run_idx:973 / 1000: 2.374 ms
run_idx:974 / 1000: 2.43 ms
run_idx:975 / 1000: 2.405 ms
run_idx:976 / 1000: 2.385 ms
run_idx:977 / 1000: 2.376 ms
run_idx:978 / 1000: 2.378 ms
run_idx:979 / 1000: 2.372 ms
run_idx:980 / 1000: 2.552 ms
run_idx:981 / 1000: 2.476 ms
run_idx:982 / 1000: 2.504 ms
run_idx:983 / 1000: 2.496 ms
run_idx:984 / 1000: 2.437 ms
run_idx:985 / 1000: 2.401 ms
run_idx:986 / 1000: 2.675 ms
run_idx:987 / 1000: 2.556 ms
run_idx:988 / 1000: 2.477 ms
run_idx:989 / 1000: 2.512 ms
run_idx:990 / 1000: 2.482 ms
run_idx:991 / 1000: 2.721 ms
run_idx:992 / 1000: 2.656 ms
run_idx:993 / 1000: 2.565 ms
run_idx:994 / 1000: 2.507 ms
run_idx:995 / 1000: 2.502 ms
run_idx:996 / 1000: 2.536 ms
run_idx:997 / 1000: 2.432 ms
run_idx:998 / 1000: 2.379 ms
run_idx:999 / 1000: 2.367 ms
run_idx:1000 / 1000: 2.365 ms

======= benchmark summary =======
input_shape(s) (NCHW):84,400, :
output_shape(s)      :84
model_file :.\opt_x86.nb
input_file :.\40_input_data.txt
output_file:.\out.txt
warmup :10
repeats:1000
max_duration:3.306 ms
min_duration:2.314 ms
avg_duration:2.44124 ms
```