### PR TITLE
[ARM-FP16]fix precision profiler  error

### DIFF
--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -260,7 +260,7 @@ void LightPredictor::DequantizeWeight() {
 typedef __fp16 float16_t;
 void LightPredictor::WeightFP32ToFP16() {
   std::shared_ptr<const cpp::ProgramDesc> program_desc = program_desc_;
-  std::vector<std::string> fp16_ops{"conv2d", "fc"};
+  std::vector<std::string> fp16_ops{"conv2d", "depthwise_conv2d", "fc"};
   for (size_t i = 0; i < program_desc->BlocksSize(); i++) {
     auto* block = program_desc->GetBlock<cpp::BlockDesc>(i);
     for (size_t k = 0; k < block->OpsSize(); ++k) {

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -260,7 +260,7 @@ void LightPredictor::DequantizeWeight() {
 typedef __fp16 float16_t;
 void LightPredictor::WeightFP32ToFP16() {
   std::shared_ptr<const cpp::ProgramDesc> program_desc = program_desc_;
-  std::vector<std::string> fp16_ops{"conv2d"};
+  std::vector<std::string> fp16_ops{"conv2d", "fc"};
   for (size_t i = 0; i < program_desc->BlocksSize(); i++) {
     auto* block = program_desc->GetBlock<cpp::BlockDesc>(i);
     for (size_t k = 0; k < block->OpsSize(); ++k) {

--- a/lite/core/mir/fp16_attribute_pass.h
+++ b/lite/core/mir/fp16_attribute_pass.h
@@ -35,7 +35,7 @@ class FP16AttributePass : public ProgramPass {
   void Apply(const std::unique_ptr<SSAGraph>& graph) override;
 
  private:
-  std::vector<std::string> fp16_ops_{"conv2d"};
+  std::vector<std::string> fp16_ops_{"conv2d", "fc"};
 };
 
 }  // namespace mir

--- a/lite/core/mir/fp16_attribute_pass.h
+++ b/lite/core/mir/fp16_attribute_pass.h
@@ -35,7 +35,7 @@ class FP16AttributePass : public ProgramPass {
   void Apply(const std::unique_ptr<SSAGraph>& graph) override;
 
  private:
-  std::vector<std::string> fp16_ops_{"conv2d", "fc"};
+  std::vector<std::string> fp16_ops_{"conv2d", "depthwise_conv2d", "fc"};
 };
 
 }  // namespace mir

--- a/lite/core/profile/precision_profiler.h
+++ b/lite/core/profile/precision_profiler.h
@@ -265,6 +265,17 @@ class PrecisionProfiler {
           write_result_to_file&& write_tensorfile<float>(in, name, log_dir_);
           return;
         }
+#ifdef ENABLE_ARM_FP16
+        case PRECISION(kFP16): {
+          auto ptr = in->data<__fp16>();
+          *mean = compute_mean<__fp16>(ptr, in->numel());
+          *std_dev =
+              compute_standard_deviation<__fp16>(ptr, in->numel(), true, *mean);
+          *ave_grow_rate = compute_average_grow_rate<__fp16>(ptr, in->numel());
+          write_result_to_file&& write_tensorfile<__fp16>(in, name, log_dir_);
+          return;
+        }
+#endif
         case PRECISION(kBool): {
           auto ptr = in->data<bool>();
           *mean = -333333333333;

--- a/lite/kernels/arm/calib_compute.h
+++ b/lite/kernels/arm/calib_compute.h
@@ -34,9 +34,10 @@ class CalibComputeFp32ToInt8
  private:
 };
 #ifdef ENABLE_ARM_FP16
+typedef __fp16 float16_t;
 template <DataLayoutType DLType>
 class CalibComputeFp32ToFp16
-    : public KernelLite<TARGET(kARM), PRECISION(kInt8), DLType> {
+    : public KernelLite<TARGET(kARM), PRECISION(kFP16), DLType> {
  public:
   using param_t = operators::CalibParam;
 
@@ -49,7 +50,7 @@ class CalibComputeFp32ToFp16
 
 template <DataLayoutType DLType>
 class CalibComputeFp16ToFp32
-    : public KernelLite<TARGET(kARM), PRECISION(kInt8), DLType> {
+    : public KernelLite<TARGET(kARM), PRECISION(kFP16), DLType> {
  public:
   using param_t = operators::CalibParam;
 

--- a/lite/kernels/arm/transpose_compute.cc
+++ b/lite/kernels/arm/transpose_compute.cc
@@ -268,6 +268,11 @@ void TransposeCompute::Run() {
     case PRECISION(kInt64):
       TransposeCompute_<int64_t>(axis, input, output);
       break;
+#ifdef ENABLE_ARM_FP16
+    case PRECISION(kFP16):
+      TransposeCompute_<__fp16>(axis, input, output);
+      break;
+#endif
     case PRECISION(kFloat):
       TransposeCompute_<float>(axis, input, output);
       break;


### PR DESCRIPTION
 add fc weights(fp32->fp16) in fp16__attribute_pass, fix precision profiler fp16 compute error. test=develop