### PR TITLE
[BUG FIX] Remove flto cmake flags on static lib to support Android10.0+

### DIFF
--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -85,7 +85,7 @@ else()
     else()
         # 1. enable -flto compiling flag if toochain==gcc
         # TODO (hong19860320): Disable lto temporarily since it causes fail to catch the exceptions in android when toolchain is gcc.
-        if (ARM_TARGET_LANG STREQUAL "gcc") #gcc
+        if (NOT (ARM_TARGET_LANG STREQUAL "clang"))
             set(TARGET_COMIPILE_FLAGS "-fdata-sections -flto")
         else()
             set(TARGET_COMIPILE_FLAGS "-fdata-sections")

--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -87,7 +87,7 @@ else()
         # TODO (hong19860320): Disable lto temporarily since it causes fail to catch the exceptions in android when toolchain is gcc.
         if (ARM_TARGET_LANG STREQUAL "gcc") #gcc
             set(TARGET_COMIPILE_FLAGS "-fdata-sections -flto")
-        elseif(ARM_TARGET_LANG STREQUAL "clang")
+        else()
             set(TARGET_COMIPILE_FLAGS "-fdata-sections")
         endif()
         if (ARM_TARGET_OS STREQUAL "android" AND LITE_WITH_EXCEPTION)

--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -86,12 +86,13 @@ else()
         # 1. enable -flto compiling flag if toochain==gcc
         # TODO (hong19860320): Disable lto temporarily since it causes fail to catch the exceptions in android when toolchain is gcc.
         if (NOT (ARM_TARGET_LANG STREQUAL "clang"))
-            set(TARGET_COMIPILE_FLAGS "-fdata-sections -flto")
+            if (ARM_TARGET_OS STREQUAL "android" AND LITE_WITH_EXCEPTION)
+                set(TARGET_COMIPILE_FLAGS "")
+            else()
+                set(TARGET_COMIPILE_FLAGS "-fdata-sections -flto")
+            endif()
         else()
             set(TARGET_COMIPILE_FLAGS "-fdata-sections")
-        endif()
-        if (ARM_TARGET_OS STREQUAL "android" AND LITE_WITH_EXCEPTION)
-            set(TARGET_COMIPILE_FLAGS "")
         endif()
         #   1.1 enable -flto on PADDLELITE_OBJS
         set_target_properties(PADDLELITE_OBJS PROPERTIES COMPILE_FLAGS "${TARGET_COMIPILE_FLAGS}")

--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -84,19 +84,14 @@ else()
         add_library(paddle_api_light_bundled STATIC $<TARGET_OBJECTS:PADDLELITE_OBJS>)
     else()
         # 1. enable -flto compiling flag if toochain==gcc
-        set(TARGET_COMIPILE_FLAGS "-fdata-sections")
-        if (NOT (ARM_TARGET_LANG STREQUAL "clang")) #gcc
-            set(TARGET_COMIPILE_FLAGS "${TARGET_COMIPILE_FLAGS} -flto")
-            # '-flto' is only supported by gcc-ar, while gcc-ar is not supported on MacOs
-            if(NOT ${HOST_SYSTEM} MATCHES "macosx")
-                SET(CMAKE_AR "gcc-ar")
-                SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
-                SET(CMAKE_CXX_ARCHIVE_FINISH   true)
-            endif()
-            # TODO (hong19860320): Disable lto temporarily since it causes fail to catch the exceptions in android when toolchain is gcc.
-            if (ARM_TARGET_OS STREQUAL "android" AND LITE_WITH_EXCEPTION)
-                set(TARGET_COMIPILE_FLAGS "")
-            endif()
+        # TODO (hong19860320): Disable lto temporarily since it causes fail to catch the exceptions in android when toolchain is gcc.
+        if (ARM_TARGET_LANG STREQUAL "gcc") #gcc
+            set(TARGET_COMIPILE_FLAGS "-fdata-sections -flto")
+        elseif(ARM_TARGET_LANG STREQUAL "clang")
+            set(TARGET_COMIPILE_FLAGS "-fdata-sections")
+        endif()
+        if (ARM_TARGET_OS STREQUAL "android" AND LITE_WITH_EXCEPTION)
+            set(TARGET_COMIPILE_FLAGS "")
         endif()
         #   1.1 enable -flto on PADDLELITE_OBJS
         set_target_properties(PADDLELITE_OBJS PROPERTIES COMPILE_FLAGS "${TARGET_COMIPILE_FLAGS}")
@@ -130,11 +125,11 @@ else()
         endif()
 
         # 4. produce static lib `libpaddle_api_light_bundled.a` from `PADDLELITE_OBJS`
-        # '-flto' is only supported by gcc-ar, while gcc-ar is not supported on MacOs
-        if(NOT ${HOST_SYSTEM} MATCHES "macosx")
-            add_library(paddle_api_light_bundled STATIC $<TARGET_OBJECTS:PADDLELITE_OBJS>)
-        else()
+        # '-flto' is only supported by dynamic lib
+        if(TARGET_COMIPILE_FLAGS MATCHES ".*-flto.*")
             add_library(paddle_api_light_bundled STATIC ${__lite_cc_files} paddle_api.cc light_api.cc light_api_impl.cc)
+        else()
+            add_library(paddle_api_light_bundled STATIC $<TARGET_OBJECTS:PADDLELITE_OBJS>)
         endif()
     endif()
 endif()


### PR DESCRIPTION
- 当Android静态库含有flto编译选项、不支持Android 10.0以上版本，错误信息：
``` shell
error: executable's TLS segment is underaligned: alignment is 8, needs to be at least 64 for ARM64 Bionic
```
- 本PR解决方法
  - 如果编译选项中含有`flto`， 则单独构建出不含flto选项的静态库
``` shell
# tiny_publish、android
1. Without flto
# P&S: these libraries will share the same intermediate objects cache.
__lite_cc_files -----> PADDLELITE_OBJS    -------> cxx_dynamic_library
                          | +jni_cc_files  ------> jni_dynamic_library
                          |----------------------> cxx_static_library

2、 If with flto
__lite_cc_files -----> PADDLELITE_OBJS    -------> cxx_dynamic_library
            |               | +jni_cc_files  ------> jni_dynamic_library
            |----------without-flto--------> cxx_static_library （consuming more time）
```