### PR TITLE
[SHELL] Add script for striping android lib according to input models

### DIFF
--- a/lite/tools/build_android_by_models.sh
+++ b/lite/tools/build_android_by_models.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -e
+set -x
+
+## Global variables
+workspace=$PWD/$(dirname $0)
+readonly workspace=${workspace%%lite/tools*}
+WITH_LOG=OFF
+WITH_CV=ON
+WITH_EXCEPTION=ON
+
+
+## step 1: compile opt tool
+cd $workspace
+if [ ! -f build.opt/lite/api/opt ]; then
+./lite/tools/build.sh build_optimize_tool
+fi
+cd build.opt/lite/api
+rm -rf models &&  cp -rf $1 ./models
+
+###  models names
+models_names=$(ls models)
+## step 2. convert models
+rm -rf models_opt && mkdir models_opt
+for name in $models_names
+do
+  if [[ $(ls models/$name | wc -l) -gt 2 ]]
+  then
+    if [[ -f models/$name/__model__ ]]
+	then
+      ./opt --model_dir=./models/$name --valid_targets=arm --optimize_out=./models_opt/$name --record_tailoring_info=true
+    else
+      echo "Error: unsupported model format /models/$name"
+      exit 1
+    fi
+  else
+    if [[ -f models/$name/model ]] && [[ -f models/$name/params ]]
+	then
+	./opt --model_file=./models/$name/model --param_file=./models/$name/params --valid_targets=arm --optimize_out=./models_opt/$name --record_tailoring_info=true
+	else
+	  echo "Error: unsupported model format /models/$name"
+	  exit 1
+	fi
+  fi
+done
+
+
+# step 3. record model infos
+rm -rf model_info && mkdir model_info
+rm -rf optimized_model && mkdir optimized_model
+content=$(ls ./models_opt | grep -v .nb)
+
+for dir_name in $content
+do
+cat ./models_opt/$dir_name/.tailored_kernels_list >> ./model_info/tailored_kernels_list 
+cat ./models_opt/$dir_name/.tailored_kernels_source_list >> ./model_info/tailored_kernels_source_list
+cat ./models_opt/$dir_name/.tailored_ops_list >> ./model_info/tailored_ops_list
+cat ./models_opt/$dir_name/.tailored_ops_source_list >> ./model_info/tailored_ops_source_list
+cp -f ./models_opt/$dir_name.nb optimized_model
+done
+
+sort -n ./model_info/tailored_kernels_list | uniq > ./model_info/.tailored_kernels_list
+sort -n ./model_info/tailored_kernels_source_list | uniq > ./model_info/.tailored_kernels_source_list
+sort -n ./model_info/tailored_ops_list | uniq > ./model_info/.tailored_ops_list
+sort -n ./model_info/tailored_ops_source_list | uniq > ./model_info/.tailored_ops_source_list
+
+rm -rf $(ls ./models_opt | grep -v .nb)
+
+# step 4. compiling iOS lib
+cd $workspace
+./lite/tools/build_android.sh --with_strip=ON --opt_model_dir=$workspace/build.opt/lite/api/model_info --with_log=$WITH_LOG --with_cv=$WITH_CV --with_exception=$WITH_EXCEPTION
+./lite/tools/build_android.sh --with_strip=ON --opt_model_dir=$workspace/build.opt/lite/api/model_info --with_log=$WITH_LOG --arch=armv7 --with_cv=$WITH_CV  --with_exception=$WITH_EXCEPTION
+
+# step 5. pack compiling results and optimized models
+result_name=android_lib
+rm -rf $result_name && mkdir $result_name
+cp -rf build.lite.android.armv7.gcc/inference_lite_lib.android.armv7 $result_name/armv7.gcc
+cp -rf build.lite.android.armv8.gcc/inference_lite_lib.android.armv8 $result_name/armv8.gcc
+cp build.opt/lite/api/opt $result_name/
+mv build.opt/lite/api/optimized_model $result_name
+
+# step6. compress the result into tar file
+tar zcf $result_name.tar.gz $result_name


### PR DESCRIPTION
### Usage
- `lite/tools/build_android_by_models.sh ABSOULTE_PATH_TO_MODELDIR`
  - `ABSOULTE_PATH_TO_MODELDIR`: absolute path、modeldir contains various models 
  - eg. ABSOULTE_PATH_TO_MODELDIR
    - `mobilenet_v1`: model + params
    - `efficient_b0`: `__model__` + weight1 +weight2 + ...
    - ...
### Result
- `android_lib`
  - `armv7.gcc` : armv7 library
  - `armv8.gcc` : armv8 library
  - `opt`      : model optimize tool
  - `optimized_model` : model after opt