### PR TITLE
Fix conditional_block error

### DIFF
--- a/lite/operators/conditional_block_op.cc
+++ b/lite/operators/conditional_block_op.cc
@@ -34,18 +34,21 @@ bool ConditionalBlockOp::AttachImpl(const cpp::OpDesc& op_desc, Scope* scope) {
   param_.cond = scope->FindVar(condition)->GetMutable<lite::Tensor>();
   auto inputs = op_desc.Input("Input");
   param_.inputs.clear();
+
   for (const auto& input : inputs) {
     auto* var = scope->FindVar(input);
     CHECK(var);
-    param_.inputs.push_back(var->GetMutable<lite::Tensor>());
+    if (var->IsType<lite::Tensor>()) {
+      auto* tensor = var->GetMutable<lite::Tensor>();
+      param_.inputs.push_back(tensor);
+    } else if (var->IsType<std::vector<lite::Tensor>>()) {
+      auto* tensors = var->GetMutable<std::vector<lite::Tensor>>();
+      for (auto& tensor : *tensors) {
+        param_.inputs.push_back(&tensor);
+      }
+    }
   }
-  param_.outs.clear();
-  auto outs = op_desc.Output("Out");
-  for (const auto& out : outs) {
-    auto* var = scope->FindVar(out);
-    CHECK(var);
-    param_.outs.push_back(var->GetMutable<lite::Tensor>());
-  }
+
   param_.is_scalar_condition = op_desc.GetAttr<bool>("is_scalar_condition");
   // obtain sub_block in core program.cc
   CHECK(param_.program_desc);


### PR DESCRIPTION
conditional_block op的属性is_scalar_condition，如果为True，则根据cond变量来决定是否执行，如果为False，则根据input输入是否都初始化来决定是否执行。

conditional_block只需要attach一下输入，不需要attach输出。