### PR TITLE
【ARM FP16】support paddings[0]!=paddings[1] FP16 conv_dw compute

### DIFF
--- a/lite/kernels/arm/conv_compute.cc
+++ b/lite/kernels/arm/conv_compute.cc
@@ -143,9 +143,10 @@ void ConvCompute<PRECISION(kFP16), PRECISION(kFP16)>::PrepareForRun() {
   auto act_param = param.activation_param;
   auto act_type = act_param.active_type;
   bool has_active = act_param.has_active;
+  bool pads_less = ((paddings[1] < 2) && (paddings[3] < 2));
   bool conv_3x3_wino = (ic < 8) || (oc < 8);
-  if (param.groups == ic && ic == oc && kps_equal && pads_equal &&
-      no_dilation && flag_dw_3x3) {
+  if (param.groups == ic && ic == oc && kps_equal && pads_less && no_dilation &&
+      flag_dw_3x3) {
     impl_ = new DepthwiseConv<PRECISION(kFP16), PRECISION(kFP16)>;
   } else if (param.groups == 1 && kw == 3 && sw == 2 && no_dilation &&
              ks_equal) {

--- a/lite/kernels/arm/conv_depthwise.h
+++ b/lite/kernels/arm/conv_depthwise.h
@@ -56,7 +56,19 @@ class DepthwiseConv : public KernelLite<TARGET(kARM), Ptype> {
     ch->kernel_func_name = kernel_func_name_;
   }
 
-  std::string kernel_func_name_{"NotImplForConvDw"};
+  std::string kernel_func_name_{"NotImplForConvDW"};
+#define PROFILE_INFO(dtype1, dtype2)                                        \
+  template <>                                                               \
+  void DepthwiseConv<PRECISION(dtype1), PRECISION(dtype2)>::                \
+      SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) { \
+    ch->kernel_func_name = kernel_func_name_;                               \
+  }
+
+#define KERNEL_FUNC_NAME(kernel_func_name) kernel_func_name_ = kernel_func_name;
+
+#else
+#define PROFILE_INFO(dtype1, dtype2)
+#define KERNEL_FUNC_NAME(kernel_func_name)
 #endif
 
  private:

--- a/lite/tests/math/conv_fp16_compute_test.cc
+++ b/lite/tests/math/conv_fp16_compute_test.cc
@@ -291,25 +291,27 @@ TEST(TestConv3x3DwFp16, test_conv3x3_depthwise) {
   if (FLAGS_basic_test) {
     for (auto& stride : {1, 2}) {
       for (auto& pad : {0, 1}) {
-        for (auto& flag_bias : {false, true}) {
-          for (auto& flag_act : {0, 1}) {
-            for (auto& c : {4, 7, 8, 10, 11, 16}) {
-              DDim weights_dim({c, 1, 3, 3});
-              for (auto& batch : {1}) {
-                for (auto& h : {12, 13, 14, 15, 16, 17, 18, 33}) {
-                  DDim dim_in({batch, c, h, h});
-                  const float leakey_relu_scale = 1.0f;
-                  test_conv_fp16(dim_in,
-                                 weights_dim,
-                                 c,
-                                 {stride, stride},
-                                 {pad, pad, pad, pad},
-                                 {1, 1},
-                                 flag_bias,
-                                 flag_act,
-                                 {FLAGS_threads},
-                                 {FLAGS_power_mode},
-                                 leakey_relu_scale);
+        for (auto& pad1 : {0, 1}) {
+          for (auto& flag_bias : {false, true}) {
+            for (auto& flag_act : {0, 1}) {
+              for (auto& c : {4, 7, 8, 10, 11, 16}) {
+                DDim weights_dim({c, 1, 3, 3});
+                for (auto& batch : {1}) {
+                  for (auto& h : {12, 13, 14, 15, 16, 17, 18, 33}) {
+                    DDim dim_in({batch, c, h, h});
+                    const float leakey_relu_scale = 1.0f;
+                    test_conv_fp16(dim_in,
+                                   weights_dim,
+                                   c,
+                                   {stride, stride},
+                                   {pad, pad1, pad, pad1},
+                                   {1, 1},
+                                   flag_bias,
+                                   flag_act,
+                                   {FLAGS_threads},
+                                   {FLAGS_power_mode},
+                                   leakey_relu_scale);
+                  }
                 }
               }
             }


### PR DESCRIPTION
添加不对称的pad_h 或pad_w的conv_depthwise FP16 OP支持，例如paddings=[0,1,0,1] 的conv_3x3s1p0_dw 实现

855-v8-单线程性能：

  | FP32 | FP16 | now_fp16 | improve(fp16/now_fp16-1
-- | -- | -- | -- | --
tf2pd_mv1 | 29.6807 | 19.8139 | 15.9472 | 24.25%
tf2pd_mv2 | 34.5664 | 25.8503 | 18.107 | 42.76%

