### PR TITLE
[cherry-pick]add input tensor precision type check for LightPredictor.test=develop

### DIFF
--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -120,6 +120,10 @@ std::vector<std::string> LightPredictor::GetInputNames() {
 std::vector<std::string> LightPredictor::GetOutputNames() {
   return output_names_;
 }
+// get input tensor precision type
+const std::vector<PrecisionType>& LightPredictor::GetInputPrecisions() const {
+  return input_precisions_;
+}
 // append the names of inputs and outputs into input_names_ and output_names_
 void LightPredictor::PrepareFeedFetch() {
   std::vector<const cpp::OpDesc*> feeds;
@@ -137,6 +141,7 @@ void LightPredictor::PrepareFeedFetch() {
   }
   input_names_.resize(feeds.size());
   output_names_.resize(fetchs.size());
+  input_precisions_.resize(feeds.size());
   for (size_t i = 0; i < feeds.size(); i++) {
     input_names_[feeds[i]->GetAttr<int>("col")] =
         feeds[i]->Output("Out").front();
@@ -144,6 +149,9 @@ void LightPredictor::PrepareFeedFetch() {
   for (size_t i = 0; i < fetchs.size(); i++) {
     output_names_[fetchs[i]->GetAttr<int>("col")] =
         fetchs[i]->Input("X").front();
+  }
+  for (size_t i = 0; i < feeds.size(); i++) {
+    input_precisions_[i] = GetInput(i)->precision();
   }
 }
 
@@ -162,7 +170,13 @@ void LightPredictor::BuildRuntimeProgram(
     for (size_t var_idx = 0; var_idx < var_size; ++var_idx) {
       auto var_desc = block_desc->GetVar<cpp::VarDesc>(var_idx);
       if (!var_desc->Persistable()) {
-        exe_scope->Var(var_desc->Name());
+        auto* var = exe_scope->Var(var_desc->Name());
+        if (var_desc->GetType() == lite::VarDescAPI::Type::LOD_TENSOR) {
+          const auto var_data_type =
+              ConvertPrecisionType(var_desc->GetDataType());
+          auto* tensor = var->GetMutable<lite::Tensor>();
+          tensor->set_precision(var_data_type);
+        }
       } else {
         if (var_desc->Name() == "feed" || var_desc->Name() == "fetch") continue;
         scope_->Var(var_desc->Name());
@@ -291,6 +305,19 @@ void LightPredictor::WeightFP32ToFP16() {
   }
 }
 #endif
+
+void LightPredictor::CheckInputValid() {
+  for (size_t idx = 0; idx < input_precisions_.size(); ++idx) {
+    if (GetInput(idx)->precision() != input_precisions_[idx]) {
+      LOG(WARNING) << " Error input tensor precision type. Input index (" << idx
+                   << ") Tensor name (" << input_names_[idx]
+                   << ") Require Precision type ("
+                   << PrecisionToStr(input_precisions_[idx])
+                   << ") Input Precision type ("
+                   << PrecisionToStr(GetInput(idx)->precision()) << ").";
+    }
+  }
+}
 
 }  // namespace lite
 }  // namespace paddle

--- a/lite/api/light_api.h
+++ b/lite/api/light_api.h
@@ -62,7 +62,10 @@ class LITE_API LightPredictor {
     Build(model_dir, model_buffer, param_buffer, model_type, model_from_memory);
   }
 
-  void Run() { program_->Run(); }
+  void Run() {
+    CheckInputValid();
+    program_->Run();
+  }
 
   // Get offset-th col of feed inputs.
   Tensor* GetInput(size_t offset);
@@ -79,10 +82,16 @@ class LITE_API LightPredictor {
   // get inputnames and get outputnames.
   std::vector<std::string> GetInputNames();
   std::vector<std::string> GetOutputNames();
+  // get input tensor precision type
+  const std::vector<PrecisionType>& GetInputPrecisions() const;
   void PrepareFeedFetch();
   Scope* scope() { return scope_.get(); }
 
  private:
+  // check if the input tensor precision type is correct.
+  // would be called in Run().
+  void CheckInputValid();
+
   void Build(const std::string& lite_model_file,
              bool model_from_memory = false);
 
@@ -109,6 +118,7 @@ class LITE_API LightPredictor {
   std::shared_ptr<cpp::ProgramDesc> program_desc_;
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;
+  std::vector<PrecisionType> input_precisions_;
 };
 
 class LightPredictorImpl : public lite_api::PaddlePredictor {

--- a/lite/api/light_api_test.cc
+++ b/lite/api/light_api_test.cc
@@ -45,6 +45,10 @@ TEST(LightAPI, load) {
     LOG(INFO) << "outputnames: " << outputs[i];
   }
 
+  auto& precisions = predictor.GetInputPrecisions();
+  ASSERT_EQ(precisions.size(), 1);
+  ASSERT_EQ(precisions[0], PrecisionType::kFloat);
+
   predictor.Run();
 
   const auto* output = predictor.GetOutput(0);


### PR DESCRIPTION
添加输入tensor类型检测，作为https://github.com/PaddlePaddle/Paddle-Lite/pull/5682的后续。
5682 pr仅仅对 CxxConfig创建的Predictor增加了输入tensor类型检测。
此次pr给MobileConfig创建的LightPredictor增加了输入tensor类型检测。
chrry_pick到release/v2.9分支