### PR TITLE
[CI] Cherry-pick CI scripts into release/v2.8 branch

### DIFF
--- a/tools/ci_tools/README.md
+++ b/tools/ci_tools/README.md
@@ -1,0 +1,6 @@
+# Paddle-Lite Continuous Integration scripts:
+- `ci_android_publish.sh`: checking publish period on android platform.
+- `ci_iOS_publish.sh`: checking publish period on iOS platform.
+- `ci_mac_publish.sh`: checking publish period on x86 mac platform.
+- `ci_android_unit_test.sh`: checking unit tests on android backend.
+- `ci_android_opencl_unit_test.sh`: checking unit tests on opencl android backend.

--- a/tools/ci_tools/ci_android_opencl_unit_test.sh
+++ b/tools/ci_tools/ci_android_opencl_unit_test.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+set +x
+set -e
+
+# Absolute path of Paddle-Lite source code.
+SHELL_FOLDER=$(cd "$(dirname "$0")";pwd)
+WORKSPACE=${SHELL_FOLDER%tools/ci_tools*}
+TESTS_FILE="./lite_tests.txt"
+NUM_PROC=4
+
+skip_list=("test_model_parser" "test_mobilenetv1" "test_mobilenetv2" \
+            "test_resnet50" "test_inceptionv4" "test_light_api" "test_apis" \
+            "test_paddle_api" "test_cxx_api" "test_gen_code" \
+            "test_mobilenetv1_int8" "test_subgraph_pass" \
+            "test_grid_sampler_image_opencl" "test_lrn_image_opencl" \
+            "test_pad2d_image_opencl" "test_transformer_with_mask_fp32_arm" \
+            "test_mobilenetv1_int16" "test_mobilenetv1_opt_quant" \
+            "test_fast_rcnn" "test_inception_v4_fp32_arm" "test_mobilenet_v1_fp32_arm" \
+            "test_mobilenet_v2_fp32_arm" "test_mobilenet_v3_small_x1_0_fp32_arm" \
+            "test_mobilenet_v3_large_x1_0_fp32_arm" "test_resnet50_fp32_arm" \
+            "test_squeezenet_fp32_arm" "test_mobilenet_v1_int8_arm" \
+            "test_mobilenet_v2_int8_arm" "test_resnet50_int8_arm" \
+            "test_mobilenet_v1_int8_dygraph_arm" "test_ocr_lstm_int8_arm" \
+            "get_conv_latency" "get_batchnorm_latency" "get_pooling_latency" \
+            "get_fc_latency" "get_activation_latency" \
+            "test_lac_crf_fp32_arm" "test_nlp_lstm_int8_arm")
+
+# if operating in mac env, we should expand the maximum file num
+os_name=`uname -s`
+if [ ${os_name} == "Darwin" ]; then
+   ulimit -n 1024
+fi
+
+####################################################################################################
+# 1. functions of prepare workspace before compiling
+####################################################################################################
+
+# 1.1 generate `__generated_code__.cc`, which is dependended by some targets in cmake.
+# here we fake an empty file to make cmake works.
+function prepare_workspace {
+    local root_dir=$1
+    local build_dir=$2
+    # 1. Prepare gen_code file
+    GEN_CODE_PATH_PREFIX=$build_dir/lite/gen_code
+    mkdir -p ${GEN_CODE_PATH_PREFIX}
+    touch ${GEN_CODE_PATH_PREFIX}/__generated_code__.cc
+    # 2.Prepare debug tool
+    DEBUG_TOOL_PATH_PREFIX=$build_dir/lite/tools/debug
+    mkdir -p ${DEBUG_TOOL_PATH_PREFIX}
+    cp $root_dir/lite/tools/debug/analysis_tool.py ${DEBUG_TOOL_PATH_PREFIX}/
+}
+
+
+# 1.2 prepare source code of opencl lib
+# here we bundle all cl files into a cc file to bundle all opencl kernels into a single lib
+function prepare_opencl_source_code {
+    local root_dir=$1
+    local build_dir=$2
+    # in build directory
+    # Prepare opencl_kernels_source.cc file
+    GEN_CODE_PATH_OPENCL=$root_dir/lite/backends/opencl
+    rm -f GEN_CODE_PATH_OPENCL/opencl_kernels_source.cc
+    OPENCL_KERNELS_PATH=$root_dir/lite/backends/opencl/cl_kernel
+    mkdir -p ${GEN_CODE_PATH_OPENCL}
+    touch $GEN_CODE_PATH_OPENCL/opencl_kernels_source.cc
+    python $root_dir/lite/tools/cmake_tools/gen_opencl_code.py $OPENCL_KERNELS_PATH $GEN_CODE_PATH_OPENCL/opencl_kernels_source.cc
+}
+
+####################################################################################################
+
+
+# 2 function of opencl compiling
+# here we compile android lib and unit test.
+function build_opencl {
+  os=$1
+  arch=$2
+  toolchain=$3
+
+  build_directory=$WORKSPACE/ci.android.opencl.$arch.$toolchain
+  rm -rf $build_directory && mkdir -p $build_directory
+
+
+  git submodule update --init --recursive
+  prepare_workspace $WORKSPACE $build_directory
+  prepare_opencl_source_code $WORKSPACE $build_dir
+
+  cd $build_directory
+  cmake .. \
+      -DLITE_WITH_OPENCL=ON \
+      -DWITH_GPU=OFF \
+      -DWITH_MKL=OFF \
+      -DWITH_LITE=ON \
+      -DLITE_WITH_CUDA=OFF \
+      -DLITE_WITH_X86=OFF \
+      -DLITE_WITH_ARM=ON \
+      -DWITH_ARM_DOTPROD=ON   \
+      -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=ON \
+      -DWITH_TESTING=ON \
+      -DLITE_BUILD_EXTRA=ON \
+      -DLITE_WITH_LOG=ON \
+      -DLITE_WITH_CV=OFF \
+      -DARM_TARGET_OS=$os -DARM_TARGET_ARCH_ABI=$arch -DARM_TARGET_LANG=$toolchain
+
+  make opencl_clhpp -j$NUM_PROC
+  make lite_compile_deps -j$NUM_PROC
+  cd - > /dev/null
+}
+
+function test_arm_android {
+  unit_test=$1
+  adb_devices=$2
+  adb_work_dir=$3
+  unit_test_path=$(find ./lite -name $unit_test)
+  adb -s $adb_devices push $unit_test_path /data/local/tmp/$adb_work_dir
+  adb -s $adb_devices shell "cd /data/local/tmp/$adb_work_dir && ./$unit_test"
+}
+
+function build_test_android_opencl {
+  arch=$1
+  toolchain=$2
+  adb_device=$3
+  adb_workdir=$4
+
+  build_opencl android $arch $toolchain
+
+  # opencl test should be marked with `opencl`
+  opencl_test_mark="opencl"
+  adb_devices=($(adb devices |grep -v devices |grep device | awk -F " " '{print $1}'))
+
+  build_directory=$WORKSPACE/ci.android.opencl.$arch.$toolchain
+  cd $build_directory
+
+
+  adb -s ${adb_devices[0]} shell "cd /data/local/tmp && rm -rf $adb_workdir && mkdir $adb_workdir"
+  for _test in $(cat $TESTS_FILE); do
+      local to_skip=0
+      for skip_name in ${skip_list[@]}; do
+          if [ $skip_name = $_test ]; then
+              echo "to skip " $skip_name
+              to_skip=1
+          fi
+      done
+
+      # tell if this test is marked with `opencl`
+      if [[ $_test == *$opencl_test_mark* ]] && [[ $to_skip -eq 0 ]]; then
+          test_arm_android $_test ${adb_devices[0]} $adb_workdir
+      fi
+  done
+  adb -s ${adb_devices[0]} shell "cd /data/local/tmp && rm -rf $adb_workdir"
+}
+
+# $1 adb_device index. eg. 1
+# $2 workspace name on adb.  eg. work_tmp1
+build_test_android_opencl armv7 gcc $1 $2
+build_test_android_opencl armv8 gcc $1 $2

--- a/tools/ci_tools/ci_android_publish.sh
+++ b/tools/ci_tools/ci_android_publish.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Start the CI task of examining Android inference lib compiling.
+set +x
+set -e
+
+#####################################################################################################
+# Usage: test the publish period on Android platform.
+# Data: 20210104
+# Author: DannyIsFunny
+#####################################################################################################
+
+#####################################################################################################
+# 1. global variables, you can change them according to your requirements
+#####################################################################################################
+# Architecture: armv7 or armv8, default armv8.
+ARCH=(armv8 armv7)
+# Toolchain: gcc or clang, default gcc.
+TOOLCHAIN=(gcc clang)
+# Absolute path of Paddle-Lite source code.
+SHELL_FOLDER=$(cd "$(dirname "$0")";pwd)
+WORKSPACE=${SHELL_FOLDER%tools/ci_tools*}
+#####################################################################################################
+
+####################################################################################################
+# Functions of Android compiling test.
+# Globals:
+#   WORKSPACE
+# Arguments:
+#   1. architecture
+#   2. toolchain
+#   3. with extra or not
+# Returns:
+#   None
+####################################################################################################
+function publish_inference_lib {
+  local arch=$1
+  local toolchain=$2
+  local with_extra=$3
+  cd $WORKSPACE
+  # Remove Compiling Cache
+  rm -rf build*
+  # Compiling inference library
+  ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=$with_extra
+  # Checking results: cplus and java inference lib.
+  if [ -d build*/inference*/cxx/lib ] && [ -d build*/inference*/java/so ]; then
+    cxx_results=$(ls build*/inference*/cxx/lib | wc -l)
+    java_results=$(ls build*/inference*/java/so | wc -l)
+      if [ $cxx_results -ge 2 ] && [ $java_results -ge 1 ]; then
+          return 0
+      fi
+  fi
+  # Error message.
+  echo "**************************************************************************************"
+  echo -e "* Android compiling task failed on the following instruction:"
+  echo -e "*     ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=ON"
+  echo "**************************************************************************************"
+  exit 1
+}
+
+
+# Compiling test
+for arch in ${ARCH[@]}; do
+  for toolchain in ${TOOLCHAIN[@]}; do
+    cd $WORKSPACE
+    publish_inference_lib $arch $toolchain ON
+  done
+done    

--- a/tools/ci_tools/ci_android_unit_test.sh
+++ b/tools/ci_tools/ci_android_unit_test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+set +x
+set -e
+
+# Absolute path of Paddle-Lite source code.
+SHELL_FOLDER=$(cd "$(dirname "$0")";pwd)
+WORKSPACE=${SHELL_FOLDER%tools/ci_tools*}
+TESTS_FILE="./lite_tests.txt"
+NUM_PROC=4
+
+skip_list=("test_model_parser" "test_mobilenetv1" "test_mobilenetv2" \
+            "test_resnet50" "test_inceptionv4" "test_light_api" "test_apis" \
+            "test_paddle_api" "test_cxx_api" "test_gen_code" \
+            "test_mobilenetv1_int8" "test_subgraph_pass" \
+            "test_transformer_with_mask_fp32_arm" \
+            "test_mobilenetv1_int16" "test_mobilenetv1_opt_quant" \
+            "test_fast_rcnn" "test_inception_v4_fp32_arm" "test_mobilenet_v1_fp32_arm" \
+            "test_mobilenet_v2_fp32_arm" "test_mobilenet_v3_small_x1_0_fp32_arm" \
+            "test_mobilenet_v3_large_x1_0_fp32_arm" "test_resnet50_fp32_arm" \
+            "test_squeezenet_fp32_arm" "test_mobilenet_v1_int8_arm" \
+            "test_mobilenet_v2_int8_arm" "test_resnet50_int8_arm" \
+            "test_mobilenet_v1_int8_dygraph_arm" "test_ocr_lstm_int8_arm" \
+            "get_conv_latency" "get_batchnorm_latency" "get_pooling_latency" \
+            "get_fc_latency" "get_activation_latency" "test_generated_code" \
+            "test_lac_crf_fp32_arm" "test_nlp_lstm_int8_arm")
+
+# if operating in mac env, we should expand the maximum file num
+os_name=`uname -s`
+if [ ${os_name} == "Darwin" ]; then
+   ulimit -n 1024
+fi
+
+####################################################################################################
+# 1. functions of prepare workspace before compiling
+####################################################################################################
+
+# 1.1 generate `__generated_code__.cc`, which is dependended by some targets in cmake.
+# here we fake an empty file to make cmake works.
+function prepare_workspace {
+    local root_dir=$1
+    local build_dir=$2
+    # 1. Prepare gen_code file
+    GEN_CODE_PATH_PREFIX=$build_dir/lite/gen_code
+    mkdir -p ${GEN_CODE_PATH_PREFIX}
+    touch ${GEN_CODE_PATH_PREFIX}/__generated_code__.cc
+    # 2.Prepare debug tool
+    DEBUG_TOOL_PATH_PREFIX=$build_dir/lite/tools/debug
+    mkdir -p ${DEBUG_TOOL_PATH_PREFIX}
+    cp $root_dir/lite/tools/debug/analysis_tool.py ${DEBUG_TOOL_PATH_PREFIX}/
+}
+
+####################################################################################################
+
+# test the inference high level api
+function test_arm_api {
+    local adb_device=$1
+    local adb_work_dir=$2
+    local test_name="test_paddle_api"
+
+    make $test_name -j$NUM_PROC
+
+    local model_path=$(find . -name "lite_naive_model")
+    local remote_model=paddle_api
+    local testpath=$(find ./lite -name ${test_name})
+
+
+    adb -s $adb_device push $testpath /data/local/tmp/$adb_work_dir
+    adb -s $adb_device shell chmod +x "/data/local/tmp/$adb_work_dir/$test_name"
+    adb -s $adb_device push $model_path /data/local/tmp/$adb_work_dir/$remote_model
+    adb -s $adb_device shell "cd /data/local/tmp/$adb_work_dir && ./$test_name --model_dir $remote_model"
+}
+
+# 2 function of compiling
+# here we compile android lib and unit test.
+function build_android {
+  os=$1
+  arch=$2
+  toolchain=$3
+
+  build_directory=$WORKSPACE/ci.android.$arch.$toolchain
+  rm -rf $build_directory && mkdir -p $build_directory
+
+
+  git submodule update --init --recursive
+  prepare_workspace $WORKSPACE $build_directory
+
+  cd $build_directory
+  cmake .. \
+      -DWITH_GPU=OFF \
+      -DWITH_MKL=OFF \
+      -DWITH_LITE=ON \
+      -DLITE_WITH_CUDA=OFF \
+      -DLITE_WITH_X86=OFF \
+      -DLITE_WITH_ARM=ON \
+      -DWITH_ARM_DOTPROD=ON   \
+      -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=ON \
+      -DWITH_TESTING=ON \
+      -DLITE_BUILD_EXTRA=ON \
+      -DLITE_WITH_TRAIN=ON \
+      -DARM_TARGET_OS=$os -DARM_TARGET_ARCH_ABI=$arch -DARM_TARGET_LANG=$toolchain
+
+  make lite_compile_deps -j$NUM_PROC
+  cd - > /dev/null
+}
+
+function test_arm_unit_test {
+  unit_test=$1
+  adb_devices=$2
+  adb_work_dir=$3
+  unit_test_path=$(find ./lite -name $unit_test)
+  adb -s $adb_devices push $unit_test_path /data/local/tmp/$adb_work_dir
+  adb -s $adb_devices shell "cd /data/local/tmp/$adb_work_dir && ./$unit_test"
+}
+
+function build_test_android {
+  arch=$1
+  toolchain=$2
+  adb_device=$3
+  adb_workdir=$4
+
+  build_android android $arch $toolchain
+
+  adb_devices=($(adb devices |grep -v devices |grep device | awk -F " " '{print $1}'))
+
+  build_directory=$WORKSPACE/ci.android.$arch.$toolchain
+  cd $build_directory
+
+
+  adb -s ${adb_devices[0]} shell "cd /data/local/tmp && rm -rf $adb_workdir && mkdir $adb_workdir"
+  for _test in $(cat $TESTS_FILE); do
+      local to_skip=0
+      for skip_name in ${skip_list[@]}; do
+          if [ $skip_name = $_test ]; then
+              echo "to skip " $skip_name
+              to_skip=1
+          fi
+      done
+
+      if [[ $to_skip -eq 0 ]]; then
+          test_arm_unit_test $_test ${adb_devices[0]} $adb_workdir
+      fi
+  done
+  test_arm_api ${adb_devices[0]} $adb_work_dir
+  adb -s ${adb_devices[0]} shell "cd /data/local/tmp && rm -rf $adb_workdir"
+}
+
+# $1 adb_device index. eg. 1
+# $2 workspace name on adb.  eg. work_tmp1
+build_test_android armv7 gcc $1 $2
+build_test_android armv8 gcc $1 $2

--- a/tools/ci_tools/ci_ios_publish.sh
+++ b/tools/ci_tools/ci_ios_publish.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Start the CI task of examining iOS inference lib compiling.
+set +x
+set -e
+
+#####################################################################################################
+# Usage: test the publish period on iOS platform.
+# Data: 20210125
+# Author: DannyIsFunny
+#####################################################################################################
+
+#####################################################################################################
+# 1. global variables, you can change them according to your requirements
+#####################################################################################################
+# Architecture: armv7 or armv8, default armv8.
+ARCH=(armv8 armv7)
+# Absolute path of Paddle-Lite source code.
+SHELL_FOLDER=$(cd "$(dirname "$0")";pwd)
+WORKSPACE=${SHELL_FOLDER%tools/ci_tools*}
+#####################################################################################################
+
+####################################################################################################
+# Functions of iOS compiling test.
+# Globals:
+#   WORKSPACE
+# Arguments:
+#   1. architecture
+#   2. with extra or not
+# Returns:
+#   None
+####################################################################################################
+function publish_inference_lib {
+  local arch=$1
+  local with_extra=$2
+  cd $WORKSPACE
+  # Remove Compiling Cache
+  rm -rf build*
+  # Compiling inference library
+  ./lite/tools/build_ios.sh --arch=$arch --with_extra=$with_extra
+  # Checking results: cplus and java inference lib.
+  if [ -d build*/inference*/lib ]; then
+    cxx_results=$(ls build*/inference*/lib | wc -l)
+    if [ $cxx_results -ge 1 ] ; then
+        return 0
+    fi
+  fi
+  # Error message.
+  echo "**************************************************************************************"
+  echo -e "* iOS compiling task failed on the following instruction:"
+  echo -e "*     ./lite/tools/build_ios.sh --arch=$arch --with_extra=ON"
+  echo "**************************************************************************************"
+  exit 1
+}
+
+
+# Compiling test
+for arch in ${ARCH[@]}; do
+  cd $WORKSPACE
+  publish_inference_lib $arch ON
+done    

--- a/tools/ci_tools/ci_mac_publish.sh
+++ b/tools/ci_tools/ci_mac_publish.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Start the CI task of examining Android inference lib compiling.
+set +x
+set -e
+
+#####################################################################################################
+# Usage: test the publish period on Android platform.
+# Data: 20210104
+# Author: DannyIsFunny
+#####################################################################################################
+
+#####################################################################################################
+# 1. global variables, you can change them according to your requirements
+#####################################################################################################
+# Python version
+PYTHON_VERSION=(2.7)
+# Absolute path of Paddle-Lite source code.
+SHELL_FOLDER=$(cd "$(dirname "$0")";pwd)
+WORKSPACE=${SHELL_FOLDER%tools/ci_tools*}
+# OpenCL
+BUILD_OPENCL=ON
+# Model download url
+mobilenet_v1_url=http://paddle-inference-dist.bj.bcebos.com/mobilenet_v1.tar.gz
+
+####################################################################################################
+# Functions of downloading model file
+# Arguments:
+#   1. model_name
+#   2. downloading url
+####################################################################################################
+function prepare_model {
+  local model_name=$1
+  local download_url=$2
+  wget $download_url
+  tar zxf $model_name.tar.gz
+}
+
+####################################################################################################
+# Functions of Android compiling test.
+# Globals:
+#   WORKSPACE
+# Arguments:
+#   1. python version
+####################################################################################################
+function publish_inference_lib {
+  cd $WORKSPACE
+  # Local variables
+  python_version=$1
+  # Remove Compiling Cache
+  rm -rf build*
+  for python_version in ${PYTHON_VERSION[@]}; do
+    # Step1. Compiling python installer on mac
+    ./lite/tools/build.sh \
+      --build_python=ON \
+      --python_version=$python_version \
+      --build_opencl=$BUILD_OPENCL \
+      x86
+    # Step2. Checking results: cplus and python inference lib.
+    if [ -d build.lite.x86/inference_lite_lib/cxx/lib ] && [ -d build.lite.x86/inference_lite_lib/python/install/dist ]; then
+      # test python installer
+      cd build.lite.x86
+      python$python_version -m pip install --force-reinstall  inference_lite_lib/python/install/dist/*.whl
+      # download test model
+      prepare_model mobilenet_v1 $mobilenet_v1_url
+      # test opt
+      paddle_lite_opt
+      paddle_lite_opt --model_dir=mobilenet_v1 --optimize_out=mobilenet_v1_arm
+      paddle_lite_opt --model_dir=mobilenet_v1 --valid_targets=x86 --optimize_out=mobilenet_v1_x86
+      paddle_lite_opt --model_dir=mobilenet_v1 --valid_targets=x86_opencl --optimize_out=mobilenet_v1_x86_opencl
+      # test inference demo
+      cd inference_lite_lib/demo/python
+      python$python_version mobilenetv1_full_api.py  --model_dir=$WORKSPACE/build.lite.x86/mobilenet_v1
+      python$python_version mobilenetv1_light_api.py  --model_dir=$WORKSPACE/build.lite.x86/mobilenet_v1_x86.nb
+      python$python_version mobilenetv1_light_api.py  --model_dir=$WORKSPACE/build.lite.x86/mobilenet_v1_x86_opencl.nb
+      # uninstall
+	  python$python_version -m pip uninstall -y paddlelite
+    else
+      # Error message.
+      echo "**************************************************************************************"
+      echo -e "* Mac python installer compiling task failed on the following instruction:"
+      echo -e "*     ./lite/tools/build.sh --with_python=ON --python_version=$python_version"
+      echo "**************************************************************************************"
+      exit 1
+    fi
+  done
+}
+
+# Compiling test
+for version in ${PYTHON_VERSION[@]}; do
+    publish_inference_lib $version
+done    


### PR DESCRIPTION
# Paddle-Lite Continuous Integration scripts:
- `ci_android_publish.sh`: checking publish period on android platform.
- `ci_iOS_publish.sh`: checking publish period on iOS platform.
- `ci_mac_publish.sh`: checking publish period on x86 mac platform.
- `ci_android_unit_test.sh`: checking unit tests on android backend.
- `ci_android_opencl_unit_test.sh`: checking unit tests on opencl android backend.