### PR TITLE
[Framework] Improvement on error message

### DIFF
--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -345,7 +345,8 @@ void PrintHelpInfo() {
       "  Display operators in the input model\n"
       "  How to print detailed information: export GLOG_v=1 \n";
   OPT_LOG << "opt version:" << opt_version;
-  OPT_LOG_FATAL << help_info;
+  OPT_LOG << help_info;
+  exit(1);
 }
 
 // Parse Input command

--- a/lite/api/opt_base.cc
+++ b/lite/api/opt_base.cc
@@ -294,7 +294,8 @@ void OptBase::PrintHelpInfo() {
       "------------------------------------------------------------------------"
       "-----------------------------------------------------------\n";
   OPT_LOG << "opt version:" << opt_version;
-  OPT_LOG_ERROR << help_info;
+  OPT_LOG << help_info;
+  exit(1);
 }
 
 void OptBase::PrintExecutableBinHelpInfo() {
@@ -329,7 +330,7 @@ void OptBase::PrintExecutableBinHelpInfo() {
       "nna|intel_fpga)`"
       "  Display operators in the input model\n";
   OPT_LOG << "paddlelite opt version:" << opt_version;
-  OPT_LOG_FATAL << help_info;
+  OPT_LOG << help_info;
 }
 
 // 2. Print supported info of inputed ops

--- a/lite/core/mir/node.cc
+++ b/lite/core/mir/node.cc
@@ -35,11 +35,11 @@ KernelBase &mir::Node::Stmt::picked_kernel() {
   std::string error_message =
       "Error: Please use Paddle-Lite lib with all ops, which is marked with "
       "`with_extra`. Current lib is of tiny_publish, in which only basic "
-      "kernels are included and we can not create kernel for '"
-      << op_type()
-      << "'.\n Two ways are suggested to get Paddle-Lite lib with all ops:\n   "
-         " 1. Download pre-commit lib which is marked with `with_extra`.\n    "
-         "2. Compile Paddle-Lite with command `--with_extra=ON`.";
+      "kernels are included and we can not create kernel for '" +
+      op_type() +
+      "'.\n Two ways are suggested to get Paddle-Lite lib with all ops:\n    "
+      "1. Download pre-commit lib which is marked with `with_extra`.\n    2. "
+      "Compile Paddle-Lite with command `--with_extra=ON`.";
 #else
   std::string error_message =
       "Error: This model is not supported, because kernel for '" + op_type() +
@@ -68,11 +68,11 @@ void mir::Node::Stmt::ResetOp(const cpp::OpDesc &op_desc,
   std::string error_message =
       "Error: Please use Paddle-Lite lib with all ops, which is marked with "
       "`with_extra`. Current lib is of tiny_publish, in which only basic ops "
-      "are included and we can not create operator '"
-      << op_desc.Type()
-      << "'.\n Two ways are suggested to get Paddle-Lite lib with all ops:\n   "
-         " 1. Download pre-commit lib which is marked with `with_extra`.\n    "
-         "2. Compile Paddle-Lite with command `--with_extra=ON`.";
+      "are included and we can not create operator '" +
+      op_desc.Type() +
+      "'.\n Two ways are suggested to get Paddle-Lite lib with all ops:\n    "
+      "1. Download pre-commit lib which is marked with `with_extra`.\n    2. "
+      "Compile Paddle-Lite with command `--with_extra=ON`.";
 #else
   std::string error_message =
       "Error: This model is not supported, because operator '" +

--- a/lite/core/mir/node.cc
+++ b/lite/core/mir/node.cc
@@ -29,7 +29,23 @@ Place mir::Node::Stmt::place() const {
 }
 
 KernelBase &mir::Node::Stmt::picked_kernel() {
-  CHECK(!valid_kernels_.empty()) << "no kernel for " << op_type();
+// Error message: if current kernel is not supported, WITH_EXTRA lib is
+// suggested.
+#ifndef LITE_BUILD_EXTRA
+  std::string error_message =
+      "Error: Please use Paddle-Lite lib with all ops, which is marked with "
+      "`with_extra`. Current lib is of tiny_publish, in which only basic "
+      "kernels are included and we can not create kernel for '"
+      << op_type()
+      << "'.\n Two ways are suggested to get Paddle-Lite lib with all ops:\n   "
+         " 1. Download pre-commit lib which is marked with `with_extra`.\n    "
+         "2. Compile Paddle-Lite with command `--with_extra=ON`.";
+#else
+  std::string error_message =
+      "Error: This model is not supported, because kernel for '" + op_type() +
+      "' is not supported by Paddle-Lite.";
+#endif
+  CHECK(!valid_kernels_.empty()) << error_message;
   return *valid_kernels_.front();
 }
 
@@ -46,13 +62,29 @@ void mir::Node::Stmt::ResetOp(const cpp::OpDesc &op_desc,
   op_->Attach(op_desc, the_scope);
   // Recreate the kernels with the latest OpInfo.
   valid_kernels_.clear();
-
+// Error message: if current kernel is not supported, WITH_EXTRA lib is
+// suggested.
+#ifndef LITE_BUILD_EXTRA
+  std::string error_message =
+      "Error: Please use Paddle-Lite lib with all ops, which is marked with "
+      "`with_extra`. Current lib is of tiny_publish, in which only basic ops "
+      "are included and we can not create operator '"
+      << op_desc.Type()
+      << "'.\n Two ways are suggested to get Paddle-Lite lib with all ops:\n   "
+         " 1. Download pre-commit lib which is marked with `with_extra`.\n    "
+         "2. Compile Paddle-Lite with command `--with_extra=ON`.";
+#else
+  std::string error_message =
+      "Error: This model is not supported, because operator '" +
+      op_desc.Type() + "' is not supported by Paddle-Lite.";
+#endif
   if (!op_ || op_->op_info()->Type() != op_desc.Type()) {
     op_ = LiteOpRegistry::Global().Create(op_desc.Type());
-    CHECK(op_) << "No op found for " << op_desc.Type();
+    CHECK(op_) << error_message;
   }
   valid_kernels_ = op_->CreateKernels(valid_places);
 }
+
 void mir::Node::Stmt::ResetKernels(const std::vector<Place> &valid_places) {
   CHECK(op_) << "change valid place failed, not created op";
   valid_kernels_.clear();

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -210,7 +210,7 @@ RuntimeProgram::RuntimeProgram(
         "Compile Paddle-Lite with command `--with_extra=ON`.";
 #else
     std::string ops_error_message =
-        "Error: This model is not supported, because operator '" + op_type +
+        "\nError: This model is not supported, because operator '" + op_type +
         "' is not supported by Paddle-Lite.";
 #endif
     CHECK(op) << ops_error_message;
@@ -253,8 +253,8 @@ RuntimeProgram::RuntimeProgram(
           "Compile Paddle-Lite with command `--with_extra=ON`.";
 #else
       std::string kernels_error_message =
-          "Error: This model is not supported, because kernel for '" + op_type +
-          "' is not supported by Paddle-Lite.";
+          "\nError: This model is not supported, because kernel for '" +
+          op_type + "' is not supported by Paddle-Lite.";
 #endif
 
       auto kernels = op->CreateKernels({place});

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -195,7 +195,26 @@ RuntimeProgram::RuntimeProgram(
     // if (op_type == "feed" || op_type == "fetch") continue;
     // Create op and pick up the best kernel
     auto op = LiteOpRegistry::Global().Create(op_type);
-    CHECK(op) << "no Op found for " << op_type;
+
+// Error message: if current kernel is not supported, WITH_EXTRA lib is
+// suggested.
+#ifndef LITE_BUILD_EXTRA
+    std::string ops_error_message =
+        "\nError: Please use Paddle-Lite lib with all ops, which is marked "
+        "with "
+        "`with_extra`. Current lib is of tiny_publish, in which only basic "
+        "ops are included and we can not create operator '" +
+        op_type +
+        "'.\n Two ways are suggested to get Paddle-Lite lib with all ops:\n    "
+        "1. Download pre-commit lib which is marked with `with_extra`.\n    2. "
+        "Compile Paddle-Lite with command `--with_extra=ON`.";
+#else
+    std::string ops_error_message =
+        "Error: This model is not supported, because operator '" + op_type +
+        "' is not supported by Paddle-Lite.";
+#endif
+    CHECK(op) << ops_error_message;
+
     if (op_type == "while") {
       static_cast<operators::WhileOp*>(op.get())->SetProgramDesc(program_desc);
     } else if (op_type == "conditional_block") {
@@ -216,8 +235,30 @@ RuntimeProgram::RuntimeProgram(
       KernelBase::ParseKernelType(kernel_type, &op_type, &alias, &place);
       VLOG(3) << "Found the attr '" << kKernelTypeAttr << "': " << kernel_type
               << " for " << op_type;
+
+// Error message: if current kernel is not supported, WITH_EXTRA lib is
+// suggested.
+#ifndef LITE_BUILD_EXTRA
+      std::string kernels_error_message =
+          "\nError: Please use Paddle-Lite lib with all ops, which is marked "
+          "with "
+          "`with_extra`. Current lib is of tiny_publish, in which only basic "
+          "kernels "
+          "are included and we can not create kernel for '" +
+          op_type +
+          "'.\n Two ways are suggested to get Paddle-Lite lib with all "
+          "kernels:\n    "
+          "1. Download pre-commit lib which is marked with `with_extra`.\n    "
+          "2. "
+          "Compile Paddle-Lite with command `--with_extra=ON`.";
+#else
+      std::string kernels_error_message =
+          "Error: This model is not supported, because kernel for '" + op_type +
+          "' is not supported by Paddle-Lite.";
+#endif
+
       auto kernels = op->CreateKernels({place});
-      CHECK_GT(kernels.size(), 0) << "No kernels found for " << op_type;
+      CHECK_GT(kernels.size(), 0) << kernels_error_message;
       auto it = std::find_if(
           kernels.begin(), kernels.end(), [&](std::unique_ptr<KernelBase>& it) {
             return it->alias() == alias;

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -139,7 +139,7 @@ void PrintPbModelErrorMessage() {
              << "      2. You can also appoint the model and params file in "
                 "custom format:\n"
              << "          eg. |-- set_model_file('custom_model_name')\n"
-             << "              |-- set_params_file('custom_params_name')'\n";
+             << "              |-- set_params_file('custom_params_name')'";
 }
 // Find correct model filename
 std::string FindModelFileName(const std::string &model_dir,
@@ -165,7 +165,7 @@ std::string FindModelFileName(const std::string &model_dir,
     } else {
       LOG(FATAL) << "\nError, the model file '" << model_file
                  << "' is not existed. Please confirm that you have inputed "
-                    "correct model file path.\n";
+                    "correct model file path.";
     }
   }
   return prog_path;
@@ -225,7 +225,7 @@ void LoadModelPb(const std::string &model_dir,
 
   // Load model topology data from file.
   std::string prog_path = FindModelFileName(model_dir, model_file, combined);
-  OPT_LOG << "Start load model topology data from " << prog_path;
+  OPT_LOG << "Loading topology data from " << prog_path;
   framework::proto::ProgramDesc pb_proto_prog =
       *LoadProgram(prog_path, model_buffer);
   pb::ProgramDesc pb_prog(&pb_proto_prog);
@@ -234,23 +234,24 @@ void LoadModelPb(const std::string &model_dir,
 
   // Load params data from file.
   // NOTE: Only main block be used now.
-  OPT_LOG << "Start load model params...";
   CHECK(!(!combined && !model_buffer.is_empty()))
       << "If you want use the model_from_memory,"
       << " you should load the combined model using cfg.set_model_buffer "
          "interface.";
   if (!combined) {
+    OPT_LOG << "Loading non-combined params data from " << model_dir;
     LoadNonCombinedParamsPb(model_dir, cpp_prog, model_buffer, scope);
   } else {
+    OPT_LOG << "Loading params data from " << param_file;
     if (!IsFileExists(param_file)) {
-      LOG(FATAL) << "\nError, the param file '" << param_file
+      LOG(FATAL) << "Error, the param file '" << param_file
                  << "' is not existed. Please confirm that you have inputed "
-                    "correct param file path.\n";
+                    "correct param file path.";
     }
 
     LoadCombinedParamsPb(param_file, scope, *cpp_prog, model_buffer);
   }
-  OPT_LOG << "Load protobuf model successfully\n";
+  OPT_LOG << "1. Model is successfully loaded!";
 }
 
 void SaveModelPb(const std::string &model_dir,
@@ -553,7 +554,8 @@ void SaveModelNaive(const std::string &model_file,
       break;
     }
   }
-  OPT_LOG << "Save optimized model into " << prog_path << " successfully";
+  OPT_LOG << "2. Model is optimized and saved into " << prog_path
+          << " successfully";
 }
 
 template <typename T>

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -872,7 +872,7 @@ void LoadModelFbsFromFile(model_parser::BinaryFileReader *reader,
   const std::string paddle_version = version();
   const std::string opt_version_str = opt_version;
   if (paddle_version != opt_version_str) {
-    LOG(WARNING) << "warning: the version of opt that transformed this model "
+    LOG(WARNING) << "\nwarning: the version of opt that transformed this model "
                     "is not consistent with current Paddle-Lite version."
                     "\n      version of opt:"
                  << static_cast<const char *>(opt_version)


### PR DESCRIPTION
### (1) opt model transformation message is improved:
```
# eg. 
./opt --model_dir=./mobilenet_v1/ --optimize_out=hzq
```
![image](https://user-images.githubusercontent.com/45189361/115545024-e776fa00-a2d5-11eb-862c-92ca51b5bba9.png)

### (2) Runtime error message is improved: 
- if some kernel/op is not supported and basic lib is currently applied, it's suggested to use lite lib with all ops.

![image](https://user-images.githubusercontent.com/45189361/115550275-3de73700-a2dc-11eb-8b13-e1a7fd4ec0fa.png)

- if some kernel/op is not supported and lib with all ops is already applied:

![image](https://user-images.githubusercontent.com/45189361/115552268-b3ec9d80-a2de-11eb-84c3-b2a7403a0d7e.png)

### (3) Warning message if opt version is not compatible with current lib version

![image](https://user-images.githubusercontent.com/45189361/115552699-2cebf500-a2df-11eb-91e3-f6d2f2242047.png)
