### PR TITLE
[Pass] Fuse scale(with act) + scale(without act)

### DIFF
--- a/lite/api/paddle_use_passes.h
+++ b/lite/api/paddle_use_passes.h
@@ -48,6 +48,7 @@ USE_MIR_PASS(lite_conv_activation_fuse_pass);
 USE_MIR_PASS(lite_var_conv_2d_activation_fuse_pass);
 USE_MIR_PASS(lite_match_matrix_activation_fuse_pass);
 USE_MIR_PASS(lite_scales_fuse_pass);
+USE_MIR_PASS(lite_scaleacts_fuse_pass);
 USE_MIR_PASS(lite_sequence_reverse_embedding_fuse_pass);
 USE_MIR_PASS(lite_elementwise_activation_fuse_pass);
 USE_MIR_PASS(lite_elementwise_scale_fuse_pass);

--- a/lite/backends/opencl/cl_kernel/image/scale_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/scale_kernel.cl
@@ -28,6 +28,7 @@ __kernel void scale(__read_only image2d_t input,
 
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(x, y), in);
 }
+
 __kernel void scale_relu6(__read_only image2d_t input,
                           __write_only image2d_t output,
                           __private float scale,
@@ -41,5 +42,24 @@ __kernel void scale_relu6(__read_only image2d_t input,
   in = CONVERT_TYPE_TO(scale, CL_DTYPE) * in + CONVERT_TYPE_TO(bias, CL_DTYPE);
   in = max((CL_DTYPE4)(0.0f, 0.0f, 0.0f, 0.0f), in);
   in = min((CL_DTYPE4)(alpha, alpha, alpha, alpha), in);
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(x, y), in);
+}
+
+__kernel void scaleacts(__read_only image2d_t input,
+                        __write_only image2d_t output,
+                        __private float scale,
+                        __private float bias,
+                        __private float alpha,
+                        __private float scale1,
+                        __private float bias1) {
+
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  CL_DTYPE4 in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(x, y));
+  in = CONVERT_TYPE_TO(scale, CL_DTYPE) * in + CONVERT_TYPE_TO(bias, CL_DTYPE);
+  in = max((CL_DTYPE4)(0.0f, 0.0f, 0.0f, 0.0f), in);
+  in = min((CL_DTYPE4)(alpha, alpha, alpha, alpha), in);
+  in = CONVERT_TYPE_TO(scale1, CL_DTYPE) * in + CONVERT_TYPE_TO(bias1, CL_DTYPE);
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(x, y), in);
 }

--- a/lite/core/mir/CMakeLists.txt
+++ b/lite/core/mir/CMakeLists.txt
@@ -55,6 +55,7 @@ lite_cc_library(mir_passes
       fusion/__xpu__graph_dedup_pass.cc
       fusion/match_matrix_activation_fuse_pass.cc
       fusion/scales_fuse_pass.cc
+      fusion/scaleacts_fuse_pass.cc
       fusion/sequence_reverse_embedding_fuse_pass.cc
       fusion/instance_norm_activation_fuse_pass.cc
       fusion/elementwise_add_scale_fuse_pass.cc

--- a/lite/core/mir/fusion/CMakeLists.txt
+++ b/lite/core/mir/fusion/CMakeLists.txt
@@ -98,6 +98,7 @@ set(mir_fusers
     fuse_inplace
     fuse_match_matrix_activation
     fuse_scales
+    fuse_scaleacts
     fuse_sequence_reverse_embedding
     fuse_instance_norm_activation
     fuse_elementwise_add_scale

--- a/lite/core/mir/fusion/CMakeLists.txt
+++ b/lite/core/mir/fusion/CMakeLists.txt
@@ -61,6 +61,9 @@ lite_cc_library(fuse_match_matrix_activation
 lite_cc_library(fuse_scales
         SRCS scales_fuser.cc
         DEPS pattern_matcher_high_api)
+lite_cc_library(fuse_scaleacts
+        SRCS scaleacts_fuser.cc
+        DEPS pattern_matcher_high_api)
 lite_cc_library(fuse_sequence_reverse_embedding
         SRCS sequence_reverse_embedding_fuser.cc
         DEPS pattern_matcher_high_api)

--- a/lite/core/mir/fusion/scaleacts_fuse_pass.cc
+++ b/lite/core/mir/fusion/scaleacts_fuse_pass.cc
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/mir/fusion/scaleacts_fuse_pass.h"
+
+#include <memory>
+#include <vector>
+
+#include "lite/core/mir/fusion/scaleacts_fuser.h"
+#include "lite/core/mir/pass_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+void ScaleactsFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
+  fusion::ScaleactsFuser fuser;
+  fuser(graph.get());
+}
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_MIR_PASS(lite_scaleacts_fuse_pass,
+                  paddle::lite::mir::ScaleactsFusePass)
+    .BindTargets({TARGET(kOpenCL)});

--- a/lite/core/mir/fusion/scaleacts_fuse_pass.h
+++ b/lite/core/mir/fusion/scaleacts_fuse_pass.h
@@ -22,7 +22,10 @@ namespace paddle {
 namespace lite {
 namespace mir {
 
-// This pass fuse two scale ops to one scale op.
+// This pass fuses two scale ops to one scale op.
+// Caculation will not be reduced by this pass but two ops fused to one.
+// This will reduce running time on gpu device.
+// MobilenetV3 has this pattern.
 //
 // For example:
 //     scale(has act func)
@@ -32,7 +35,7 @@ namespace mir {
 //     scale(no act func)
 //
 // After this pass is applied:
-//     scale
+//     scale( out = scale1 * (act(scale*in + bias)) + bias1 )
 
 class ScaleactsFusePass : public ProgramPass {
  public:

--- a/lite/core/mir/fusion/scaleacts_fuse_pass.h
+++ b/lite/core/mir/fusion/scaleacts_fuse_pass.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include "lite/core/mir/pass.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+// This pass fuse two scale ops to one scale op.
+//
+// For example:
+//     scale(has act func)
+//       |
+//       |
+//       |
+//     scale(no act func)
+//
+// After this pass is applied:
+//     scale
+
+class ScaleactsFusePass : public ProgramPass {
+ public:
+  void Apply(const std::unique_ptr<SSAGraph>& graph) override;
+};
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/mir/fusion/scaleacts_fuser.cc
+++ b/lite/core/mir/fusion/scaleacts_fuser.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/core/mir/fusion/scales_fuser.h"
+#include "lite/core/mir/fusion/scaleacts_fuser.h"
 #include <memory>
 #include <vector>
 
@@ -21,11 +21,19 @@ namespace lite {
 namespace mir {
 namespace fusion {
 
-void ScalesFuser::BuildPattern() {
+void ScaleactsFuser::BuildPattern() {
   // create input nodes.
   auto* x = VarNode("x")->assert_is_op_input("scale", "X")->AsInput();
 
-  auto scales_teller = [](const Node* node) -> bool {
+  auto scales_teller1 = [](const Node* node) -> bool {
+    bool bias_after_scale =
+        const_cast<Node*>(node)->AsStmt().op_info()->GetAttr<bool>(
+            "bias_after_scale");
+    bool has_act =
+        const_cast<Node*>(node)->AsStmt().op_info()->HasAttr("activation_type");
+    return bias_after_scale && has_act;
+  };
+  auto scales_teller2 = [](const Node* node) -> bool {
     bool bias_after_scale =
         const_cast<Node*>(node)->AsStmt().op_info()->GetAttr<bool>(
             "bias_after_scale");
@@ -37,11 +45,11 @@ void ScalesFuser::BuildPattern() {
   // create op nodes
   auto* scale1 = OpNode("scale1", "scale")
                      ->assert_is_op("scale")
-                     ->assert_node_satisfied(scales_teller)
+                     ->assert_node_satisfied(scales_teller1)
                      ->AsIntermediate();
   auto* scale2 = OpNode("scale2", "scale")
                      ->assert_is_op("scale")
-                     ->assert_node_satisfied(scales_teller)
+                     ->assert_node_satisfied(scales_teller2)
                      ->AsIntermediate();
 
   // create intermediate nodes
@@ -57,7 +65,8 @@ void ScalesFuser::BuildPattern() {
   *x >> *scale1 >> *scale1_out >> *scale2 >> *out;
 }
 
-void ScalesFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
+void ScaleactsFuser::InsertNewNode(SSAGraph* graph,
+                                   const key2nodes_t& matched) {
   auto op_desc = GenOpDesc(matched);
   auto scale_op = LiteOpRegistry::Global().Create("scale");
   auto scale = matched.at("scale1")->stmt()->op();
@@ -71,19 +80,19 @@ void ScalesFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
   IR_NODE_LINK_TO(new_op_node, matched.at("out"));
 }
 
-cpp::OpDesc ScalesFuser::GenOpDesc(const key2nodes_t& matched) {
-  auto op_desc = *matched.at("scale1")->stmt()->op_info();
-  float scale1 = op_desc.GetAttr<float>("scale");
-  float bias1 = op_desc.GetAttr<float>("bias");
-  float scale2 =
-      matched.at("scale2")->stmt()->op_info()->GetAttr<float>("scale");
-  float bias2 = matched.at("scale2")->stmt()->op_info()->GetAttr<float>("bias");
+cpp::OpDesc ScaleactsFuser::GenOpDesc(const key2nodes_t& matched) {
+  auto op_desc = matched.at("scale2")->stmt()->op_info();
+  float scale1 = op_desc->GetAttr<float>("scale");
+  float bias1 = op_desc->GetAttr<float>("bias");
 
-  op_desc.SetAttr<float>("scale", scale1 * scale2);
-  op_desc.SetAttr<float>("bias", bias1 * scale2 + bias2);
+  op_desc.SetAttr<bool>("fuse_scaleact", true);
+  op_desc.SetAttr<float>("scale1", scale1);
+  op_desc.SetAttr<float>("bias1", bias1);
 
   auto& out_name = matched.at("out")->arg()->name;
   op_desc.SetOutput("Out", {out_name});
+
+  // should we consider int8 case?
 
   return op_desc;
 }

--- a/lite/core/mir/fusion/scaleacts_fuser.cc
+++ b/lite/core/mir/fusion/scaleacts_fuser.cc
@@ -81,13 +81,14 @@ void ScaleactsFuser::InsertNewNode(SSAGraph* graph,
 }
 
 cpp::OpDesc ScaleactsFuser::GenOpDesc(const key2nodes_t& matched) {
-  auto op_desc = matched.at("scale2")->stmt()->op_info();
-  float scale1 = op_desc->GetAttr<float>("scale");
-  float bias1 = op_desc->GetAttr<float>("bias");
+  auto* op_desc_tmp = matched.at("scale2")->stmt()->op_info();
+  float scale1 = op_desc_tmp->GetAttr<float>("scale");
+  float bias1 = op_desc_tmp->GetAttr<float>("bias");
 
-  op_desc.SetAttr<bool>("fuse_scaleact", true);
-  op_desc.SetAttr<float>("scale1", scale1);
-  op_desc.SetAttr<float>("bias1", bias1);
+  auto op_desc = *matched.at("scale1")->stmt()->op_info();
+  op_desc.SetAttr("fuse_scaleact", true);
+  op_desc.SetAttr("scale1", scale1);
+  op_desc.SetAttr("bias1", bias1);
 
   auto& out_name = matched.at("out")->arg()->name;
   op_desc.SetOutput("Out", {out_name});

--- a/lite/core/mir/fusion/scaleacts_fuser.cc
+++ b/lite/core/mir/fusion/scaleacts_fuser.cc
@@ -93,8 +93,6 @@ cpp::OpDesc ScaleactsFuser::GenOpDesc(const key2nodes_t& matched) {
   auto& out_name = matched.at("out")->arg()->name;
   op_desc.SetOutput("Out", {out_name});
 
-  // should we consider int8 case?
-
   return op_desc;
 }
 

--- a/lite/core/mir/fusion/scaleacts_fuser.h
+++ b/lite/core/mir/fusion/scaleacts_fuser.h
@@ -25,8 +25,6 @@ namespace fusion {
 
 class ScaleactsFuser : public FuseBase {
  public:
-  ScaleactsFuser() {}
-
   void BuildPattern() override;
   void InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) override;
 

--- a/lite/core/mir/fusion/scaleacts_fuser.h
+++ b/lite/core/mir/fusion/scaleacts_fuser.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include "lite/core/mir/pattern_matcher_high_api.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+namespace fusion {
+
+class ScaleactsFuser : public FuseBase {
+ public:
+  ScaleactsFuser() {}
+
+  void BuildPattern() override;
+  void InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) override;
+
+ private:
+  cpp::OpDesc GenOpDesc(const key2nodes_t& matched) override;
+};
+
+}  // namespace fusion
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/optimizer.h
+++ b/lite/core/optimizer.h
@@ -111,6 +111,7 @@ class Optimizer {
          "elementwise_mul_constant_eliminate_pass",     //
          "lite_sequence_pool_concat_fuse_pass",         //
          "lite_scale_activation_fuse_pass",             //
+         "lite_scaleacts_fuse_pass",                    //
          "lite_elementwise_scale_fuse_pass",            //
          "lite_instance_norm_activation_fuse_pass",     //
          "lite_fc_prelu_fuse_pass",                     //

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -281,11 +281,15 @@ struct ScaleParam : ParamBase {
   lite::Tensor* output{};
 
   float scale{1.f};
-  float bias{};
+  float bias{0.f};
   bool bias_after_scale{true};
   std::string activation_type{""};
   bool fuse_relu{false};
   float alpha{6.f};
+
+  bool fuse_scaleact{false};
+  float scale1{1.f};
+  float bias1{0.f};
   ///////////////////////////////////////////////////////////////////////////////////
   // get a vector of input tensors
   const std::vector<const Tensor*>* input_tensor_ptrs() override {
@@ -2354,3 +2358,4 @@ struct ArgsortParam : ParamBase {
 }  // namespace operators
 }  // namespace lite
 }  // namespace paddle
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -2358,4 +2358,3 @@ struct ArgsortParam : ParamBase {
 }  // namespace operators
 }  // namespace lite
 }  // namespace paddle
-// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.

--- a/lite/operators/scale_op.cc
+++ b/lite/operators/scale_op.cc
@@ -54,6 +54,7 @@ bool ScaleOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
     }
 
     if (op_desc.HasAttr("fuse_scaleact")) {
+      param_.fuse_scaleact = op_desc.GetAttr<bool>("fuse_scaleact");
       param_.scale1 = op_desc.GetAttr<float>("scale1");
       param_.bias1 = op_desc.GetAttr<float>("bias1");
     }

--- a/lite/operators/scale_op.cc
+++ b/lite/operators/scale_op.cc
@@ -53,6 +53,10 @@ bool ScaleOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
           << "The fused conv only supports fuse with relu and leaky relu";
     }
   }
+  if (op_desc.HasAttr("fuse_scaleact")) {
+    param_.scale1 = op_desc.GetAttr<float>("scale1");
+    param_.bias1 = op_desc.GetAttr<float>("bias1");
+  }
   CHECK(param_.x);
   CHECK(param_.output);
   return true;

--- a/lite/operators/scale_op.cc
+++ b/lite/operators/scale_op.cc
@@ -52,10 +52,11 @@ bool ScaleOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
       CHECK(false)
           << "The fused conv only supports fuse with relu and leaky relu";
     }
-  }
-  if (op_desc.HasAttr("fuse_scaleact")) {
-    param_.scale1 = op_desc.GetAttr<float>("scale1");
-    param_.bias1 = op_desc.GetAttr<float>("bias1");
+
+    if (op_desc.HasAttr("fuse_scaleact")) {
+      param_.scale1 = op_desc.GetAttr<float>("scale1");
+      param_.bias1 = op_desc.GetAttr<float>("bias1");
+    }
   }
   CHECK(param_.x);
   CHECK(param_.output);

--- a/lite/operators/scale_op.h
+++ b/lite/operators/scale_op.h
@@ -45,6 +45,7 @@ class ScaleOp : public OpLite {
     ch->remark =
         param_.activation_type + "alpha" + std::to_string(param_.alpha);
     ch->macs = param_.x->numel() * 1.f;
+    if (param_.fuse_scaleact) ch->macs *= 2;
   }
 #endif
 


### PR DESCRIPTION
**【背景】**
mobilenetv3-large 模型中有 `scale --> relu6 ---> scale` 结构，经过  `lite_scale_activation_fuse_pass` 后，变为 `scale(relu6) ---> scale` 。
由于 scale 属于小算子，即单位计算密度低，在 GPU 上连续执行多个小算子的开销占比较大，因此通常会将多个小算子融合为一个算子，这样就减少了 kernel 个数，进而减少了 kernel 启动的时间开销。

**【本PR工作】**
实现 `scale(relu6) ---> scale` 结构融合为 `scale` 的 pass，只应用到 kOpenCL 设备。

**【效果】**
运行 ssd_mobilenetv3-large(320x320)，scale_relu6 和 scale 这两个算子均有 20 个，累加耗时数据如下，单位 ms
![image](https://user-images.githubusercontent.com/24290792/116094266-f85eab80-a6d9-11eb-9009-f6e7cd194548.png)