### PR TITLE
[armlinux] Fix compile error on cxx demo

### DIFF
--- a/docs/source_compile/compile_linux.md
+++ b/docs/source_compile/compile_linux.md
@@ -92,6 +92,13 @@ inference_lite_lib.armlinux.armv8
 --opt_model_dir:          输入模型的绝对路径，需要为opt转化之后的模型
 ```
 
+- 编译支持 OpenCL 的预测库
+
+```
+./lite/tools/build_linux.sh --with_opencl=ON
+```
+
+
 - 编译 瑞芯微(Rockchip) NPU 预测库方法，详情请参考：[PaddleLite使用RK NPU预测部署](../demo_guides/rockchip_npu)
 
 ```shell

--- a/lite/demo/cxx/armlinux_mobilenetv1_full_demo/CMakeLists.txt
+++ b/lite/demo/cxx/armlinux_mobilenetv1_full_demo/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.8)
 
 set(TARGET mobilenet_full_api)
 
+# Set ARMLINUX_ARCH_ABI to armv8 or armv7 or armv7hf
+set(ARMLINUX_ARCH_ABI armv8)
+
 # 1. path to Paddle-Lite lib
 set(LITE_DIR "${PROJECT_SOURCE_DIR}/../../../cxx")
 
@@ -11,7 +14,23 @@ link_directories(${LITE_DIR}/lib)
 include_directories(${LITE_DIR}/include)
 
 # 3. compile options 
-add_definitions(-std=c++11 -g -O3 -pthread)
+if(ARMLINUX_ARCH_ABI STREQUAL "armv8")
+  set(CMAKE_C_COMPILER "aarch64-linux-gnu-gcc")
+  set(CMAKE_CXX_COMPILER "aarch64-linux-gnu-g++")
+elseif(ARMLINUX_ARCH_ABI STREQUAL "armv7")
+  set(CMAKE_C_COMPILER "arm-linux-gnueabi-gcc")
+  set(CMAKE_CXX_COMPILER "arm-linux-gnueabi-g++")
+elseif(ARMLINUX_ARCH_ABI STREQUAL "armv7hf")
+  set(CMAKE_C_COMPILER "arm-linux-gnueabihf-gcc")
+  set(CMAKE_CXX_COMPILER "arm-linux-gnueabihf-g++")
+else()
+  message(FATAL_ERROR "Illegal ARMLINUX_ARCH_ABI: ${ARMLINUX_ARCH_ABI}")
+endif()
+
+message(STATUS "armlinux CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
+message(STATUS "armlinux CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
+
+add_definitions(-std=c++11 -O3 -pthread)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 
 # 4.add executable output

--- a/lite/demo/cxx/armlinux_mobilenetv1_light_demo/CMakeLists.txt
+++ b/lite/demo/cxx/armlinux_mobilenetv1_light_demo/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.8)
 
 set(TARGET mobilenet_light_api)
 
+# Set ARMLINUX_ARCH_ABI to armv8 or armv7 or armv7hf
+set(ARMLINUX_ARCH_ABI armv8)
+
 # 1. path to Paddle-Lite lib
 set(LITE_DIR "${PROJECT_SOURCE_DIR}/../../../cxx")
 
@@ -11,7 +14,23 @@ link_directories(${LITE_DIR}/lib)
 include_directories(${LITE_DIR}/include)
 
 # 3. compile options 
-add_definitions(-std=c++11 -g -O3 -pthread)
+if(ARMLINUX_ARCH_ABI STREQUAL "armv8")
+  set(CMAKE_C_COMPILER "aarch64-linux-gnu-gcc")
+  set(CMAKE_CXX_COMPILER "aarch64-linux-gnu-g++")
+elseif(ARMLINUX_ARCH_ABI STREQUAL "armv7")
+  set(CMAKE_C_COMPILER "arm-linux-gnueabi-gcc")
+  set(CMAKE_CXX_COMPILER "arm-linux-gnueabi-g++")
+elseif(ARMLINUX_ARCH_ABI STREQUAL "armv7hf")
+  set(CMAKE_C_COMPILER "arm-linux-gnueabihf-gcc")
+  set(CMAKE_CXX_COMPILER "arm-linux-gnueabihf-g++")
+else()
+  message(FATAL_ERROR "Illegal ARMLINUX_ARCH_ABI: ${ARMLINUX_ARCH_ABI}")
+endif()
+
+message(STATUS "armlinux CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
+message(STATUS "armlinux CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
+
+add_definitions(-std=c++11 -O3 -pthread)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 
 # 4.add executable output


### PR DESCRIPTION
【问题描述】
在交叉编译环境下，编译 armlinux 下预测库正常，但是在编译 cxx demo code 时报错，原因是 cxx demo 编译时使用的是 host 机器上的 CC/CXX，应该使用 交叉编译环境下的 CC/CXX。
直接在 armlinux 下编译 cxx demo code，正常。

【工作】
修改 armlinux cxx demo code 中的 CMakeLists.txt，设置交叉编译环境下的 CC/CXX；该修改不影响直接在 armlinux 下编译 cxx demo code。