### PR TITLE
[Fusion] add matmul+elementwise_add fusion

### DIFF
--- a/lite/api/paddle_use_passes.h
+++ b/lite/api/paddle_use_passes.h
@@ -36,6 +36,7 @@ USE_MIR_PASS(lite_squeeze2_matmul_fuse_pass);
 USE_MIR_PASS(lite_reshape2_matmul_fuse_pass);
 USE_MIR_PASS(lite_matmul_fuse_pass);
 USE_MIR_PASS(lite_fc_fuse_pass);
+USE_MIR_PASS(lite_matmul_element_add_fuse_pass);
 USE_MIR_PASS(lite_shuffle_channel_fuse_pass);
 USE_MIR_PASS(lite_transpose_softmax_transpose_fuse_pass);
 USE_MIR_PASS(lite_interpolate_fuse_pass);

--- a/lite/core/mir/CMakeLists.txt
+++ b/lite/core/mir/CMakeLists.txt
@@ -12,6 +12,7 @@ lite_cc_library(mir_passes
   SRCS
       fusion/fc_fuse_pass.cc
       fusion/matmul_fuse_pass.cc
+      fusion/matmul_elementwise_add_fuse_pass.cc
       fusion/reshape2_matmul_fuse_pass.cc
       fusion/squeeze2_matmul_fuse_pass.cc
       fusion/shuffle_channel_fuse_pass.cc

--- a/lite/core/mir/fusion/CMakeLists.txt
+++ b/lite/core/mir/fusion/CMakeLists.txt
@@ -1,6 +1,9 @@
 lite_cc_library(fuse_fc
         SRCS fc_fuser.cc
         DEPS pattern_matcher_high_api)
+lite_cc_library(fuse_matmul_elementwise_add
+        SRCS matmul_elementwise_add_fuser.cc
+        DEPS pattern_matcher_high_api)
 lite_cc_library(fuse_reshape2_matmul
         SRCS reshape2_matmul_fuser.cc
         DEPS pattern_matcher_high_api)
@@ -75,6 +78,7 @@ set(mir_fusers
     fuse_reshape2_matmul
     fuse_squeeze2_matmul
     fuse_matmul
+    fuse_matmul_elementwise_add
     fuse_fc
     fuse_shuffle_channel
     fuse_conv_elementwise

--- a/lite/core/mir/fusion/fc_fuse_pass.cc
+++ b/lite/core/mir/fusion/fc_fuse_pass.cc
@@ -23,7 +23,7 @@ namespace lite {
 namespace mir {
 
 void FcFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
-#if defined(LITE_WITH_X86) || defined(LITE_WITH_CUDA)
+#if defined(LITE_WITH_X86) || defined(LITE_WITH_CUDA) || defined(LITE_WITH_ARM)
 #ifdef LITE_WITH_MLU
   fusion::FcFuser fuser(false);
   fuser(graph.get());

--- a/lite/core/mir/fusion/fc_fuse_pass.cc
+++ b/lite/core/mir/fusion/fc_fuse_pass.cc
@@ -23,7 +23,7 @@ namespace lite {
 namespace mir {
 
 void FcFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
-#if defined(LITE_WITH_X86) || defined(LITE_WITH_CUDA) || defined(LITE_WITH_ARM)
+#if defined(LITE_WITH_X86) || defined(LITE_WITH_CUDA)
 #ifdef LITE_WITH_MLU
   fusion::FcFuser fuser(false);
   fuser(graph.get());

--- a/lite/core/mir/fusion/matmul_elementwise_add_fuse_pass.cc
+++ b/lite/core/mir/fusion/matmul_elementwise_add_fuse_pass.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/mir/fusion/matmul_elementwise_add_fuse_pass.h"
+#include <memory>
+#include <vector>
+#include "lite/core/mir/fusion/matmul_elementwise_add_fuser.h"
+#include "lite/core/mir/pass_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+void MatmulElementwiseAddFusePass::Apply(
+    const std::unique_ptr<SSAGraph>& graph) {
+#if defined(LITE_WITH_X86) || defined(LITE_WITH_CUDA)
+#ifdef LITE_WITH_MLU
+  fusion::MatmulElementwiseAddFuser fuser(false);
+  fuser(graph.get());
+#else
+  fusion::MatmulElementwiseAddFuser fuser(true);
+  fuser(graph.get());
+#endif
+#endif
+  fusion::MatmulElementwiseAddFuser fuser2(false);
+  fuser2(graph.get());
+#ifdef LITE_WITH_FPGA
+  fusion::MatmulElementwiseAddFuser fpga_fuser(true);
+  fpga_fuser(graph.get());
+#endif
+}
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_MIR_PASS(lite_matmul_element_add_fuse_pass,
+                  paddle::lite::mir::MatmulElementwiseAddFusePass)
+    .BindTargets({TARGET(kAny)})
+    .ExcludeTargets({TARGET(kXPU)})
+#if (!defined(LITE_WITH_MLU) && !defined(LITE_WITH_HUAWEI_ASCEND_NPU))
+    .ExcludeTargets({TARGET(kX86)})
+#endif
+    .ExcludeTargets({TARGET(kBM)})
+    .BindKernel("fc");

--- a/lite/core/mir/fusion/matmul_elementwise_add_fuse_pass.cc
+++ b/lite/core/mir/fusion/matmul_elementwise_add_fuse_pass.cc
@@ -24,7 +24,7 @@ namespace mir {
 
 void MatmulElementwiseAddFusePass::Apply(
     const std::unique_ptr<SSAGraph>& graph) {
-#if defined(LITE_WITH_X86) || defined(LITE_WITH_CUDA)
+#if defined(LITE_WITH_X86) || defined(LITE_WITH_CUDA) || defined(LITE_WITH_ARM)
 #ifdef LITE_WITH_MLU
   fusion::MatmulElementwiseAddFuser fuser(false);
   fuser(graph.get());
@@ -49,8 +49,4 @@ REGISTER_MIR_PASS(lite_matmul_element_add_fuse_pass,
                   paddle::lite::mir::MatmulElementwiseAddFusePass)
     .BindTargets({TARGET(kAny)})
     .ExcludeTargets({TARGET(kXPU)})
-#if (!defined(LITE_WITH_MLU) && !defined(LITE_WITH_HUAWEI_ASCEND_NPU))
-    .ExcludeTargets({TARGET(kX86)})
-#endif
-    .ExcludeTargets({TARGET(kBM)})
     .BindKernel("fc");

--- a/lite/core/mir/fusion/matmul_elementwise_add_fuse_pass.cc
+++ b/lite/core/mir/fusion/matmul_elementwise_add_fuse_pass.cc
@@ -24,6 +24,11 @@ namespace mir {
 
 void MatmulElementwiseAddFusePass::Apply(
     const std::unique_ptr<SSAGraph>& graph) {
+  for (auto& place : graph->valid_places()) {
+    if (place.precision == PRECISION(kInt8)) {
+      return;
+    }
+  }
 #if defined(LITE_WITH_X86) || defined(LITE_WITH_CUDA) || defined(LITE_WITH_ARM)
 #ifdef LITE_WITH_MLU
   fusion::MatmulElementwiseAddFuser fuser(false);

--- a/lite/core/mir/fusion/matmul_elementwise_add_fuse_pass.h
+++ b/lite/core/mir/fusion/matmul_elementwise_add_fuse_pass.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include "lite/core/mir/pass.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+class MatmulElementwiseAddFusePass : public ProgramPass {
+ public:
+  void Apply(const std::unique_ptr<SSAGraph>& graph) override;
+};
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/mir/fusion/matmul_elementwise_add_fuser.cc
+++ b/lite/core/mir/fusion/matmul_elementwise_add_fuser.cc
@@ -1,0 +1,130 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/mir/fusion/matmul_elementwise_add_fuser.h"
+#include <memory>
+#include <vector>
+
+namespace paddle {
+namespace lite {
+namespace mir {
+namespace fusion {
+
+void MatmulElementwiseAddFuser::BuildPattern() {
+  // create nodes.
+  auto* x = VarNode("x")->assert_is_op_input("matmul", "X");
+  auto* W = VarNode("W")->assert_is_op_input("matmul", "Y");
+  auto* b = VarNode("b")->assert_is_persistable_var();
+  /*
+   * The mul op must satisfy the following conditions:
+   * 1. the transpose_X and transpose_Y attrs are false
+   * 2. the alpha attr is 1.0
+   */
+  auto* matmul = OpNode("matmul", "matmul")
+                     ->assert_op_attr<bool>("transpose_X", false)
+                     ->assert_op_attr<bool>("transpose_Y", false)
+                     ->assert_op_attr_satisfied<float>("alpha", [](float attr) {
+                       return (std::fabs(attr - 1.0) < 1e-5);
+                     });
+  auto* matmul_out = VarNode("matmul_out");
+  auto* add = OpNode("add", "elementwise_add");
+  auto* Out = VarNode("Out");
+
+  // create topology.
+  std::vector<PMNode*> matmul_inputs{W, x};
+  std::vector<PMNode*> add_inputs{mul_out, b};
+  matmul_inputs >> *matmul >> *matmul_out;
+
+  // Some op specialities.
+  matmul_out->AsIntermediate();
+  matmul->AsIntermediate();
+  add->AsIntermediate();
+
+  if (with_relu_) {
+    auto* add_out = VarNode("add_out");
+    auto* relu = OpNode("relu", "relu");
+    std::vector<PMNode*> relu_inputs{add_out};
+    add_inputs >> *add >> *add_out;
+    relu_inputs >> *relu >> *Out;
+    add_out->AsIntermediate();
+    relu->AsIntermediate();
+  } else {
+    add_inputs >> *add >> *Out;
+  }
+}
+
+void MatmulElementwiseAddFuser::InsertNewNode(SSAGraph* graph,
+                                              const key2nodes_t& matched) {
+  auto op_desc = GenOpDesc(matched);
+  auto fc_op = LiteOpRegistry::Global().Create("fc");
+  auto mul = matched.at("matmul")->stmt()->op();
+  auto* scope = mul->scope();
+  auto& valid_places = mul->valid_places();
+  fc_op->Attach(op_desc, scope);
+
+  auto* new_op_node = graph->GraphCreateInstructNode(fc_op, valid_places);
+
+  IR_NODE_LINK_TO(matched.at("W"), new_op_node);
+  IR_NODE_LINK_TO(matched.at("x"), new_op_node);
+  IR_NODE_LINK_TO(matched.at("b"), new_op_node);
+  IR_NODE_LINK_TO(new_op_node, matched.at("Out"));
+}
+
+cpp::OpDesc MatmulElementwiseAddFuser::GenOpDesc(const key2nodes_t& matched) {
+  auto op_desc = *matched.at("matmul")->stmt()->op_info();
+
+  // Get the input scale from mul
+  std::vector<float> x_scale_vct;
+  std::vector<float> y_scale_vct;
+  auto input_x_name = op_desc.Input("X").front();
+  auto input_y_name = op_desc.Input("Y").front();
+  bool is_quantized_op = op_desc.HasInputScale(input_x_name) &&
+                         op_desc.HasInputScale(input_y_name);
+  if (is_quantized_op) {
+    x_scale_vct = op_desc.GetInputScale(input_x_name);
+    y_scale_vct = op_desc.GetInputScale(op_desc.Input("Y").front());
+  }
+  auto* scope = const_cast<Node*>(node)->AsStmt().op()->scope();
+  auto x_shape = scope->FindVar(input_x_name)->Get<lite::Tensor>().dims();
+  int x_num_col_dims = x_shape.size() - 1;
+  VLOG(4) << "x_shape: " << x_shape;
+  VLOG(4) << "y_shape: "
+          << scope->FindVar(input_y_name)->Get<lite::Tensor>().dims();
+  VLOG(4) << "x_num_col_dims: " << x_num_col_dims;
+
+  op_desc.mutable_inputs()->clear();
+  op_desc.mutable_outputs()->clear();
+  op_desc.SetType("fc");
+  op_desc.SetInput("Input", {matched.at("x")->arg()->name});
+  op_desc.SetInput("W", {matched.at("W")->arg()->name});
+  op_desc.SetInput("Bias", {matched.at("b")->arg()->name});
+  op_desc.SetOutput("Out", {matched.at("Out")->arg()->name});
+  op_desc.SetAttr("in_num_col_dims", x_num_col_dims);
+  if (with_relu_) {
+    op_desc.SetAttr("activation_type", std::string{"relu"});
+  }
+
+  // Set the input scale into fc
+  if (is_quantized_op) {
+    op_desc.SetInputScale(matched.at("x")->arg()->name, x_scale_vct);
+    op_desc.SetInputScale(matched.at("W")->arg()->name, y_scale_vct);
+  }
+
+  return op_desc;
+}
+
+}  // namespace fusion
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/mir/fusion/matmul_elementwise_add_fuser.cc
+++ b/lite/core/mir/fusion/matmul_elementwise_add_fuser.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "lite/core/mir/fusion/matmul_elementwise_add_fuser.h"
+#include <cmath>
 #include <memory>
 #include <vector>
 

--- a/lite/core/mir/fusion/matmul_elementwise_add_fuser.cc
+++ b/lite/core/mir/fusion/matmul_elementwise_add_fuser.cc
@@ -43,7 +43,7 @@ void MatmulElementwiseAddFuser::BuildPattern() {
 
   // create topology.
   std::vector<PMNode*> matmul_inputs{W, x};
-  std::vector<PMNode*> add_inputs{mul_out, b};
+  std::vector<PMNode*> add_inputs{matmul_out, b};
   matmul_inputs >> *matmul >> *matmul_out;
 
   // Some op specialities.
@@ -95,7 +95,7 @@ cpp::OpDesc MatmulElementwiseAddFuser::GenOpDesc(const key2nodes_t& matched) {
     x_scale_vct = op_desc.GetInputScale(input_x_name);
     y_scale_vct = op_desc.GetInputScale(op_desc.Input("Y").front());
   }
-  auto* scope = const_cast<Node*>(node)->AsStmt().op()->scope();
+  auto* scope = matched.at("matmul")->stmt()->op()->scope();
   auto x_shape = scope->FindVar(input_x_name)->Get<lite::Tensor>().dims();
   int x_num_col_dims = x_shape.size() - 1;
   VLOG(4) << "x_shape: " << x_shape;

--- a/lite/core/mir/fusion/matmul_elementwise_add_fuser.cc
+++ b/lite/core/mir/fusion/matmul_elementwise_add_fuser.cc
@@ -25,7 +25,8 @@ namespace fusion {
 void MatmulElementwiseAddFuser::BuildPattern() {
   // create nodes.
   auto* x = VarNode("x")->assert_is_op_input("matmul", "X");
-  auto* W = VarNode("W")->assert_is_op_input("matmul", "Y");
+  auto* W = VarNode("W")->assert_is_persistable_var()->assert_is_op_input(
+      "matmul", "Y");
   auto* b = VarNode("b")->assert_is_persistable_var();
   /*
    * The mul op must satisfy the following conditions:

--- a/lite/core/mir/fusion/matmul_elementwise_add_fuser.h
+++ b/lite/core/mir/fusion/matmul_elementwise_add_fuser.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include "lite/core/mir/pattern_matcher_high_api.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+namespace fusion {
+
+class MatmulElementwiseAddFuser : public FuseBase {
+ public:
+  explicit MatmulElementwiseAddFuser(bool with_relu) : with_relu_(with_relu) {}
+  void BuildPattern() override;
+  void InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) override;
+
+ private:
+  cpp::OpDesc GenOpDesc(const key2nodes_t& matched) override;
+  bool with_relu_;
+};
+
+}  // namespace fusion
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -99,6 +99,7 @@ class Optimizer {
          "lite_match_matrix_activation_fuse_pass",      //
          "lite_squeeze2_matmul_fuse_pass",              //
          "lite_reshape2_matmul_fuse_pass",              //
+         "lite_matmul_element_add_fuse_pass",           //
          "lite_matmul_fuse_pass",                       //
          "lite_fc_fuse_pass",                           //
          "lite_shuffle_channel_fuse_pass",              //


### PR DESCRIPTION
855-v8-1-thread | old | Now | improve
-- | -- | -- | --
ch_ppocr_mobile_v2 | 6.21652 | 5.5737 | 11.533%
matmul+elementwise_add  融合不支持int8 融合，如以下结构：
<img width="491" alt="image" src="https://user-images.githubusercontent.com/38650344/115713091-32614200-a3a8-11eb-9f7b-0e78bf3ec350.png">
后续，需要想方法修复这个结构（这个结构，会实现融合，导致计算结果不对）