### PR TITLE
[utils] Fix mkdir fail on arm

### DIFF
--- a/lite/utils/io.h
+++ b/lite/utils/io.h
@@ -38,6 +38,10 @@ static bool IsFileExists(const std::string& path) {
 
 // ARM mobile not support mkdir in C++
 static void MkDirRecur(const std::string& path) {
+  if (IsFileExists(path)) {
+    LOG(INFO) << "Directory [" << path << "] exists!";
+    return;
+  }
 #ifndef LITE_WITH_ARM
 
 #ifdef _WIN32


### PR DESCRIPTION
- 问题
  - 在 arm 平台下开启精度 profile 时，在调用`MkDirRecur`创建文件夹时报错
  
![image](https://user-images.githubusercontent.com/24290792/118111103-d2454500-b415-11eb-847a-9e1d97b80471.png)

- 原因
  - `mkdir`函数只能创建一个空文件夹，当文件夹已经存在时，函数会返回 -1，导致 CHECK_NE fail
- 解决方法
  - 在创建文件夹之前加入判断路径是否存在，如果已存在则跳过。  