### PR TITLE
[OpenCL] Fix select built-in function

### DIFF
--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -93,7 +93,7 @@ __constant sampler_t SAMPLER =
 inline CL_DTYPE activation(CL_DTYPE in, CL_DTYPE prelu_alpha) {
   CL_DTYPE output = in;
 #ifdef PRELU
-  output = select(prelu_alpha * in, in, in >= (CL_DTYPE)0);
+  output = select(prelu_alpha * in, in, (ushort)(isgreaterequal(in, 0)));
 #endif
 
 #ifdef RELU

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -215,6 +215,7 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
              "and you have Write&Read permission. Jump to build program "
              "from source.";
     } else {
+      LOG(INFO) << "Load opencl kernel bin file: " << bin_file;
       ret = Deserialize(bin_file, &programs_precompiled_binary_);
       CHECK(ret) << "Deserialize failed.";
 
@@ -236,9 +237,9 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
       } else if (host::memcmp(((sn_iter->second)[0]).data(),
                               GetSN(build_option).data(),
                               GetSN(build_option).length())) {
-        LOG(INFO) << "size of sn_info: " << ((sn_iter->second)[0]).size();
-        LOG(INFO) << "size of GetSN: " << GetSN(build_option).length();
-        LOG(INFO) << "GetSN: " << GetSN(build_option);
+        LOG(INFO) << "size of sn_info: " << ((sn_iter->second)[0]).size()
+                  << "\nsize of GetSN: " << GetSN(build_option).length()
+                  << "\nGetSN: " << GetSN(build_option);
         LOG(WARNING) << "The precompiled OpenCL binary[" << bin_file
                      << "] is invalid!";
         delete_bin_flag = true;
@@ -264,19 +265,17 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
           std::unique_ptr<cl::Program> ptr(new cl::Program(program));
           programs_[prog_key] = std::move(ptr);
         }
-      }
 
-      auto it = programs_.find(program_key);
-      if (it != programs_.end()) {
-#ifdef LITE_WITH_LOG
-        VLOG(3) << " --- program -> " << program_key
-                << " has been built in binary --- ";
-#endif
-        gotten_bin_flag_ = true;
-        ret = true;
-      } else {
-        delete_bin_flag = true;
-        // Jump to build from source
+        auto it = programs_.find(program_key);
+        if (it != programs_.end()) {
+          VLOG(3) << " --- program -> " << program_key
+                  << " has been built in binary --- ";
+          gotten_bin_flag_ = true;
+          ret = true;
+        } else {
+          delete_bin_flag = true;
+          // Jump to build from source
+        }
       }
     }
 


### PR DESCRIPTION
**【问题】**
在华为 mate30 手机上运行 mtcnn_det1 模型，提示如下报错：
```
<source>:47:10: error: call to 'select' is ambiguous
output = select(prelu_alpha * in, in, in >= (CL_DTYPE)0);
```
在高通系列手机上运行正常。

**【原因】**
OpenCL API 规范中指出 `select`在对不同类型的标量进行比较时，需使用不同类型的判断返回值，如下所示：
```
select(half a, half b, ushort c)
select(float a, float b, uint c)
```
问题代码在比较`half`类型数据时，`c`值是`bool`类型，应该为`ushort`类型。
Mali GPU 系列手机在编译 OpenCL kernel 时进行了严格语法检查，因此会报错；高通系列手机则执行了宽松的语法检查（对不符合规范的代码由编译器进行了隐式转换），因此不会报错。

备注：额外修复了 kernel 二进制 cache 机制中的执行逻辑。