### PR TITLE
[Compile] Static c++ library will not be compiled by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ lite_option(WITH_SYSTEM_BLAS    "Use system blas library"           OFF)
 
 # for lite, both server and mobile framework.
 lite_option(LITE_WITH_JAVA      "Enable Java JNI lib in lite mode" OFF)
+lite_option(LITE_WITH_STATIC_LIB      "Enable static cplus lib in lite mode" OFF)
 lite_option(LITE_WITH_PYTHON    "Enable Python api lib in lite mode" OFF)
 lite_option(LITE_WITH_CUDA      "Enable CUDA in lite mode" OFF)
 lite_option(LITE_WITH_X86       "Enable X86 in lite mode"  ON)

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -389,21 +389,31 @@ if (LITE_WITH_LIGHT_WEIGHT_FRAMEWORK AND LITE_WITH_ARM)
             add_dependencies(publish_inference tiny_publish_lib)
         else()
             if ((ARM_TARGET_OS STREQUAL "android") OR (ARM_TARGET_OS STREQUAL "armlinux"))
+                # compile cplus shared library, pack the cplus demo and lib into the publish directory.
                 add_custom_target(tiny_publish_cxx_lib ${TARGET}
                     COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx"
                     COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
                     COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
                     COMMAND cp "${CMAKE_SOURCE_DIR}/lite/api/paddle_*.h" "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
-                    COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/libpaddle_api_light_bundled.a" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
                     COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/libpaddle_light_api_shared.so" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
                     COMMAND cp "${CMAKE_SOURCE_DIR}/lite/utils/cv/paddle_*.h" "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
                     )
                 add_dependencies(tiny_publish_cxx_lib paddle_light_api_shared)
-                add_dependencies(tiny_publish_cxx_lib paddle_api_light_bundled)
                 add_dependencies(publish_inference tiny_publish_cxx_lib)
                 if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
                     add_custom_command(TARGET tiny_publish_cxx_lib POST_BUILD
                                 COMMAND ${CMAKE_STRIP} "-s" ${INFER_LITE_PUBLISH_ROOT}/cxx/lib/libpaddle_light_api_shared.so)
+                endif()
+                # compile cplus static library, pack static lib into the publish directory.
+                if(LITE_WITH_STATIC_LIB)
+                    add_custom_target(tiny_publish_cxx_static_lib ${TARGET}
+                        COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx"
+                        COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/include"
+                        COMMAND mkdir -p "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+                        COMMAND cp "${CMAKE_BINARY_DIR}/lite/api/libpaddle_api_light_bundled.a" "${INFER_LITE_PUBLISH_ROOT}/cxx/lib"
+                        )
+                    add_dependencies(tiny_publish_cxx_static_lib paddle_api_light_bundled)
+                    add_dependencies(publish_inference tiny_publish_cxx_static_lib)
                 endif()
             endif()
         endif()

--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -19,6 +19,8 @@ TOOLCHAIN=gcc
 WITH_EXTRA=OFF
 # ON or OFF, default ON.
 WITH_JAVA=ON
+# ON or OFF, default is OFF
+WITH_STATIC_LIB=OFF
 # controls whether to compile cv functions into lib, default is OFF.
 WITH_CV=OFF
 # controls whether to hide log information, default is ON.
@@ -194,6 +196,7 @@ function make_tiny_publish_so {
       -DLITE_BUILD_TAILOR=$WITH_STRIP \
       -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \
       -DLITE_WITH_JAVA=$WITH_JAVA \
+      -DLITE_WITH_STATIC_LIB=$WITH_STATIC_LIB \
       -DLITE_WITH_CV=$WITH_CV \
       -DLITE_WITH_NPU=$WITH_HUAWEI_KIRIN_NPU \
       -DNPU_DDK_ROOT=$HUAWEI_KIRIN_NPU_SDK_ROOT \
@@ -257,6 +260,7 @@ function make_full_publish_so {
       -DLITE_BUILD_TAILOR=$WITH_STRIP \
       -DLITE_OPTMODEL_DIR=$OPTMODEL_DIR \
       -DLITE_WITH_JAVA=$WITH_JAVA \
+      -DLITE_WITH_STATIC_LIB=$WITH_STATIC_LIB \
       -DLITE_WITH_CV=$WITH_CV \
       -DLITE_WITH_NPU=$WITH_HUAWEI_KIRIN_NPU \
       -DNPU_DDK_ROOT=$HUAWEI_KIRIN_NPU_SDK_ROOT \
@@ -301,6 +305,7 @@ function print_usage {
     echo -e "|     --toolchain: (gcc|clang), defalut is gcc                                                                                         |"
     echo -e "|     --android_stl: (c++_static|c++_shared), default is c++_static                                                                    |"
     echo -e "|     --with_java: (OFF|ON); controls whether to publish java api lib, default is ON                                                   |"
+    echo -e "|     --with_static_lib: (OFF|ON); controls whether to publish c++ api static lib, default is OFF                                      |"
     echo -e "|     --with_cv: (OFF|ON); controls whether to compile cv functions into lib, default is OFF                                           |"
     echo -e "|     --with_log: (OFF|ON); controls whether to print log information, default is ON                                                   |"
     echo -e "|     --with_exception: (OFF|ON); controls whether to throw the exception when error occurs, default is OFF                            |"
@@ -466,6 +471,11 @@ function main {
             # controls whether to include FP16 kernels, default is OFF
             --with_arm82_fp16=*)
                 BUILD_ARM82_FP16="${i#*=}"
+                shift
+                ;;
+            # controls whether to compile cplus static library, default is OFF
+            --with_static_lib=*)
+                WITH_STATIC_LIB="${i#*=}"
                 shift
                 ;;
             help)

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -13,6 +13,8 @@ WITH_EXTRA=OFF
 # controls whether to compile python lib, default is OFF.
 WITH_PYTHON=OFF
 PY_VERSION=""
+# ON or OFF, default is OFF
+WITH_STATIC_LIB=OFF
 # controls whether to compile cv functions into lib, default is OFF.
 WITH_CV=OFF
 # controls whether to print log information, default is ON.
@@ -66,6 +68,7 @@ function init_cmake_mutable_options {
                         -DLITE_BUILD_EXTRA=$WITH_EXTRA \
                         -DLITE_WITH_PYTHON=$WITH_PYTHON \
                         -DPY_VERSION=$PY_VERSION \
+                        -DLITE_WITH_STATIC_LIB=$WITH_STATIC_LIB \
                         -DLITE_WITH_CV=$WITH_CV \
                         -DLITE_WITH_LOG=$WITH_LOG \
                         -DLITE_WITH_EXCEPTION=$WITH_EXCEPTION \
@@ -225,6 +228,7 @@ function print_usage {
     echo -e "|     --with_extra: (OFF|ON); controls whether to publish extra operators and kernels for (sequence-related model such as OCR or NLP), default is OFF  |"
     echo -e "|     --with_python: (OFF|ON); controls whether to build python lib or whl, default is OFF                                                             |"
     echo -e "|     --python_version: (2.7|3.5|3.7); controls python version to compile whl, default is None                                                         |"
+    echo -e "|     --with_static_lib: (OFF|ON); controls whether to publish c++ api static lib, default is OFF                                                      |"
     echo -e "|     --with_cv: (OFF|ON); controls whether to compile cv functions into lib, default is OFF                                                           |"
     echo -e "|     --with_log: (OFF|ON); controls whether to print log information, default is ON                                                                   |"
     echo -e "|     --with_exception: (OFF|ON); controls whether to throw the exception when error occurs, default is OFF                                            |"
@@ -277,6 +281,11 @@ function main {
             # ON or OFF, default OFF
             --with_extra=*)
                 WITH_EXTRA="${i#*=}"
+                shift
+                ;;
+            # controls whether to compile cplus static library, default is OFF
+            --with_static_lib=*)
+                WITH_STATIC_LIB="${i#*=}"
                 shift
                 ;;
             # ON or OFF, default OFF

--- a/tools/ci_tools/ci_android_publish.sh
+++ b/tools/ci_tools/ci_android_publish.sh
@@ -41,7 +41,7 @@ function publish_inference_lib {
   # Remove Compiling Cache
   rm -rf build*
   # Compiling inference library
-  ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=$with_extra
+  ./lite/tools/build_android.sh --arch=$arch --toolchain=$toolchain  --with_extra=$with_extra  --with_static_lib=ON
   # Checking results: cplus and java inference lib.
   if [ -d build*/inference*/cxx/lib ] && [ -d build*/inference*/java/so ]; then
     cxx_results=$(ls build*/inference*/cxx/lib | wc -l)


### PR DESCRIPTION
Android\ArmLinux 编译默认只产出动态库，如果想产出静态库需要打开编译选项 `with_static_lib`
``` shell
# 编译Android 静态库
./lite/tools/build_android.sh --with_static_lib=ON
```