### PR TITLE
[OpenCL]conv common support group

### DIFF
--- a/lite/backends/opencl/cl_image_converter.h
+++ b/lite/backends/opencl/cl_image_converter.h
@@ -141,6 +141,13 @@ class CLImageConverterNBlock : public CLImageConverterBase {
                    float *tensor,
                    const DDim &image_dim,
                    const DDim &tensor_dim) override;
+  void GroupPadding(const float *src,
+                    float *dst,
+                    int group,
+                    int output_c,
+                    int input_c,
+                    int filter_h,
+                    int filter_w);
 };
 
 class CLImageConverterDWFilter : public CLImageConverterBase {

--- a/lite/kernels/opencl/conv_image_compute_test.cc
+++ b/lite/kernels/opencl/conv_image_compute_test.cc
@@ -1520,8 +1520,8 @@ TEST(conv2d, compute_image2d_7x7) {
 // #define LOOP_TEST
 TEST(conv2d, compute_image2d_common) {
   // conv infos
-  const int ksize_x = 7;
-  const int ksize_y = 1;
+  const int ksize_x = 3;
+  const int ksize_y = 3;
   int loop_cnt = 0;
 
 #ifdef LOOP_TEST
@@ -1538,8 +1538,8 @@ TEST(conv2d, compute_image2d_common) {
           for (bool bias_flag : {true, false}) {
             for (std::string relu_flag : {"", "relu"}) {
 #else
-  const int pad_left = 3;
-  const int pad_up = 0;
+  const int pad_left = 1;
+  const int pad_up = 1;
   const int dilation = 1;
 
 #if 0  // small scale with group, but result of cpu reference is wrong
@@ -1552,7 +1552,7 @@ const int stride = 2;
                 const int oc = 2;
 #else  // big scale with group
   const int stride = 1;
-  const int group = 1;
+  const int group = 2;
   const int batch_size = 1;
   const int ic = 64 / 1;
   const int ih = 54 / 1;
@@ -1565,7 +1565,7 @@ const int stride = 2;
 #endif
               int filter_channel = ic;
               if (group > 1) {
-                filter_channel = 1;
+                filter_channel = filter_channel / group;
               }
 
               const int oh =


### PR DESCRIPTION
common_conv目前支持group的方法是：filter pad为group=1时filter的形状，然后按照group=1时的普通卷积处理。