### PR TITLE
fix bugs in graph data structure, test=develop

### DIFF
--- a/lite/api/paddle_use_passes.h
+++ b/lite/api/paddle_use_passes.h
@@ -76,6 +76,7 @@ USE_MIR_PASS(control_flow_op_unused_inputs_and_outputs_eliminate_pass)
 USE_MIR_PASS(lite_scale_activation_fuse_pass);
 USE_MIR_PASS(lite_instance_norm_activation_fuse_pass);
 USE_MIR_PASS(lite_fc_prelu_fuse_pass);
+USE_MIR_PASS(cycle_removal_pass);
 USE_MIR_PASS(__xpu__resnet_fuse_pass);
 USE_MIR_PASS(__xpu__resnet_d_fuse_pass);
 USE_MIR_PASS(__xpu__resnet_cbam_fuse_pass);

--- a/lite/core/mir/CMakeLists.txt
+++ b/lite/core/mir/CMakeLists.txt
@@ -82,6 +82,7 @@ lite_cc_library(mir_passes
       restrict_quantized_op_with_same_input_output_scale_pass.cc
       post_quant_dynamic_pass.cc
       fp16_attribute_pass.cc
+      cycle_removal_pass.cc
   DEPS mir_pass types context ${mir_fusers} ${mir_subgraphs})
 
 # lite_cc_test(test_ssa_graph SRCS ssa_graph_test.cc DEPS

--- a/lite/core/mir/cycle_removal_pass.cc
+++ b/lite/core/mir/cycle_removal_pass.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/mir/cycle_removal_pass.h"
+#include <memory>
+#include <string>
+#include "lite/core/mir/pass_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+namespace fusion {
+
+SelfLoopDetector::SelfLoopDetector(const std::string& op_type) {
+  op_type_ = op_type;
+}
+
+void SelfLoopDetector::BuildPattern() {
+  mir::PMNode* io_var = VarNode("io_var")
+                            ->assert_is_op_input(op_type_)
+                            ->assert_is_op_output(op_type_)
+                            ->AsIntermediate();
+  mir::PMNode* self_loop_op = OpNode("self_loop_op", op_type_);
+  *io_var >> *self_loop_op >> *io_var;
+}
+
+void SelfLoopDetector::InsertNewNode(SSAGraph* graph,
+                                     const key2nodes_t& matched) {
+  mir::Node* arg_node{matched.at("io_var")};
+  mir::Node* op_node{matched.at("self_loop_op")};
+  mir::Node::Arg* arg{arg_node->arg()};
+  mir::Node::Stmt* op{op_node->stmt()};
+
+  const std::string& var_name{arg->name};
+  const std::string new_input_name{var_name + "__IN_VAR"};
+  const std::string new_output_name{var_name + "__OUT_VAR"};
+
+  mir::Node* new_input_node{graph->NewArgumentNode(new_input_name)};
+  mir::Node* new_output_node{graph->NewArgumentNode(new_output_name)};
+  new_input_node->AsArg().type = arg->type;
+  new_output_node->AsArg().type = arg->type;
+
+  op->mutable_op_info()->UpdateAllInputs(var_name, new_input_name);
+  op->mutable_op_info()->UpdateAllOutputs(var_name, new_output_name);
+
+  RemoveDirectedLink(arg_node, op_node);
+  DirectedLink(new_input_node, op_node);
+  RemoveDirectedLink(op_node, arg_node);
+  DirectedLink(op_node, new_output_node);
+}
+}  // namespace fusion
+
+void CycleRemovalPass::Apply(const std::unique_ptr<SSAGraph>& graph) {
+  for (auto op_type : {"batch_norm"}) {
+    fusion::SelfLoopDetector fuser(op_type);
+    fuser(graph.get());
+  }
+}
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_MIR_PASS(cycle_removal_pass, paddle::lite::mir::CycleRemovalPass)
+    .BindTargets({TARGET(kAny)});

--- a/lite/core/mir/cycle_removal_pass.h
+++ b/lite/core/mir/cycle_removal_pass.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include "lite/core/mir/pass.h"
+#include "lite/core/mir/pattern_matcher_high_api.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+namespace fusion {
+
+class SelfLoopDetector : public FuseBase {
+ public:
+  explicit SelfLoopDetector(const std::string& op_type);
+  void BuildPattern() override;
+
+  void InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) override;
+
+ private:
+  std::string op_type_;
+};
+}  // namespace fusion
+
+class CycleRemovalPass : public ProgramPass {
+ public:
+  void Apply(const std::unique_ptr<SSAGraph>& graph) override;
+};
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/mir/graph_visualize_pass.cc
+++ b/lite/core/mir/graph_visualize_pass.cc
@@ -83,23 +83,23 @@ std::string Visualize(mir::SSAGraph* graph) {
   };
   int op_idx = 0;
   std::set<std::string> exists_var_names;
-  for (auto& node : graph->StmtTopologicalOrder()) {
-    if (!node->IsStmt()) continue;
-    auto op_info = node->AsStmt().op_info();
+  for (auto& node : graph->mutable_nodes()) {
+    if (!node.IsStmt()) continue;
+    auto op_info = node.AsStmt().op_info();
     auto op_type = op_info->Type();
     std::string op_name;
-    if (node->AsStmt().need_sync_) {
+    if (node.AsStmt().need_sync_) {
       std::ostringstream oss;
-      for (size_t i = 0; i < node->AsStmt().sync_streams_.size(); ++i) {
-        oss << std::to_string(node->AsStmt().sync_streams_[i]);
-        if (i != node->AsStmt().sync_streams_.size() - 1) {
+      for (size_t i = 0; i < node.AsStmt().sync_streams_.size(); ++i) {
+        oss << std::to_string(node.AsStmt().sync_streams_[i]);
+        if (i != node.AsStmt().sync_streams_.size() - 1) {
           oss << ",";
         }
       }
       op_name = string_format("%s%d, stream=%d, sync_streams={%s}",
                               op_type.c_str(),
                               op_idx++,
-                              node->AsStmt().stream_id_,
+                              node.AsStmt().stream_id_,
                               oss.str().c_str());
     } else {
       op_name = string_format("%s%d", op_type.c_str(), op_idx++);
@@ -110,7 +110,7 @@ std::string Visualize(mir::SSAGraph* graph) {
                  Dot::Attr("style", "filled"),
                  Dot::Attr("color", "black"),
                  Dot::Attr("fillcolor", "yellow")});
-    for (auto& x : node->inlinks) {
+    for (auto& x : node.inlinks) {
       std::string var_name;
       if (x->AsArg().lane != -1) {
         var_name = string_format(
@@ -132,7 +132,7 @@ std::string Visualize(mir::SSAGraph* graph) {
       }
       dot.AddEdge(var_name, op_name, attrs);
     }
-    for (auto& x : node->outlinks) {
+    for (auto& x : node.outlinks) {
       std::string var_name;
       if (x->AsArg().lane != -1) {
         var_name = string_format(

--- a/lite/core/mir/ssa_graph.cc
+++ b/lite/core/mir/ssa_graph.cc
@@ -96,14 +96,14 @@ bool SSAGraph::DepthFirstSearch(
   data->stack.insert(node);
   for (auto adj : adj_list.at(node)) {
     if (data->visited.find(adj) == data->visited.end()) {
-      data->reverse[adj] = node;
+      data->reverse_edge[adj] = node;
       if (!DepthFirstSearch(adj_list, adj, data)) {
         has_cycle = true;
       }
     } else if (data->stack.find(adj) != data->stack.end()) {
       has_cycle = true;
       std::stack<mir::Node *> cycle;
-      for (auto *n = node; n != adj; n = data->reverse.at(n)) {
+      for (auto *n = node; n != adj; n = data->reverse_edge.at(n)) {
         cycle.push(n);
       }
       cycle.push(adj);
@@ -117,7 +117,7 @@ bool SSAGraph::DepthFirstSearch(
       }
     }
   }
-  data->res.push_back(node);
+  data->post_order.emplace_back(node);
   data->stack.erase(node);
   return !has_cycle;
 }
@@ -135,8 +135,8 @@ std::vector<mir::Node *> SSAGraph::StmtTopologicalOrder() {
       DepthFirstSearch(adj_list, adj.first, &data);
     }
   }
-
-  return data.res;
+  std::reverse(std::begin(data.post_order), std::end(data.post_order));
+  return std::move(data.post_order);
 }
 
 std::vector<mir::Node *> SSAGraph::NodeTopologicalOrder() {
@@ -152,7 +152,8 @@ std::vector<mir::Node *> SSAGraph::NodeTopologicalOrder() {
     }
   }
 
-  return data.res;
+  std::reverse(std::begin(data.post_order), std::end(data.post_order));
+  return std::move(data.post_order);
 }
 
 bool SSAGraph::IsDirectedAcyclic() {

--- a/lite/core/mir/ssa_graph.h
+++ b/lite/core/mir/ssa_graph.h
@@ -51,6 +51,8 @@ class SSAGraph : GraphBase {
 
   std::vector<mir::Node *> NodeTopologicalOrder();
 
+  bool IsDirectedAcyclic();
+
   // The inputs of the graph.
   std::vector<mir::Node *> inputs();
 
@@ -79,6 +81,15 @@ class SSAGraph : GraphBase {
   void SetValidPlaces(const std::vector<Place> &x) { valid_places_ = x; }
 
  private:
+  enum class NodeType { kUnk = 0, kStmt, kAny };
+  struct SortStackData {
+    NodeType node_type{NodeType::kAny};
+    std::set<mir::Node *> visited;
+    std::vector<mir::Node *> res;
+    std::map<mir::Node *, mir::Node *> reverse;
+    std::set<mir::Node *> stack;
+  };
+
   mir::Node *Argument(const std::string &name);
   // Check the bidirectional connection.
   bool CheckBidirectionalConnection();
@@ -98,10 +109,10 @@ class SSAGraph : GraphBase {
   // Build node inlink edge table.
   std::map<mir::Node *, std::set<mir::Node *>> BuildNodeAdjList();
 
-  void SortHelper(const std::map<mir::Node *, std::set<mir::Node *>> &adj_list,
-                  mir::Node *node,
-                  std::set<mir::Node *> *visited,
-                  std::vector<mir::Node *> *ret);
+  bool DepthFirstSearch(
+      const std::map<mir::Node *, std::set<mir::Node *>> &adj_list,
+      mir::Node *node,
+      SortStackData *data);
 
  private:
   std::list<mir::Node> node_storage_;

--- a/lite/core/mir/ssa_graph.h
+++ b/lite/core/mir/ssa_graph.h
@@ -85,8 +85,8 @@ class SSAGraph : GraphBase {
   struct SortStackData {
     NodeType node_type{NodeType::kAny};
     std::set<mir::Node *> visited;
-    std::vector<mir::Node *> res;
-    std::map<mir::Node *, mir::Node *> reverse;
+    std::vector<mir::Node *> post_order;
+    std::map<mir::Node *, mir::Node *> reverse_edge;
     std::set<mir::Node *> stack;
   };
 

--- a/lite/core/mir/subgraph/subgraph_detector.cc
+++ b/lite/core/mir/subgraph/subgraph_detector.cc
@@ -128,12 +128,12 @@ void SubgraphDetector::node_dat_t::UnionFindCombine(node_dat_t *candidate) {
   std::set<node_dat_t *> outputs(candidate->outlinks.begin(),
                                  candidate->outlinks.end());
   for (auto *out_node : outlinks) {
-    if (out_node != candidate) {
+    if (out_node != candidate && out_node != this) {
       outputs.insert(out_node);
     }
   }
   for (auto *in_node : candidate->inlinks) {
-    if (in_node != this) {
+    if (in_node != candidate && in_node != this) {
       inputs.insert(in_node);
     }
   }

--- a/lite/core/mir/subgraph/subgraph_detector_test.cc
+++ b/lite/core/mir/subgraph/subgraph_detector_test.cc
@@ -18,6 +18,8 @@
 #include <vector>
 #include "lite/api/paddle_use_ops.h"
 #include "lite/api/paddle_use_passes.h"
+#include "lite/core/mir/cycle_removal_pass.h"
+#include "lite/core/mir/graph_visualize_pass.h"
 #include "lite/core/mir/ssa_graph.h"
 #include "lite/core/program.h"
 #include "lite/model_parser/cpp_desc.h"
@@ -208,6 +210,10 @@ TEST(Subgraph, detect_custom_model) {
   Program program(program_desc, scope, valid_places);
   auto graph = std::unique_ptr<mir::SSAGraph>(new mir::SSAGraph());
   graph->Build(program, valid_places);
+  mir::Visualize(graph.get());
+  mir::fusion::SelfLoopDetector fuser("batch_norm");
+  fuser(graph.get());
+  mir::Visualize(graph.get());
   // Apply subgraph detector and check results
   auto teller = [](mir::Node* node) {
     if (!node->IsStmt()) return false;

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -82,7 +82,8 @@ class Optimizer {
     InitControlFlowOpUnusedInputsAndOutputsEliminatePass();
 
     std::vector<std::string> passes_local{
-        {"lite_quant_dequant_fuse_pass",             //
+        {"cycle_removal_pass",                       //
+         "lite_quant_dequant_fuse_pass",             //
          "weight_quantization_preprocess_pass",      //
          "remove_scale1_pass",                       //
          "adaptive_1x1_pool2d_convert_global_pass",  //


### PR DESCRIPTION
本提交使 `SSAGraph` 正确处理有环图。

1、修改 `SSAGraph` 的构造函数，修复计算图存在有向环时，由于 `Program` 中子节点输入变量先于父节点输出变量出现，造成计算图存在重名节点的问题。
2、将 `SSAGraph::AdjList` 含义明确为有向图自身的临接表，而非有向图的反向临接表，增强可读性。
3、将 `SSAGraph::SortHelper` 更名为 `SSAGraph::DepthFirstSearch`，明确为生成深度优先遍历的节点序，并在遍历过程中检测有向环。
4、增加一个方法 `SSAGraph::IsDirectedAcyclic` 返回图中是否存在环。有向有环图是不存在拓扑排序的，但为了向后兼容，没有增加遍历过程中对无环的条件约束。
5、修改 `Visualize(mir::SSAGraph* graph)`，使有环图打印不丢失节点。
6、增加数据结构 `SSAGraph::SortStackData` 和 `SSAGraph::NodeType`，用于减少成员函数参数个数。
7、修复 `SubgraphDetector::node_dat_t::UnionFindCombine` 在 BatchNorm / FakeQuantize 输入输出成环时的判断遗漏问题。
8、问题 1 产生的额外同名节点，使 BatchNorm / FakeQuantize 计算图恰好有向无环，从而顺利通过后续 `Pass`；但实际上过去多数的 BatchNorm / FakeQuantize 计算图是有环的。所以在修复问题 1 后，产生的正确的有环图无法通过 `SubgraphDetector`。新增一个 `CycleRemovalPass`，去除这种情况下产生的算子环。

在 使 `SSAGraph` 可处理有向有环图后，它更适合叫做 `DirectedGraph`，后续可能修改名称。