### PR TITLE
add input tensor precision type check for LightPredictor.test=develop

### DIFF
--- a/lite/api/light_api.h
+++ b/lite/api/light_api.h
@@ -62,7 +62,10 @@ class LITE_API LightPredictor {
     Build(model_dir, model_buffer, param_buffer, model_type, model_from_memory);
   }
 
-  void Run() { program_->Run(); }
+  void Run() {
+    CheckInputValid();
+    program_->Run();
+  }
 
   // Get offset-th col of feed inputs.
   Tensor* GetInput(size_t offset);
@@ -79,10 +82,16 @@ class LITE_API LightPredictor {
   // get inputnames and get outputnames.
   std::vector<std::string> GetInputNames();
   std::vector<std::string> GetOutputNames();
+  // get input tensor precision type
+  const std::vector<PrecisionType>& GetInputPrecisions() const;
   void PrepareFeedFetch();
   Scope* scope() { return scope_.get(); }
 
  private:
+  // check if the input tensor precision type is correct.
+  // would be called in Run().
+  void CheckInputValid();
+
   void Build(const std::string& lite_model_file,
              bool model_from_memory = false);
 
@@ -109,6 +118,7 @@ class LITE_API LightPredictor {
   std::shared_ptr<cpp::ProgramDesc> program_desc_;
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;
+  std::vector<PrecisionType> input_precisions_;
 };
 
 class LightPredictorImpl : public lite_api::PaddlePredictor {

--- a/lite/api/light_api_test.cc
+++ b/lite/api/light_api_test.cc
@@ -45,6 +45,10 @@ TEST(LightAPI, load) {
     LOG(INFO) << "outputnames: " << outputs[i];
   }
 
+  auto& precisions = predictor.GetInputPrecisions();
+  ASSERT_EQ(precisions.size(), 1);
+  ASSERT_EQ(precisions[0], PrecisionType::kFloat);
+
   predictor.Run();
 
   const auto* output = predictor.GetOutput(0);


### PR DESCRIPTION
添加输入tensor类型检测，作为https://github.com/PaddlePaddle/Paddle-Lite/pull/5682的后续。
5682 pr仅仅对 CxxConfig创建的Predictor增加了输入tensor类型检测。
此次pr给MobileConfig创建的LightPredictor增加了输入tensor类型检测。
cheery pick到release/v2.9