### PR TITLE
[BUG FIX] Fix the issue that script `build_android_by_models.sh` is not applicable for model with `calib_once` op

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -141,6 +141,9 @@ void Predictor::SaveOpKernelInfo(const std::string &model_dir) {
     std::string op_path = op2pathmap[*op_info];
     fputs(op_path.c_str(), opf_source);
     fputc('\n', opf_source);
+    if (op_path == "calib_once_op.cc") {
+      fputs("calib_op.cc\n", opf_source);
+    }
   }
   std::fclose(opf_source);
   std::fclose(opf);


### PR DESCRIPTION
### Issue
- strip lib according to models failed if input models contain calib_once op but not calib op

### Explaination

- the inner defination of `calib_once` is dependent on `calib`, if we only compile calib_once into lib, error will occurs
