### PR TITLE
[OpenCL] Delete armv7 kernel binary when running armv8, vice versa

### DIFF
--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -216,8 +216,8 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
              "from source.";
     } else {
       LOG(INFO) << "Load opencl kernel bin file: " << bin_file;
-      ret = Deserialize(bin_file, &programs_precompiled_binary_);
-      CHECK(ret) << "Deserialize failed.";
+      bool success = Deserialize(bin_file, &programs_precompiled_binary_);
+      CHECK(success) << "Deserialize failed!";
 
       VLOG(3) << "sn_key: " << sn_key_;
       VLOG(3) << "map size: " << programs_precompiled_binary_.size();
@@ -237,9 +237,12 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
       } else if (host::memcmp(((sn_iter->second)[0]).data(),
                               GetSN(build_option).data(),
                               GetSN(build_option).length())) {
-        LOG(INFO) << "size of sn_info: " << ((sn_iter->second)[0]).size()
-                  << "\nsize of GetSN: " << GetSN(build_option).length()
-                  << "\nGetSN: " << GetSN(build_option);
+        std::string sn_str(reinterpret_cast<char*>((sn_iter->second)[0].data()),
+                           (sn_iter->second)[0].size());
+        LOG(INFO) << "\nSN required: " << GetSN(build_option)
+                  << "\tsize: " << GetSN(build_option).length()
+                  << "\nSN in bin file: " << sn_str
+                  << "\tsize: " << ((sn_iter->second)[0]).size();
         LOG(WARNING) << "The precompiled OpenCL binary[" << bin_file
                      << "] is invalid!";
         delete_bin_flag = true;
@@ -250,13 +253,12 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
 #endif
         // loop all programs of the binary file
         cl_int status{CL_SUCCESS};
-        const std::vector<cl::Device> device{*device_};
         for (auto& ins : programs_precompiled_binary_) {
           std::string prog_key = ins.first;
           if (prog_key == sn_key_) continue;  // skip sn_key
 
           cl::Program program(
-              *context_, {*device_}, ins.second, nullptr, &status);
+              context(), {device()}, ins.second, nullptr, &status);
           CL_CHECK_FATAL_SOLID(status);
           auto pos_start = prog_key.find_first_of("-D");
           std::string options = prog_key.substr(pos_start);
@@ -281,6 +283,8 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
 
     if (delete_bin_flag) {
       remove_file(bin_file);
+      programs_precompiled_binary_.clear();
+      programs_.clear();
     }
   } else if (gotten_bin_flag_) {
     // This case happened when model has updated. Bin file should be updated
@@ -296,7 +300,7 @@ bool CLRuntime::CheckFromPrecompiledBinary(const std::string& program_key,
 bool CLRuntime::CheckFromSource(const std::string& file_name,
                                 const std::string& program_key,
                                 const std::string& build_option) {
-  auto ptr = CreateProgramFromSource(*context_, file_name);
+  auto ptr = CreateProgramFromSource(context(), file_name);
   auto program = ptr.get();
 #ifdef LITE_WITH_LOG
   VLOG(3) << " --- begin build program from source -> " << program_key
@@ -351,7 +355,7 @@ std::unique_ptr<cl::Program> CLRuntime::CreateProgramFromSource(
 }
 
 bool CLRuntime::BuildProgram(cl::Program* program, const std::string& options) {
-  status_ = program->build({*device_}, options.c_str());
+  status_ = program->build({device()}, options.c_str());
   CL_CHECK_ERROR(status_);
 
   if (status_ != CL_SUCCESS) {
@@ -376,6 +380,13 @@ void CLRuntime::SaveProgram() {
     bool ret = Serialize(binary_file, programs_precompiled_binary_);
     CHECK(ret) << "Serialize failed for opencl binary_file:" << binary_file;
 #ifdef LITE_WITH_LOG
+    if (programs_precompiled_binary_.find(sn_key_) !=
+        programs_precompiled_binary_.end()) {
+      std::string sn_str(reinterpret_cast<char*>(
+                             programs_precompiled_binary_[sn_key_][0].data()),
+                         programs_precompiled_binary_[sn_key_][0].size());
+      LOG(INFO) << "SN stored: " << sn_str;
+    }
     LOG(INFO) << "Programs have been serialized to disk successfully. File: "
               << binary_file;
 #endif
@@ -471,14 +482,31 @@ std::string CLRuntime::GetSN(const std::string options) {
   // Identifier info(Serial Number) for each binary file: lite version,
   // build options, platform info, device version, driver version
   STL::stringstream sn_ss;
-  std::string lite_version = lite::version() + "; ";
-  std::string platform_info = platform_->getInfo<CL_PLATFORM_NAME>() + ", " +
-                              platform_->getInfo<CL_PLATFORM_PROFILE>() + "; ";
-  std::string device_version = device_->getInfo<CL_DEVICE_VERSION>() + "; ";
-  std::string driver_version = device_->getInfo<CL_DRIVER_VERSION>() + "; ";
-  std::string place_holder{"place_holder"};
-  sn_ss << lite_version << options << platform_info << device_version
-        << driver_version << place_holder;
+
+  const std::string aarch =
+#if defined(__aarch64__)
+      "android_armv8";
+#else
+      "android_armv7";
+#endif
+#if defined(_WIN64)
+  "win64";
+#elif defined(_WIN32)
+  "win32";
+#endif
+
+  const std::string aarch_info = aarch + "; ";
+  const std::string lite_version = lite::version() + "; ";
+  const std::string platform_info =
+      platform_->getInfo<CL_PLATFORM_NAME>() + ", " +
+      platform_->getInfo<CL_PLATFORM_PROFILE>() + "; ";
+  const std::string device_version =
+      device_->getInfo<CL_DEVICE_VERSION>() + "; ";
+  const std::string driver_version =
+      device_->getInfo<CL_DRIVER_VERSION>() + "; ";
+  const std::string place_holder{"place_holder"};
+  sn_ss << aarch_info << lite_version << options << platform_info
+        << device_version << driver_version << place_holder;
   return sn_ss.str();
 }
 


### PR DESCRIPTION
【问题】
OpenCL 在线编译生成的 kernel binary 是区分 armv7 和 armv8 的，比如 armv8 运行时读取 armv7 生成的 kernel binary 就会报错`cl::runtime.cc:259 CheckFromPrecompiledBinary] OpenCL error with code CL_INVALID_VALUE`。

【解决方法】
在 kernel binary 唯一识别号 SN 中加入编译时的 arm 架构信息，运行时检查 binary 中的 SN 是否与所要求的 SN 是否一致即可。如果不一致，需要清空`programs_precompiled_binary_`和`programs_`，并删除无效的 binary 文件。

另外，如果用户指定的 binary file name 不变，当分别运行两个不同的模型时，会发生部分所需编译的 kernel 不在之前 binary file 中的情况，这时也应删除无效的 binary 文件，但不清空`programs_precompiled_binary_`和`programs_`，原因是这两个 map 中已经含有了部分有效的 kernel。