### PR TITLE
文档问题 2.8-rc  ->  v2.8 

### DIFF
--- a/docs/source_compile/compile_linux.md
+++ b/docs/source_compile/compile_linux.md
@@ -11,7 +11,7 @@
 ```shell
 # 1. 下载Paddle-Lite源码 并切换到release分支
 git clone https://github.com/PaddlePaddle/Paddle-Lite.git
-cd Paddle-Lite && git checkout 2.8-rc
+cd Paddle-Lite && git checkout v2.8
 
 # (可选) 删除此目录，编译脚本会自动从国内CDN下载第三方库文件
 # rm -rf third-party


### PR DESCRIPTION
```
X:\XXX\Paddle-Lite>git checkout 2.8-rc
error: pathspec '2.8-rc' did not match any file(s) known to git
```

```
X:\XXX\Paddle-Lite>git branch -a

* develop
  remotes/origin/AIpioneer-patch-1
  remotes/origin/HEAD -> origin/develop
  remotes/origin/_release/2.7-beta
  remotes/origin/_release/v2.6.2
  remotes/origin/_release/v2.7-beta1
  remotes/origin/chenjiaoAngel-patch-1
  remotes/origin/cherry-android-version
  remotes/origin/develop
  remotes/origin/filter
  remotes/origin/fix-some-cmake-issues
  remotes/origin/gh-pages
  remotes/origin/release/v2.0.0
  remotes/origin/release/v2.0.0-beta1
  remotes/origin/release/v2.0.0-beta2
  remotes/origin/release/v2.0.0-rc
  remotes/origin/release/v2.1.0
  remotes/origin/release/v2.2.0
  remotes/origin/release/v2.3
  remotes/origin/release/v2.6
  remotes/origin/release/v2.6.0
  remotes/origin/release/v2.7
  remotes/origin/release/v2.8
  remotes/origin/revert-4368-hongming/test_v26
```

可能是：
```
git checkout v2.8
```