### PR TITLE
[XPU] fix io_copy

### DIFF
--- a/lite/kernels/xpu/io_copy_compute.cc
+++ b/lite/kernels/xpu/io_copy_compute.cc
@@ -97,7 +97,7 @@ class IoCopyXPUToHostCompute
       }
     } else if (x->target() == TARGET(kHost) || x->target() == TARGET(kX86) ||
                x->target() == TARGET(kARM)) {
-      y->ShareDataWith(*x);
+      y->CopyDataFrom(*x);
     } else {
       LOG(FATAL) << "IoCopyXPUToHost can not handle with the input target: "
                  << lite_api::TargetToStr(x->target());


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50474132/114333565-2e991880-9b7b-11eb-97c0-99361ea49b69.png)
bug触发过程：
- conditional_block条件判断为false，不会执行其中的OP，导致原本应该是xpu上的tensor实际是在host上。此时io_copy (xpu to host) 执行ShareDataWith，输出内存复用输入内存（但是实际上输入的内存是没有分配的）
- conditional_block条件判断为true，使得tensor数据分配到xpu上。此时io_copy (xpu to host) 执行xpu到host的拷贝，而不会重新分配host上空间，导致拷贝到了一块未知的内存。