### PR TITLE
[BUGFIX] Fix windows compiling error

### DIFF
--- a/lite/backends/x86/port.h
+++ b/lite/backends/x86/port.h
@@ -68,19 +68,6 @@ static void *dlopen(const char *filename, int flag) {
   return reinterpret_cast<void *>(hModule);
 }
 
-#ifdef LITE_WITH_LOG
-extern struct timeval;
-static int gettimeofday(struct timeval *tp, void *tzp) {
-  LARGE_INTEGER now, freq;
-  QueryPerformanceCounter(&now);
-  QueryPerformanceFrequency(&freq);
-  tp->tv_sec = now.QuadPart / freq.QuadPart;
-  tp->tv_usec = (now.QuadPart % freq.QuadPart) * 1000000 / freq.QuadPart;
-  // uint64_t elapsed_time = sec * 1000000 + usec;
-
-  return (0);
-}
-#endif  // LITE_WITH_LOG
 #endif  // !_WIN32
 
 static void ExecShellCommand(const std::string &cmd, std::string *message) {


### PR DESCRIPTION
### BUG FIX
- windows compiling error： redefinition of `gettimeofday`
  - first defined in: `logging.h`
  - defined again in:  `port.h`