### PR TITLE
[Framework] Add host::memcmp method #5571

### DIFF
--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -75,6 +75,19 @@ inline void memcpy(void* dst, const void* src, size_t size) {
     std::memcpy(dst, src, size);
   }
 }
+
+// Reinterprets the objects pointed to by lhs and rhs as arrays of
+// unsigned char and compares the first count characters of these arrays.
+inline int memcmp(const void* lhs, const void* rhs, std::size_t count) {
+  if (count > 0) {
+    CHECK(lhs) << "Error: the destination of memcpy can not be nullptr.";
+    CHECK(rhs) << "Error: the source of memcpy can not be nullptr.";
+    return std::memcmp(lhs, rhs, count);
+  } else {
+    return 0;
+  }
+}
+
 }  // namespace host
 
 // Memory copy directions.


### PR DESCRIPTION
cherry-picked from #5471
### Effect of Current PR
- 新增带指针检查的 `host::memcmp`方法
### TODO
- `host` 命名空间别名为`arm`， `host` 命名空间中的`malloc`、`memcpy`、`memcmp` 方法在`arm` 命名空间都可以使用