### PR TITLE
[profile] fix unused variable error when precision_profiler ON

### DIFF
--- a/lite/core/profile/precision_profiler.h
+++ b/lite/core/profile/precision_profiler.h
@@ -277,7 +277,6 @@ class PrecisionProfiler {
         }
 #endif
         case PRECISION(kBool): {
-          auto ptr = in->data<bool>();
           *mean = -333333333333;
           *std_dev = -33333333333;
           *ave_grow_rate = -33333333333;


### PR DESCRIPTION
# description
fix unused variable compiling error when precision_profiler ON