### PR TITLE
[BUG FIX] Fix op AttachImpl

### DIFF
--- a/lite/operators/conditional_block_op.cc
+++ b/lite/operators/conditional_block_op.cc
@@ -33,11 +33,13 @@ bool ConditionalBlockOp::AttachImpl(const cpp::OpDesc& op_desc, Scope* scope) {
   auto condition = op_desc.Input("Cond").front();
   param_.cond = scope->FindVar(condition)->GetMutable<lite::Tensor>();
   auto inputs = op_desc.Input("Input");
+  param_.inputs.clear();
   for (const auto& input : inputs) {
     auto* var = scope->FindVar(input);
     CHECK(var);
     param_.inputs.push_back(var->GetMutable<lite::Tensor>());
   }
+  param_.outs.clear();
   auto outs = op_desc.Output("Out");
   for (const auto& out : outs) {
     auto* var = scope->FindVar(out);

--- a/lite/operators/fake_channel_wise_dequantize_max_abs.h
+++ b/lite/operators/fake_channel_wise_dequantize_max_abs.h
@@ -43,6 +43,7 @@ class FakeChannelWiseDequantizeMaxAbsOpLite : public OpLite {
     param_.x = scope->FindVar(x)->GetMutable<lite::Tensor>();
 
     auto args = op_desc.Input("Scales");
+    param_.scale_tensors.clear();
     for (auto arg : args) {
       auto *var = scope->FindVar(arg);
       if (var != nullptr) {

--- a/lite/operators/interpolate_op.cc
+++ b/lite/operators/interpolate_op.cc
@@ -97,6 +97,7 @@ bool InterpolateOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   }
 
   if (op_desc.HasInput("SizeTensor")) {
+    param_.SizeTensor.clear();
     auto size_tensor = op_desc.Input("SizeTensor");
     for (auto var : size_tensor) {
       param_.SizeTensor.push_back(

--- a/lite/operators/interpolate_v2_op.cc
+++ b/lite/operators/interpolate_v2_op.cc
@@ -107,6 +107,7 @@ bool InterpolateV2Op::AttachImpl(const cpp::OpDesc& op_desc,
   }
 
   if (op_desc.HasInput("SizeTensor")) {
+    param_.SizeTensor.clear();
     auto size_tensor = op_desc.Input("SizeTensor");
     for (auto var : size_tensor) {
       param_.SizeTensor.push_back(

--- a/lite/operators/retinanet_detection_output_op.cc
+++ b/lite/operators/retinanet_detection_output_op.cc
@@ -54,14 +54,17 @@ bool RetinanetDetectionOutputOpLite::InferShapeImpl() const {
 
 bool RetinanetDetectionOutputOpLite::AttachImpl(const cpp::OpDesc &op_desc,
                                                 lite::Scope *scope) {
+  param_.bboxes.clear();
   for (auto arg_name : op_desc.Input("BBoxes")) {
     param_.bboxes.push_back(
         scope->FindVar(arg_name)->GetMutable<lite::Tensor>());
   }
+  param_.scores.clear();
   for (auto arg_name : op_desc.Input("Scores")) {
     param_.scores.push_back(
         scope->FindVar(arg_name)->GetMutable<lite::Tensor>());
   }
+  param_.anchors.clear();
   for (auto arg_name : op_desc.Input("Anchors")) {
     param_.anchors.push_back(
         scope->FindVar(arg_name)->GetMutable<lite::Tensor>());

--- a/lite/operators/slice_op.cc
+++ b/lite/operators/slice_op.cc
@@ -124,6 +124,7 @@ bool SliceOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   param_.StartsTensorList.clear();
   if (opdesc.HasInput("StartsTensorList") &&
       !opdesc.Input("StartsTensorList").empty()) {
+    param_.StartsTensorList.clear();
     auto StartsTensorList = opdesc.Input("StartsTensorList");
     for (auto var : StartsTensorList) {
       param_.StartsTensorList.push_back(
@@ -136,6 +137,7 @@ bool SliceOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   param_.EndsTensorList.clear();
   if (opdesc.HasInput("EndsTensorList") &&
       !opdesc.Input("EndsTensorList").empty()) {
+    param_.EndsTensorList.clear();
     auto EndsTensorList = opdesc.Input("EndsTensorList");
     for (auto var : EndsTensorList) {
       param_.EndsTensorList.push_back(

--- a/lite/operators/strided_slice_op.cc
+++ b/lite/operators/strided_slice_op.cc
@@ -208,6 +208,7 @@ bool StridedSliceOp::AttachImpl(const cpp::OpDesc &op_desc,
   auto strides_size = param_.strides.size();
   if (op_desc.HasInput("StartsTensorList") &&
       !op_desc.Input("StartsTensorList").empty()) {
+    param_.StartsTensorList.clear();
     auto inputs = op_desc.Input("StartsTensorList");
     for (auto var : inputs) {
       param_.StartsTensorList.push_back(
@@ -216,6 +217,7 @@ bool StridedSliceOp::AttachImpl(const cpp::OpDesc &op_desc,
   }
   if (op_desc.HasInput("EndsTensorList") &&
       !op_desc.Input("EndsTensorList").empty()) {
+    param_.EndsTensorList.clear();
     auto inputs = op_desc.Input("EndsTensorList");
     for (auto var : inputs) {
       param_.EndsTensorList.push_back(
@@ -224,6 +226,7 @@ bool StridedSliceOp::AttachImpl(const cpp::OpDesc &op_desc,
   }
   if (op_desc.HasInput("StridesTensorList") &&
       !op_desc.Input("StridesTensorList").empty()) {
+    param_.StridesTensorList.clear();
     auto inputs = op_desc.Input("StridesTensorList");
     for (auto var : inputs) {
       param_.StridesTensorList.push_back(


### PR DESCRIPTION
### 问题描述
- 使用CxxConfig 直接加载某个业务模型运行失败
- 使用MobileConfig 加载opt转化之后模型运行成功

### 问题定位
- 一些op实现 中AttachImpl 的实现连续执行两次会出错

### 本PR工作
- 扫描并修复了op中的此类问题