### PR TITLE
[PROFILE][OPENCL] Fix OpenCl kernel for FP32/16 compatibility & cl kernel time profiler statistic. test=develop

### DIFF
--- a/lite/core/kernel.h
+++ b/lite/core/kernel.h
@@ -109,9 +109,9 @@ class KernelBase {
     Run();
 
     if (is_first_epoch_for_profiler_ && (!is_kernel_test_)) {
-      SetProfileRuntimeKernelInfo(profiler_->GetOpCharacter(profile_id_));
       is_first_epoch_for_profiler_ = false;
     }
+    SetProfileRuntimeKernelInfo(profiler_->GetOpCharacter(profile_id_));
 
     if (!is_kernel_test_) {
       profiler_->StopTiming(profile::Type::kDispatch, profile_id_, ctx_.get());

--- a/lite/core/kernel.h
+++ b/lite/core/kernel.h
@@ -107,7 +107,7 @@ class KernelBase {
     }
 
     Run();
-   
+
     // skip test
     if (!is_kernel_test_) {
       SetProfileRuntimeKernelInfo(profiler_->GetOpCharacter(profile_id_));

--- a/lite/core/kernel.h
+++ b/lite/core/kernel.h
@@ -107,13 +107,10 @@ class KernelBase {
     }
 
     Run();
-
-    if (is_first_epoch_for_profiler_ && (!is_kernel_test_)) {
-      is_first_epoch_for_profiler_ = false;
-    }
-    SetProfileRuntimeKernelInfo(profiler_->GetOpCharacter(profile_id_));
-
+   
+    // skip test
     if (!is_kernel_test_) {
+      SetProfileRuntimeKernelInfo(profiler_->GetOpCharacter(profile_id_));
       profiler_->StopTiming(profile::Type::kDispatch, profile_id_, ctx_.get());
     }
 
@@ -208,7 +205,6 @@ class KernelBase {
 #ifdef LITE_WITH_PROFILE
   profile::Profiler* profiler_{nullptr};
   int profile_id_{-1};
-  bool is_first_epoch_for_profiler_{true};
   bool is_kernel_test_{true};
 #endif
 #ifdef LITE_WITH_OPENCL

--- a/lite/kernels/opencl/elementwise_sub_image_compute.cc
+++ b/lite/kernels/opencl/elementwise_sub_image_compute.cc
@@ -82,10 +82,10 @@ void ElementwiseSubImageCompute::Run() {
       default_convertor.InitImageDimInfoWith(out->dims());  // w, h
   auto y_img_shape = default_convertor.InitImageDimInfoWith(y->dims());
 
-  auto* x_img = x->data<half_t, cl::Image2D>();
-  auto* y_img = y->data<half_t, cl::Image2D>();
-  auto* out_img = out->mutable_data<half_t, cl::Image2D>(out_img_shape[0],
-                                                         out_img_shape[1]);
+  auto* x_img = GET_DATA_GPU(x);
+  auto* y_img = GET_DATA_GPU(y);
+  auto* out_img =
+      MUTABLE_DATA_GPU(out, out_img_shape[0], out_img_shape[1], nullptr);
 
 #ifdef LITE_WITH_LOG
   VLOG(4) << "x_img_shape[w,h]:" << x_img_width << " " << x_img_height;

--- a/lite/kernels/opencl/expand_image_compute.cc
+++ b/lite/kernels/opencl/expand_image_compute.cc
@@ -105,9 +105,9 @@ class ExpandComputeImage2D : public KernelLite<TARGET(kOpenCL),
   }
 
   void Run() override {
-    auto* x_img = expand_param_->X->data<half_t, cl::Image2D>();
-    auto* out_img = expand_param_->Out->mutable_data<half_t, cl::Image2D>(
-        out_img_shape_[0], out_img_shape_[1]);
+    auto* x_img = GET_DATA_GPU(expand_param_->X);
+    auto* out_img = MUTABLE_DATA_GPU(
+        expand_param_->Out, out_img_shape_[0], out_img_shape_[1], nullptr);
     auto expand_times = expand_param_->expand_times;
 
     auto x_dims = expand_param_->X->dims();

--- a/lite/kernels/opencl/grid_sampler_image_compute.cc
+++ b/lite/kernels/opencl/grid_sampler_image_compute.cc
@@ -110,10 +110,10 @@ class GridSamplerImageCompute : public KernelLite<TARGET(kOpenCL),
     int out_height = out_dims[2];
     int out_width = out_dims[3];
 
-    auto* x_img = x->data<half_t, cl::Image2D>();
-    auto* grid_img = x->data<half_t, cl::Image2D>();
-    auto* out_img = out->mutable_data<half_t, cl::Image2D>(out_img_shape_[0],
-                                                           out_img_shape_[1]);
+    auto* x_img = GET_DATA_GPU(x);
+    auto* grid_img = GET_DATA_GPU(x);
+    auto* out_img =
+        MUTABLE_DATA_GPU(out, out_img_shape_[0], out_img_shape_[1], nullptr);
 
 #ifdef LITE_WITH_LOG
     auto in_dims = x->dims();

--- a/lite/kernels/opencl/instance_norm_image_compute.cc
+++ b/lite/kernels/opencl/instance_norm_image_compute.cc
@@ -94,10 +94,10 @@ class InstanceNormImageCompute : public KernelLite<TARGET(kOpenCL),
              cround * sizeof(half_t));
     }
     DDim scale_img_size{{ cgroup, batch }};
-    scale_image_.mutable_data<half_t, cl::Image2D>(
-        scale_img_size[0], scale_img_size[1], scale_img.data());
-    bias_image_.mutable_data<half_t, cl::Image2D>(
-        scale_img_size[0], scale_img_size[1], bias_img.data());
+    MUTABLE_DATA_GPU(
+        &scale_image_, scale_img_size[0], scale_img_size[1], scale_img.data());
+    MUTABLE_DATA_GPU(
+        &bias_image_, scale_img_size[0], scale_img_size[1], bias_img.data());
   }
 
   void ReInitWhenNeeded() override {
@@ -153,11 +153,11 @@ class InstanceNormImageCompute : public KernelLite<TARGET(kOpenCL),
 #endif
 
     auto out_image_shape = InitImageDimInfoWith(out_dims);
-    auto* x_img = x->data<half_t, cl::Image2D>();
-    auto* out_img = out->mutable_data<half_t, cl::Image2D>(
-        out_image_shape["width"], out_image_shape["height"]);
-    auto* scale_img = scale_image_.data<half_t, cl::Image2D>();
-    auto* bias_img = bias_image_.data<half_t, cl::Image2D>();
+    auto* x_img = GET_DATA_GPU(x);
+    auto* out_img = MUTABLE_DATA_GPU(
+        out, out_image_shape["width"], out_image_shape["height"], nullptr);
+    auto* scale_img = GET_DATA_GPU(&scale_image_);
+    auto* bias_img = GET_DATA_GPU(&bias_image_);
 
     cl_int status = kernel_.setArg(0, out_w);
     CL_CHECK_FATAL(status);

--- a/lite/kernels/opencl/lrn_image_compute.cc
+++ b/lite/kernels/opencl/lrn_image_compute.cc
@@ -82,11 +82,11 @@ class LrnImageCompute : public KernelLite<TARGET(kOpenCL),
 #endif
 
     auto out_image_shape = InitImageDimInfoWith(out_dims);
-    auto* x_img = x->data<half_t, cl::Image2D>();
+    auto* x_img = GET_DATA_GPU(x);
     // VLOG(4) << "x_image: " << x_img;
 
-    auto* out_img = out->mutable_data<half_t, cl::Image2D>(
-        out_image_shape["width"], out_image_shape["height"]);
+    auto* out_img = MUTABLE_DATA_GPU(
+        out, out_image_shape["width"], out_image_shape["height"], nullptr);
 
 #ifdef LITE_WITH_LOG
     // VLOG(4) << "out_image" << out_img;

--- a/lite/kernels/opencl/nearest_interp_image_compute.cc
+++ b/lite/kernels/opencl/nearest_interp_image_compute.cc
@@ -53,14 +53,12 @@ class NearestInterpComputeImageDefault
     auto& param = *param_.get_mutable<param_t>();
     const auto& x_dims = param.X->dims();
     const auto& y_dims = param.Out->dims();
-    auto* x_img =
-        param.X->data<half_t,
-                      cl::Image2D>();  // use half_t represents half float
+    auto* x_img = GET_DATA_GPU(param.X);
     auto out_image_shape = InitImageDimInfoWith(y_dims);
-    auto* out_img = param.Out->mutable_data<half_t, cl::Image2D>(  // use half_t
-        // represents half float
-        out_image_shape["width"],
-        out_image_shape["height"]);
+    auto* out_img = MUTABLE_DATA_GPU(param.Out,
+                                     out_image_shape["width"],
+                                     out_image_shape["height"],
+                                     nullptr);
 
     float scale_h = y_dims[2] / x_dims[2];
     float scale_w = y_dims[3] / x_dims[3];

--- a/lite/kernels/opencl/pad2d_image_compute.cc
+++ b/lite/kernels/opencl/pad2d_image_compute.cc
@@ -85,10 +85,10 @@ class Pad2dCompute : public KernelLite<TARGET(kOpenCL),
 #endif
 
     auto out_image_shape = InitImageDimInfoWith(out_dims);
-    auto* x_img = x->data<half_t, cl::Image2D>();
+    auto* x_img = GET_DATA_GPU(x);
 
-    auto* out_img = out->mutable_data<half_t, cl::Image2D>(
-        out_image_shape["width"], out_image_shape["height"]);
+    auto* out_img = MUTABLE_DATA_GPU(
+        out, out_image_shape["width"], out_image_shape["height"], nullptr);
 
 #ifdef LITE_WITH_LOG
     VLOG(4) << "out_image_shape[w,h]: " << out_image_shape["width"] << " "

--- a/lite/kernels/opencl/pixel_shuffle_image_compute.cc
+++ b/lite/kernels/opencl/pixel_shuffle_image_compute.cc
@@ -87,10 +87,11 @@ class PixelShuffleComputeImage2D
   }
 
   void Run() override {
-    auto* x_img = pixel_shuffle_param_->x->data<half_t, cl::Image2D>();
-    auto* out_img =
-        pixel_shuffle_param_->output->mutable_data<half_t, cl::Image2D>(
-            out_img_shape_[0], out_img_shape_[1]);
+    auto* x_img = GET_DATA_GPU(pixel_shuffle_param_->x);
+    auto* out_img = MUTABLE_DATA_GPU(pixel_shuffle_param_->output,
+                                     out_img_shape_[0],
+                                     out_img_shape_[1],
+                                     nullptr);
 
     auto x_dims = pixel_shuffle_param_->x->dims();
 

--- a/lite/kernels/opencl/reshape_image_compute.cc
+++ b/lite/kernels/opencl/reshape_image_compute.cc
@@ -67,7 +67,7 @@ class ReshapeComputeFloatImage : public KernelLite<TARGET(kOpenCL),
     const int64_t& input_image_width = input_image_shape.at("width");
     const int64_t& input_image_height = input_image_shape.at("height");
 
-    const cl::Image2D* const x_image = x->data<half_t, cl::Image2D>();
+    auto* x_image = GET_DATA_GPU(x);
 
     const std::vector<int>& shape_vct = param.shape_vct;
     Tensor* const output = param.output;
@@ -76,8 +76,10 @@ class ReshapeComputeFloatImage : public KernelLite<TARGET(kOpenCL),
 
     const std::map<std::string, size_t>& out_image_shape =
         InitImageDimInfoWith(out_dims);
-    cl::Image2D* const out_image = output->mutable_data<half_t, cl::Image2D>(
-        out_image_shape.at("width"), out_image_shape.at("height"));
+    auto* out_image = MUTABLE_DATA_GPU(output,
+                                       out_image_shape.at("width"),
+                                       out_image_shape.at("height"),
+                                       nullptr);
 #ifdef LITE_WITH_LOG
     VLOG(4) << "out_dims=   " << out_dims;
 #endif

--- a/lite/kernels/opencl/shuffle_channel_image_compute.cc
+++ b/lite/kernels/opencl/shuffle_channel_image_compute.cc
@@ -60,11 +60,13 @@ class ShuffleChannelComputeImage2D
     int group = param.group;
     int group_size = channels / group;
 
-    auto* x_img = param.X->data<half_t, cl::Image2D>();
+    auto* x_img = GET_DATA_GPU(param.X);
 
     auto out_image_shape = InitImageDimInfoWith(out_dims);
-    auto* out_img = param.Out->mutable_data<half_t, cl::Image2D>(
-        out_image_shape["width"], out_image_shape["height"]);
+    auto* out_img = MUTABLE_DATA_GPU(param.Out,
+                                     out_image_shape["width"],
+                                     out_image_shape["height"],
+                                     nullptr);
 
     auto& context = ctx_->As<OpenCLContext>();
     CHECK(context.cl_context() != nullptr);

--- a/lite/kernels/opencl/slice_image_compute.cc
+++ b/lite/kernels/opencl/slice_image_compute.cc
@@ -51,7 +51,7 @@ class SliceComputeImage2D : public KernelLite<TARGET(kOpenCL),
   void Run() override {
     const auto& param = *param_.get_mutable<param_t>();
     const auto& in_dims = param.X->dims();
-    auto* x_img = param.X->data<half_t, cl::Image2D>();
+    auto* x_img = GET_DATA_GPU(param.X);
     auto& out_dims = param.Out->dims();
 
     std::vector<int> axes = param.axes;
@@ -68,8 +68,10 @@ class SliceComputeImage2D : public KernelLite<TARGET(kOpenCL),
     int dim_w = in_dims[axis + 2];
 
     auto out_image_shape = InitImageDimInfoWith(out_dims);
-    auto* out_img = param.Out->mutable_data<half_t, cl::Image2D>(
-        out_image_shape["width"], out_image_shape["height"]);
+    auto* out_img = MUTABLE_DATA_GPU(param.Out,
+                                     out_image_shape["width"],
+                                     out_image_shape["height"],
+                                     nullptr);
 
     auto& context = ctx_->As<OpenCLContext>();
     CHECK(context.cl_context() != nullptr);

--- a/lite/kernels/opencl/split_image_compute.cc
+++ b/lite/kernels/opencl/split_image_compute.cc
@@ -132,13 +132,15 @@ class SplitComputeImage2D : public KernelLite<TARGET(kOpenCL),
     const auto& x_dims = split_param_->x->dims();
     const int out0_dims_axis = split_param_->output[0]->dims()[axis_];
     const auto out_num = split_param_->output.size();
-    const auto* x_img = split_param_->x->data<half_t, cl::Image2D>();
+    const auto* x_img = GET_DATA_GPU(split_param_->x);
 
     std::vector<cl::Image2D*> out_img{out_num};
     for (auto i = 0; i < split_param_->output.size(); i++) {
       auto image_shape = InitImageDimInfoWith(split_param_->output[i]->dims());
-      out_img[i] = split_param_->output[i]->mutable_data<half_t, cl::Image2D>(
-          image_shape["width"], image_shape["height"]);
+      out_img[i] = MUTABLE_DATA_GPU(split_param_->output[i],
+                                    image_shape["width"],
+                                    image_shape["height"],
+                                    nullptr);
     }
 
     auto& context = ctx_->As<OpenCLContext>();

--- a/lite/kernels/opencl/trigonometric_image_compute.cc
+++ b/lite/kernels/opencl/trigonometric_image_compute.cc
@@ -80,10 +80,11 @@ class TrigonometricComputeImage2D
   }
 
   void Run() override {
-    auto* x_img = trigonometric_param_->X->data<half_t, cl::Image2D>();
-    auto* out_img =
-        trigonometric_param_->Out->mutable_data<half_t, cl::Image2D>(
-            out_img_shape_[0], out_img_shape_[1]);
+    auto* x_img = GET_DATA_GPU(trigonometric_param_->X);
+    auto* out_img = MUTABLE_DATA_GPU(trigonometric_param_->Out,
+                                     out_img_shape_[0],
+                                     out_img_shape_[1],
+                                     nullptr);
 
     auto& context = ctx_->As<OpenCLContext>();
     CHECK(context.cl_context() != nullptr);


### PR DESCRIPTION
# 状态：等待review

## 主要内容

- 修复OpenCL性能Profiler的clMax/clAvg/clMin时间恒定的情况；
- 修复OpenCL kernel对FP32/16兼容的剩余的13个kernel：elementwise_sub/expan/grid_sampler/instance_norm/lrn/nearest_interp/pool2d/pixel_shuffle/reshape/shuffle_channel/slice/split/trigonometric。