### PR TITLE
[DOCS] Update docs to v2.9

### DIFF
--- a/docs/api_reference/python_api/opt.md
+++ b/docs/api_reference/python_api/opt.md
@@ -120,6 +120,9 @@ opt.set_valid_places("arm,opencl")
 
 - `quant_type(str)`-支持设置为`QUANT_INT16`和`QUANT_INT8`
 
+### `enable_fp16()`
+
+启用`Float16 训练后量化`。将模型中权重数据量化为`Float16`对模型精度有一点影响，运行耗时和内存占用几乎降低一半。
 
 ### `run()`
 

--- a/docs/introduction/support_hardware.md
+++ b/docs/introduction/support_hardware.md
@@ -33,9 +33,15 @@ Paddle Lite支持移动端GPU和Nvidia端上GPU设备，支持列表如下：
   Nvida tegra系列: tx1, tx2, nano, xavier
 
 ## FPGA
-Paddle Lite支持FPGA，支持列表如下：
+Paddle Lite支持 **百度 FPGA**，支持列表如下：
 - 百度Edgeboard系列：ZU9, ZU5, ZU3
 
+Paddle Lite支持 **英特尔 (Intel) FPGA**，支持列表如下：
+- 支持芯片：英特尔FPGA Cyclone V系列芯片
+- 支持设备：
+  - 海运捷讯C5MB（英特尔FPGA Cyclone V）开发板
+  - 海运捷讯C5CB（英特尔FPGA Cyclone V）开发板
+  - 海运捷讯C5TB（英特尔FPGA Cyclone V）开发板
 ## 百度 (Baidu) XPU
 Paddle Lite支持百度XPU，支持列表如下：
 - 百度昆仑818-100芯片
@@ -55,11 +61,6 @@ Paddle Lite支持华为达芬奇架构NPU，支持列表如下：
 Paddle Lite支持 瑞芯微 (Rockchip) NPU，支持列表如下：
 - 支持芯片：RK1808, RK1806，暂不支持RK3399Pro
 - 支持设备：RK1808/1806 EVB，TB-RK1808S0
-
-## 英特尔 (Intel) FPGA
-Paddle Lite支持 英特尔 (Inel) FPGA，支持列表如下：
-- 支持芯片：Cyclone V
-- 支持设备：C5MB，C5TB和C5CB
 
 ## 联发科 (MediaTek) APU
 Paddle Lite支持 联发科 (MediaTek) APU，支持列表如下：

--- a/docs/introduction/support_operation_list.md
+++ b/docs/introduction/support_operation_list.md
@@ -1,6 +1,6 @@
 # 支持算子
 
-当前Paddle-Lite共计支持算子204个，其中基础算子78个，附加算子127个。
+当前Paddle-Lite共计支持算子209个，其中基础算子78个，附加算子131个。
 
 ### 基础算子
 
@@ -94,7 +94,7 @@ Host端Kernel是算子在任意CPU上纯C/C++的具体实现，具有可移植�
 
 ### 附加算子
 
-附加算子共计127个，需要在编译时打开`--build_extra=ON`开关才会编译，具体请参考[参数详情](../source_compile/library)。
+附加算子共计131个，需要在编译时打开`--build_extra=ON`开关才会编译，具体请参考[参数详情](../source_compile/library)。
 
 | OP Name | Host | X86 | CUDA | ARM | OpenCL | FPGA | 华为NPU | 百度XPU | 瑞芯微NPU | 联发科APU | 英特尔FPGA |
 |-:|-|-|-|-|-|-|-|-|-|-|-|
@@ -110,6 +110,7 @@ Host端Kernel是算子在任意CPU上纯C/C++的具体实现，具有可移植�
 | clip | 　 | 　 | 　 | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | collect_fpn_proposals | 　 | 　 | 　 | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | conditional_block | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
+| correlation | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | crf_decoding | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | crop | 　 | 　 | 　 | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | ctc_align | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
@@ -163,6 +164,7 @@ Host端Kernel是算子在任意CPU上纯C/C++的具体实现，具有可移植�
 | not_equal | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | one_hot | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | pixel_shuffle | Y | 　 | 　 | Y | Y | 　 | 　 | 　 | 　 | 　 | 　 |
+| polygon_box_transform | Y | 　 | 　 |   | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | pow | 　 | 　 | 　 | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | print | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | read_from_array | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
@@ -173,7 +175,9 @@ Host端Kernel是算子在任意CPU上纯C/C++的具体实现，具有可移植�
 | relu_clipped | 　 | 　 | 　 | Y | 　 | 　 | Y | 　 | 　 | 　 | 　 |
 | retinanet_detection_output | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | roi_align | 　 | 　 | 　 | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
+| roi_perspective_transform | Y | 　 | 　 |   | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | rsqrt | 　 | 　 | 　 | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
+| scatter_nd_add | Y　 |   |   | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | search_aligned_mat_mul | 　 | Y | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | search_attention_padding_mask | 　 | Y | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |
 | search_grnn | 　 | Y | Y | 　 | 　 | 　 | 　 | 　 | 　 | 　 | 　 |

--- a/docs/source_compile/library_tailoring.md
+++ b/docs/source_compile/library_tailoring.md
@@ -5,17 +5,12 @@ Paddle-Lite支持**根据模型裁剪预测库**功能。Paddle-Lite的一般编
 
 ## 效果展示(Android动态预测库体积)
 
-| 测试模型 | 裁剪开关  | **libpaddle_lite_jni.so** |转化后模型中的OP|
+| 测试模型 | 裁剪开关  | **libpaddle_light_api_shared.so** |转化后模型中的OP|
 | ------------------ | ---------------------------- | -------- |------------------|
-| mobilenetv1（armv8） | 裁剪前 | 1.5M                | feed,etch,conv2d,depthwise_conv2d,fc,fpool2d,softmax     |
-| mobilenetv1（armv8） | 裁剪后 |  788K              |feed,etch,conv2d,depthwise_conv2d,fc,fpool2d,softmax|
-| mobilenetv2（armv8） | 裁剪前 | 1.5M                | feed,fetch,conv2d,depthwise_conv2d,elementwise_add,fc,pool2d,relu6,softmax |
-| mobilenetv2（armv8） | 裁剪后 |  912K          |feed,fetch,conv2d,depthwise_conv2d,elementwise_add,fc,pool2d,relu6,softmax|
-| mobilenetv1（armv7） | 裁剪前 | 938K     |feed,fetch,concat,conv2d,dropout,fc,pool2d,softmax|
-| mobilenetv1（armv7） | 裁剪后 | 607K   |feed,fetch,concat,conv2d,dropout,fc,pool2d,softmax|
-| mobilenetv2（armv7） | 裁剪前 | 938K | feed,fetch,conv2d,depthwise_conv2d,elementwise_add,fc,pool2d,relu6,softmax |
-| mobilenetv2（armv7） | 裁剪后 |687K          |feed,fetch,conv2d,depthwise_conv2d,elementwise_add,fc,pool2d,relu6,softmax|
-
+| mobilenetv1（armv8） | 裁剪前 | 1.5 MB       | conv2d,depthwise_conv2d,fc,pool2d,softmax |
+| mobilenetv1（armv8） | 裁剪后 |  859 KB     | conv2d,depthwise_conv2d,fc,pool2d,softmax |
+| mobilenetv1（armv7） | 裁剪前 | 967 KB | conv2d,depthwise_conv2d,fc,pool2d,softmax |
+| mobilenetv1（armv7） | 裁剪后 | 563 KB |conv2d,depthwise_conv2d,fc,pool2d,softmax|
 
 
 ## 实现过程：

--- a/docs/user_guides/model_optimize_tool.md
+++ b/docs/user_guides/model_optimize_tool.md
@@ -5,28 +5,22 @@ Paddle-Lite 提供了多种策略来自动优化原始的训练模型，其中�
 
 具体使用方法介绍如下：
 
-## opt 下载和使用方法
-### 方法一： 通过Python 安装和调用 opt 工具
-- 支持环境：`windows\Mac\Ubuntu`
-- 安装方法: 通过`pip`工具安装`Paddle-Lite`到`Python`
+## opt 安装和使用方法
+- 安装方法
+  - 环境要求：`windows\Mac\Ubuntu`
+  - 环境依赖： 
+    - python == `2.7`/`3.5`/`3.6`/`3.7`
+    - pip
 ```bash
-# 当前最新版本是 2.8
-pip install paddlelite==2.8
+# 当前最新版本是 2.9
+pip install paddlelite==2.9
 ```
-- 使用`opt`转化和分析模型
-    - 方法一： [使用终端命令](./opt/opt_python) （支持Mac/Ubuntu)
-    - 方法二： [使用python脚本](../api_reference/python_api/opt)（支持window/Mac/Ubuntu）
+- `opt`转化和分析模型： 可通过**终端命令**或**Python脚本**调用
+    - [终端命令方法](./opt/opt_python) （支持`Mac/Ubuntu`)
+    - [python脚本方法](../api_reference/python_api/opt)（支持`Window/Mac/Ubuntu`）
 
 
-### 方法二： 下载和调用 opt 可执行文件
-- 支持环境：`Mac\Ubuntu`
-- 安装方法: 直接下载可执行文件
-从[release界面](https://github.com/PaddlePaddle/Paddle-Lite/releases)或[预测库下载界面](../quick_start/release_lib)下载与预测库版本一致的`opt`工具
-- 使用`opt`转化和分析模型
-    - 方法：[直接下载并执行opt可执行工具](./opt/opt_bin)（支持Mac/Ubuntu)
-
-
-## 合并x2paddle和opt的一键脚本
+## 合并x2paddle和opt功能的一键脚本
 
 **背景**：如果想用Paddle-Lite运行第三方来源（tensorflow、caffe、onnx）模型，一般需要经过两次转化。即使用x2paddle工具将第三方模型转化为PaddlePaddle格式，再使用opt将PaddlePaddle模型转化为Padde-Lite可支持格式。
 为了简化这一过程，我们提供了：

--- a/docs/user_guides/x2paddle.md
+++ b/docs/user_guides/x2paddle.md
@@ -8,6 +8,9 @@ X2Paddle可以将caffe、tensorflow、onnx模型转换成Paddle支持的模型�
 
 ## 安装
 
+- 环境依赖
+  - python >= 3.5
+  - paddlepaddle >= 2.0.0
 ```
 pip install x2paddle
 ```


### PR DESCRIPTION
- 更新文档信息到 `v2.9`
- opt 文档较大改动
  - 删除opt_bin 相关文档、只保留opt 的python 调用方法
  - opt 相关操作使用gif 动图的方法展现

**举例**
![trans](https://user-images.githubusercontent.com/45189361/119163491-0a8bf980-ba8e-11eb-93db-5b415be31e77.gif)
