### PR TITLE
[Compile] Fix flto bug with clang

### DIFF
--- a/cmake/cross_compiling/preproject.cmake
+++ b/cmake/cross_compiling/preproject.cmake
@@ -44,10 +44,15 @@ check_input_var(ARM_TARGET_LANG DEFAULT "gcc" LIST "gcc" "clang")
 check_input_var(ARM_TARGET_LIB_TYPE DEFAULT "static" LIST "static" "shared")
 
 if (LITE_ON_TINY_PUBLISH OR LITE_WITH_LTO)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+  if(ARM_TARGET_LANG STREQUAL "gcc")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+  else()
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -flto=full")
+  endif()
 endif()
 
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+message(STATUS "CMAKE_CXX_FLAGS_RELEASE: ${CMAKE_CXX_FLAGS_RELEASE}")
 
 if(ARM_TARGET_OS STREQUAL "android")
   include(cross_compiling/android)

--- a/cmake/cross_compiling/preproject.cmake
+++ b/cmake/cross_compiling/preproject.cmake
@@ -47,7 +47,7 @@ if (LITE_ON_TINY_PUBLISH OR LITE_WITH_LTO)
   if(ARM_TARGET_LANG STREQUAL "gcc")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
   else()
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -flto=full")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -flto=thin")
   endif()
 endif()
 


### PR DESCRIPTION
【本PR工作】
解决使用 clang 增量编译时在 link 阶段提示：`Optimization level must be between 0 and 3`的错误。

【分析】
Clang's LTO plugin just doesn't accept -Os or -Oz
https://stackoverflow.com/questions/56238019/linker-error-when-enabling-link-time-optimization-in-ndk