### PR TITLE
[OpenCL] Not use flush command queue by default

### DIFF
--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -1346,9 +1346,10 @@ void ConvImageCompute::Run() {
   (this->*impl_)();
 
   auto& context = ctx_->As<OpenCLContext>();
+  /*
   status_ = context.cl_context()->RunKernel(
       kernel_, global_work_size_, local_work_size_, &event_);
-  /*
+  */
   status_ = EnqueueNDRangeKernel(context,
                                  kernel_,
                                  cl::NullRange,
@@ -1356,7 +1357,6 @@ void ConvImageCompute::Run() {
                                  local_work_size_,
                                  nullptr,
                                  event_);
-  */
   CL_CHECK_FATAL(status_);
 }
 


### PR DESCRIPTION
AI-RANK中大量测试发现，设置刷新频率 10 并不能显著提高性能，有时由于存在性能波动，部分测试结果反而变差。因此，暂时关闭该选项。