### PR TITLE
[OpenCL] enhance ssd_boxes_calc_offline_pass

### DIFF
--- a/lite/core/mir/elimination/ssd_boxes_calc_offline_pass.h
+++ b/lite/core/mir/elimination/ssd_boxes_calc_offline_pass.h
@@ -30,8 +30,8 @@ namespace mir {
 // Prior-box don't depend on feature-map data, only depend on image &
 // feature-map size,
 // so if the shape is determined, we can calculate it offline in opt stage,
-// and the reshape & flatten & concat which linked with prior-box can calculate
-// offline too.
+// and the reshape(2) & flatten(2) & concat which linked with prior-box can
+// be calculate offline too.
 //
 // For example:
 //   image-size            feature-size       image-size            feature-size

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -1011,8 +1011,8 @@ struct PriorBoxParam : ParamBase {
   lite::Tensor* boxes{};
   lite::Tensor* variances{};
 
-  bool flip;
-  bool clip;
+  bool flip{true};
+  bool clip{true};
   std::vector<float> min_sizes;
   std::vector<float> max_sizes;
   std::vector<float> aspect_ratios;

--- a/lite/operators/prior_box_op.cc
+++ b/lite/operators/prior_box_op.cc
@@ -40,13 +40,15 @@ bool PriorBoxOpLite::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   param_.boxes = scope->FindVar(boxes)->GetMutable<lite::Tensor>();
   param_.variances = scope->FindVar(variances)->GetMutable<lite::Tensor>();
 
-  param_.clip = opdesc.GetAttr<bool>("clip");
   param_.min_sizes = opdesc.GetAttr<std::vector<float>>("min_sizes");
   param_.max_sizes = opdesc.GetAttr<std::vector<float>>("max_sizes");
   param_.aspect_ratios = opdesc.GetAttr<std::vector<float>>("aspect_ratios");
   param_.variances_ = opdesc.GetAttr<std::vector<float>>("variances");
   if (opdesc.HasAttr("flip")) {
     param_.flip = opdesc.GetAttr<bool>("flip");
+  }
+  if (opdesc.HasAttr("clip")) {
+    param_.clip = opdesc.GetAttr<bool>("clip");
   }
   if (opdesc.HasAttr("img_w")) {
     param_.img_w = opdesc.GetAttr<int>("img_w");
@@ -60,7 +62,9 @@ bool PriorBoxOpLite::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   if (opdesc.HasAttr("step_h")) {
     param_.step_h = opdesc.GetAttr<float>("step_h");
   }
-  param_.offset = opdesc.GetAttr<float>("offset");
+  if (opdesc.HasAttr("offset")) {
+    param_.offset = opdesc.GetAttr<float>("offset");
+  }
   if (opdesc.HasAttr("prior_num")) {
     param_.prior_num = opdesc.GetAttr<int>("prior_num");
   }


### PR DESCRIPTION
cherry-pick #5964 

**【本PR内容】**

1. 由于`reshape` 和 `reshape2`, `flatten` 和 `flatten2` 是一样的，因此在 ssd_boxes_calc_offline_pass 中加入对 `reshape` 和 `flatten`的支持，这样就可以处理 ssd_mobilenetv1 模型了；
2. 之前版本的`prior_box` 参数属性没有与 paddle 1.8/2.0 严格对齐，主要是部分参数不是必须项，且没有设置默认值，这会在 opt 时引起找不到一些参数，如：
```
Loading topology data from /island/original_models.backup/ssd_mobilenet_v1/__model__
Loading non-combined params data from /island/original_models.backup/ssd_mobilenet_v1
1. Model is successfully loaded!
[F  4/23  9:20: 9.820 ...Lite/lite/model_parser/general/op_desc.h:118 GetAttr] Check failed: it != attrs().end(): No attributes called min_max_aspect_ratios_order found for prior_box
```
3. 去掉编译警告