### PR TITLE
[OPENCL] More check for opencl Image/Buffer Malloc & show log when execeding image2d max size. test=develop

### DIFF
--- a/lite/backends/opencl/target_wrapper.cc
+++ b/lite/backends/opencl/target_wrapper.cc
@@ -71,9 +71,13 @@ bool ImageValid(const size_t req_img_w, const size_t req_img_h) {
   auto max_img_w = dev_map["CL_DEVICE_IMAGE2D_MAX_WIDTH"];
   auto max_img_h = dev_map["CL_DEVICE_IMAGE2D_MAX_HEIGHT"];
   if (req_img_w > max_img_w || req_img_h > max_img_h) {
-    LOG(FATAL) << "malloc image is out of max image size(w,h):" << max_img_w
-               << "," << max_img_h << ", need image size(w,h):" << req_img_w
-               << "," << req_img_h;
+    std::string log = "malloc image is out of max image size(w,h):" +
+                      std::to_string(max_img_w) + "," +
+                      std::to_string(max_img_h) + ", need image size(w,h):" +
+                      std::to_string(req_img_w) + "," +
+                      std::to_string(req_img_h);
+    std::cout << log << std::endl;
+    LOG(FATAL) << log;
     valid = false;
   }
   return valid;

--- a/lite/backends/opencl/target_wrapper.cc
+++ b/lite/backends/opencl/target_wrapper.cc
@@ -38,7 +38,25 @@ static cl_channel_type GetCLChannelType(const PrecisionType type) {
   }
 }
 
+bool BufferValid(const size_t req_size) {
+  bool valid = true;
+  std::map<std::string, size_t> &dev_map = CLRuntime::Global()->GetDeviceInfo();
+  const size_t max_global_mem_size =
+      dev_map["CL_DEVICE_GLOBAL_MEM_SIZE_KB"] * 1000.;
+  if (req_size > max_global_mem_size) {
+    std::string log = "malloc buffer is out of max global mem size(byte):" +
+                      std::to_string(max_global_mem_size) +
+                      ", but required global mem size(byte):" +
+                      std::to_string(req_size);
+    std::cout << log << std::endl;
+    LOG(FATAL) << log;
+    valid = false;
+  }
+  return valid;
+}
+
 void *TargetWrapperCL::Malloc(size_t size) {
+  BufferValid(size);
   cl_int status;
   cl::Buffer *buffer = new cl::Buffer(CLRuntime::Global()->context(),
                                       CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR,
@@ -166,6 +184,7 @@ void TargetWrapperCL::FreeImage(void *image) {
 }
 
 void *TargetWrapperCL::Map(void *buffer, size_t offset, size_t size) {
+  BufferValid(size);
   cl::Buffer *cl_buffer = static_cast<cl::Buffer *>(buffer);
   cl_int status;
   void *mapped_ptr = CLRuntime::Global()->command_queue().enqueueMapBuffer(
@@ -189,6 +208,7 @@ void *TargetWrapperCL::MapImage(void *image,
                                 const size_t cl_image2d_height,
                                 size_t cl_image2d_row_pitch,
                                 size_t cl_image2d_slice_pitch) {
+  ImageValid(cl_image2d_width, cl_image2d_height);
   cl::Image2D *cl_image = static_cast<cl::Image2D *>(image);
   cl::array<size_t, 3> origin = {0, 0, 0};
   cl::array<size_t, 3> region = {cl_image2d_width, cl_image2d_height, 1};
@@ -222,6 +242,7 @@ void TargetWrapperCL::MemcpySync(void *dst,
                                  const void *src,
                                  size_t size,
                                  IoDirection dir) {
+  BufferValid(size);
   cl_int status;
   auto stream = CLRuntime::Global()->command_queue();
   switch (dir) {
@@ -266,6 +287,7 @@ void TargetWrapperCL::MemcpyAsync(void *dst,
                                   size_t size,
                                   IoDirection dir,
                                   const stream_t &stream) {
+  BufferValid(size);
   cl_int status;
   switch (dir) {
     case IoDirection::DtoD:
@@ -310,6 +332,7 @@ void TargetWrapperCL::ImgcpySync(void *dst,
                                  const size_t cl_image2d_row_pitch,
                                  const size_t cl_image2d_slice_pitch,
                                  IoDirection dir) {
+  ImageValid(cl_image2d_width, cl_image2d_height);
   cl::array<size_t, 3> origin = {0, 0, 0};
   cl::array<size_t, 3> region = {cl_image2d_width, cl_image2d_height, 1};
   cl_int status;
@@ -363,6 +386,7 @@ void TargetWrapperCL::ImgcpyAsync(void *dst,
                                   const size_t cl_image2d_slice_pitch,
                                   IoDirection dir,
                                   const stream_t &stream) {
+  ImageValid(cl_image2d_width, cl_image2d_height);
   cl::array<size_t, 3> origin = {0, 0, 0};
   cl::array<size_t, 3> region = {cl_image2d_width, cl_image2d_height, 1};
   cl_int status;


### PR DESCRIPTION
# 状态：等等review

## 主要内容

在对Image2D Malloc和Buffer申请空间前，判断需要的buffer size是否超出global最大mem，或image size的宽度和高度是否超过Image2D的最大限制，若超出则给出提示。


## 测试

```shell
raw_input_shapes: 1,3,2240,2240
input shape: 1,3,2240,2240
is_opencl_backend_valid:1
input_shapes.size():1
malloc image is out of max image size(w,h):16384,16384, need image size(w,h):17920,1120
terminating with uncaught exception of type std::exception: std::exception
/usr/local/google/buildbot/src/android/ndk-release-r17/external/libcxx/../../external/libcxxabi/src/abort_message.cpp:73: abort_message: assertion "terminating with uncaught exception of type std::exception: std::exception" failed
Aborted
```