### PR TITLE
[OpenCL]fix tf_shufflenet model segmentation bug

### DIFF
--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -80,8 +80,15 @@ class LayoutComputeBufferChwToImageDefault
 
     // out info
     std::vector<size_t> new_dims = {1, 1, 1, 1};
-    for (int tidx = 0; tidx < x_dims.size(); ++tidx) {
-      new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
+    if (x_dims.size() == 5) {
+      new_dims[4 - x_dims.size() + 1] = x_dims[0] * x_dims[1];
+      for (int tidx = 2; tidx < x_dims.size(); ++tidx) {
+        new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
+      }
+    } else {
+      for (int tidx = 0; tidx < x_dims.size(); ++tidx) {
+        new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
+      }
     }
     const int out_C = new_dims[1];
     const int out_H = new_dims[2];
@@ -207,8 +214,15 @@ class LayoutComputeImageDefaultToBufferChw
     auto x_image_shape = InitImageDimInfoWith(x_dims);
 
     std::vector<size_t> new_dims = {1, 1, 1, 1};
-    for (int j = 0; j < x_dims.size(); ++j) {
-      new_dims[4 - x_dims.size() + j] = x_dims[j];
+    if (x_dims.size() == 5) {
+      new_dims[4 - x_dims.size() + 1] = x_dims[0] * x_dims[1];
+      for (int j = 2; j < x_dims.size(); ++j) {
+        new_dims[4 - x_dims.size() + j] = x_dims[j];
+      }
+    } else {
+      for (int j = 0; j < x_dims.size(); ++j) {
+        new_dims[4 - x_dims.size() + j] = x_dims[j];
+      }
     }
 
 #ifdef LITE_WITH_LOG
@@ -322,8 +336,15 @@ class LayoutComputeBufferChwToImage2DNw
 
     // out info
     std::vector<size_t> new_dims = {1, 1, 1, 1};
-    for (int tidx = 0; tidx < x_dims.size(); ++tidx) {
-      new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
+    if (x_dims.size() == 5) {
+      new_dims[4 - x_dims.size() + 1] = x_dims[0] * x_dims[1];
+      for (int tidx = 2; tidx < x_dims.size(); ++tidx) {
+        new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
+      }
+    } else {
+      for (int tidx = 0; tidx < x_dims.size(); ++tidx) {
+        new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
+      }
     }
 
     const int out_N = new_dims[0];

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -85,10 +85,13 @@ class LayoutComputeBufferChwToImageDefault
       for (int tidx = 2; tidx < x_dims.size(); ++tidx) {
         new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
       }
-    } else {
+    } else if (x_dims.size() < 5) {
       for (int tidx = 0; tidx < x_dims.size(); ++tidx) {
         new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
       }
+    } else {
+      LOG(FATAL) << "unsupported layout tensor dims size, the dims size is:"
+                 << x_dims.size();
     }
     const int out_C = new_dims[1];
     const int out_H = new_dims[2];
@@ -219,10 +222,13 @@ class LayoutComputeImageDefaultToBufferChw
       for (int j = 2; j < x_dims.size(); ++j) {
         new_dims[4 - x_dims.size() + j] = x_dims[j];
       }
-    } else {
+    } else if (x_dims.size() < 5) {
       for (int j = 0; j < x_dims.size(); ++j) {
         new_dims[4 - x_dims.size() + j] = x_dims[j];
       }
+    } else {
+      LOG(FATAL) << "unsupported layout tensor dims size, the dims size is: "
+                 << x_dims.size();
     }
 
 #ifdef LITE_WITH_LOG
@@ -341,10 +347,13 @@ class LayoutComputeBufferChwToImage2DNw
       for (int tidx = 2; tidx < x_dims.size(); ++tidx) {
         new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
       }
-    } else {
+    } else if (x_dims.size() < 5) {
       for (int tidx = 0; tidx < x_dims.size(); ++tidx) {
         new_dims[4 - x_dims.size() + tidx] = x_dims[tidx];
       }
+    } else {
+      LOG(FATAL) << "unsupported layout tensor dims size, the dims size is:"
+                 << x_dims.size();
     }
 
     const int out_N = new_dims[0];


### PR DESCRIPTION
导致tf_shufflenet segmentation的原因是原先的layout转换中不支持5维的tensor，本pr添加layout对5维tensor的支持。