### PR TITLE
[Framework] Fix precision cast optimize method

### DIFF
--- a/lite/core/mir/generate_program_pass.cc
+++ b/lite/core/mir/generate_program_pass.cc
@@ -75,19 +75,19 @@ void GenerateProgramPass::Apply(const std::unique_ptr<SSAGraph>& graph) {
     for (auto* in : inlinks) {
       // Create the new var manually.
       auto in_arg_name = in->AsArg().name;
-      auto* tmp_tensor = node->AsStmt()
-                             .op()
-                             ->scope()
-                             ->Var(in_arg_name)
-                             ->GetMutable<lite::Tensor>();
-      if (!(in->AsArg().is_weight) && in->AsArg().type->IsTensor() &&
-          (tmp_tensor->precision() != in->AsArg().type->precision())) {
-        tmp_tensor->set_precision(in->AsArg().type->precision());
+      if (!(in->AsArg().is_weight) && in->AsArg().type->IsTensor()) {
+        auto* tmp_tensor = node->AsStmt()
+                               .op()
+                               ->scope()
+                               ->Var(in_arg_name)
+                               ->GetMutable<lite::Tensor>();
+        if ((tmp_tensor->precision() != in->AsArg().type->precision())) {
+          tmp_tensor->set_precision(in->AsArg().type->precision());
+        }
       }
     }
   }
 }
-
 }  // namespace mir
 }  // namespace lite
 }  // namespace paddle

--- a/lite/core/mir/generate_program_pass.cc
+++ b/lite/core/mir/generate_program_pass.cc
@@ -62,7 +62,7 @@ void GenerateProgramPass::Apply(const std::unique_ptr<SSAGraph>& graph) {
     }
   }
 
-  // record the copied node.
+  // Update precision info after opt optimizations are operated.
   std::vector<std::string> skip_ops = {
       "while", "conditional_block", "feed", "fetch"};
 

--- a/lite/core/mir/type_precision_cast_pass.cc
+++ b/lite/core/mir/type_precision_cast_pass.cc
@@ -224,7 +224,12 @@ void PrecisionCastPass::AddCastInst(const Type& from,
     CHECK(cast_op) << "create op [" << cast_op << "] failed";
 
     // Create the new var manually.
-    inst_node->AsStmt().op()->scope()->Var(cast_op_output_name);
+    auto* cast_op_output_tensor = inst_node->AsStmt()
+                                      .op()
+                                      ->scope()
+                                      ->Var(cast_op_output_name)
+                                      ->GetMutable<lite::Tensor>();
+    cast_op_output_tensor->set_precision(to.precision());
 
     // Create Calib Instruction.
     cpp::OpDesc op_desc;

--- a/lite/core/mir/variable_place_inference_pass.cc
+++ b/lite/core/mir/variable_place_inference_pass.cc
@@ -23,6 +23,7 @@ namespace mir {
 void VariablePlaceInferencePass::Apply(const std::unique_ptr<SSAGraph> &graph) {
   MarkInputPlace(graph.get());
   InferenceArgumentPlace(graph.get());
+  InferenceKernelWithUncertainPrecision(graph.get());
   CheckAllArgumentTypeDetermined(graph.get());
 }
 

--- a/lite/core/mir/variable_place_inference_pass.h
+++ b/lite/core/mir/variable_place_inference_pass.h
@@ -89,6 +89,9 @@ class VariablePlaceInferencePass : public DebugPass {
     if (precision == PRECISION(kUnk)) {
       precision = b->precision();
     }
+    if (b->precision() == PRECISION(kAny)) {
+      precision = PRECISION(kUnk);
+    }
     if (layout == DATALAYOUT(kUnk)) {
       layout = b->layout();
     }

--- a/lite/core/mir/variable_place_inference_pass.h
+++ b/lite/core/mir/variable_place_inference_pass.h
@@ -226,19 +226,10 @@ class VariablePlaceInferencePass : public DebugPass {
           !op_info->HasAttr("dtype")) {
         const auto* decl_input_type = kernel.GetInputDeclType("X");
         const auto* decl_output_type = kernel.GetOutputDeclType("Out");
-        if (decl_input_type->precision() == PRECISION(kAny) &&
+        if (decl_input_type->IsTensor() && decl_output_type->IsTensor() &&
+            decl_input_type->precision() == PRECISION(kAny) &&
             decl_output_type->precision() == PRECISION(kAny)) {
-          auto inputs = op_info->inputs();
-          auto x_var_name = inputs["X"].front();
-
-          auto* x_var_tensor =
-              inst.op()->scope()->Var(x_var_name)->GetMutable<lite::Tensor>();
-
-          auto outputs = op_info->outputs();
-          auto out_var_name = outputs["Out"].front();
-          auto* out_var_tensor =
-              inst.op()->scope()->Var(out_var_name)->GetMutable<lite::Tensor>();
-          out_var_tensor->set_precision(x_var_tensor->precision());
+          inst.op()->InferType();
         }
       }
     }

--- a/lite/core/mir/variable_place_inference_pass.h
+++ b/lite/core/mir/variable_place_inference_pass.h
@@ -214,13 +214,16 @@ class VariablePlaceInferencePass : public DebugPass {
   //     will be updated:
   //     reshape op_info: X:var1(precisionFloat16), Out:var2(precsionFloat16)
   void InferenceKernelWithUncertainPrecision(SSAGraph* graph) {
+    std::vector<std::string> skiped_ops = {"feed", "fetch", "while"};
     for (auto& node : graph->StmtTopologicalOrder()) {
       auto& inst = node->AsStmt();
       const auto* op_info = inst.op_info();
       const auto& op_type = op_info->Type();
       auto& kernel = inst.picked_kernel();
-      if (op_type != "feed" && op_type != "fetch" && op_info->HasInput("X") &&
-          op_info->HasOutput("Out") && !op_info->HasAttr("dtype")) {
+      if (std::find(skiped_ops.begin(), skiped_ops.end(), op_type) ==
+              skiped_ops.end() &&
+          op_info->HasInput("X") && op_info->HasOutput("Out") &&
+          !op_info->HasAttr("dtype")) {
         const auto* decl_input_type = kernel.GetInputDeclType("X");
         const auto* decl_output_type = kernel.GetOutputDeclType("Out");
         if (decl_input_type->precision() == PRECISION(kAny) &&

--- a/lite/core/mir/variable_place_inference_pass.h
+++ b/lite/core/mir/variable_place_inference_pass.h
@@ -214,7 +214,8 @@ class VariablePlaceInferencePass : public DebugPass {
   //     will be updated:
   //     reshape op_info: X:var1(precisionFloat16), Out:var2(precsionFloat16)
   void InferenceKernelWithUncertainPrecision(SSAGraph* graph) {
-    std::vector<std::string> skiped_ops = {"feed", "fetch", "while"};
+    std::vector<std::string> skiped_ops = {
+        "feed", "fetch", "while", "subgraph", "io_copy", "io_copy_once"};
     for (auto& node : graph->StmtTopologicalOrder()) {
       auto& inst = node->AsStmt();
       const auto* op_info = inst.op_info();

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -74,6 +74,7 @@ class OpLite : public Registry {
     LOG(FATAL) << "Error! " << op_type_
                << "::InferType() function must be registered for op "
                << op_type_;
+    return false;
   }
 #endif
   // Run this operator.

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -68,7 +68,6 @@ class OpLite : public Registry {
   // Inference the outputs' shape.
   virtual bool InferShapeImpl() const { return true; }
   virtual bool InferShape();
-#ifndef LITE_ON_TINY_PUBLISH
   // Infer the outputs's data type during opt period
   virtual bool InferType() {
     LOG(FATAL) << "Error! " << op_type_
@@ -76,7 +75,6 @@ class OpLite : public Registry {
                << op_type_;
     return false;
   }
-#endif
   // Run this operator.
   virtual bool Run();
   // Indicate whether the Op runs only once or not

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -68,6 +68,14 @@ class OpLite : public Registry {
   // Inference the outputs' shape.
   virtual bool InferShapeImpl() const { return true; }
   virtual bool InferShape();
+#ifndef LITE_ON_TINY_PUBLISH
+  // Infer the outputs's data type during opt period
+  virtual bool InferType() {
+    LOG(FATAL) << "Error! " << op_type_
+               << "::InferType() function must be registered for op "
+               << op_type_;
+  }
+#endif
   // Run this operator.
   virtual bool Run();
   // Indicate whether the Op runs only once or not

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -97,10 +97,10 @@ void RuntimeProgram::SaveToProgram(
               v->SetShape(tensor->dims().data());
               auto precision = tensor->precision();
               switch (precision) {
-#define SET_DATATYPE(precision__, data_type)           \
-  case PrecisionType::precision__:                     \
-    v->SetDataType(data_type);                         \
-    LOG(INFO) << "Update var " << var_name << " done"; \
+#define SET_DATATYPE(precision__, data_type)         \
+  case PrecisionType::precision__:                   \
+    v->SetDataType(data_type);                       \
+    VLOG(1) << "Update var " << var_name << " done"; \
     break
                 SET_DATATYPE(kBool, VarDescAPI::VarDataType::BOOL);
                 SET_DATATYPE(kFloat, VarDescAPI::VarDataType::FP32);

--- a/lite/kernels/host/while_compute.h
+++ b/lite/kernels/host/while_compute.h
@@ -35,9 +35,7 @@ class WhileCompute
   void PrepareForRun() override;
 
   virtual ~WhileCompute() = default;
-#ifndef LITE_ON_TINY_PUBLISH
-  bool InferType() override { return true; }
-#endif
+
  private:
   std::unique_ptr<RuntimeProgram> program_;
 };

--- a/lite/kernels/host/while_compute.h
+++ b/lite/kernels/host/while_compute.h
@@ -35,7 +35,9 @@ class WhileCompute
   void PrepareForRun() override;
 
   virtual ~WhileCompute() = default;
-
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override { return true; }
+#endif
  private:
   std::unique_ptr<RuntimeProgram> program_;
 };

--- a/lite/model_parser/pb/utils.cc
+++ b/lite/model_parser/pb/utils.cc
@@ -52,6 +52,7 @@ lite::VarDataType ConvertVarType(
     break
     CASE(FP64);
     CASE(FP32);
+    CASE(FP16);
     CASE(INT8);
     CASE(UINT8);
     CASE(INT16);

--- a/lite/operators/assign_op.h
+++ b/lite/operators/assign_op.h
@@ -37,14 +37,12 @@ class AssignOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "assign"; }
 
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     if (param_.X) {
       param_.Out->set_precision(param_.X->precision());
     }
     return true;
   }
-#endif
 
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {

--- a/lite/operators/assign_op.h
+++ b/lite/operators/assign_op.h
@@ -37,6 +37,15 @@ class AssignOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "assign"; }
 
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    if (param_.X) {
+      param_.Out->set_precision(param_.X->precision());
+    }
+    return true;
+  }
+#endif
+
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     auto input_dims = param_.X->dims();

--- a/lite/operators/concat_op.h
+++ b/lite/operators/concat_op.h
@@ -37,6 +37,13 @@ class ConcatOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "concat"; }
 
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.out->set_precision(param_.in.front()->precision());
+    return true;
+  }
+#endif
+
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     auto output_dims = param_.output->dims();

--- a/lite/operators/concat_op.h
+++ b/lite/operators/concat_op.h
@@ -37,12 +37,10 @@ class ConcatOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "concat"; }
 
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.output->set_precision(param_.x.front()->precision());
     return true;
   }
-#endif
 
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {

--- a/lite/operators/concat_op.h
+++ b/lite/operators/concat_op.h
@@ -39,7 +39,7 @@ class ConcatOpLite : public OpLite {
 
 #ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
-    param_.out->set_precision(param_.in.front()->precision());
+    param_.output->set_precision(param_.x.front()->precision());
     return true;
   }
 #endif

--- a/lite/operators/fill_any_like_op.h
+++ b/lite/operators/fill_any_like_op.h
@@ -38,6 +38,11 @@ class FillAnyLikeOp : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "fill_any_like"; }
 
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+
  private:
   mutable FillAnyLikeParam param_;
 };

--- a/lite/operators/fill_constant_op.h
+++ b/lite/operators/fill_constant_op.h
@@ -38,6 +38,13 @@ class FillConstantOp : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "fill_constant"; }
 
+  bool InferType() override {
+    if (param_.value_tensor) {
+      param_.out->set_precision(param_.value_tensor->precision());
+    }
+    return true;
+  }
+
  private:
   mutable FillConstantParam param_;
 };

--- a/lite/operators/flatten_op.cc
+++ b/lite/operators/flatten_op.cc
@@ -158,7 +158,24 @@ bool FlattenContiguousRangeOp::InferShapeImpl() const {
 
   return true;
 }
+#ifndef LITE_ON_TINY_PUBLISH
+bool FlattenOp::InferType() {
+  param_.output->set_precision(param_.x->precision());
+  return true;
+}
 
+bool Flatten2Op::InferType() {
+  param_.output->set_precision(param_.x->precision());
+  param_.xshape->set_precision(PRECISION(kInt64));
+  return true;
+}
+
+bool FlattenContiguousRangeOp::InferType() {
+  param_.out->set_precision(param_.x->precision());
+  param_.xshape->set_precision(PRECISION(kInt64));
+  return true;
+}
+#endif
 }  // namespace operators
 }  // namespace lite
 }  // namespace paddle

--- a/lite/operators/flatten_op.cc
+++ b/lite/operators/flatten_op.cc
@@ -158,24 +158,6 @@ bool FlattenContiguousRangeOp::InferShapeImpl() const {
 
   return true;
 }
-#ifndef LITE_ON_TINY_PUBLISH
-bool FlattenOp::InferType() {
-  param_.output->set_precision(param_.x->precision());
-  return true;
-}
-
-bool Flatten2Op::InferType() {
-  param_.output->set_precision(param_.x->precision());
-  param_.xshape->set_precision(PRECISION(kInt64));
-  return true;
-}
-
-bool FlattenContiguousRangeOp::InferType() {
-  param_.out->set_precision(param_.x->precision());
-  param_.xshape->set_precision(PRECISION(kInt64));
-  return true;
-}
-#endif
 }  // namespace operators
 }  // namespace lite
 }  // namespace paddle

--- a/lite/operators/flatten_op.cc
+++ b/lite/operators/flatten_op.cc
@@ -158,6 +158,7 @@ bool FlattenContiguousRangeOp::InferShapeImpl() const {
 
   return true;
 }
+
 }  // namespace operators
 }  // namespace lite
 }  // namespace paddle

--- a/lite/operators/flatten_op.h
+++ b/lite/operators/flatten_op.h
@@ -31,7 +31,10 @@ class FlattenOp : public OpLite {
   bool CheckShape() const override;
 
 #ifndef LITE_ON_TINY_PUBLISH
-  bool InferType() override;
+  bool InferType() override {
+    param_.output->set_precision(param_.x->precision());
+    return true;
+  }
 #endif
   bool InferShapeImpl() const override;
 
@@ -52,7 +55,11 @@ class Flatten2Op : public FlattenOp {
 
   bool CheckShape() const override;
 #ifndef LITE_ON_TINY_PUBLISH
-  bool InferType() override;
+  bool InferType() override {
+    param_.output->set_precision(param_.x->precision());
+    param_.xshape->set_precision(PRECISION(kInt64));
+    return true;
+  }
 #endif
   bool InferShapeImpl() const override;
 
@@ -70,7 +77,11 @@ class FlattenContiguousRangeOp : public OpLite {
 
   bool CheckShape() const override;
 #ifndef LITE_ON_TINY_PUBLISH
-  bool InferType() override;
+  bool InferType() override {
+    param_.out->set_precision(param_.x->precision());
+    param_.xshape->set_precision(PRECISION(kInt64));
+    return true;
+  }
 #endif
   bool InferShapeImpl() const override;
 

--- a/lite/operators/flatten_op.h
+++ b/lite/operators/flatten_op.h
@@ -30,6 +30,9 @@ class FlattenOp : public OpLite {
 
   bool CheckShape() const override;
 
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override;
+#endif
   bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
@@ -48,7 +51,9 @@ class Flatten2Op : public FlattenOp {
   explicit Flatten2Op(const std::string &op_type) : FlattenOp(op_type) {}
 
   bool CheckShape() const override;
-
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override;
+#endif
   bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
@@ -64,7 +69,9 @@ class FlattenContiguousRangeOp : public OpLite {
       : OpLite(op_type) {}
 
   bool CheckShape() const override;
-
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override;
+#endif
   bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;

--- a/lite/operators/flatten_op.h
+++ b/lite/operators/flatten_op.h
@@ -30,12 +30,11 @@ class FlattenOp : public OpLite {
 
   bool CheckShape() const override;
 
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.output->set_precision(param_.x->precision());
     return true;
   }
-#endif
+
   bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
@@ -54,13 +53,13 @@ class Flatten2Op : public FlattenOp {
   explicit Flatten2Op(const std::string &op_type) : FlattenOp(op_type) {}
 
   bool CheckShape() const override;
-#ifndef LITE_ON_TINY_PUBLISH
+
   bool InferType() override {
     param_.output->set_precision(param_.x->precision());
     param_.xshape->set_precision(PRECISION(kInt64));
     return true;
   }
-#endif
+
   bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;

--- a/lite/operators/gather_nd_op.h
+++ b/lite/operators/gather_nd_op.h
@@ -37,12 +37,10 @@ class GatherNdOp : public OpLite {
 
   std::string DebugString() const override { return "gather_nd"; }
 
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.out->set_precision(param_.x->precision());
     return true;
   }
-#endif
 
  private:
   mutable GatherNdParam param_;

--- a/lite/operators/gather_nd_op.h
+++ b/lite/operators/gather_nd_op.h
@@ -37,6 +37,13 @@ class GatherNdOp : public OpLite {
 
   std::string DebugString() const override { return "gather_nd"; }
 
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.out->set_precision(param_.x->precision());
+    return true;
+  }
+#endif
+
  private:
   mutable GatherNdParam param_;
 };

--- a/lite/operators/gather_op.h
+++ b/lite/operators/gather_op.h
@@ -39,7 +39,7 @@ class GatherOp : public OpLite {
   std::string DebugString() const override { return "gather"; }
 
   bool InferType() override {
-    param_.X->set_precision(param_.Out->precision());
+    param_.Out->set_precision(param_.X->precision());
     return true;
   }
 

--- a/lite/operators/gather_op.h
+++ b/lite/operators/gather_op.h
@@ -38,6 +38,11 @@ class GatherOp : public OpLite {
 
   std::string DebugString() const override { return "gather"; }
 
+  bool InferType() override {
+    param_.X->set_precision(param_.Out->precision());
+    return true;
+  }
+
  private:
   mutable GatherParam param_;
 };

--- a/lite/operators/increment_op.h
+++ b/lite/operators/increment_op.h
@@ -38,6 +38,11 @@ class IncrementOp : public OpLite {
 
   std::string DebugString() const override { return "increment"; }
 
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     ch->input_shape = ch->DimToStr(param_.X->dims());

--- a/lite/operators/lod_reset_op.h
+++ b/lite/operators/lod_reset_op.h
@@ -38,6 +38,11 @@ class LodResetOp : public OpLite {
 
   std::string DebugString() const override { return "lod_reset"; }
 
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+
  private:
   mutable LodResetParam param_;
 };

--- a/lite/operators/print_op.h
+++ b/lite/operators/print_op.h
@@ -37,12 +37,10 @@ class PrintOp : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "print"; }
 
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.out->set_precision(param_.in->precision());
     return true;
   }
-#endif
 
  private:
   mutable PrintParam param_;

--- a/lite/operators/print_op.h
+++ b/lite/operators/print_op.h
@@ -37,6 +37,13 @@ class PrintOp : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "print"; }
 
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.out->set_precision(param_.in->precision());
+    return true;
+  }
+#endif
+
  private:
   mutable PrintParam param_;
 };

--- a/lite/operators/reshape_op.h
+++ b/lite/operators/reshape_op.h
@@ -37,6 +37,13 @@ class ReshapeOp : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "reshape"; }
 
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.output->set_precision(param_.x->precision());
+    return true;
+  }
+#endif
+
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     auto input_dims = param_.x->dims();
@@ -63,6 +70,12 @@ class Reshape2Op : public ReshapeOp {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "reshape2"; }
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.output->set_precision(param_.x->precision());
+    return true;
+  }
+#endif
 };
 
 std::vector<DDim::value_type> ValidateShape(const std::vector<int> &shape,

--- a/lite/operators/reshape_op.h
+++ b/lite/operators/reshape_op.h
@@ -37,12 +37,10 @@ class ReshapeOp : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "reshape"; }
 
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.output->set_precision(param_.x->precision());
     return true;
   }
-#endif
 
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
@@ -70,12 +68,11 @@ class Reshape2Op : public ReshapeOp {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "reshape2"; }
-#ifndef LITE_ON_TINY_PUBLISH
+
   bool InferType() override {
     param_.output->set_precision(param_.x->precision());
     return true;
   }
-#endif
 };
 
 std::vector<DDim::value_type> ValidateShape(const std::vector<int> &shape,

--- a/lite/operators/select_input_op.h
+++ b/lite/operators/select_input_op.h
@@ -37,6 +37,11 @@ class SelectInputOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "selectInput"; }
 
+  bool InferType() override {
+    param_.Out->set_precision(param_.X[0]->precision());
+    return true;
+  }
+
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     auto output_dims = param_.Out->dims();

--- a/lite/operators/squeeze_op.h
+++ b/lite/operators/squeeze_op.h
@@ -36,7 +36,12 @@ class SqueezeOp : public OpLite {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "squeeze"; }
-
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+#endif
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     auto input_dims = param_.X->dims();
@@ -63,7 +68,12 @@ class Squeeze2Op : public SqueezeOp {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "squeeze2"; }
-
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+#endif
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     auto input_dims = param_.X->dims();

--- a/lite/operators/squeeze_op.h
+++ b/lite/operators/squeeze_op.h
@@ -36,12 +36,12 @@ class SqueezeOp : public OpLite {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "squeeze"; }
-#ifndef LITE_ON_TINY_PUBLISH
+
   bool InferType() override {
     param_.Out->set_precision(param_.X->precision());
     return true;
   }
-#endif
+
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     auto input_dims = param_.X->dims();
@@ -68,12 +68,12 @@ class Squeeze2Op : public SqueezeOp {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "squeeze2"; }
-#ifndef LITE_ON_TINY_PUBLISH
+
   bool InferType() override {
     param_.Out->set_precision(param_.X->precision());
     return true;
   }
-#endif
+
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
     auto input_dims = param_.X->dims();

--- a/lite/operators/transpose_op.h
+++ b/lite/operators/transpose_op.h
@@ -38,12 +38,10 @@ class TransposeOp : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "transpose"; }
 
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.output->set_precision(param_.x->precision());
     return true;
   }
-#endif
 
  private:
   mutable TransposeParam param_;
@@ -64,12 +62,10 @@ class Transpose2Op : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "transpose2"; }
 
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.output->set_precision(param_.x->precision());
     return true;
   }
-#endif
 
  private:
   mutable TransposeParam param_;

--- a/lite/operators/transpose_op.h
+++ b/lite/operators/transpose_op.h
@@ -38,6 +38,13 @@ class TransposeOp : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "transpose"; }
 
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.output->set_precision(param_.x->precision());
+    return true;
+  }
+#endif
+
  private:
   mutable TransposeParam param_;
 };
@@ -56,6 +63,13 @@ class Transpose2Op : public OpLite {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "transpose2"; }
+
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.output->set_precision(param_.x->precision());
+    return true;
+  }
+#endif
 
  private:
   mutable TransposeParam param_;

--- a/lite/operators/unsqueeze_op.h
+++ b/lite/operators/unsqueeze_op.h
@@ -36,12 +36,12 @@ class UnsqueezeOp : public OpLite {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "unsqueeze"; }
-#ifndef LITE_ON_TINY_PUBLISH
+
   bool InferType() override {
     param_.Out->set_precision(param_.X->precision());
     return true;
   }
-#endif
+
  protected:
   mutable UnsqueezeParam param_;
 };
@@ -59,12 +59,11 @@ class Unsqueeze2Op : public UnsqueezeOp {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "unsqueeze2"; }
-#ifndef LITE_ON_TINY_PUBLISH
+
   bool InferType() override {
     param_.Out->set_precision(param_.X->precision());
     return true;
   }
-#endif
 };
 
 }  // namespace operators

--- a/lite/operators/unsqueeze_op.h
+++ b/lite/operators/unsqueeze_op.h
@@ -36,7 +36,12 @@ class UnsqueezeOp : public OpLite {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "unsqueeze"; }
-
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+#endif
  protected:
   mutable UnsqueezeParam param_;
 };
@@ -54,6 +59,12 @@ class Unsqueeze2Op : public UnsqueezeOp {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "unsqueeze2"; }
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+#endif
 };
 
 }  // namespace operators

--- a/lite/operators/where_op.h
+++ b/lite/operators/where_op.h
@@ -30,7 +30,12 @@ class WhereOp : public OpLite {
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "where_op"; }
-
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override {
+    param_.out->set_precision(param_.x->precision());
+    return true;
+  }
+#endif
  private:
   mutable WhereParam param_;
 };

--- a/lite/operators/where_op.h
+++ b/lite/operators/where_op.h
@@ -30,12 +30,11 @@ class WhereOp : public OpLite {
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "where_op"; }
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.out->set_precision(param_.x->precision());
     return true;
   }
-#endif
+
  private:
   mutable WhereParam param_;
 };

--- a/lite/operators/while_op.h
+++ b/lite/operators/while_op.h
@@ -46,9 +46,7 @@ class WhileOp : public OpLite {
     return param_.program_desc;
   }
 
-#ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override { return true; }
-#endif
 
  private:
   mutable WhileParam param_;

--- a/lite/operators/while_op.h
+++ b/lite/operators/while_op.h
@@ -46,6 +46,10 @@ class WhileOp : public OpLite {
     return param_.program_desc;
   }
 
+#ifndef LITE_ON_TINY_PUBLISH
+  bool InferType() override { return true; }
+#endif
+
  private:
   mutable WhileParam param_;
 };


### PR DESCRIPTION
### Issue
- many precision info got lost after opt conversion
- after precision_cast method (`precision_type_cast_pass`), precision info of inserted calib kernel will get lost
- precision_cast method can not work well for kernel with Precision::kAny inputs/outputs
  - some useless cast kernels may be inserted into optimized program , which costs a waste of time consumption.
![image](https://user-images.githubusercontent.com/45189361/114650037-1ad4ea00-9d14-11eb-812e-bd243f0dea4e.png)

### Effect of Current PR

- Tensors' precision info will be saved into optimized model.
   - original model info with tensor precision info
   - pick kernels (`static_kernel_pick_pass`)
   - Update tensors' precision from picked kernel's registry info (`variable_place_inference_pass`)
   - Determine kernel's output precision whose input(X)/output(Out) are both registered as kAny precision (`variable_place_inference_pass`)
   - Check precision info in optimized topology and inset precision_cast op to implement precision conflicts (`type_precision_cast_pass`)
   - Update runtime program and save the transformed precision info into optimized model (`generated_program_pass`)
- precision_cast method can work well for kernel with Precision::kAny inputs/outputs
    - Determine kernel's output precision whose input(X)/output(Out) are both registered as kAny precision
![image](https://user-images.githubusercontent.com/45189361/114675838-461eff80-9d3b-11eb-9c15-71c096a22cec.png)

### Framework change: `OpLite::InferType` is added
 - if corresponding kernel is registered as {input precision::kAny, output precision::kAny }, op::InferType will be applied to infer the outputs' precision. 
 - if corresponding kernel is registered as {input precision::kAny, output precision::kAny } , and op::InferType has not be registered, error info will be printed:
 
``` shell
Error! flatten_contiguous_range::InferType() function must be registered for op flatten_contiguous_range
```


### related works

-  Op registries  listed below are added with functor `InferType`
   - flatten_contiguous_range/flatten/flatten2
   - gather_nd
   - print
   - reshape/reshape2
   - squeeze/squeeze2
   - uniform_random
   - unsqueeze/unsqueeze2
   - where

### Others 
- this PR has caused an increment of 4K on basic lib size