### PR TITLE
fix v7 gemv trans bugs

### DIFF
--- a/lite/backends/arm/math/gemv_arm_int8.cc
+++ b/lite/backends/arm/math/gemv_arm_int8.cc
@@ -1611,7 +1611,7 @@ bool gemv_int8_trans_oth(const int8_t* A,
   int cnt = N >> 2;
   int tail = N & 3;
   int stride_in = M << 2;
-#pragma omp parallel for
+  // #pragma omp parallel for
   for (int i = 0; i < cnt; i++) {
     const int8_t* in_ptr0 = data_in;
     const int8_t* in_ptr1 = in_ptr0 + M;

--- a/lite/backends/arm/math/gemv_arm_int8.cc
+++ b/lite/backends/arm/math/gemv_arm_int8.cc
@@ -1276,7 +1276,7 @@ bool gemv_int8_trans_oth(const int8_t* A,
   int cnt_4 = tail >> 2;
   int tail_4 = tail & 3;
   int stride_in = M << 3;
-#pragma omp parallel for
+  // #pragma omp parallel for
   for (int i = 0; i < cnt; i++) {
     const int8_t* in_ptr0 = data_in;
     const int8_t* in_ptr1 = in_ptr0 + M;

--- a/lite/kernels/arm/matmul_compute.cc
+++ b/lite/kernels/arm/matmul_compute.cc
@@ -29,7 +29,13 @@ void MatMulCompute<PRECISION(kFloat), PRECISION(kFloat)>::PrepareForRun() {
 }
 
 template <>
-void MatMulCompute<PRECISION(kInt8), PRECISION(kFloat)>::PrepareForRun() {
+void MatMulCompute<PRECISION(kInt8), PRECISION(kFloat)>::PrepareForRun() {}
+
+template <>
+void MatMulCompute<PRECISION(kFloat), PRECISION(kFloat)>::ReInitWhenNeeded() {}
+
+template <>
+void MatMulCompute<PRECISION(kInt8), PRECISION(kFloat)>::ReInitWhenNeeded() {
   auto& ctx = this->ctx_->template As<ARMContext>();
   auto& param = Param<param_t>();
   auto x_dims = param.X->dims();

--- a/lite/kernels/arm/matmul_compute.h
+++ b/lite/kernels/arm/matmul_compute.h
@@ -30,6 +30,8 @@ class MatMulCompute : public KernelLite<TARGET(kARM), PType> {
 
   void PrepareForRun() override;
 
+  void ReInitWhenNeeded() override;
+
   void Run() override;
 
   virtual ~MatMulCompute() = default;


### PR DESCRIPTION
CRNN 量化模型线程支持：
1.修复lite/backends/arm/math/gemv_arm_int8.cc：gemv_int8_trans_oth函数v7版本多线程bug。