### PR TITLE
[OpenCL] BindTargets kOpenCL for conv_conv_fuse_pass

### DIFF
--- a/lite/core/mir/fusion/conv_conv_fuse_pass.cc
+++ b/lite/core/mir/fusion/conv_conv_fuse_pass.cc
@@ -31,7 +31,8 @@ void ConvConvFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   bool has_int8 = false;
   bool has_weight_quant = false;
   for (auto& place : graph->valid_places()) {
-    if (place.target == TARGET(kARM) || place.target == TARGET(kHost)) {
+    if (place.target == TARGET(kARM) || place.target == TARGET(kHost) ||
+        place.target == TARGET(kOpenCL)) {
       if (place.precision == PRECISION(kInt8)) {
         has_int8 = true;
       }
@@ -77,4 +78,4 @@ void ConvConvFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 }  // namespace paddle
 
 REGISTER_MIR_PASS(lite_conv_conv_fuse_pass, paddle::lite::mir::ConvConvFusePass)
-    .BindTargets({TARGET(kARM)});
+    .BindTargets({TARGET(kARM), TARGET(kOpenCL)});


### PR DESCRIPTION
MobileNetV3_small_x1_0_infer 中含有一个符合条件的 conv+conv 子结构，可以应用 conv_conv_fuse_pass。