### PR TITLE
[Framework]Update docker image script

### DIFF
--- a/lite/tools/Dockerfile.mobile
+++ b/lite/tools/Dockerfile.mobile
@@ -15,27 +15,20 @@ RUN sed -ie 's|<version>|xenial|' /etc/apt/sources.list
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --no-install-recommends \
         clang-format-3.8 \
-        cmake-curses-gui \
         curl \
-        fish \
-        gawk \
         gcc \
         g++ \
         git \
-        graphviz \
-        less \
         make \
-        patch \
+        patchelf \
         python \
+        android-tools-adb \
+        python-dev \
         python-pip \
         python-setuptools \
         unzip \
         vim \
         wget
-
-# timezone
-RUN apt install tzdata
-RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/timezone && echo 'Asia/Shanghai' >/etc/timezone
 
 # for android simulator
 RUN apt-get install -y --no-install-recommends \
@@ -50,8 +43,8 @@ RUN apt-get install -y --no-install-recommends \
 RUN curl -O https://mms-res.cdn.bcebos.com/cmake-3.10.3-Linux-x86_64.tar.gz && \
         tar xzf cmake-3.10.3-Linux-x86_64.tar.gz && \
         mv cmake-3.10.3-Linux-x86_64 /opt/cmake-3.10 && \
-        mv /usr/bin/cmake /usr/bin/cmake.bak && ln -s /opt/cmake-3.10/bin/cmake /usr/bin/cmake && \
-        mv /usr/bin/ccmake /usr/bin/ccmake.bak && ln -s /opt/cmake-3.10/bin/ccmake /usr/bin/ccmake
+        ln -s /opt/cmake-3.10/bin/cmake /usr/bin/cmake && \
+        ln -s /opt/cmake-3.10/bin/ccmake /usr/bin/ccmake
 
 # for arm linux compile
 RUN apt-get install -y --no-install-recommends \
@@ -62,35 +55,20 @@ RUN apt-get install -y --no-install-recommends \
         gcc-aarch64-linux-gnu \
         g++-aarch64-linux-gnu 
 
-# for android ndk17c
+# for android ndk17c and ndk20b
 RUN cd /tmp && curl -O https://dl.google.com/android/repository/android-ndk-r17c-linux-x86_64.zip
+RUN cd /tmp && curl -O https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
 ENV NDK_ROOT /opt/android-ndk-r17c
+ENV NDK_ROOT_R20B /opt/android-ndk-r20b
 RUN cd /opt && unzip /tmp/android-ndk-r17c-linux-x86_64.zip
+RUN cd /opt && unzip /tmp/android-ndk-r20b-linux-x86_64.zip
 
-# for android simulator
-ENV ANDROID_HOME /opt/android_sdk
-ENV PATH $PATH:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools/bin
-RUN wget "https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip" && \
-    unzip sdk-tools-linux-4333796.zip -d /opt/android_sdk && \
-    mkdir /root/.android && touch /root/.android/repositories.cfg && \
-    echo y | sdkmanager "platform-tools" "emulator" && \
-    echo y | sdkmanager "platforms;android-24" && \
-    echo y | sdkmanager "system-images;android-24;google_apis;arm64-v8a" "system-images;android-24;google_apis;armeabi-v7a"
-
-# this will install the ndk19c and only use clang to compile, then can replace the ndk17c
-# echo y | sdkmanager "ndk;19.2.5345600"
-
-# Expose android port
-EXPOSE 5555
-EXPOSE 5557
 # VNC port
 EXPOSE 5900
 
 # clean
 RUN ln -s clang-format-3.8 /usr/bin/clang-format
-RUN pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --upgrade pip
 RUN pip install -i https://pypi.tuna.tsinghua.edu.cn/simple wheel
 RUN pip install -i https://pypi.tuna.tsinghua.edu.cn/simple pre-commit
 RUN apt-get autoremove -y && apt-get clean
 RUN rm -rf /sdk-tools-linux-4333796.zip /tmp/android-ndk-r17c-linux-x86_64.zip /cmake-3.10.3-Linux-x86_64.tar.gz
- 


### PR DESCRIPTION
- 降低docker镜像体积（移除timezone、adb simulator等无关库）
  - 修改前镜像体积：12G
  - 修改后镜像体积：8.38G
![image](https://user-images.githubusercontent.com/45189361/113298686-aa4ec600-932e-11eb-9d38-c83fd42ebf3d.png)

- Docker支持Python编译（python-dev、patchelf)
- Docker 支持DNK20b