### PR TITLE
[BUG FIX] Fix the issue that paddle_lite_opt can not transform quantified model

### DIFF
--- a/lite/api/python/bin/paddle_lite_opt
+++ b/lite/api/python/bin/paddle_lite_opt
@@ -75,7 +75,7 @@ def main():
     if args.optimize_out is not None:
          a.set_optimize_out(args.optimize_out)
     if args.valid_targets is not None:
-         if args.enable_fp16 is not None:
+         if args.enable_fp16 == "true":
               a.set_valid_places(args.valid_targets, True)
          else:
               a.set_valid_places(args.valid_targets, False)


### PR DESCRIPTION
- reason: FP16 quantification has been set to be enabled by default, it will conflict with int8 or int16 quantification