### PR TITLE
[Python API] add opt.enable_fp16

### DIFF
--- a/lite/api/opt_base.cc
+++ b/lite/api/opt_base.cc
@@ -59,13 +59,12 @@ void OptBase::SetPassesInternal(
   opt_config_.set_passes_internal(passes_internal);
 }
 
-void OptBase::SetValidPlaces(const std::string& valid_places,
-                             bool enable_fp16) {
+void OptBase::SetValidPlaces(const std::string& valid_places) {
   valid_places_.clear();
   auto target_reprs = lite::Split(valid_places, ",");
   for (auto& target_repr : target_reprs) {
     if (target_repr == "arm") {
-      if (enable_fp16) {
+      if (enable_fp16_) {
         valid_places_.emplace_back(
             Place{TARGET(kARM), PRECISION(kFP16), DATALAYOUT(kNCHW)});
       }
@@ -149,13 +148,12 @@ void OptBase::RunOptimize(const std::string& model_dir_path,
                           const std::string& param_path,
                           const std::string& model_type,
                           const std::string& valid_places,
-                          const bool enable_fp16,
                           const std::string& optimized_out_path) {
   SetModelDir(model_dir_path);
   SetModelFile(model_path);
   SetParamFile(param_path);
   SetModelType(model_type);
-  SetValidPlaces(valid_places, enable_fp16);
+  SetValidPlaces(valid_places);
   SetOptimizeOut(optimized_out_path);
   CheckIfModelSupported(false);
   OpKernelInfoCollector::Global().SetKernel2path(kernel2path_map);

--- a/lite/api/opt_base.h
+++ b/lite/api/opt_base.h
@@ -47,7 +47,8 @@ class LITE_API OptBase {
   void SetModelDir(const std::string &model_dir_path);
   void SetModelFile(const std::string &model_path);
   void SetParamFile(const std::string &param_path);
-  void SetValidPlaces(const std::string &valid_places, bool enable_fp16);
+  void EnableFloat16() { enable_fp16_ = true; }
+  void SetValidPlaces(const std::string &valid_places);
   void SetOptimizeOut(const std::string &lite_out_name);
   void RecordModelInfo(bool record_strip_info = true);
   void SetQuantModel(bool quant_model);
@@ -64,7 +65,6 @@ class LITE_API OptBase {
                    const std::string &param_path = "",
                    const std::string &model_type = "",
                    const std::string &valid_places = "",
-                   const bool enable_fp16 = false,
                    const std::string &optimized_out_path = "");
   // fuctions of printing info
   // 1. help info
@@ -83,6 +83,7 @@ class LITE_API OptBase {
   void CheckIfModelSupported(bool print_ops_info = true);
 
  private:
+  bool enable_fp16_{false};
   CxxConfig opt_config_;
   // valid places for the optimized_model
   std::vector<Place> valid_places_;

--- a/lite/api/python/bin/paddle_lite_opt
+++ b/lite/api/python/bin/paddle_lite_opt
@@ -76,9 +76,10 @@ def main():
          a.set_optimize_out(args.optimize_out)
     if args.valid_targets is not None:
          if args.enable_fp16 == "true":
-              a.set_valid_places(args.valid_targets, True)
+              a.enable_fp16()
+              a.set_valid_places(args.valid_targets)
          else:
-              a.set_valid_places(args.valid_targets, False)
+              a.set_valid_places(args.valid_targets)
     if args.param_file is not None:
          a.set_param_file(args.param_file)
     if args.record_tailoring_info == "true":

--- a/lite/api/python/pybind/pybind.cc
+++ b/lite/api/python/pybind/pybind.cc
@@ -64,6 +64,7 @@ void BindLiteOpt(py::module *m) {
       .def("set_model_file", &OptBase::SetModelFile)
       .def("set_param_file", &OptBase::SetParamFile)
       .def("set_valid_places", &OptBase::SetValidPlaces)
+      .def("enable_fp16", &OptBase::EnableFloat16)
       .def("set_optimize_out", &OptBase::SetOptimizeOut)
       .def("set_model_type", &OptBase::SetModelType)
       .def("set_quant_model", &OptBase::SetQuantModel)


### PR DESCRIPTION
- Add python api : `opt::enable_fp16` to enable float16 calculation
