### PR TITLE
[OpenCL] Enhance precompile

### DIFF
--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -278,7 +278,7 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
     if (delete_bin_flag) {
       remove_file(bin_file);
     }
-  } else if (gotten_bin_flag_ && !programs_.empty() && !(path_name.empty())) {
+  } else if (gotten_bin_flag_) {
     // This case happened when model has updated. Bin file should be updated
     // accordingly.
     delete_bin_flag = true;

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 #include <utility>
 #include <vector>
 #include "lite/backends/opencl/utils/cache.h"
+#include "lite/core/target_wrapper.h"
 #include "lite/core/version.h"
 #include "lite/utils/cp_logging.h"
 #include "lite/utils/io.h"
@@ -200,7 +201,7 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
              "and you have Write&Read permission. Jump to build program "
              "from source.";
     } else {
-      bool ret = Deserialize(bin_file, &programs_precompiled_binary_);
+      ret = Deserialize(bin_file, &programs_precompiled_binary_);
       CHECK(ret) << "Deserialize failed.";
 
       VLOG(3) << "sn_key: " << sn_key_;
@@ -218,9 +219,9 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
                      << "] is illegal!";
         delete_bin_flag = true;
         // Jump to build from source
-      } else if (memcmp(((sn_iter->second)[0]).data(),
-                        GetSN(build_option).data(),
-                        GetSN(build_option).length())) {
+      } else if (host::memcmp(((sn_iter->second)[0]).data(),
+                              GetSN(build_option).data(),
+                              GetSN(build_option).length())) {
         LOG(INFO) << "size of sn_info: " << ((sn_iter->second)[0]).size();
         LOG(INFO) << "size of GetSN: " << GetSN(build_option).length();
         LOG(INFO) << "GetSN: " << GetSN(build_option);

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -188,6 +188,8 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
   bool ret = false;
   bool delete_bin_flag = false;
   auto path_name = GetBinaryPathName();
+  if (path_name.size() != 2) return ret;
+
   // find binary
   std::string bin_file = path_name.at(0) + "/" + path_name.at(1);
   auto remove_file = [](const std::string& bin_file) {

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -302,6 +302,7 @@ class CLRuntime {
   std::vector<std::string> binary_path_name_;
   // magic number for precompiled binary
   const std::string sn_key_{"lite_opencl_precompiled_binary_identifier"};
+  bool gotten_bin_flag_{false};
 };
 
 }  // namespace lite

--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -145,9 +145,6 @@ void RunModel(std::string model_dir,
   //  Uncomment code below to enable OpenCL
   /*
   if (is_opencl_backend_valid) {
-    // give opencl nb model dir
-    config.set_model_from_file(model_dir);
-
     // Set opencl kernel binary.
     // Large addtitional prepare time is cost due to algorithm selecting and
     // building kernel from source code.
@@ -156,6 +153,9 @@ void RunModel(std::string model_dir,
     // The 1st running time will be a bit longer due to the compiling time if
     // you don't call `set_opencl binary_path_name` explicitly.
     // So call `set_opencl binary_path_name` explicitly is strongly recommended.
+
+    // Make sure you have write permission of the binary path.
+    // We strongly recommend each model has a unique binary name.
     const std::string bin_path = "/data/local/tmp/";
     const std::string bin_name = "lite_opencl_kernel.bin";
     config.set_opencl_binary_path_name(bin_path, bin_name);

--- a/lite/demo/cxx/x86_mobilenetv1_light_demo/mobilenet_light_api.cc
+++ b/lite/demo/cxx/x86_mobilenetv1_light_demo/mobilenet_light_api.cc
@@ -149,10 +149,23 @@ void RunModel(std::string model_dir,
       ::IsOpenCLBackendValid(false /*check_fp16_valid = false*/);
   std::cout << "is_opencl_backend_valid:" << is_opencl_backend_valid
             << std::endl;
-  /*  Uncomment code below to enable OpenCL
+  //  Uncomment code below to enable OpenCL
+  /*
   if (is_opencl_backend_valid) {
-    // give opencl nb model dir
-    config.set_model_from_file(model_dir);
+    // Set opencl kernel binary.
+    // Large addtitional prepare time is cost due to algorithm selecting and
+    // building kernel from source code.
+    // Prepare time can be reduced dramitically after building algorithm file
+    // and OpenCL kernel binary on the first running.
+    // The 1st running time will be a bit longer due to the compiling time if
+    // you don't call `set_opencl binary_path_name` explicitly.
+    // So call `set_opencl binary_path_name` explicitly is strongly recommended.
+
+    // Make sure you have write permission of the binary path.
+    // We strongly recommend each model has a unique binary name.
+    const std::string bin_path = "./";
+    const std::string bin_name = "lite_opencl_kernel.bin";
+    config.set_opencl_binary_path_name(bin_path, bin_name);
 
     // opencl tune option
     // CL_TUNE_NONE: 0


### PR DESCRIPTION
【本PR工作】

- 对 #5104  的增强：支持当网络模型名字不变但模型结构改变时，自动失效之前编译好的 binary 并删除该文件，然后重新生成一个新的 binary；
- 使用更为安全的`host::memcmp`。