### PR TITLE
[BUG FIX] Fix sum op attach implementation

### DIFF
--- a/lite/operators/sum_op.cc
+++ b/lite/operators/sum_op.cc
@@ -35,6 +35,7 @@ bool SumOpLite::InferShapeImpl() const {
 
 bool SumOpLite::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   auto X_names = opdesc.Input("X");
+  param_.X.clear();
   for (auto input_name : X_names) {
     auto input_var = scope->FindVar(input_name);
     CHECK(input_var);


### PR DESCRIPTION
### 问题描述
- 使用CxxConfig 直接加载某个业务模型运行失败
- 使用MobileConfig 加载opt转化之后模型运行成功

### 问题定位
sum op 实现中的`AttachImpl` 的实现与内存复用方法 `memory_optimize_pass` 不兼容 
- sum op 中AttachImpl 的实现连续执行两次会出错