### PR TITLE
[XPU] sdk download from url

### DIFF
--- a/cmake/device/xpu.cmake
+++ b/cmake/device/xpu.cmake
@@ -16,31 +16,82 @@ if(NOT LITE_WITH_XPU)
     return()
 endif()
 
+set(XPU_SOURCE_DIR ${THIRD_PARTY_PATH}/xpu)
+
 if(NOT XPU_SDK_ROOT)
     INCLUDE(ExternalProject)
 
-    if(LITE_WITH_X86)
-        set(XPU_URL "https://paddlelite-demo.bj.bcebos.com/devices/baidu/xpu_toolchain-centos6.3-x86_64-gcc8.2.0-latest.tar.gz")
-    elseif(LITE_WITH_ARM)
-        set(XPU_URL "https://paddlelite-demo.bj.bcebos.com/devices/baidu/xpu_toolchain-ubuntu18.04.4-cross_compiling-aarch64-gcc5.4-latest.tar.gz")
-    else()
-        message(FATAL_ERROR "xpu doesn't supported the host device")
+    if(NOT XPU_SDK_URL)
+        set(XPU_SDK_URL "https://baidu-kunlun-product.cdn.bcebos.com/KL-SDK/klsdk-dev_paddle")
     endif()
 
-    set(XPU_SOURCE_DIR "${THIRD_PARTY_PATH}/xpu")
+    if(NOT XPU_SDK_ENV)
+        if(LITE_WITH_X86)
+            set(XPU_SDK_ENV "bdcentos_x86_64")
+        elseif(LITE_WITH_ARM)
+            set(XPU_SDK_ENV "kylin_aarch64")
+        else()
+            message(FATAL_ERROR "xpu doesn't supported the host env")
+        endif()
+    endif()
+
+    # get xre from XPU_XRE_URL
+    set(XPU_XRE_FILE "xre-${XPU_SDK_ENV}")
+    set(XPU_XRE_URL "${XPU_SDK_URL}/${XPU_XRE_FILE}.tar.gz")
+    message(STATUS "XPU_XRE_URL: ${XPU_XRE_URL}")
 
     ExternalProject_Add(
-        extern_xpu_sdk
+        extern_xpu_xre
         ${EXTERNAL_PROJECT_LOG_ARGS}
         DOWNLOAD_DIR          ${XPU_SOURCE_DIR}
-        DOWNLOAD_COMMAND      wget --no-check-certificate -c -q -O xpu_toolchain.tar.gz ${XPU_URL} && tar xf xpu_toolchain.tar.gz
+        DOWNLOAD_COMMAND      wget --no-check-certificate -c -q ${XPU_XRE_URL} && tar xf ${XPU_XRE_FILE}.tar.gz
         CONFIGURE_COMMAND     ""
         BUILD_COMMAND         ""
         UPDATE_COMMAND        ""
         INSTALL_COMMAND       ""
     )
 
-    set(XPU_SDK_ROOT ${XPU_SOURCE_DIR}/xpu_toolchain)
+    set(XPU_XRE_ROOT            "${XPU_SOURCE_DIR}/${XPU_XRE_FILE}/xre"  CACHE PATH "xpu xre include directory" FORCE)
+    set(XPU_XRE_INCLUDE_DIR     "${XPU_XRE_ROOT}/include" CACHE PATH "xpu xre include directory" FORCE)
+    set(XPURT_LIB               "${XPU_XRE_ROOT}/so/libxpurt.so" CACHE FILEPATH "libxpurt.so" FORCE)
+
+    INCLUDE_DIRECTORIES(${XPU_XRE_INCLUDE_DIR})
+
+    ADD_LIBRARY(xpurt SHARED IMPORTED GLOBAL)
+    SET_PROPERTY(TARGET xpurt PROPERTY IMPORTED_LOCATION ${XPURT_LIB})
+    ADD_DEPENDENCIES(xpurt extern_xpu_xre)
+
+    set(xpu_runtime_libs xpurt CACHE INTERNAL "xpu runtime libs")
+
+    # get xdnn from XPU_XDNN_URL
+    set(XPU_XDNN_FILE "xdnn-${XPU_SDK_ENV}")
+    set(XPU_XDNN_URL "${XPU_SDK_URL}/${XPU_XDNN_FILE}.tar.gz")
+    message(STATUS "XPU_XDNN_URL: ${XPU_XDNN_URL}")
+
+    ExternalProject_Add(
+        extern_xpu_xdnn
+        ${EXTERNAL_PROJECT_LOG_ARGS}
+        DOWNLOAD_DIR          ${XPU_SOURCE_DIR}
+        DOWNLOAD_COMMAND      wget --no-check-certificate -c -q ${XPU_XDNN_URL} && tar xf ${XPU_XDNN_FILE}.tar.gz
+        CONFIGURE_COMMAND     ""
+        BUILD_COMMAND         ""
+        UPDATE_COMMAND        ""
+        INSTALL_COMMAND       ""
+    )
+
+    set(XPU_XDNN_ROOT           "${XPU_SOURCE_DIR}/${XPU_XDNN_FILE}/xdnn" CACHE PATH "xpu xdnn root" FORCE)
+    set(XPU_XDNN_INCLUDE_DIR    "${XPU_XDNN_ROOT}/include" CACHE PATH "xpu xdnn include directory" FORCE)
+    set(XPUAPI_LIB              "${XPU_XDNN_ROOT}/so/libxpuapi.so" CACHE FILEPATH "libxpuapi.so" FORCE)
+
+    INCLUDE_DIRECTORIES(${XPU_XDNN_INCLUDE_DIR})
+
+    ADD_LIBRARY(xpuapi SHARED IMPORTED GLOBAL)
+    SET_PROPERTY(TARGET xpuapi PROPERTY IMPORTED_LOCATION ${XPUAPI_LIB})
+    ADD_DEPENDENCIES(xpuapi extern_xpu_xdnn extern_xpu_xre)
+
+    set(xpu_builder_libs xpuapi CACHE INTERNAL "xpu builder libs")
+
+    return()
 endif()
 
 message(STATUS "XPU_SDK_ROOT: ${XPU_SDK_ROOT}")
@@ -53,11 +104,9 @@ INCLUDE_DIRECTORIES(${XPU_XTDK_INCLUDE_DIR})
 
 ADD_LIBRARY(xpuapi SHARED IMPORTED GLOBAL)
 SET_PROPERTY(TARGET xpuapi PROPERTY IMPORTED_LOCATION ${XPUAPI_LIB})
-ADD_DEPENDENCIES(xpuapi extern_xpu_sdk)
 
 ADD_LIBRARY(xpurt SHARED IMPORTED GLOBAL)
 SET_PROPERTY(TARGET xpurt PROPERTY IMPORTED_LOCATION ${XPURT_LIB})
-ADD_DEPENDENCIES(xpurt extern_xpu_sdk)
 
 set(xpu_runtime_libs xpuapi xpurt CACHE INTERNAL "xpu runtime libs")
 set(xpu_builder_libs xpuapi xpurt CACHE INTERNAL "xpu builder libs")
@@ -73,19 +122,15 @@ if(LITE_WITH_XTCL)
 
     ADD_LIBRARY(xtcl SHARED IMPORTED GLOBAL)
     SET_PROPERTY(TARGET xtcl PROPERTY IMPORTED_LOCATION ${XTCL_LIB})
-    ADD_DEPENDENCIES(xtcl extern_xpu_sdk)
 
     ADD_LIBRARY(tvm SHARED IMPORTED GLOBAL)
     SET_PROPERTY(TARGET tvm PROPERTY IMPORTED_LOCATION ${TVM_LIB})
-    ADD_DEPENDENCIES(tvm extern_xpu_sdk)
 
     ADD_LIBRARY(llvm_8 SHARED IMPORTED GLOBAL)
     SET_PROPERTY(TARGET llvm_8 PROPERTY IMPORTED_LOCATION ${LLVM_8_LIB})
-    ADD_DEPENDENCIES(llvm_8 extern_xpu_sdk)
 
     ADD_LIBRARY(xpujitc SHARED IMPORTED GLOBAL)
     SET_PROPERTY(TARGET xpujitc PROPERTY IMPORTED_LOCATION ${XPUJITC_LIB})
-    ADD_DEPENDENCIES(xpujitc extern_xpu_sdk)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDMLC_USE_GLOG=1")
 

--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -37,7 +37,9 @@ BUILD_NPU=OFF
 NPU_DDK_ROOT="$(pwd)/ai_ddk_lib/" # Download HiAI DDK from https://developer.huawei.com/consumer/cn/hiai/
 BUILD_XPU=OFF
 BUILD_XTCL=OFF
-XPU_SDK_ROOT="$(pwd)/xpu_sdk_lib/"
+XPU_SDK_ROOT=""
+XPU_SDK_URL=""
+XPU_SDK_ENV=""
 BUILD_APU=OFF
 APU_DDK_ROOT="$(pwd)/apu_sdk_lib/"
 BUILD_RKNPU=OFF
@@ -184,6 +186,8 @@ function make_tiny_publish_so {
       -DLITE_WITH_XPU=$BUILD_XPU \
       -DLITE_WITH_XTCL=$BUILD_XTCL \
       -DXPU_SDK_ROOT=$XPU_SDK_ROOT \
+      -DXPU_SDK_URL=$XPU_SDK_URL \
+      -DXPU_SDK_ENV=$XPU_SDK_ENV \
       -DLITE_WITH_APU=$BUILD_APU \
       -DAPU_DDK_ROOT=$APU_DDK_ROOT \
       -DLITE_WITH_RKNPU=$BUILD_RKNPU \
@@ -294,6 +298,8 @@ function make_full_publish_so {
       -DLITE_WITH_XPU=$BUILD_XPU \
       -DLITE_WITH_XTCL=$BUILD_XTCL \
       -DXPU_SDK_ROOT=$XPU_SDK_ROOT \
+      -DXPU_SDK_URL=$XPU_SDK_URL \
+      -DXPU_SDK_ENV=$XPU_SDK_ENV \
       -DLITE_WITH_RKNPU=$BUILD_RKNPU \
       -DRKNPU_DDK_ROOT=$RKNPU_DDK_ROOT \
       -DLITE_WITH_TRAIN=$BUILD_TRAIN \
@@ -343,6 +349,8 @@ function make_all_tests {
       -DLITE_WITH_XPU=$BUILD_XPU \
       -DLITE_WITH_XTCL=$BUILD_XTCL \
       -DXPU_SDK_ROOT=$XPU_SDK_ROOT \
+      -DXPU_SDK_URL=$XPU_SDK_URL \
+      -DXPU_SDK_ENV=$XPU_SDK_ENV \
       -DLITE_WITH_APU=$BUILD_APU \
       -DAPU_DDK_ROOT=$APU_DDK_ROOT \
       -DLITE_WITH_RKNPU=$BUILD_RKNPU \
@@ -426,7 +434,9 @@ function make_cuda {
             -DLITE_WITH_EXCEPTION=$WITH_EXCEPTION \
             -DLITE_WITH_XPU=$BUILD_XPU \
             -DLITE_WITH_XTCL=$BUILD_XTCL \
-            -DXPU_SDK_ROOT=$XPU_SDK_ROOT
+            -DXPU_SDK_ROOT=$XPU_SDK_ROOT \
+            -DXPU_SDK_URL=$XPU_SDK_URL \
+            -DXPU_SDK_ENV=$XPU_SDK_ENV
  
   make -j$NUM_PROC
   make publish_inference -j$NUM_PROC
@@ -486,6 +496,8 @@ function make_x86 {
             -DLITE_WITH_XPU=$BUILD_XPU \
             -DLITE_WITH_XTCL=$BUILD_XTCL \
             -DXPU_SDK_ROOT=$XPU_SDK_ROOT \
+            -DXPU_SDK_URL=$XPU_SDK_URL \
+            -DXPU_SDK_ENV=$XPU_SDK_ENV \
             -DLITE_WITH_HUAWEI_ASCEND_NPU=$WITH_HUAWEI_ASCEND_NPU \
             -DHUAWEI_ASCEND_NPU_DDK_ROOT=$HUAWEI_ASCEND_NPU_DDK_ROOT \
             -DCMAKE_BUILD_TYPE=Release \
@@ -673,7 +685,18 @@ function main {
                 shift
                 ;;
             --xpu_sdk_root=*)
-                XPU_SDK_ROOT=$(readlink -f ${i#*=})
+                XPU_SDK_ROOT=${i#*=}
+                if [ -n "${XPU_SDK_ROOT}" ]; then
+                    XPU_SDK_ROOT=$(readlink -f ${XPU_SDK_ROOT})
+                fi
+                shift
+                ;;
+            --xpu_sdk_url=*)
+                XPU_SDK_URL="${i#*=}"
+                shift
+                ;;
+            --xpu_sdk_env=*)
+                XPU_SDK_ENV="${i#*=}"
                 shift
                 ;;
             --python_executable=*)

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -35,6 +35,8 @@ IMAGINATION_NNA_SDK_ROOT="$(pwd)/imagination_nna_sdk"
 # options of compiling baidu XPU lib.
 WITH_BAIDU_XPU=OFF
 BAIDU_XPU_SDK_ROOT=""
+BAIDU_XPU_SDK_URL=""
+BAIDU_XPU_SDK_ENV=""
 # options of compiling intel fpga.
 WITH_INTEL_FPGA=OFF
 INTEL_FPGA_SDK_ROOT="$(pwd)/intel_fpga_sdk" 
@@ -79,6 +81,8 @@ function init_cmake_mutable_options {
                         -DRKNPU_DDK_ROOT=$ROCKCHIP_NPU_SDK_ROOT \
                         -DLITE_WITH_XPU=$WITH_BAIDU_XPU \
                         -DXPU_SDK_ROOT=$BAIDU_XPU_SDK_ROOT \
+                        -DXPU_SDK_URL=$BAIDU_XPU_SDK_URL \
+                        -DXPU_SDK_ENV=$BAIDU_XPU_SDK_ENV \
                         -DLITE_WITH_TRAIN=$WITH_TRAIN  \
                         -DLITE_WITH_IMAGINATION_NNA=$WITH_IMAGINATION_NNA \
                         -DIMAGINATION_NNA_SDK_ROOT=${IMAGINATION_NNA_SDK_ROOT} \
@@ -251,9 +255,11 @@ function print_usage {
     echo -e "|  detailed information about Paddle-Lite RKNPU:  https://paddle-lite.readthedocs.io/zh/latest/demo_guides/rockchip_npu.html                           |"
     echo -e "|                                                                                                                                                      |"
     echo -e "|  arguments of baidu xpu library compiling:                                                                                                           |"
-    echo -e "|     ./lite/tools/build_linux.sh --with_baidu_xpu=ON --baidu_xpu_sdk_root=YourBaiduXpuSdkPath                                                         |"
+    echo -e "|     ./lite/tools/build_linux.sh --with_baidu_xpu=ON                                                                                                  |"
     echo -e "|     --with_baidu_xpu: (OFF|ON); controls whether to compile lib for baidu_xpu, default is OFF                                                        |"
-    echo -e "|     --baidu_xpu_sdk_root: (path to baidu_xpu DDK file) required when compiling baidu_xpu library                                                     |"
+    echo -e "|     --baidu_xpu_sdk_root: (path to baidu_xpu DDK file) optional                                                                                      |"
+    echo -e "|     --baidu_xpu_sdk_url: (baidu_xpu sdk download url) optional                                                                                       |"
+    echo -e "|     --baidu_xpu_sdk_env: (bdcentos_x86_64|centos7_x86_64|ubuntu_x86_64|kylin_aarch64) optional                                                       |"
     echo "--------------------------------------------------------------------------------------------------------------------------------------------------------"
     echo
 }
@@ -353,6 +359,14 @@ function main {
                 ;;
             --baidu_xpu_sdk_root=*)
                 BAIDU_XPU_SDK_ROOT="${i#*=}"
+                shift
+                ;;
+            --baidu_xpu_sdk_url=*)
+                BAIDU_XPU_SDK_URL="${i#*=}"
+                shift
+                ;;
+            --baidu_xpu_sdk_env=*)
+                BAIDU_XPU_SDK_ENV="${i#*=}"
                 shift
                 ;;
             # compiling lib which can operate on intel fpga.


### PR DESCRIPTION
- XPU_SDK_ROOT: 兼容原来的方式，暂时保留。优先级高于XPU_SDK_URL。可选项，默认为空。
- XPU_SDK_URL: sdk下载地址前缀。可选项，默认为```https://baidu-kunlun-product.cdn.bcebos.com/KL-SDK/klsdk-dev_paddle```。
- XPU_SDK_ENV: sdk的编译环境。可选项(bdcentos_x86_64|centos7_x86_64|ubuntu_x86_64|kylin_aarch64)，x86下默认为bdcentos_x86_64，arm下默认为kylin_aarch64