### PR TITLE
[lib_size] refine runtime_program in tiny_publish and remove unused NHWC calib kernels,test=develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ message(STATUS "C compiler: ${CMAKE_C_COMPILER}, version: "
         "${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
 message(STATUS "AR tools: ${CMAKE_AR}")
 
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--as-needed")
 
 if(WIN32)
     option(MSVC_STATIC_CRT "use static C Runtime library by default" ON)

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -29,6 +29,7 @@
 namespace paddle {
 namespace lite {
 
+#ifndef LITE_ON_TINY_PUBLISH
 void RuntimeProgram::SaveToProgram(
     std::shared_ptr<cpp::ProgramDesc> program_desc) {
   LOG(INFO) << "Into SaveToProgram";
@@ -163,6 +164,7 @@ void RuntimeProgram::SaveToProgram(
   }
   LOG(INFO) << "SaveToProgram done";
 }
+#endif
 
 // Create runtime program from sub_block desc according to block_idx and
 // program_desc, which is used for while/conditional_block/subgraph op.

--- a/lite/core/program.h
+++ b/lite/core/program.h
@@ -253,9 +253,11 @@ class LITE_API RuntimeProgram {
 
   size_t block_size() { return instructions_.size(); }
 
+#ifndef LITE_ON_TINY_PUBLISH
   // Update the ops and vars of all of blocks to the given program_desc
   // according to the instructions
   void SaveToProgram(std::shared_ptr<cpp::ProgramDesc> program_desc);
+#endif
 
  private:
   RuntimeProgram(const RuntimeProgram&) = delete;

--- a/lite/kernels/arm/calib_compute.cc
+++ b/lite/kernels/arm/calib_compute.cc
@@ -242,40 +242,6 @@ REGISTER_LITE_KERNEL(
 REGISTER_LITE_KERNEL(
     calib,
     kARM,
-    kInt8,
-    kNHWC,
-    paddle::lite::kernels::arm::CalibComputeFp32ToInt8<DATALAYOUT(kNHWC)>,
-    fp32_to_int8)
-    .BindInput("Input",
-               {LiteType::GetTensorTy(TARGET(kARM),
-                                      PRECISION(kFloat),
-                                      DATALAYOUT(kNHWC))})
-    .BindOutput("Out",
-                {LiteType::GetTensorTy(TARGET(kARM),
-                                       PRECISION(kInt8),
-                                       DATALAYOUT(kNHWC))})
-    .Finalize();
-
-REGISTER_LITE_KERNEL(
-    calib,
-    kARM,
-    kInt8,
-    kNHWC,
-    paddle::lite::kernels::arm::CalibComputeInt8ToFp32<DATALAYOUT(kNHWC)>,
-    int8_to_fp32)
-    .BindInput("Input",
-               {LiteType::GetTensorTy(TARGET(kARM),
-                                      PRECISION(kInt8),
-                                      DATALAYOUT(kNHWC))})
-    .BindOutput("Out",
-                {LiteType::GetTensorTy(TARGET(kARM),
-                                       PRECISION(kFloat),
-                                       DATALAYOUT(kNHWC))})
-    .Finalize();
-
-REGISTER_LITE_KERNEL(
-    calib,
-    kARM,
     kInt64,
     kNCHW,
     paddle::lite::kernels::arm::CalibComputeInt64ToInt32<DATALAYOUT(kNCHW)>,
@@ -311,40 +277,6 @@ REGISTER_LITE_KERNEL(
     int8_to_fp32)
     .BindInput("Input", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
-    .Finalize();
-
-REGISTER_LITE_KERNEL(
-    calib_once,
-    kARM,
-    kInt8,
-    kNHWC,
-    paddle::lite::kernels::arm::CalibComputeFp32ToInt8<DATALAYOUT(kNHWC)>,
-    fp32_to_int8)
-    .BindInput("Input",
-               {LiteType::GetTensorTy(TARGET(kARM),
-                                      PRECISION(kFloat),
-                                      DATALAYOUT(kNHWC))})
-    .BindOutput("Out",
-                {LiteType::GetTensorTy(TARGET(kARM),
-                                       PRECISION(kInt8),
-                                       DATALAYOUT(kNHWC))})
-    .Finalize();
-
-REGISTER_LITE_KERNEL(
-    calib_once,
-    kARM,
-    kInt8,
-    kNHWC,
-    paddle::lite::kernels::arm::CalibComputeInt8ToFp32<DATALAYOUT(kNHWC)>,
-    int8_to_fp32)
-    .BindInput("Input",
-               {LiteType::GetTensorTy(TARGET(kARM),
-                                      PRECISION(kInt8),
-                                      DATALAYOUT(kNHWC))})
-    .BindOutput("Out",
-                {LiteType::GetTensorTy(TARGET(kARM),
-                                       PRECISION(kFloat),
-                                       DATALAYOUT(kNHWC))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(


### PR DESCRIPTION
精简runtime_program在tiny_publish下的接口 & 删除calib_op NHWC下的unused kernel, 优化库体积24K；