### PR TITLE
[BUG FIX] A collection of bug fixes for v2.9

### DIFF
--- a/docs/source_compile/library_tailoring.md
+++ b/docs/source_compile/library_tailoring.md
@@ -22,10 +22,13 @@ Paddle-Lite支持**根据模型裁剪预测库**功能。Paddle-Lite的一般编
 
 
 ### Step 1. 准备模型
-- 模型格式：只支持以下两种模型格式
+- 模型格式：只支持以下五种模型格式
 ``` shell
-# 格式一 : model params
-# 格式二 : __model__ + var1 + var2 + ...
+# 格式一 : __model__ + var1 + var2 + ...
+# 格式二 : model + var1 + var2 + ...
+# 格式三 : pdmodel + pdiparams
+# 格式四 : model +  params
+# 格式五 : model + weights
 ```
 
 - 所有模型放入同一个文件夹
@@ -88,12 +91,12 @@ cd Paddle-Lite
 - 编译产出
 
 ```shell
-# 编译产出位于： Paddle-Lite/android-lib
+# 编译产出位于： Paddle-Lite/iOS-lib
 iOS_lib  (Android 编译产出)
    |---- armv7            （armv7 iOS预测库&demo)
    |---- armv8            （armv8 iOS预测库&demo)
    |---- opt              （模型转换工具opt)
-   |---- optimized_model  （opt转化后的Android移动端模型)
+   |---- optimized_model  （opt转化后的iOS移动端模型)
               |---- mobilenet_v1.nb
               |---- shufflenet_v1.nb
 ```

--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -454,7 +454,7 @@ void Predictor::CheckPaddleOpVersions(
           // registry.
           if ((model_op_version_index > iter->second) &&
               (model_op_version_index != -1)) {
-            LOG(WARNING) << "Error: incompatible paddle op version. Kernel ("
+            LOG(WARNING) << "Warning: incompatible paddle op version. Kernel ("
                          << kernel->name() << ") requires that op_version("
                          << iter->first << ")==" << iter->second
                          << ". However, the op_version(" << iter->first

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -208,8 +208,8 @@ RuntimeProgram::RuntimeProgram(
         "ops are included and we can not create operator '" +
         op_type +
         "'.\n Two ways are suggested to get Paddle-Lite lib with all ops:\n    "
-        "1. Download pre-commit lib which is marked with `with_extra`.\n    2. "
-        "Compile Paddle-Lite with command `--with_extra=ON`.";
+        "1. Download pre-compiled lib which is marked with `with_extra`.\n    "
+        "2. Compile Paddle-Lite with command `--with_extra=ON`.";
 #else
     std::string ops_error_message =
         "\nError: This model is not supported, because operator '" + op_type +

--- a/lite/operators/expand_op.h
+++ b/lite/operators/expand_op.h
@@ -35,6 +35,11 @@ class ExpandOpLite : public OpLite {
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "expand"; }
 
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+
  private:
   mutable ExpandParam param_;
 };

--- a/lite/tools/build_android_by_models.sh
+++ b/lite/tools/build_android_by_models.sh
@@ -24,24 +24,7 @@ models_names=$(ls models)
 rm -rf models_opt && mkdir models_opt
 for name in $models_names
 do
-  if [[ $(ls models/$name | wc -l) -gt 2 ]]
-  then
-    if [[ -f models/$name/__model__ ]]
-	then
-      ./opt --model_dir=./models/$name --valid_targets=arm --optimize_out=./models_opt/$name --record_tailoring_info=true
-    else
-      echo "Error: unsupported model format /models/$name"
-      exit 1
-    fi
-  else
-    if [[ -f models/$name/model ]] && [[ -f models/$name/params ]]
-	then
-	./opt --model_file=./models/$name/model --param_file=./models/$name/params --valid_targets=arm --optimize_out=./models_opt/$name --record_tailoring_info=true
-	else
-	  echo "Error: unsupported model format /models/$name"
-	  exit 1
-	fi
-  fi
+  ./opt --model_dir=./models/$name --valid_targets=arm --optimize_out=./models_opt/$name --record_tailoring_info=true
 done
 
 

--- a/lite/tools/build_ios_by_models.sh
+++ b/lite/tools/build_ios_by_models.sh
@@ -24,24 +24,7 @@ models_names=$(ls models)
 rm -rf models_opt && mkdir models_opt
 for name in $models_names
 do
-  if [[ $(ls models/$name | wc -l) -gt 2 ]]
-  then
-    if [[ -f models/$name/__model__ ]]
-	then
-      ./opt --model_dir=./models/$name --valid_targets=arm --optimize_out=./models_opt/$name --record_tailoring_info=true
-    else
-      echo "Error: unsupported model format /models/$name"
-      exit 1
-    fi
-  else
-    if [[ -f models/$name/model ]] && [[ -f models/$name/params ]]
-	then
-	./opt --model_file=./models/$name/model --param_file=./models/$name/params --valid_targets=arm --optimize_out=./models_opt/$name --record_tailoring_info=true
-	else
-	  echo "Error: unsupported model format /models/$name"
-	  exit 1
-	fi
-  fi
+  ./opt --model_dir=./models/$name --valid_targets=arm --optimize_out=./models_opt/$name --record_tailoring_info=true
 done
 
 


### PR DESCRIPTION
cherry-picked from #5952

### BUG FIX I
- 模型裁剪： 
  - 修复文档错误
  - 删除脚本中对 模型格式的检查 （因为opt 优化后、加载模型时会检查、不需要脚本再次检查）
### BUG FIX II
- InferType
  - 为`cast`算子、`expand` 算子补充InferType实现
- 图分析阶段
   - 解决 `InferenceKernelWithUncertainPrecision`中`InferType`不生效问题 (因为graph 与 opInfo 中的精度信息没有相互同步)

### BUG FIX III
- OP版本不一致的报错信息
  -  之前报错信息是： "Error, ..." 实际不会异常退出、只是一条warning警告信息
  - 本PR将这个报错信息改为：“Warning, ...”