### PR TITLE
[BUG FIX] Fix compiling error on MacOS

### DIFF
--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -55,7 +55,7 @@ if ((NOT LITE_ON_TINY_PUBLISH) AND (LITE_WITH_CUDA OR LITE_WITH_X86 OR LITE_WITH
         target_link_libraries(paddle_light_api_shared shlwapi.lib)
     endif()
     target_link_libraries(paddle_light_api_shared ${light_lib_DEPS} ${arm_kernels} ${npu_kernels} ${huawei_ascend_npu_kernels} ${rknpu_kernels} ${apu_kernels})
-   if(APPLE)
+   if(${HOST_SYSTEM} MATCHES "macosx")
         set(LINK_MAP_FILE "${PADDLE_SOURCE_DIR}/lite/core/exported_symbols.lds")
         set(LINK_FLAGS "-Wl,-exported_symbols_list, ${LINK_MAP_FILE}")
         add_custom_command(OUTPUT ${LINK_MAP_FILE} COMMAND ...)
@@ -84,7 +84,7 @@ else()
         if (NOT (ARM_TARGET_LANG STREQUAL "clang")) #gcc
             set(TARGET_COMIPILE_FLAGS "${TARGET_COMIPILE_FLAGS} -flto")
             # '-flto' is only supported by gcc-ar, while gcc-ar is not supported on MacOs
-            if(NOT APPLE)
+            if(NOT ${HOST_SYSTEM} MATCHES "macosx")
                 SET(CMAKE_AR "gcc-ar")
                 SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
                 SET(CMAKE_CXX_ARCHIVE_FINISH   true)
@@ -127,10 +127,10 @@ else()
 
         # 4. produce static lib `libpaddle_api_light_bundled.a` from `PADDLELITE_OBJS`
         # '-flto' is only supported by gcc-ar, while gcc-ar is not supported on MacOs
-        if(NOT APPLE)
+        if(NOT ${HOST_SYSTEM} MATCHES "macosx")
             add_library(paddle_api_light_bundled STATIC $<TARGET_OBJECTS:PADDLELITE_OBJS>)
         else()
-            add_library(paddle_api_light_bundled SHARED ${__lite_cc_files} paddle_api.cc light_api.cc light_api_impl.cc)
+            add_library(paddle_api_light_bundled STATIC ${__lite_cc_files} paddle_api.cc light_api.cc light_api_impl.cc)
         endif()
     endif()
 endif()


### PR DESCRIPTION
- 修复macOS上android 预测库编译失败问题
  - `cd Paddle-Lite && ./lite/tools/build_android.sh`

- 问题原因： Android.cmake 中将 `CMAKE_SYSTEM_NAME` 强制写成 `Android`， 导致cmake 判断当前操作系统是Android， `if (APPLE)`判断失效
  - 代码位置：  https://github.com/PaddlePaddle/Paddle-Lite/blob/b9117a6a1b3a0e2ecd52dc73b505b57c6139276c/cmake/cross_compiling/android.cmake#L65

- 当前修改为什么有效：
  - system.cmake中在android.cmake执行前记录了当前的操作系统信息 `CMAKE_SYSTEM_NAME`  到变量 `HOST_SYSTEM
`
  - 代码位置： https://github.com/PaddlePaddle/Paddle-Lite/blob/b9117a6a1b3a0e2ecd52dc73b505b57c6139276c/cmake/system.cmake#L27
  - system.cmake 在android.cmake之前生效： 
    - system.cmake : https://github.com/PaddlePaddle/Paddle-Lite/blob/b9117a6a1b3a0e2ecd52dc73b505b57c6139276c/CMakeLists.txt#L28
    - android.cmake : https://github.com/PaddlePaddle/Paddle-Lite/blob/b9117a6a1b3a0e2ecd52dc73b505b57c6139276c/CMakeLists.txt#L29

结论： 当前Lite 在编译过程无法通过` if(APPLE) `判断当前操作系统， 可以通过`HOST_SYSTEM`判断