### PR TITLE
[Compile] Add FP16 compile and Ci scripts

### DIFF
--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -57,7 +57,7 @@ if ((NOT LITE_ON_TINY_PUBLISH) AND (LITE_WITH_CUDA OR LITE_WITH_X86 OR LITE_WITH
     target_link_libraries(paddle_light_api_shared ${light_lib_DEPS} ${arm_kernels} ${npu_kernels} ${huawei_ascend_npu_kernels} ${rknpu_kernels} ${apu_kernels})
    if(${HOST_SYSTEM} MATCHES "macosx")
         set(LINK_MAP_FILE "${PADDLE_SOURCE_DIR}/lite/core/exported_symbols.lds")
-        set(LINK_FLAGS "-Wl,-exported_symbols_list, ${LINK_MAP_FILE}")
+        set(LINK_FLAGS "-Wl,-exported_symbols_list ${LINK_MAP_FILE}")
         add_custom_command(OUTPUT ${LINK_MAP_FILE} COMMAND ...)
         add_custom_target(custom_linker_map DEPENDS ${LINK_MAP_FILE})
         set_target_properties(paddle_full_api_shared PROPERTIES LINK_FLAGS ${LINK_FLAGS})

--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -55,7 +55,7 @@ if ((NOT LITE_ON_TINY_PUBLISH) AND (LITE_WITH_CUDA OR LITE_WITH_X86 OR LITE_WITH
         target_link_libraries(paddle_light_api_shared shlwapi.lib)
     endif()
     target_link_libraries(paddle_light_api_shared ${light_lib_DEPS} ${arm_kernels} ${npu_kernels} ${huawei_ascend_npu_kernels} ${rknpu_kernels} ${apu_kernels})
-   if(${HOST_SYSTEM} MATCHES "macosx")
+   if(${HOST_SYSTEM} MATCHES "macosx" AND NOT (ARM_TARGET_LANG STREQUAL "clang"))
         set(LINK_MAP_FILE "${PADDLE_SOURCE_DIR}/lite/core/exported_symbols.lds")
         set(LINK_FLAGS "-Wl,-exported_symbols_list ${LINK_MAP_FILE}")
         add_custom_command(OUTPUT ${LINK_MAP_FILE} COMMAND ...)

--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -25,6 +25,8 @@ WITH_CV=OFF
 WITH_LOG=ON
 # controls whether to throw the exception when error occurs, default is OFF
 WITH_EXCEPTION=OFF
+# controls whether to include FP16 kernels, default is OFF
+BUILD_ARM82_FP16=OFF
 # options of striping lib according to input model.
 OPTMODEL_DIR=""
 WITH_STRIP=OFF
@@ -177,6 +179,10 @@ function make_tiny_publish_so {
   if [ "${WITH_STRIP}" == "ON" ]; then
       WITH_EXTRA=ON
   fi
+  if [ "${BUILD_ARM82_FP16}" == "ON" ]; then
+      TOOLCHAIN=clang
+      ARCH=armv8
+  fi
 
   # android api level for android version
   set_android_api_level
@@ -196,6 +202,7 @@ function make_tiny_publish_so {
       -DLITE_WITH_OPENCL=$WITH_OPENCL \
       -DARM_TARGET_ARCH_ABI=$ARCH \
       -DARM_TARGET_LANG=$TOOLCHAIN \
+      -DLITE_WITH_ARM82_FP16=$BUILD_ARM82_FP16 \
       -DANDROID_STL_TYPE=$ANDROID_STL"
 
   cmake $workspace \
@@ -236,7 +243,10 @@ function make_full_publish_so {
   if [ "${WITH_STRIP}" == "ON" ]; then
       WITH_EXTRA=ON
   fi
-
+  if [ "${BUILD_ARM82_FP16}" == "ON" ]; then
+      TOOLCHAIN=clang
+      ARCH=armv8
+  fi
   # android api level for android version
   set_android_api_level
 
@@ -257,6 +267,7 @@ function make_full_publish_so {
       -DARM_TARGET_LANG=$TOOLCHAIN \
       -DLITE_WITH_TRAIN=$WITH_TRAIN \
       -DLITE_WITH_PROFILE=$WITH_PROFILE \
+      -DLITE_WITH_ARM82_FP16=$BUILD_ARM82_FP16 \
       -DLITE_WITH_PRECISION_PROFILE=$WITH_PRECISION_PROFILE \
       -DANDROID_STL_TYPE=$ANDROID_STL"
 
@@ -296,6 +307,8 @@ function print_usage {
     echo -e "|     --with_extra: (OFF|ON); controls whether to publish extra operators and kernels for (sequence-related model such as OCR or NLP)  |"
     echo -e "|     --with_profile: (OFF|ON); controls whether to support time profile, default is OFF                                               |"
     echo -e "|     --with_precision_profile: (OFF|ON); controls whether to support precision profile, default is OFF                                |"
+    echo -e "|     --with_arm82_fp16: (OFF|ON); controls whether to include FP16 kernels, default is OFF                                            |"
+    echo -e "|                                  warning: when --with_arm82_fp16=ON, toolchain will be set as clang, arch will be set as armv8.      |"
     echo -e "|     --android_api_level: (16~27); control android api level, default is 16 on armv7 and 21 on armv8. You could set a specific        |"
     echo -e "|             android_api_level as you need.                                                                                           |"
     echo -e "|                       | Paddle-Lite Requird / ARM ABI      | armv7 | armv8 |                                                         |"
@@ -448,6 +461,11 @@ function main {
             # compiling lib with precision profile, default OFF.
             --with_precision_profile=*)
                 WITH_PRECISION_PROFILE="${i#*=}"
+                shift
+                ;;
+            # controls whether to include FP16 kernels, default is OFF
+            --with_arm82_fp16=*)
+                BUILD_ARM82_FP16="${i#*=}"
                 shift
                 ;;
             help)

--- a/tools/ci_tools/ci_android_unit_test.sh
+++ b/tools/ci_tools/ci_android_unit_test.sh
@@ -8,6 +8,9 @@ WORKSPACE=${SHELL_FOLDER%tools/ci_tools*}
 TESTS_FILE="./lite_tests.txt"
 NUM_PROC=4
 
+# controls whether to include FP16 kernels, default is OFF
+BUILD_ARM82_FP16=OFF
+
 skip_list=("test_model_parser" "test_mobilenetv1" "test_mobilenetv2" \
             "test_resnet50" "test_inceptionv4" "test_light_api" "test_apis" \
             "test_paddle_api" "test_cxx_api" "test_gen_code" \
@@ -98,6 +101,7 @@ function build_android {
       -DWITH_TESTING=ON \
       -DLITE_BUILD_EXTRA=ON \
       -DLITE_WITH_TRAIN=ON \
+      -DLITE_WITH_ARM82_FP16=$BUILD_ARM82_FP16 \
       -DARM_TARGET_OS=$os -DARM_TARGET_ARCH_ABI=$arch -DARM_TARGET_LANG=$toolchain
 
   make lite_compile_deps -j$NUM_PROC
@@ -145,7 +149,12 @@ function build_test_android {
   adb -s ${adb_devices[0]} shell "cd /data/local/tmp && rm -rf $adb_workdir"
 }
 
-# $1 adb_device index. eg. 1
-# $2 workspace name on adb.  eg. work_tmp1
-build_test_android armv7 gcc $1 $2
-build_test_android armv8 gcc $1 $2
+if [ $# -eq 3 ] ; then
+  BUILD_ARM82_FP16=ON
+  build_test_android armv8 clang $1 $2
+else
+ # $1 adb_device index. eg. 1
+ # $2 workspace name on adb.  eg. work_tmp1
+  build_test_android armv7 gcc $1 $2
+  build_test_android armv8 gcc $1 $2
+fi

--- a/tools/ci_tools/ci_android_unit_test.sh
+++ b/tools/ci_tools/ci_android_unit_test.sh
@@ -162,7 +162,6 @@ fi
 if [ $# -eq 3 ] && [ $3 == "enable_fp16" ] ; then
     BUILD_ARM82_FP16=ON
     build_test_android armv8 clang $1 $2
-    build_test_android armv7 clang $1 $2
 else
     # $1 adb_device index. eg. 1
     # $2 workspace name on adb.  eg. work_tmp1

--- a/tools/ci_tools/ci_android_unit_test.sh
+++ b/tools/ci_tools/ci_android_unit_test.sh
@@ -149,7 +149,7 @@ function build_test_android {
   adb -s ${adb_devices[0]} shell "cd /data/local/tmp && rm -rf $adb_workdir"
 }
 
-if [ $# -eq 3 ] ; then
+if [ $# -eq 3 ] && [ $3 == "enable_fp16"] ; then
   BUILD_ARM82_FP16=ON
   build_test_android armv8 clang $1 $2
 else

--- a/tools/ci_tools/ci_android_unit_test.sh
+++ b/tools/ci_tools/ci_android_unit_test.sh
@@ -149,12 +149,23 @@ function build_test_android {
   adb -s ${adb_devices[0]} shell "cd /data/local/tmp && rm -rf $adb_workdir"
 }
 
-if [ $# -eq 3 ] && [ $3 == "enable_fp16"] ; then
-  BUILD_ARM82_FP16=ON
-  build_test_android armv8 clang $1 $2
+# print help infomation
+if [ $# -lt 1 ] ; then
+    echo "Usage Explaination:"
+    echo " (1) tools/ci_tools/ci_android_unit_test.sh adb_index adb_workname : compile and perform FP32 android unit tests. "
+    echo "         eg. tools/ci_tools/ci_android_unit_test.sh 0 adb_work01 "
+    echo " (2) tools/ci_tools/ci_android_unit_test.sh adb_index adb_workname  enable_fp16: compile and perform FP16 android unit tests. "
+    echo "         eg. tools/ci_tools/ci_android_unit_test.sh 0 adb_work02 enable_fp16 "
+    exit 0
+fi
+
+if [ $# -eq 3 ] && [ $3 == "enable_fp16" ] ; then
+    BUILD_ARM82_FP16=ON
+    build_test_android armv8 clang $1 $2
+    build_test_android armv7 clang $1 $2
 else
- # $1 adb_device index. eg. 1
- # $2 workspace name on adb.  eg. work_tmp1
-  build_test_android armv7 gcc $1 $2
-  build_test_android armv8 gcc $1 $2
+    # $1 adb_device index. eg. 1
+    # $2 workspace name on adb.  eg. work_tmp1
+    build_test_android armv7 gcc $1 $2
+    build_test_android armv8 gcc $1 $2
 fi


### PR DESCRIPTION
- 增加FP16编译逻辑到： `build_android.sh`
- 增加FP16 Android CI 任务 到 `ci_build_android_unit_test.sh`
- 修复FP16 在macOS上编译失败问题