### PR TITLE
[lib_size] opt kernel registry for tiny publish,test=develop

### DIFF
--- a/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
+++ b/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc
@@ -177,11 +177,6 @@ void RunModel(std::string model_dir,
       // CL_PRECISION_FP16: 2, force fp16
       config.set_opencl_precision(CL_PRECISION_FP16);
     }
-  } else {
-    std::cout << "Unsupport opencl nb model." << std::endl;
-    exit(1);
-    // you can give backup cpu nb model instead
-    // config.set_model_from_file(cpu_nb_model_dir);
   }
 
   // NOTE: To load model transformed by model_optimize_tool before

--- a/lite/kernels/arm/calib_compute.cc
+++ b/lite/kernels/arm/calib_compute.cc
@@ -242,40 +242,6 @@ REGISTER_LITE_KERNEL(
 REGISTER_LITE_KERNEL(
     calib,
     kARM,
-    kInt8,
-    kNHWC,
-    paddle::lite::kernels::arm::CalibComputeFp32ToInt8<DATALAYOUT(kNHWC)>,
-    fp32_to_int8)
-    .BindInput("Input",
-               {LiteType::GetTensorTy(TARGET(kARM),
-                                      PRECISION(kFloat),
-                                      DATALAYOUT(kNHWC))})
-    .BindOutput("Out",
-                {LiteType::GetTensorTy(TARGET(kARM),
-                                       PRECISION(kInt8),
-                                       DATALAYOUT(kNHWC))})
-    .Finalize();
-
-REGISTER_LITE_KERNEL(
-    calib,
-    kARM,
-    kInt8,
-    kNHWC,
-    paddle::lite::kernels::arm::CalibComputeInt8ToFp32<DATALAYOUT(kNHWC)>,
-    int8_to_fp32)
-    .BindInput("Input",
-               {LiteType::GetTensorTy(TARGET(kARM),
-                                      PRECISION(kInt8),
-                                      DATALAYOUT(kNHWC))})
-    .BindOutput("Out",
-                {LiteType::GetTensorTy(TARGET(kARM),
-                                       PRECISION(kFloat),
-                                       DATALAYOUT(kNHWC))})
-    .Finalize();
-
-REGISTER_LITE_KERNEL(
-    calib,
-    kARM,
     kInt64,
     kNCHW,
     paddle::lite::kernels::arm::CalibComputeInt64ToInt32<DATALAYOUT(kNCHW)>,
@@ -311,40 +277,6 @@ REGISTER_LITE_KERNEL(
     int8_to_fp32)
     .BindInput("Input", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
-    .Finalize();
-
-REGISTER_LITE_KERNEL(
-    calib_once,
-    kARM,
-    kInt8,
-    kNHWC,
-    paddle::lite::kernels::arm::CalibComputeFp32ToInt8<DATALAYOUT(kNHWC)>,
-    fp32_to_int8)
-    .BindInput("Input",
-               {LiteType::GetTensorTy(TARGET(kARM),
-                                      PRECISION(kFloat),
-                                      DATALAYOUT(kNHWC))})
-    .BindOutput("Out",
-                {LiteType::GetTensorTy(TARGET(kARM),
-                                       PRECISION(kInt8),
-                                       DATALAYOUT(kNHWC))})
-    .Finalize();
-
-REGISTER_LITE_KERNEL(
-    calib_once,
-    kARM,
-    kInt8,
-    kNHWC,
-    paddle::lite::kernels::arm::CalibComputeInt8ToFp32<DATALAYOUT(kNHWC)>,
-    int8_to_fp32)
-    .BindInput("Input",
-               {LiteType::GetTensorTy(TARGET(kARM),
-                                      PRECISION(kInt8),
-                                      DATALAYOUT(kNHWC))})
-    .BindOutput("Out",
-                {LiteType::GetTensorTy(TARGET(kARM),
-                                       PRECISION(kFloat),
-                                       DATALAYOUT(kNHWC))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(


### PR DESCRIPTION
修改tiny_publish下使用REGISTER_LITE_KERNEL宏注册kernel调用ParamTypeRegistry的实现，封装一层dummy ParamTypeRegistry供tiny_publish下的调用；c++_shared/armv8测试库体积变化：
修改前：1900KB      修改后：1860KB
减小ParamTypeRegistry类生成的static对象包含的std::map数据域，同时去除calib op注册的NHWC layout的kernel（跟洪明确认过不需要），该PR优化库体积约40KB