### PR TITLE
[XPU] Remove unnecessary std::cout statements

### DIFF
--- a/lite/core/mir/fusion/__xpu__multi_encoder_fuse_pass.cc
+++ b/lite/core/mir/fusion/__xpu__multi_encoder_fuse_pass.cc
@@ -76,7 +76,6 @@ class XPUSingleEncoderFuser : public FuseBase {
     if (with_q_scale_) {
       target_op_type = "scale";
     }
-    std::cout << "target_op_type=" << target_op_type << std::endl;
     auto* q_transpose2 = OpNode("q_transpose2", "transpose2")->AsIntermediate();
     auto* q_transpose2_out = VarNode("q_transpose2_out")
                                  ->assert_is_op_output("transpose2", "Out")


### PR DESCRIPTION
test=develop, test=xpu