### PR TITLE
[BUG FIX] Fix the scripts of updating FlatBuffer

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -54,8 +54,7 @@ MIN_ANDROID_API_LEVEL_ARMV8=21
 ANDROID_API_LEVEL="Default"
 CMAKE_API_LEVEL_OPTIONS=""
 
-readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
-
+readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 readonly workspace=$PWD
 
 function readlinkf() {
@@ -99,13 +98,13 @@ function prepare_opencl_source_code {
 }
 
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
+        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
             wget $THIRDPARTY_TAR
         fi
-        tar xzf third-party-05b862.tar.gz
+        tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -54,7 +54,7 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 # 2. local variables, these variables should not be changed.
 #####################################################################################################
 # url that stores third-party zip file to accelerate third-paty lib installation
-readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
+readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 # absolute path of Paddle-Lite.
 readonly workspace=$PWD/$(dirname $0)/../../
 # basic options for android compiling.
@@ -113,13 +113,13 @@ function prepare_opencl_source_code {
 # 3.3 prepare third_party libraries for compiling
 # here we store third_party libraries into Paddle-Lite/third-party
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
+        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
             wget $THIRDPARTY_TAR
         fi
-        tar xzf third-party-05b862.tar.gz
+        tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_bm.sh
+++ b/lite/tools/build_bm.sh
@@ -28,17 +28,17 @@ readonly CMAKE_COMMON_OPTIONS="-DWITH_LITE=ON \
 
 readonly NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-1}
 
-readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
+readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 readonly workspace=$(pwd)
 
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
+        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
             wget $THIRDPARTY_TAR
         fi
-        tar xzf third-party-05b862.tar.gz
+        tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -46,7 +46,7 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 # 2. local variables, these variables should not be changed.
 #####################################################################################################
 # url that stores third-party zip file to accelerate third-paty lib installation
-readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
+readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 # absolute path of Paddle-Lite.
 readonly workspace=$PWD/$(dirname $0)/../../
 # basic options for linux compiling.
@@ -123,12 +123,12 @@ function prepare_opencl_source_code {
 # 3.3 prepare third_party libraries for compiling
 # here we store third_party libraries into Paddle-Lite/third-party
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
         rm -rf $workspace/third-party
-        if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
+        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
             wget $THIRDPARTY_TAR
         fi
-        tar xzf third-party-05b862.tar.gz
+        tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_mlu.sh
+++ b/lite/tools/build_mlu.sh
@@ -29,17 +29,17 @@ readonly CMAKE_COMMON_OPTIONS="-DWITH_LITE=ON \
 
 readonly NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}
 
-readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
+readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 readonly workspace=$(pwd)
 
 function prepare_thirdparty {
     if [ ! -d $workspace/third-party ]; then
         rm -rf $workspace/third-party
     fi
-    if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
+    if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
         wget $THIRDPARTY_TAR
     fi
-    tar xvf third-party-05b862.tar.gz
+    tar xvf third-party-ea5576.tar.gz
 }
 
 # for code gen, a source file is generated after a test, but is dependended by some targets in cmake.

--- a/lite/tools/build_npu.sh
+++ b/lite/tools/build_npu.sh
@@ -45,16 +45,16 @@ function prepare_workspace {
 }
 
 function prepare_thirdparty {
-    readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
+    readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 
     readonly workspace=$PWD
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
         rm -rf $workspace/third-party
 
-         if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
+         if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
             wget $THIRDPARTY_TAR
         fi
-        tar xzf third-party-05b862.tar.gz
+        tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_rknpu.sh
+++ b/lite/tools/build_rknpu.sh
@@ -42,16 +42,16 @@ function prepare_workspace {
 }
 
 function prepare_thirdparty {
-    readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
+    readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 
     readonly workspace=$PWD
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
         rm -rf $workspace/third-party
 
-         if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
+         if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
             wget $THIRDPARTY_TAR
         fi
-        tar xzf third-party-05b862.tar.gz
+        tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_windows.bat
+++ b/lite/tools/build_windows.bat
@@ -18,7 +18,7 @@ set WITH_OPENCL=OFF
 set WITH_AVX=ON
 set WITH_STRIP=OFF
 set OPTMODEL_DIR=""
-set THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
+set THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 
 set workspace=%source_path%
 set /a cores=%number_of_processors%-2 > null
@@ -171,25 +171,25 @@ goto:eof
 
 :prepare_thirdparty
     if  EXIST "%workspace%\third-party" (
-        if NOT EXIST "%workspace%\third-party-05b862.tar.gz" (
-            echo "The directory of third_party exists, the third-party-05b862.tar.gz not exists."
+        if NOT EXIST "%workspace%\third-party-ea5576.tar.gz" (
+            echo "The directory of third_party exists, the third-party-ea5576.tar.gz not exists."
         ) else (
-               echo "The directory of third_party exists, the third-party-05b862.tar.gz exists."
+               echo "The directory of third_party exists, the third-party-ea5576.tar.gz exists."
                call:rm_rebuild_dir "%workspace%\third-party"
-               !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-05b862.tar.gz %workspace%
+               !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-ea5576.tar.gz %workspace%
         )
     ) else (
-        if NOT EXIST "%workspace%\third-party-05b862.tar.gz" (
-            echo "The directory of third_party not exists, the third-party-05b862.tar.gz not exists."
+        if NOT EXIST "%workspace%\third-party-ea5576.tar.gz" (
+            echo "The directory of third_party not exists, the third-party-ea5576.tar.gz not exists."
             call:download_third_party
-            if EXIST "%workspace%\third-party-05b862.tar.gz" (
-                !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-05b862.tar.gz %workspace%
+            if EXIST "%workspace%\third-party-ea5576.tar.gz" (
+                !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-ea5576.tar.gz %workspace%
             ) else (
-                echo "------------Can't download the third-party-05b862.tar.gz!------"
+                echo "------------Can't download the third-party-ea5576.tar.gz!------"
             )
         ) else (
-            echo "The directory of third_party not exists, the third-party-05b862.tar.gz exists."
-            !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-05b862.tar.gz %workspace%
+            echo "The directory of third_party not exists, the third-party-ea5576.tar.gz exists."
+            !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-ea5576.tar.gz %workspace%
         )
 
     )
@@ -197,8 +197,8 @@ goto:eof
 goto:eof
 
 :download_third_party
-powershell.exe (new-object System.Net.WebClient).DownloadFile('https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz', ^
-'%workspace%\third-party-05b862.tar.gz')
+powershell.exe (new-object System.Net.WebClient).DownloadFile('https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-ea5576.tar.gz', ^
+'%workspace%\third-party-ea5576.tar.gz')
 goto:eof
 
 :prepare_opencl_source_code

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -11,7 +11,7 @@ NUM_PROC=4
 readonly ADB_WORK_DIR="/data/local/tmp"
 readonly common_flags="-DWITH_LITE=ON -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=OFF -DWITH_PYTHON=OFF -DWITH_TESTING=ON -DLITE_WITH_ARM=OFF"
 
-readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
+readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 readonly workspace=$PWD
 
 NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}
@@ -35,13 +35,13 @@ fi
 
 function prepare_thirdparty {
     cd $workspace
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
+        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
             wget $THIRDPARTY_TAR
         fi
-        tar xzf third-party-05b862.tar.gz
+        tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/ci_test.sh
+++ b/lite/tools/ci_test.sh
@@ -6,7 +6,7 @@ TESTS_FILE="./lite_tests.txt"
 LIBS_FILE="./lite_libs.txt"
 LITE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)"
 
-readonly THIRDPARTY_TAR=https://paddle-inference-dist.bj.bcebos.com/PaddleLite/third-party-05b862.tar.gz
+readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 readonly workspace=$PWD
 
 NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}
@@ -40,13 +40,13 @@ if [ ${os_name} == "Darwin" ]; then
 fi
 
 function prepare_thirdparty() {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-05b862.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-05b862.tar.gz ]; then
+        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
             wget $THIRDPARTY_TAR
         fi
-        tar xzf third-party-05b862.tar.gz
+        tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
     fi

--- a/third-party/flatbuffers/update_fbs.sh
+++ b/third-party/flatbuffers/update_fbs.sh
@@ -16,8 +16,7 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 # 2. local variables, these variables should not be changed.
 #####################################################################################################
 # absolute path of Paddle-Lite.
-#readonly workspace=$PWD/$(dirname $0)/../../
-readonly workspace=/workspace/hzq/releasev28/x2paddle/PR/PR2/Paddle-Lite/
+readonly workspace=$PWD/$(dirname $0)/../../
 # on mac environment, we should expand the maximum file num to compile successfully
 os_name=`uname -s`
 if [ ${os_name} == "Darwin" ]; then
@@ -58,7 +57,8 @@ function make_fbs {
   cp -rf $workspace/lite/model_parser/flatbuffers/*generated.h $workspace/third-party/flatbuffers/pre-build/
   cp -f $workspace/lite/backends/opencl/utils/cache_generated.h $workspace/third-party/flatbuffers/pre-build/
   cp -rf third_party/install/flatbuffers/include/flatbuffers $workspace/third-party/flatbuffers/pre-build/
-#  cd - > /dev/null
+  # return to original path
+  cd -
 }
 
 make_fbs


### PR DESCRIPTION
### Issue 
- `update_fbs.sh` can not work properly
- `full_publish compiling`  failed when third-party download acceleration is applied.
### Effect of Current PR
- make  `update_fbs.sh` executable
- update the third-party file saved on baiduyun