### PR TITLE
[OpenCL] Fix invalid arg size in instance_norm

### DIFF
--- a/lite/kernels/opencl/instance_norm_image_compute.cc
+++ b/lite/kernels/opencl/instance_norm_image_compute.cc
@@ -165,9 +165,9 @@ class InstanceNormImageCompute : public KernelLite<TARGET(kOpenCL),
     CL_CHECK_FATAL(status);
     status = kernel_.setArg(2, out_c_group);
     CL_CHECK_FATAL(status);
-    status = kernel_.setArg(3, lws_[1]);
+    status = kernel_.setArg(3, static_cast<int>(lws_[1]));
     CL_CHECK_FATAL(status);
-    status = kernel_.setArg(4, lws_[2]);
+    status = kernel_.setArg(4, static_cast<int>(lws_[2]));
     CL_CHECK_FATAL(status);
     status = kernel_.setArg(5, epsilon);
     CL_CHECK_FATAL(status);


### PR DESCRIPTION
setArg的参数类型需与kernel内的参数类型一致，如果不一致，不同OpenCL编译器可能无法完成隐式类型转换导致如下的运行时错误。
![image](https://user-images.githubusercontent.com/24290792/117909755-6bd4ff80-b30d-11eb-842f-2de026f37b8f.png)
