### PR TITLE
[OpenCL] Fix select fp32 compile crash

### DIFF
--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -93,7 +93,11 @@ __constant sampler_t SAMPLER =
 inline CL_DTYPE activation(CL_DTYPE in, CL_DTYPE prelu_alpha) {
   CL_DTYPE output = in;
 #ifdef PRELU
-  output = select(prelu_alpha * in, in, isgreaterequal(in, 0));
+#ifdef CL_DTYPE_half
+  output = select(prelu_alpha * in, in, (ushort)(isgreaterequal(in, 0)));
+#else
+  output = select(prelu_alpha * in, in, (uint)(isgreaterequal(in, 0)));
+#endif
 #endif
 
 #ifdef RELU
@@ -105,7 +109,13 @@ inline CL_DTYPE activation(CL_DTYPE in, CL_DTYPE prelu_alpha) {
 #endif
 
 #ifdef LEAKY_RELU
-  output = select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, isgreaterequal(in, 0));
+#ifdef CL_DTYPE_half
+  output = select(
+      (CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, (ushort)(isgreaterequal(in, 0)));
+#else
+  output = select(
+      (CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, (uint)(isgreaterequal(in, 0)));
+#endif
 #endif
 
 #ifdef HARD_SWISH

--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -93,7 +93,7 @@ __constant sampler_t SAMPLER =
 inline CL_DTYPE activation(CL_DTYPE in, CL_DTYPE prelu_alpha) {
   CL_DTYPE output = in;
 #ifdef PRELU
-  output = select(prelu_alpha * in, in, (ushort)(isgreaterequal(in, 0)));
+  output = select(prelu_alpha * in, in, isgreaterequal(in, 0));
 #endif
 
 #ifdef RELU
@@ -105,16 +105,7 @@ inline CL_DTYPE activation(CL_DTYPE in, CL_DTYPE prelu_alpha) {
 #endif
 
 #ifdef LEAKY_RELU
-#ifdef CL_DTYPE_float
-  output = select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in,
-                  in,
-                  (int)(isgreaterequal(in, 0)));  // NOLINT
-#endif
-
-#ifdef CL_DTYPE_half
-  output = select(
-      (CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, (ushort)(isgreaterequal(in, 0)));
-#endif
+  output = select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, isgreaterequal(in, 0));
 #endif
 
 #ifdef HARD_SWISH
@@ -151,11 +142,6 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in, CL_DTYPE4 prelu_alpha) {
 #ifdef LEAKY_RELU
   output = select(
       (CL_DTYPE4)(LEAKY_RELU_ALPHA)*in, in, isgreaterequal(in, (CL_DTYPE4)0));
-// same as bellow:
-// output = select((CL_DTYPE4)(LEAKY_RELU_ALPHA)*in,
-//                 in,
-//                 (ushort4)((in.x >= 0) << 15, (in.y >= 0) << 15, (in.z >= 0)
-//                 << 15, (in.w >= 0) << 15));
 #endif
 
 #ifdef HARD_SWISH

--- a/lite/backends/opencl/cl_kernel/image/conv2d_3x3_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_3x3_kernel.cl
@@ -79,106 +79,97 @@ __kernel void conv2d_3x3(__private const int global_size_dim0,
         int input_block = input_c / 4;
         int2 pos_in = (int2)(input_block * input_width + in_pos_in_one_block.x,
                              in_pos_in_one_block.y);
-        input0 = select(
+        input0 = SELECT(
             READ_IMG_TYPE(CL_DTYPE_CHAR,
                           input_image,
                           SAMPLER,
                           (int2)(pos_in.x - dilation, pos_in.y - dilation)),
             zero_dtype4,
-            (ushort4)((in_pos_in_one_block.x - dilation < 0 ||
+            in_pos_in_one_block.x - dilation < 0 ||
                        in_pos_in_one_block.y - dilation < 0 ||
                        in_pos_in_one_block.x - dilation >= input_width ||
-                       in_pos_in_one_block.y - dilation >= input_height)
-                      << 15));
+                       in_pos_in_one_block.y - dilation >= input_height);
         input1 =
-            select(READ_IMG_TYPE(CL_DTYPE_CHAR,
+            SELECT(READ_IMG_TYPE(CL_DTYPE_CHAR,
                                  input_image,
                                  SAMPLER,
                                  (int2)(pos_in.x, pos_in.y - dilation)),
                    zero_dtype4,
-                   (ushort4)((in_pos_in_one_block.x < 0 ||
+                   in_pos_in_one_block.x < 0 ||
                               in_pos_in_one_block.y - dilation < 0 ||
                               in_pos_in_one_block.x >= input_width ||
-                              in_pos_in_one_block.y - dilation >= input_height)
-                             << 15));
-        input2 = select(
+                              in_pos_in_one_block.y - dilation >= input_height);
+        input2 = SELECT(
             READ_IMG_TYPE(CL_DTYPE_CHAR,
                           input_image,
                           SAMPLER,
                           (int2)(pos_in.x + dilation, pos_in.y - dilation)),
             zero_dtype4,
-            (ushort4)((in_pos_in_one_block.x + dilation < 0 ||
+            in_pos_in_one_block.x + dilation < 0 ||
                        in_pos_in_one_block.y - dilation < 0 ||
                        in_pos_in_one_block.x + dilation >= input_width ||
-                       in_pos_in_one_block.y - dilation >= input_height)
-                      << 15));
+                       in_pos_in_one_block.y - dilation >= input_height);
 
         input3 =
-            select(READ_IMG_TYPE(CL_DTYPE_CHAR,
+            SELECT(READ_IMG_TYPE(CL_DTYPE_CHAR,
                                  input_image,
                                  SAMPLER,
                                  (int2)(pos_in.x - dilation, pos_in.y)),
                    zero_dtype4,
-                   (ushort4)((in_pos_in_one_block.x - dilation < 0 ||
+                   in_pos_in_one_block.x - dilation < 0 ||
                               in_pos_in_one_block.y < 0 ||
                               in_pos_in_one_block.x - dilation >= input_width ||
-                              in_pos_in_one_block.y >= input_height)
-                             << 15));
+                              in_pos_in_one_block.y >= input_height);
 
-        input4 = select(
+        input4 = SELECT(
             READ_IMG_TYPE(CL_DTYPE_CHAR,
                           input_image,
                           SAMPLER,
                           (int2)(pos_in.x, pos_in.y)),
             zero_dtype4,
-            (ushort4)((in_pos_in_one_block.x < 0 || in_pos_in_one_block.y < 0 ||
+            in_pos_in_one_block.x < 0 || in_pos_in_one_block.y < 0 ||
                        in_pos_in_one_block.x >= input_width ||
-                       in_pos_in_one_block.y >= input_height)
-                      << 15));
+                       in_pos_in_one_block.y >= input_height);
         input5 =
-            select(READ_IMG_TYPE(CL_DTYPE_CHAR,
+            SELECT(READ_IMG_TYPE(CL_DTYPE_CHAR,
                                  input_image,
                                  SAMPLER,
                                  (int2)(pos_in.x + dilation, pos_in.y)),
                    zero_dtype4,
-                   (ushort4)((in_pos_in_one_block.x + dilation < 0 ||
+                   in_pos_in_one_block.x + dilation < 0 ||
                               in_pos_in_one_block.y < 0 ||
                               in_pos_in_one_block.x + dilation >= input_width ||
-                              in_pos_in_one_block.y >= input_height)
-                             << 15));
-        input6 = select(
+                              in_pos_in_one_block.y >= input_height);
+        input6 = SELECT(
             READ_IMG_TYPE(CL_DTYPE_CHAR,
                           input_image,
                           SAMPLER,
                           (int2)(pos_in.x - dilation, pos_in.y + dilation)),
             zero_dtype4,
-            (ushort4)((in_pos_in_one_block.x - dilation < 0 ||
+            in_pos_in_one_block.x - dilation < 0 ||
                        in_pos_in_one_block.y + dilation < 0 ||
                        in_pos_in_one_block.x - dilation >= input_width ||
-                       in_pos_in_one_block.y + dilation >= input_height)
-                      << 15));
+                       in_pos_in_one_block.y + dilation >= input_height);
         input7 =
-            select(READ_IMG_TYPE(CL_DTYPE_CHAR,
+            SELECT(READ_IMG_TYPE(CL_DTYPE_CHAR,
                                  input_image,
                                  SAMPLER,
                                  (int2)(pos_in.x, pos_in.y + dilation)),
                    zero_dtype4,
-                   (ushort4)((in_pos_in_one_block.x < 0 ||
+                   in_pos_in_one_block.x < 0 ||
                               in_pos_in_one_block.y + dilation < 0 ||
                               in_pos_in_one_block.x >= input_width ||
-                              in_pos_in_one_block.y + dilation >= input_height)
-                             << 15));
-        input8 = select(
+                              in_pos_in_one_block.y + dilation >= input_height);
+        input8 = SELECT(
             READ_IMG_TYPE(CL_DTYPE_CHAR,
                           input_image,
                           SAMPLER,
                           (int2)(pos_in.x + dilation, pos_in.y + dilation)),
             zero_dtype4,
-            (ushort4)((in_pos_in_one_block.x + dilation < 0 ||
+            in_pos_in_one_block.x + dilation < 0 ||
                        in_pos_in_one_block.y + dilation < 0 ||
                        in_pos_in_one_block.x + dilation >= input_width ||
-                       in_pos_in_one_block.y + dilation >= input_height)
-                      << 15));
+                       in_pos_in_one_block.y + dilation >= input_height);
 
         CL_DTYPE tmp_out = 0;
         for (int j = 0; j < 9; j++) {

--- a/lite/backends/opencl/cl_kernel/image/conv2d_5x5_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_5x5_kernel.cl
@@ -86,19 +86,17 @@ __kernel void conv2d_5x5(__private const int global_size_dim0,
                          in_pos_in_one_block.y + batch_index * input_height);
     for (int j = 0; j < 5; j++) {
       for (int k = 0; k < 5; k++) {
-        input = select(
+        input = SELECT(
             READ_IMG_TYPE(CL_DTYPE_CHAR,
                           input_image,
                           SAMPLER,
                           (int2)(pos_in.x + (j - 2) * dilation,
                                  pos_in.y + (k - 2) * dilation)),
             (CL_DTYPE4)(0.0f),
-            (ushort4)(
-                (in_pos_in_one_block.x + (j - 2) * dilation < 0 ||
+                 in_pos_in_one_block.x + (j - 2) * dilation < 0 ||
                  in_pos_in_one_block.y + (k - 2) * dilation < 0 ||
                  in_pos_in_one_block.x + (j - 2) * dilation >= input_width ||
-                 in_pos_in_one_block.y + (k - 2) * dilation >= input_height)
-                << 15));
+                 in_pos_in_one_block.y + (k - 2) * dilation >= input_height);
         int filter_h = k;
         int filter_w = j;
         int filter_c = i;

--- a/lite/backends/opencl/cl_kernel/image/conv2d_7x7_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_7x7_kernel.cl
@@ -72,19 +72,17 @@ __kernel void conv2d_7x7(__private const int global_size_dim0,
                          in_pos_in_one_block.y + batch_index * input_height);
     for (int j = 0; j < 7; j++) {
       for (int k = 0; k < 7; k++) {
-        input = select(
+        input = SELECT(
             READ_IMG_TYPE(CL_DTYPE_CHAR,
                           input_image,
                           SAMPLER,
                           (int2)(pos_in.x + (j - 3) * dilation,
                                  pos_in.y + (k - 3) * dilation)),
             (CL_DTYPE4)(0.0f),
-            (ushort4)(
-                (in_pos_in_one_block.x + (j - 3) * dilation < 0 ||
+                 in_pos_in_one_block.x + (j - 3) * dilation < 0 ||
                  in_pos_in_one_block.y + (k - 3) * dilation < 0 ||
                  in_pos_in_one_block.x + (j - 3) * dilation >= input_width ||
-                 in_pos_in_one_block.y + (k - 3) * dilation >= input_height)
-                << 15));
+                 in_pos_in_one_block.y + (k - 3) * dilation >= input_height);
         int filter_h = k;
         int filter_w = j;
         int filter_c = i;


### PR DESCRIPTION
已验证 ssd_mobilenetv3_small, yolov3_mobilenet_v3 fp32/fp16 通过。

核心思想是要严格遵守 OpenCL API:
```C++
select(float4 a, float b, (u)int c)
select(half4 a, half4 b, (u)short c)
int isgreatequal(float a, float b)
int isgreatequal(half a, half b)
int4 isgreatequal(float4 a, float4 b)
short4 isgreatequal(half4 a, half4 b)
```