### PR TITLE
[cherry-pick2.8]Fix squeeze memory reuse bug

### DIFF
--- a/lite/core/mir/fusion/CMakeLists.txt
+++ b/lite/core/mir/fusion/CMakeLists.txt
@@ -64,6 +64,9 @@ lite_cc_library(fuse_instance_norm_activation
 lite_cc_library(fuse_fc_prelu
         SRCS fc_prelu_fuser.cc
         DEPS pattern_matcher_high_api)
+lite_cc_library(fuse_fc_prelu
+        SRCS fc_prelu_fuser.cc
+        DEPS pattern_matcher_high_api)
 
 set(mir_fusers
     fuse_reshape2_matmul


### PR DESCRIPTION
cherry-pick from https://github.com/PaddlePaddle/Paddle-Lite/pull/5660