### PR TITLE
[OpenCL][Kernel] Add depthwise_conv2d common impl

### DIFF
--- a/lite/backends/opencl/cl_image_converter.cc
+++ b/lite/backends/opencl/cl_image_converter.cc
@@ -563,5 +563,65 @@ void CLImageConverterNBlock::ImageToNCHW(void *image,
                                          const DDim &image_dim,
                                          const DDim &tensor_dim) {}
 
+DDim CLImageConverterDWFilter::InitImageDimInfoWith(const DDim &tensor_dim) {
+  CHECK(tensor_dim.size() == 4) << " Tensor dim is not 4.";
+  size_t N, C, H, W;
+  N = tensor_dim[0];
+  C = tensor_dim[1];
+  H = tensor_dim[2];
+  W = tensor_dim[3];
+  size_t width = H * W;
+  size_t height = ((N + 3) / 4) * C;
+  return DDim(
+      std::vector<DDim::value_type>({static_cast<DDim::value_type>(width),
+                                     static_cast<DDim::value_type>(height)}));
+}
+
+void CLImageConverterDWFilter::NCHWToImage(float *nchw,
+                                           void *image,
+                                           const DDim &tensor_dim) {
+  CHECK(tensor_dim.size() == 4) << " Tensor dim is not 4.";
+  size_t N, C, H, W;
+  N = tensor_dim[0];
+  C = tensor_dim[1];
+  H = tensor_dim[2];
+  W = tensor_dim[3];
+
+  DDim in_image_dim = InitImageDimInfoWith(tensor_dim);
+  VLOG(3) << " tensor dim: " << tensor_dim;
+  VLOG(3) << " image dim: " << in_image_dim;
+
+  size_t height = in_image_dim[1];
+  size_t n_block = height / C;
+
+  float *image_fp32 = static_cast<float *>(image);
+  half_t *image_fp16 = static_cast<half_t *>(image);
+
+  float *p = nchw;
+  size_t i0 = 0;
+  for (size_t n = 0; n < n_block * 4; n++) {
+    for (size_t c = 0; c < C; c++) {
+      for (size_t h = 0; h < H; h++) {
+        for (size_t w = 0; w < W; w++) {
+          size_t img_idx = (((n / 4) * W * H + h * W + w) * C + c) * 4 + n % 4;
+          if (n < N) {
+            fp16_support_ ? image_fp16[img_idx] = Float2Half(*p)
+                          : image_fp32[img_idx] = *p;
+            p++;
+          } else {
+            fp16_support_ ? image_fp16[img_idx] = Float2Half(0.f)
+                          : image_fp32[img_idx] = 0.f;
+          }
+        }
+      }
+    }
+  }
+}
+
+void CLImageConverterDWFilter::ImageToNCHW(void *image,
+                                           float *tensor,
+                                           const DDim &image_dim,
+                                           const DDim &tensor_dim) {}
+
 }  // namespace lite
 }  // namespace paddle

--- a/lite/backends/opencl/cl_image_converter.h
+++ b/lite/backends/opencl/cl_image_converter.h
@@ -143,5 +143,15 @@ class CLImageConverterNBlock : public CLImageConverterBase {
                    const DDim &tensor_dim) override;
 };
 
+class CLImageConverterDWFilter : public CLImageConverterBase {
+ public:
+  DDim InitImageDimInfoWith(const DDim &tensor_dim) override;
+  void NCHWToImage(float *tensor, void *image, const DDim &tensor_dim) override;
+  void ImageToNCHW(void *image,
+                   float *tensor,
+                   const DDim &image_dim,
+                   const DDim &tensor_dim) override;
+};
+
 }  // namespace lite
 }  // namespace paddle

--- a/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
@@ -14,16 +14,137 @@ limitations under the License. */
 
 #include <cl_common.h>
 
+
+__kernel void depth_conv2d_common(__private const int global_size_dim0, // out_c / 4
+                                  __private const int global_size_dim1, // out_w / 4
+                                  __private const int global_size_dim2, // out_n * out_h
+                                  __read_only image2d_t input,
+                                  __read_only image2d_t filter,
+                                  __read_only image2d_t bias,
+                                  __write_only image2d_t output,
+                                  __private const int stride_w,
+                                  __private const int stride_h,
+                                  __private const int pad_up,
+                                  __private const int pad_left,
+                                  __private const int dilation_w,
+                                  __private const int dilation_h,
+                                  __private const int input_width,
+                                  __private const int input_height,
+                                  __private const int output_width,
+                                  __private const int output_height,
+                                  __private const int filter_width,
+                                  __private const int filter_height) {
+
+  const short out_c_blk = get_global_id(0); // [0, (C+3)/4)
+  const short out_w_blk = get_global_id(1); // [0, (W+3)/4)
+  const short out_nh = get_global_id(2);    // [0, N*H)
+
+  if (out_c_blk >= global_size_dim0 || out_w_blk >= global_size_dim1
+      || out_nh >= global_size_dim2) {
+    return;
+  }
+
+  int2 out_pos = (int2)(out_c_blk * global_size_dim1 + out_w_blk, out_nh);
+
+#ifdef BIASE_CH
+  CL_DTYPE4 out0 =
+      READ_IMG_TYPE(CL_DTYPE_CHAR, bias, SAMPLER, (int2)(out_c_blk, 0));
+  CL_DTYPE4 out1 = out0;
+  CL_DTYPE4 out2 = out0;
+  CL_DTYPE4 out3 = out0;
+#elif defined(BIASE_ELE)
+  CL_DTYPE4 out0 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, SAMPLER, (int2)(out_pos.x + 0, out_pos.y));
+  CL_DTYPE4 out1 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, SAMPLER, (int2)(out_pos.x + 1, out_pos.y));
+  CL_DTYPE4 out2 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, SAMPLER, (int2)(out_pos.x + 2, out_pos.y));
+  CL_DTYPE4 out3 = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, SAMPLER, (int2)(out_pos.x + 3, out_pos.y));
+#else
+  CL_DTYPE4 out0 = 0;
+  CL_DTYPE4 out1 = 0;
+  CL_DTYPE4 out2 = 0;
+  CL_DTYPE4 out3 = 0;
+#endif
+
+  const short in_w_offset0 = mad24(out_w_blk, stride_w << 2, -(pad_left >> 1)); // out_w_blk * stride_w * 4 - pad_left/2
+  const short in_w_offset1 = in_w_offset0 + stride_w;
+  const short in_w_offset2 = in_w_offset1 + stride_w;
+  const short in_w_offset3 = in_w_offset2 + stride_w;
+
+  short in_h_idx = mad24(out_nh % output_height, stride_h, -(pad_up >> 1)); // out_nh % output_height * stride_h - pad_up/2. height index of one input feature map
+  const short batch_idx = out_nh / output_height;
+  const short in_c_blk = out_c_blk;
+
+  const short in_x_base = mul24(in_c_blk, input_width); // in_c_blk * input_width
+  for (short kh = 0; kh < filter_height; kh++) {
+    short in_pos_y = select(in_h_idx + batch_idx * input_height, -1, (in_h_idx < 0 || in_h_idx >= input_height));
+    in_h_idx += dilation_h;
+    for (short kw = 0; kw < filter_width; kw++) {
+      CL_DTYPE4 in0, in1, in2, in3;
+
+      short base = mul24(kw, dilation_w);
+      short in_w_idx = in_w_offset0 + base; // width index of one input feature map
+      short in_pos_x = select(in_x_base + in_w_idx, -1, (in_w_idx < 0 || in_w_idx >= input_width));
+      in0 = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(in_pos_x, in_pos_y));
+
+      in_w_idx = in_w_offset1 + base;
+      in_pos_x = select(in_x_base + in_w_idx, -1, (in_w_idx < 0 || in_w_idx >= input_width));
+      in1 = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(in_pos_x, in_pos_y));
+
+      in_w_idx = in_w_offset2 + base;
+      in_pos_x = select(in_x_base + in_w_idx, -1, (in_w_idx < 0 || in_w_idx >= input_width));
+      in2 = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(in_pos_x, in_pos_y));
+
+      in_w_idx = in_w_offset3 + base;
+      in_pos_x = select(in_x_base + in_w_idx, -1, (in_w_idx < 0 || in_w_idx >= input_width));
+      in3 = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(in_pos_x, in_pos_y));
+
+      short filter_idx = mad24(kh, filter_width, kw);
+      CL_DTYPE4 weights = READ_IMG_TYPE(CL_DTYPE_CHAR, filter, SAMPLER, (int2)(filter_idx, in_c_blk));
+
+      out0 = mad(in0, weights, out0);
+      out1 = mad(in1, weights, out1);
+      out2 = mad(in2, weights, out2);
+      out3 = mad(in3, weights, out3);
+    }
+  }
+
+  out0 = activation_type4(out0);
+  out1 = activation_type4(out1);
+  out2 = activation_type4(out2);
+  out3 = activation_type4(out3);
+
+#ifdef SCALE_ACTIVATION
+  out0 = fuse_scale(out0, 1.f, 0.f, 0.f);
+  out1 = fuse_scale(out1, 1.f, 0.f, 0.f);
+  out2 = fuse_scale(out2, 1.f, 0.f, 0.f);
+  out3 = fuse_scale(out3, 1.f, 0.f, 0.f);
+#endif
+
+  const short out_w_blk4 = out_w_blk << 2; // [0, W)
+  const short remain = output_width - out_w_blk4;
+  const short out_pos_x = mad24(out_c_blk, output_width, out_w_blk4);
+  if (remain >= 4) {
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x,     out_nh), out0);
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x + 1, out_nh), out1);
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x + 2, out_nh), out2);
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x + 3, out_nh), out3);
+  } else if (remain == 3) {
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x,     out_nh), out0);
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x + 1, out_nh), out1);
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x + 2, out_nh), out2);
+  } else if (remain == 2) {
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x,     out_nh), out0);
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x + 1, out_nh), out1);
+  } else if (remain == 1) {
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x,     out_nh), out0);
+  }
+}
+
 __kernel void depth_conv2d(__private const int global_size_dim0,
                            __private const int global_size_dim1,
                            __private const int global_size_dim2,
                            __read_only image2d_t input,
                            __read_only image2d_t filter,
                            __read_only image2d_t bias,
-#ifdef BATCH_NORM
-                           __read_only image2d_t new_scale,
-                           __read_only image2d_t new_biase,
-#endif
                            __write_only image2d_t output_image,
                            __private const int stride_h,
                            __private const int stride_w,
@@ -88,11 +209,6 @@ __kernel void depth_conv2d(__private const int global_size_dim0,
       output += in * f;
     }
   }
-#ifdef BATCH_NORM
-  output = output * READ_IMG_TYPE(
-                        CL_DTYPE_CHAR, new_scale, SAMPLER, (int2)(out_c, 0)) +
-           READ_IMG_TYPE(CL_DTYPE_CHAR, new_biase, SAMPLER, (int2)(out_c, 0));
-#endif
 
   output = activation_type4(output);
 

--- a/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
@@ -15,8 +15,8 @@ limitations under the License. */
 #include <cl_common.h>
 
 
-__kernel void depth_conv2d_common(__private const int global_size_dim0, // out_c / 4
-                                  __private const int global_size_dim1, // out_w / 4
+__kernel void depth_conv2d_common(__private const int global_size_dim0, // (out_c + 1) / 4
+                                  __private const int global_size_dim1, // (out_w + 1) / 4
                                   __private const int global_size_dim2, // out_n * out_h
                                   __read_only image2d_t input,
                                   __read_only image2d_t filter,
@@ -64,12 +64,12 @@ __kernel void depth_conv2d_common(__private const int global_size_dim0, // out_c
   CL_DTYPE4 out3 = 0;
 #endif
 
-  const short in_w_offset0 = mad24(out_w_blk, stride_w << 2, -(pad_left >> 1)); // out_w_blk * stride_w * 4 - pad_left/2
+  const short in_w_offset0 = mad24(out_w_blk, stride_w << 2, -pad_left); // out_w_blk * stride_w * 4 - pad_left
   const short in_w_offset1 = in_w_offset0 + stride_w;
   const short in_w_offset2 = in_w_offset1 + stride_w;
   const short in_w_offset3 = in_w_offset2 + stride_w;
 
-  short in_h_idx = mad24(out_nh % output_height, stride_h, -(pad_up >> 1)); // out_nh % output_height * stride_h - pad_up/2. height index of one input feature map
+  short in_h_idx = mad24(out_nh % output_height, stride_h, -pad_up); // out_nh % output_height * stride_h - pad_up. height index of one input feature map
   const short batch_idx = out_nh / output_height;
   const short in_c_blk = out_c_blk;
 

--- a/lite/backends/opencl/cl_utility.h
+++ b/lite/backends/opencl/cl_utility.h
@@ -65,25 +65,25 @@ const char* opencl_error_to_str(cl_int error);
       kernel, gws_offset, gws, lws, event_wait_list, &event)
 
 // mutable_data
-#define MUTABLE_DATA_GPU(tensor_instance_p, img_w, img_h, ptr)     \
-  (fp16_support_)                                                  \
-      ? (tensor_instance_p)                                        \
-            ->mutable_data<half_t, cl::Image2D>(img_w, img_h, ptr) \
-      : (tensor_instance_p)                                        \
-            ->mutable_data<float, cl::Image2D>(img_w, img_h, ptr)
+#define MUTABLE_DATA_GPU(tensor_ins_p, img_w, img_h, ptr)                    \
+  (CLRuntime::Global()->get_precision() == lite_api::CL_PRECISION_FP16)      \
+      ? (tensor_ins_p)->mutable_data<half_t, cl::Image2D>(img_w, img_h, ptr) \
+      : (tensor_ins_p)->mutable_data<float, cl::Image2D>(img_w, img_h, ptr)
 
-#define DATA_GPU(tensor_instance_p)                                          \
-  (fp16_support_) ? (tensor_instance_p)->mutable_data<half_t, cl::Image2D>() \
-                  : (tensor_instance_p)->mutable_data<float, cl::Image2D>()
+#define DATA_GPU(tensor_ins_p)                                          \
+  (CLRuntime::Global()->get_precision() == lite_api::CL_PRECISION_FP16) \
+      ? (tensor_ins_p)->mutable_data<half_t, cl::Image2D>()             \
+      : (tensor_ins_p)->mutable_data<float, cl::Image2D>()
 
-#define GET_DATA_GPU(tensor_instance_p)                              \
-  (fp16_support_) ? (tensor_instance_p)->data<half_t, cl::Image2D>() \
-                  : (tensor_instance_p)->data<float, cl::Image2D>()
+#define GET_DATA_GPU(tensor_ins_p)                                      \
+  (CLRuntime::Global()->get_precision() == lite_api::CL_PRECISION_FP16) \
+      ? (tensor_ins_p)->data<half_t, cl::Image2D>()                     \
+      : (tensor_ins_p)->data<float, cl::Image2D>()
 
-#define MUTABLE_DATA_CPU(tensor_instance_p)                             \
-  (fp16_support_)                                                       \
-      ? static_cast<void*>((tensor_instance_p)->mutable_data<half_t>()) \
-      : static_cast<void*>((tensor_instance_p)->mutable_data<float>())
+#define MUTABLE_DATA_CPU(tensor_ins_p)                                  \
+  (CLRuntime::Global()->get_precision() == lite_api::CL_PRECISION_FP16) \
+      ? static_cast<void*>((tensor_ins_p)->mutable_data<half_t>())      \
+      : static_cast<void*>((tensor_ins_p)->mutable_data<float>())
 
 }  // namespace lite
 }  // namespace paddle

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -988,9 +988,9 @@ void ConvImageCompute::DepthwiseConv2d() {
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(8, stride_h_);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(9, pad_up_);
+  status_ = kernel_.setArg(9, (pad_up_ + pad_down_) / 2);
   CL_CHECK_FATAL(status_);
-  status_ = kernel_.setArg(10, pad_left_);
+  status_ = kernel_.setArg(10, (pad_left_ + pad_right_) / 2);
   CL_CHECK_FATAL(status_);
   status_ = kernel_.setArg(11, dilation_w_);
   CL_CHECK_FATAL(status_);
@@ -1077,10 +1077,11 @@ void ConvImageCompute::PrintConvInfo() {
       has_bias_ && conv_param_->output->dims() == conv_param_->bias->dims();
 
   VLOG(4) << "input_image_shape: " << input_image_w_ << "," << input_image_h_;
-  //  VLOG(4) << "input_image: " << input_image_p_;
   VLOG(4) << "input_dims: " << conv_param_->x->dims();
   VLOG(4) << "filter_dims: " << conv_param_->filter->dims();
-  //  VLOG(4) << "filter_image: " << filter_image;
+  if (has_bias_) {
+    VLOG(4) << "bias_dims: " << conv_param_->bias->dims();
+  }
   VLOG(4) << "output_dims: " << conv_param_->output->dims();
   VLOG(4) << "out_image_shape: " << output_image_w_ << ", " << output_image_h_;
   VLOG(4) << "paddings: " << pad_left_ << "," << pad_up_;

--- a/lite/kernels/opencl/depthwise_conv2d_image_compute_test.cc
+++ b/lite/kernels/opencl/depthwise_conv2d_image_compute_test.cc
@@ -29,7 +29,7 @@ namespace lite {
 #define SHADOW_LOG VLOG(4)
 #define FP16_MAX_DIFF (1e0)
 #define FP16_ABS_DIFF (1e-1)
-// #define TEST_DEPTHWISE_CONV_IMAGE_BASIC
+#define TEST_DEPTHWISE_CONV_IMAGE_BASIC
 #define TEST_DEPTHWISE_CONV_IMAGE_3X3
 
 #define LEAKY_RELU_ALPHA (0.1)
@@ -222,278 +222,217 @@ int ConvOutputSize(int input_size,
 #ifdef TEST_DEPTHWISE_CONV_IMAGE_BASIC
 // #define LOOP_TEST
 TEST(depthwise_conv2d, compute_basic) {
-  // conv infos
-  //  const int ksize = 1;
+  const int fc = 1;
+  const int fw = 7;
+  const int fh = fw;
+  const int dilation = 1;
   const int stride = 1;
   const int pad = 0;
-  const int group = 1;
-  const int dilation = 1;
-  const int fc = 1;
-  const int batch_size = 1;
-  const int bias_flag = false;
-  const std::string relu_flag = "relu";
-//  int loop_cnt = 0;
-
+  const bool bias_flag = false;
+  const std::string relu_flag = "leaky_relu";
 #ifdef LOOP_TEST
   // for (int batch_size = 1; batch_size < 2; ++batch_size) {
-  for (int oc = 4; oc < 10; oc += 1) {         // oc = ic
-    for (int fw = 3; fw < 10; fw += 2) {       // fh = fw
-      for (int ih = fw; ih < 15; ih += 1) {    // ih
-        for (int iw = fw; iw < 15; iw += 1) {  // iw
+  for (int oc = 4; oc < 10; oc += 1) {      // oc = ic
+    for (int ih = 3; ih < 15; ih += 1) {    // ih
+      for (int iw = 3; iw < 15; iw += 1) {  // iw
 #else
-  const int oc = 32;
+  const int ic = 5;
   const int ih = 112;
   const int iw = 112;
-  const int fw = 5;
-
 #endif
-
-          const int fb = oc;
-          const int ic = oc;
-          const int fh = fw;
-
-          const int oh = ConvOutputSize(ih, fh, dilation, pad, pad, stride);
-          const int ow = ConvOutputSize(iw, fw, dilation, pad, pad, stride);
-
-          VLOG(4) << "to get kernel ...";
-          auto kernels =
-              KernelRegistry::Global().Create("depthwise_conv2d",
-                                              TARGET(kOpenCL),
-                                              PRECISION(kFP16),
-                                              DATALAYOUT(kImageDefault));
-          ASSERT_FALSE(kernels.empty());
-
-          auto kernel = std::move(kernels.front());
-          VLOG(4) << "created depthconv2d kernel";
-
-          VLOG(4) << "prepare kernel ------";
-
-          lite::Tensor input, filter, bias, output;
-          operators::ConvParam param;
-          param.x = &input;
-          param.filter = &filter;
-          param.output = &output;
-          if (bias_flag) {
-            param.bias = &bias;
-          }
-
-          if (relu_flag == "relu") {
-            param.fuse_relu = true;  // relu only
-            param.activation_param.has_active = true;
-            param.activation_param.active_type =
-                lite_api::ActivationType::kRelu;
-          } else if (relu_flag == "relu6") {
-            param.activation_param.Relu_clipped_coef = 6.f;
-            param.activation_param.has_active = true;
-            param.activation_param.active_type =
-                lite_api::ActivationType::kRelu6;
-          } else if (relu_flag == "leaky_relu") {
-            param.activation_param.active_type =
-                lite_api::ActivationType::kLeakyRelu;
-            param.activation_param.has_active = true;
-            param.activation_param.Leaky_relu_alpha = LEAKY_RELU_ALPHA;
-          } else {
-            param.fuse_relu = false;  // relu only
-            param.activation_param.has_active = false;
-          }
-
-          std::vector<int> paddings = {pad, pad, pad, pad};
-          std::vector<int> dilations = {dilation, dilation};
-
-          param.paddings = std::make_shared<std::vector<int>>(paddings);
-          param.dilations = std::make_shared<std::vector<int>>(dilations);
-          param.strides = std::vector<int>{stride, stride};
-
-          std::unique_ptr<KernelContext> context(new KernelContext);
-          context->As<OpenCLContext>().InitOnce();
-
-          std::unique_ptr<KernelContext> depth_conv_context(new KernelContext);
-          context->As<OpenCLContext>().CopySharedTo(
-              &(depth_conv_context->As<OpenCLContext>()));
-          kernel->SetContext(std::move(depth_conv_context));
-
-          const DDim& input_dim =
-              lite::DDim{std::vector<int64_t>({batch_size, ic, ih, iw})};
-
-          const DDim& filter_dim =
-              lite::DDim{std::vector<int64_t>({fb, fc, fh, fw})};
-          const DDim& out_dim =
-              lite::DDim{std::vector<int64_t>({batch_size, oc, oh, ow})};
-          // element wise bias
-          const DDim& bias_dim = lite::DDim{std::vector<int64_t>({oc})};
-
-          param.x->Resize(input_dim);
-          param.filter->Resize(filter_dim);
-          param.output->Resize(out_dim);
-
-          kernel->SetParam(param);
-
-          size_t input_image_width = iw * ((ic + 3) / 4);
-          size_t input_image_height = ih * batch_size;
-
-          size_t out_image_width = ow * ((oc + 3) / 4);
-          size_t out_image_height = oh * batch_size;
-
-          size_t bias_image_width = ow * ((oc + 3) / 4);
-          size_t bias_image_height = oh * batch_size;
-
-          size_t filter_image_width = fw * ((fb + 3) / 4);
-          size_t filter_image_height = fc * fh;
-
-          const size_t cl_image2d_row_pitch{0};
-          const size_t cl_image2d_slice_pitch{0};
-
-          std::default_random_engine engine;
-          std::uniform_real_distribution<float> gen(-5, 5);
-
-          std::vector<float> input_v(batch_size * ic * ih * iw);
-          std::vector<float> filter_v(fb * fc * fh * fw);
-          std::vector<float> output_v(batch_size * oc * ih * iw);
-          std::vector<float> bias_v(oc);
-
-          VLOG(4) << "gen input and filter ...";
-
-          for (auto& i : input_v) {
-            i = gen(engine);
-          }
-          for (auto& f : filter_v) {
-            f = gen(engine);
-          }
-
-          VLOG(4) << "after gen input and filter ...";
-          VLOG(4) << "input_v.size(): " << input_v.size();
-          VLOG(4) << "filter_v.size(): " << filter_v.size();
-          VLOG(4) << "output_v.size(): " << output_v.size();
-          VLOG(4) << "bias_v.size(): " << bias_v.size();
-          VLOG(4) << "input_dim.production(): " << input_dim.production();
-          VLOG(4) << "filter_dim.production(): " << filter_dim.production();
-          VLOG(4) << "out_dim.production(): " << out_dim.production();
-          VLOG(4) << "bias_dim.production(): " << bias_dim.production();
-          VLOG(4) << "4 * input_image_height * input_image_width: "
-                  << 4 * input_image_height * input_image_width;
-          VLOG(4) << "4 * filter_image_width * filter_image_height: "
-                  << 4 * filter_image_width * filter_image_height;
-
-          CHECK(input_dim.production() == input_v.size());
-          CHECK_LE(input_dim.production(),
-                   4 * input_image_height * input_image_width);
-          CHECK(filter_dim.production() == filter_v.size());
-          CHECK_LE(filter_dim.production(),
-                   4 * filter_image_width * filter_image_height);
-
-          paddle::lite::CLImageConverterDefault default_convertor;
-          VLOG(4) << "set mapped input  ...";
-          std::vector<half_t> x_image_v(input_image_width * input_image_height *
-                                        4);  // 4 : RGBA
-          std::vector<half_t> filter_image_v(
-              filter_image_width * filter_image_height * 4);  // 4 : RGBA
-          std::vector<half_t> bias_image_v(bias_image_width *
-                                           bias_image_height * 4);  // 4 : RGBA
-          std::vector<half_t> out_image_v(out_image_width * out_image_height *
-                                          4);  // 4 : RGBA
-
-          default_convertor.NCHWToImage(
-              input_v.data(), x_image_v.data(), input_dim);
-
-          VLOG(4) << "set mapped filter  ...";
-          paddle::lite::CLImageConverterNWBlock nw_convertor;
-          nw_convertor.NCHWToImage(
-              filter_v.data(), filter_image_v.data(), filter_dim);
-
-          auto* input_image2d = input.mutable_data<half_t, cl::Image2D>(
-              input_image_width, input_image_height, x_image_v.data());
-          auto* filter_image2d = filter.mutable_data<half_t, cl::Image2D>(
-              filter_image_width, filter_image_height, filter_image_v.data());
-
-          if (bias_flag) {
-            nw_convertor.NCHWToImage(
-                filter_v.data(), filter_image_v.data(), filter_dim);
-
-            for (int i = 0; i < bias_dim.production(); ++i) {
-              bias_v[i] = static_cast<int>(gen(engine));
-            }
-            CLImageConverterFolder folder_convertor;
-            folder_convertor.NCHWToImage(
-                bias_v.data(), bias_image_v.data(), bias_dim);
-            auto* bias_data = bias.mutable_data<half_t, cl::Image2D>(
-                bias_image_width, bias_image_height, bias_image_v.data());
-          }
-
-          VLOG(4) << "resize output  ...";
-          output.Resize(out_dim);
-
-          // cpu conv basic calc
-          lite::Tensor out_ref;
-          out_ref.Resize(out_dim);
-
-          VLOG(4) << "prepare kernel ready";
-
-          VLOG(4) << "kernel launch ...";
-          kernel->Launch();
-          VLOG(4) << "mutable output ...";
-          auto* output_image2d = output.mutable_data<half_t, cl::Image2D>(
-              out_image_width, out_image_height);
-
-          CLRuntime::Global()->command_queue().finish();
-
-          TargetWrapperCL::ImgcpySync(out_image_v.data(),
-                                      output.data<half_t, cl::Image2D>(),
-                                      out_image_width,
-                                      out_image_height,
-                                      cl_image2d_row_pitch,
-                                      cl_image2d_slice_pitch,
-                                      IoDirection::DtoH);
-          DDim out_image_shape =
-              default_convertor.InitImageDimInfoWith(output.dims());
-
-          default_convertor.ImageToNCHW(out_image_v.data(),
-                                        output_v.data(),
-                                        out_image_shape,
-                                        output.dims());
-
-          // for (int j = 0; j < input_v.size(); j += 1) {
-          //   VLOG(4) << "input_v input[" << j
-          //           << "]: " << input_v.data()[j];
-          //       std::cout<< j << "  " << input_v.data()[j] << std::endl;
-          // }
-          // std::cout << std::endl;
-
-          // for (int j = 0; j < output_v.size(); j += 1) {
-          //   VLOG(4) << "output_v output_v[" << j
-          //           << "]:" << output_v.data()[j];
-          //       std::cout << j << "  " << output_v.data()[j] <<
-          //       std::endl;
-          // }
-
-          VLOG(4) << "mutable_data out_ref_data: ";
-
-          // run cpu ref
-          auto* out_ref_data = out_ref.mutable_data<float>(TARGET(kARM));
-
-          VLOG(4) << " conv_basic beigin ..... ";
-          depth_conv<float, 1, 1>(input_v.data(),
-                                  input.dims(),
-                                  filter_v.data(),
-                                  filter.dims(),
-                                  out_ref_data,
-                                  out_dim);
-          VLOG(4) << " conv_basic end ..... ";
-
-          VLOG(4) << " input_dim: " << input_dim;
-          VLOG(4) << " filter_dim: " << filter_dim;
-          const DDim& out_image_dims = lite::DDim{
-              std::vector<int64_t>({static_cast<int64_t>(out_image_width),
-                                    static_cast<int64_t>(out_image_height)})};
-
-          for (int i = 0; i < out_dim.production(); i++) {
-            EXPECT_NEAR(output_v[i], out_ref_data[i], 1e-2);
-            if (abs(output_v[i] - out_ref_data[i]) > 1e-2) {
-              LOG(FATAL) << "error idx:" << i;
-            }
-          }
-
+        const int fb = ic;
+        const int oc = ic;
+        const int oh = ConvOutputSize(ih, fh, dilation, pad, pad, stride);
+        const int ow = ConvOutputSize(iw, fw, dilation, pad, pad, stride);
+        if (oh <= 0 || ow <= 0) {
 #ifdef LOOP_TEST
+          continue;
+#else
+    LOG(FATAL) << "Output tensor of depthwise conv is illegal!"
+               << "Please check your input dims and conv params";
+#endif
         }
+
+        LOG(INFO) << "to get kernel ...";
+        auto kernels =
+            KernelRegistry::Global().Create("depthwise_conv2d",
+                                            TARGET(kOpenCL),
+                                            PRECISION(kFP16),
+                                            DATALAYOUT(kImageDefault));
+        ASSERT_FALSE(kernels.empty());
+
+        auto kernel = std::move(kernels.front());
+
+        LOG(INFO) << "get kernel";
+        lite::Tensor input, filter, bias, output;
+        operators::ConvParam param;
+        param.x = &input;
+        param.filter = &filter;
+        param.output = &output;
+        param.groups = oc;
+        std::vector<int> paddings = {pad, pad, pad, pad};
+        param.paddings = std::make_shared<std::vector<int>>(paddings);
+        param.strides = std::vector<int>{stride, stride};
+        std::vector<int> dilations = {dilation, dilation};
+        param.dilations = std::make_shared<std::vector<int>>(dilations);
+        param.bias = bias_flag ? &bias : nullptr;
+
+        if (relu_flag == "relu") {
+          param.fuse_relu = true;  // relu only
+          param.activation_param.has_active = true;
+          param.activation_param.active_type = lite_api::ActivationType::kRelu;
+        } else if (relu_flag == "relu6") {
+          param.activation_param.Relu_clipped_coef = 6.f;
+          param.activation_param.has_active = true;
+          param.activation_param.active_type = lite_api::ActivationType::kRelu6;
+        } else if (relu_flag == "leaky_relu") {
+          param.activation_param.active_type =
+              lite_api::ActivationType::kLeakyRelu;
+          param.activation_param.has_active = true;
+          param.activation_param.Leaky_relu_alpha = LEAKY_RELU_ALPHA;
+        } else {
+          param.fuse_relu = false;  // relu only
+          param.activation_param.has_active = false;
+        }
+
+        std::unique_ptr<KernelContext> context(new KernelContext);
+        context->As<OpenCLContext>().InitOnce();
+
+        kernel->SetParam(param);
+        std::unique_ptr<KernelContext> dep_context(new KernelContext);
+        context->As<OpenCLContext>().CopySharedTo(
+            &(dep_context->As<OpenCLContext>()));
+        kernel->SetContext(std::move(dep_context));
+
+        LOG(INFO) << "kernel ready";
+        const DDim& input_dim =
+            lite::DDim{std::vector<int64_t>({1, ic, ih, iw})};
+        const DDim& filter_dim =
+            lite::DDim{std::vector<int64_t>({fb, fc, fh, fw})};
+        const DDim& output_dim =
+            lite::DDim{std::vector<int64_t>({1, oc, oh, ow})};
+        // element wise bias
+        const DDim bias_dim = DDim(std::vector<DDim::value_type>{oc});
+        input.Resize(input_dim);
+        filter.Resize(filter_dim);
+        output.Resize(output_dim);
+
+        std::default_random_engine engine;
+        std::uniform_real_distribution<float> gen(-5, 5);
+        std::vector<float> input_v(input_dim.production());
+        std::vector<float> filter_v(filter_dim.production());
+        std::vector<float> output_v(output_dim.production());
+        // int idx = 0;
+        for (auto& i : input_v) {
+          i = gen(engine);
+          // i = idx++;
+        }
+        // idx = 0;
+        for (auto& f : filter_v) {
+          f = gen(engine);
+          // f = idx++;
+        }
+        std::vector<float> bias_v;
+        if (bias_flag) {
+          bias.Resize(bias_dim);
+          bias_v.resize(bias_dim.production());
+          for (auto& b : bias_v) {
+            b = gen(engine);
+          }
+        }
+
+        LOG(INFO) << "prepare input";
+        CLImageConverterDefault* default_converter =
+            new CLImageConverterDefault();
+        DDim input_image_shape =
+            default_converter->InitImageDimInfoWith(input.dims());
+        LOG(INFO) << "input_image_shape = " << input_image_shape[0] << " "
+                  << input_image_shape[1];
+        std::vector<half_t> input_image_data(input_image_shape.production() *
+                                             4);  // 4 : RGBA
+        default_converter->NCHWToImage(
+            input_v.data(), input_image_data.data(), input.dims());
+        auto* input_image =
+            input.mutable_data<half_t, cl::Image2D>(input_image_shape[0],
+                                                    input_image_shape[1],
+                                                    input_image_data.data());
+
+        LOG(INFO) << "prepare kernel";
+        filter.Assign<float, lite::DDim, TARGET(kARM)>(filter_v.data(),
+                                                       filter_dim);
+
+        LOG(INFO) << "launch";
+        DDim output_image_shape =
+            default_converter->InitImageDimInfoWith(output.dims());
+        LOG(INFO) << "output_image_shape = " << output_image_shape[0] << " "
+                  << output_image_shape[1];
+        auto* output_image = output.mutable_data<half_t, cl::Image2D>(
+            output_image_shape[0], output_image_shape[1]);
+
+        kernel->Launch();
+
+        CLRuntime::Global()->command_queue().finish();
+
+        lite::Tensor out_ref;
+        out_ref.Resize(output_dim);
+        auto* out_ref_data = out_ref.mutable_data<float>(TARGET(kARM));
+
+        conv_basic<float, float>(input_v.data(),
+                                 out_ref_data,
+                                 1,
+                                 oc,
+                                 oh,
+                                 ow,
+                                 ic,
+                                 ih,
+                                 iw,
+                                 filter_v.data(),
+                                 bias_v.data(),
+                                 param.groups,
+                                 fw,
+                                 fh,
+                                 stride,
+                                 stride,
+                                 dilation,
+                                 dilation,
+                                 pad,
+                                 pad,
+                                 bias_flag,
+                                 relu_flag);
+
+        const size_t cl_image2d_row_pitch{0};
+        const size_t cl_image2d_slice_pitch{0};
+
+        std::vector<half_t> output_image_data(output_image_shape.production() *
+                                              4);
+        TargetWrapperCL::ImgcpySync(output_image_data.data(),
+                                    output_image,
+                                    output_image_shape[0],
+                                    output_image_shape[1],
+                                    cl_image2d_row_pitch,
+                                    cl_image2d_slice_pitch,
+                                    IoDirection::DtoH);
+
+        default_converter->ImageToNCHW(output_image_data.data(),
+                                       output_v.data(),
+                                       output_image_shape,
+                                       output.dims());
+
+        LOG(INFO) << "output_data vs output_ref_data";
+        for (int i = 0; i < output.dims().production(); i++) {
+          auto relative_diff =
+              COMPUTE_RELATIVE_DIFF(output_v[i], out_ref_data[i]);
+          auto abs_diff = COMPUTE_ABS_DIFF(output_v[i], out_ref_data[i]);
+          EXPECT_FALSE(relative_diff > FP16_MAX_DIFF &&
+                       abs_diff > FP16_ABS_DIFF);
+          if (relative_diff > FP16_MAX_DIFF && abs_diff > FP16_ABS_DIFF) {
+            LOG(FATAL) << "error idx:" << i << " output_v[" << i
+                       << "]:" << output_v[i] << " "
+                                                 "out_ref_data["
+                       << i << "]:" << out_ref_data[i];
+          }
+        }
+#ifdef LOOP_TEST
       }
     }
   }


### PR DESCRIPTION
【问题】
- 之前的 depthwise_conv2d 通用实现版本不支持`dilation_h != dilation_w`，或`pad_w != pad_h`，或`pad_left != pad_right`，或`pad_up != pad_down`的情况。这种情况在 tf2paddle 模型中较多，因此在跑 tf2paddle 模型时会计算 crash。
- 之前的 depthwise_conv2d 通用实现版本的单测代码有问题，开启单测其他代码不变的情况下运行失败。

【本PR工作】
新增支持如上两种情况，改写了 kernel 实现，主要调整有：
- 将`gws`由之前版本的`{ (out_c + 1) / 4, out_w, out_n * out_h}`调整为`{ (out_c + 1) / 4, (out_w + 1) / 4, out_n * out_h}`，这样可以增加单个线程的计算密度，同时降低总的线程数量；
- kernel 实现思路是每个线程负责计算 16 个输出数据（连续的 4 个 width 方向 x 连续的 4 个 channel 通道），之前版本是每个线程负责计算 4 个输出数据（1 个 width 方向 x 连续的 4 个 channel 通道）；
- 单测部分，增加了 depthwise_conv2d 单测对 fp32、fp16 的支持。

【效果】
之前运行 tf2pd_efficientnet 时，会因为 depthwise_conv5x5 的 padding_algorithm 是 SAME，导致 pad_up=0, pad_down=1, pad_left=0, pad_right=1，在使用之前版本时会在此 crash；
在使用本 PR 后，输出结果正确。fp16 均值和标准差（0.001, 0.000266633），ARM fp32 均值和标准差（0.001, 0.00269675）。