### PR TITLE
[ARM]add erf, sign, flip, and fix bugs

### DIFF
--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -134,7 +134,10 @@ enum class ActivationType : int {
   kSigmoid_v2 = 16,
   kTanh_v2 = 17,
   kGelu = 18,
-  NUM = 19,
+  kErf = 19,
+  kSign = 20,
+  kSoftPlus = 21,
+  NUM = 22,
 };
 
 static size_t PrecisionTypeLength(PrecisionType type) {

--- a/lite/backends/arm/math/activation.cc
+++ b/lite/backends/arm/math/activation.cc
@@ -806,6 +806,42 @@ void act_abs<float>(const float* din, float* dout, int size, int threads) {
   }
 }
 
+template <typename T>
+void erf(const T* din, T* dout, int size, int threads) {
+  for (int i = 0; i < size; ++i) {
+    dout[0] = std::erf(din[0]);
+    din++;
+    dout++;
+  }
+}
+
+template void erf<float>(const float* din, float* dout, int size, int threads);
+
+template <typename T>
+void sign(const T* din, T* dout, int size, int threads) {
+  for (int i = 0; i < size; ++i) {
+    dout[0] = (dout[0] >= (T)0) - ((T)0 >= dout[0]);
+    din++;
+    dout++;
+  }
+}
+
+template void sign<float>(const float* din, float* dout, int size, int threads);
+
+template <typename T>
+void softplus(const T* din, T* dout, int size, int threads) {
+  for (int i = 0; i < size; ++i) {
+    dout[0] = log((T)1. + exp(din[i]));
+    din++;
+    dout++;
+  }
+}
+
+template void softplus<float>(const float* din,
+                              float* dout,
+                              int size,
+                              int threads);
+
 template <>
 void act_thresholded_relu<float>(
     const float* din, float* dout, int size, float threshold, int threads) {

--- a/lite/backends/arm/math/activation.h
+++ b/lite/backends/arm/math/activation.h
@@ -99,6 +99,15 @@ void act_elu(const T* din, T* dout, int size, float alpha, int threads);
 template <typename T>
 void act_gelu(const T* din, T* dout, int size, bool approximate, int threads);
 
+template <typename T>
+void erf(const T* din, T* dout, int size, int threads);
+
+template <typename T>
+void sign(const T* din, T* dout, int size, int threads);
+
+template <typename T>
+void softplus(const T* din, T* dout, int size, int threads);
+
 }  // namespace math
 }  // namespace arm
 }  // namespace lite

--- a/lite/kernels/arm/activation_extra_compute.cc
+++ b/lite/kernels/arm/activation_extra_compute.cc
@@ -163,6 +163,45 @@ void GeluCompute::Run() {
       x_data, output_data, x_dims.production(), approximate, ctx.threads());
 }
 
+template <typename T>
+void ErfCompute<T>::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->template data<T>();
+  auto output_data = param.Out->template mutable_data<T>();
+  float alpha = param.Elu_alpha;
+  lite::arm::math::erf<T>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+template class ErfCompute<float>;
+
+template <typename T>
+void SignCompute<T>::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->template data<T>();
+  auto output_data = param.Out->template mutable_data<T>();
+  float alpha = param.Elu_alpha;
+  lite::arm::math::sign<T>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+template class SignCompute<float>;
+
+template <typename T>
+void SoftPlusCompute<T>::Run() {
+  auto& param = this->Param<param_t>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto x_dims = param.X->dims();
+  auto x_data = param.X->template data<T>();
+  auto output_data = param.Out->template mutable_data<T>();
+  float alpha = param.Elu_alpha;
+  lite::arm::math::softplus<T>(
+      x_data, output_data, x_dims.production(), ctx.threads());
+}
+template class SoftPlusCompute<float>;
+
 }  // namespace arm
 }  // namespace kernels
 }  // namespace lite
@@ -252,4 +291,22 @@ REGISTER_LITE_KERNEL(
     gelu, kARM, kFloat, kNCHW, paddle::lite::kernels::arm::GeluCompute, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+
+using float_erf = paddle::lite::kernels::arm::ErfCompute<float>;
+REGISTER_LITE_KERNEL(erf, kARM, kAny, kNCHW, float_erf, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .Finalize();
+
+using float_sign = paddle::lite::kernels::arm::SignCompute<float>;
+REGISTER_LITE_KERNEL(sign, kARM, kAny, kNCHW, float_sign, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .Finalize();
+
+using float_softplus = paddle::lite::kernels::arm::SoftPlusCompute<float>;
+REGISTER_LITE_KERNEL(softplus, kARM, kAny, kNCHW, float_softplus, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kAny))})
     .Finalize();

--- a/lite/kernels/arm/activation_extra_compute.h
+++ b/lite/kernels/arm/activation_extra_compute.h
@@ -139,6 +139,35 @@ class GeluCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
   virtual ~GeluCompute() = default;
 };
 
+template <typename T>
+class ErfCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+ public:
+  using param_t = operators::ActivationParam;
+
+  void Run() override;
+
+  virtual ~ErfCompute() = default;
+};
+
+template <typename T>
+class SignCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+ public:
+  using param_t = operators::ActivationParam;
+
+  void Run() override;
+
+  virtual ~SignCompute() = default;
+};
+
+template <typename T>
+class SoftPlusCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+ public:
+  using param_t = operators::ActivationParam;
+
+  void Run() override;
+
+  virtual ~SoftPlusCompute() = default;
+};
 }  // namespace arm
 }  // namespace kernels
 }  // namespace lite

--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -904,6 +904,16 @@ REGISTER_LITE_KERNEL(
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
+
+using elementwise_mod_int32_f =
+    paddle::lite::kernels::arm::ElementwiseModCompute<int32_t,
+                                                      PRECISION(kFloat)>;
+REGISTER_LITE_KERNEL(
+    elementwise_mod, kARM, kFloat, kNCHW, elementwise_mod_int32_f, int32_mod)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .Finalize();
 #endif  // LITE_BUILD_EXTRA
 
 using elementwise_pow_fp32_t =

--- a/lite/kernels/arm/reduce_prod_compute.cc
+++ b/lite/kernels/arm/reduce_prod_compute.cc
@@ -92,6 +92,8 @@ using reduce_prob_arm_int32 =
     paddle::lite::kernels::arm::ReduceProdCompute<int, PRECISION(kInt32)>;
 using reduce_prob_arm_float =
     paddle::lite::kernels::arm::ReduceProdCompute<float, PRECISION(kFloat)>;
+using reduce_prob_arm_int64 =
+    paddle::lite::kernels::arm::ReduceProdCompute<int64_t, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
     reduce_prod, kARM, kInt32, kNCHW, reduce_prob_arm_int32, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
@@ -102,4 +104,10 @@ REGISTER_LITE_KERNEL(
     reduce_prod, kARM, kFloat, kNCHW, reduce_prob_arm_float, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    reduce_prod, kARM, kFloat, kNCHW, reduce_prob_arm_int64, reduce_prod_i64)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();

--- a/lite/kernels/arm/slice_compute.cc
+++ b/lite/kernels/arm/slice_compute.cc
@@ -26,11 +26,20 @@ namespace arm {
 inline std::vector<int64_t> get_new_data_from_tensorlist(
     const std::vector<lite::Tensor*>& list_new_data_tensor) {
   // get tensor
+
   std::vector<int64_t> vec_new_data;
   for (size_t i = 0; i < list_new_data_tensor.size(); ++i) {
     auto tensor = list_new_data_tensor[i];
     CHECK_EQ(tensor->dims(), DDim({1})) << "shape of dim tensor should be [1]";
-    vec_new_data.push_back(static_cast<int64_t>(*tensor->data<int64_t>()));
+    if (tensor->precision() == PrecisionType::kInt32) {
+      vec_new_data.push_back(static_cast<int64_t>(*tensor->data<int32_t>()));
+    } else if (tensor->precision() == PrecisionType::kInt64) {
+      vec_new_data.push_back(static_cast<int64_t>(*tensor->data<int64_t>()));
+    } else {
+      LOG(FATAL) << "slice StartsTensor or EndsTensor :The dtype of Tensor "
+                    "must be int32 "
+                    "or int64";
+    }
   }
   return vec_new_data;
 }
@@ -38,9 +47,20 @@ inline std::vector<int64_t> get_new_data_from_tensorlist(
 inline std::vector<int64_t> get_new_data_from_tensor(
     const lite::Tensor* new_data_tensor) {
   std::vector<int64_t> vec_new_data;
-  auto* new_data = new_data_tensor->data<int64_t>();
-  vec_new_data =
-      std::vector<int64_t>(new_data, new_data + new_data_tensor->numel());
+  if (new_data_tensor->precision() == PrecisionType::kInt32) {
+    auto* new_data = new_data_tensor->data<int32_t>();
+    // a int32->int64 convert here
+    vec_new_data =
+        std::vector<int64_t>(new_data, new_data + new_data_tensor->numel());
+  } else if (new_data_tensor->precision() == PrecisionType::kInt64) {
+    auto* new_data = new_data_tensor->data<int64_t>();
+    vec_new_data =
+        std::vector<int64_t>(new_data, new_data + new_data_tensor->numel());
+  } else {
+    LOG(FATAL) << "slice StartsTensor or EndsTensor :The dtype of Tensor must "
+                  "be int32 "
+                  "or int64";
+  }
   return vec_new_data;
 }
 
@@ -176,6 +196,21 @@ void SliceCompute<T, PType>::Run() {
 using slice_float =
     paddle::lite::kernels::arm::SliceCompute<float, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(slice, kARM, kFloat, kNCHW, slice_float, def)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .BindInput("StartsTensor",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("EndsTensor",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    slice, kARM, kFloat, kNCHW, slice_float, float_i64_starts_ends)
     .BindInput("Input",
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
     .BindInput("StartsTensor",

--- a/lite/kernels/host/CMakeLists.txt
+++ b/lite/kernels/host/CMakeLists.txt
@@ -89,6 +89,7 @@ add_kernel(lod_reset_compute_host Host extra SRCS lod_reset_compute.cc DEPS ${li
 add_kernel(argsort_compute_host Host extra SRCS argsort_compute.cc DEPS ${lite_kernel_deps})
 add_kernel(distribute_fpn_proposals_compute_host Host extra SRCS distribute_fpn_proposals_compute.cc DEPS ${lite_kernel_deps})
 add_kernel(collect_fpn_proposals_compute_host Host extra SRCS collect_fpn_proposals_compute.cc DEPS ${lite_kernel_deps})
+add_kernel(flip_compute_host Host extra SRCS flip_compute.cc DEPS ${lite_kernel_deps})
 
 if(LITE_BUILD_EXTRA AND LITE_WITH_x86)
   lite_cc_test(test_where_index_compute_host SRCS where_index_compute.cc DEPS where_index_compute_host)

--- a/lite/kernels/host/compare_compute.cc
+++ b/lite/kernels/host/compare_compute.cc
@@ -14,6 +14,9 @@
 
 #include "lite/kernels/host/compare_compute.h"
 #include <math.h>
+#include <algorithm>
+#include <cstdlib>
+#include <functional>
 #include <vector>
 
 namespace paddle {
@@ -52,12 +55,114 @@ struct _NotEqualFunctor<float> {
   }
 };
 
+inline int GetElementwiseIndex(const int64_t *x_dims_array,
+                               const int max_dim,
+                               const int *index_array) {
+  int index_ = 0;
+  for (int i = 0; i < max_dim; i++) {
+    if (x_dims_array[i] > 1) {
+      index_ = index_ * x_dims_array[i] + index_array[i];
+    }
+  }
+  return index_;
+}
+
+inline void UpdateElementwiseIndexArray(const int64_t *out_dims_array,
+                                        const int max_dim,
+                                        int *index_array) {
+  for (int i = max_dim - 1; i >= 0; --i) {
+    ++index_array[i];
+    if (index_array[i] >= out_dims_array[i]) {
+      index_array[i] -= out_dims_array[i];
+    } else {
+      break;
+    }
+  }
+}
+
+template <typename Functor, typename T, typename OutType = T>
+void CommonForwardBroadcast(const T *x_data,
+                            const T *y_data,
+                            OutType *out_data,
+                            int64_t *x_dims_array,
+                            int64_t *y_dims_array,
+                            int64_t *out_dims_array,
+                            int max_dim,
+                            Functor func) {
+  std::vector<int> index_array(max_dim, 0);
+
+  const int out_size = std::accumulate(
+      out_dims_array, out_dims_array + max_dim, 1, std::multiplies<int64_t>());
+  int x_index, y_index;
+  for (int out_index = 0; out_index < out_size; ++out_index) {
+    x_index = GetElementwiseIndex(x_dims_array, max_dim, index_array.data());
+    y_index = GetElementwiseIndex(y_dims_array, max_dim, index_array.data());
+    out_data[out_index] = func(x_data[x_index], y_data[y_index]);
+
+    UpdateElementwiseIndexArray(out_dims_array, max_dim, index_array.data());
+  }
+}
+
+inline lite::DDim trim_trailing_singular_dims(const lite::DDim &dims) {
+  // Remove trailing dimensions of size 1 for y
+  auto actual_dims_size = dims.size();
+  for (; actual_dims_size != 0; --actual_dims_size) {
+    if (dims[actual_dims_size - 1] != 1) break;
+  }
+  if (actual_dims_size == dims.size()) return dims;
+  std::vector<int64_t> trim_dims;
+  trim_dims.resize(actual_dims_size);
+  for (int i = 0; i < actual_dims_size; ++i) {
+    trim_dims[i] = dims[i];
+  }
+  if (trim_dims.size() == 0) {
+    return lite::DDim();
+  }
+  lite::DDim actual_dims = lite::DDim(trim_dims);
+  return actual_dims;
+}
+
+template <typename Functor, typename T, typename OutType = T>
+void CommonElementwiseBroadcastForward(const T *x,
+                                       const T *y,
+                                       OutType *z,
+                                       const DDim &x_dims,
+                                       const DDim &y_dims,
+                                       const DDim &out_dims,
+                                       Functor func,
+                                       int axis) {
+  int max_dim = std::max(x_dims.size(), y_dims.size());
+  axis = (axis == -1 ? abs(static_cast<int>(x_dims.size()) -
+                           static_cast<int>(y_dims.size()))
+                     : axis);
+  CHECK_GE(axis, 0)
+      << "Axis should be great than or equal to 0, but received axis is "
+      << axis << ".";
+
+  CHECK_LT(axis, max_dim)
+      << "Axis should be less than %d, but received axis is " << axis << ".";
+
+  std::vector<int64_t> x_dims_array = x_dims.Vectorize();
+  std::vector<int64_t> y_dims_array = y_dims.Vectorize();
+  std::vector<int64_t> out_dims_array = out_dims.Vectorize();
+
+  CommonForwardBroadcast<Functor, T, OutType>(x,
+                                              y,
+                                              z,
+                                              x_dims_array.data(),
+                                              y_dims_array.data(),
+                                              out_dims_array.data(),
+                                              max_dim,
+                                              func);
+}
+
 inline void get_mid_dims(const lite::DDim &x_dims,
                          const lite::DDim &y_dims,
                          const int axis,
                          int *pre,
                          int *n,
-                         int *post) {
+                         int *post,
+                         int *is_run_common_broadcast) {
   *pre = 1;
   *n = 1;
   *post = 1;
@@ -66,6 +171,10 @@ inline void get_mid_dims(const lite::DDim &x_dims,
   }
 
   for (int i = 0; i < y_dims.size(); ++i) {
+    // do broadcast
+    if (x_dims[i + axis] != y_dims[i]) {
+      *is_run_common_broadcast = 1;
+    }
     (*n) *= y_dims[i];
   }
 
@@ -90,14 +199,32 @@ void CompareCompute<PType, CompareFunctor>::Run() {
       z[i] = CompareFunctor()(x[i], y[i]);
     }
   } else {
-    int axis = (param.axis == -1 ? x_dims.size() - y_dims.size() : param.axis);
+    int axis = (param.axis == -1 ? abs(static_cast<int>(x_dims.size()) -
+                                       static_cast<int>(y_dims.size()))
+                                 : param.axis);
     // If Y contains only one data, all_broad_cast mode will be applied.
     // In this mode, each member in X will compare to the only var in Y.
     if (param.Y->numel() == 1) {
       axis = x_dims.size();
     }
     int outer_num, mid_num, inner_num;
-    get_mid_dims(x_dims, y_dims, axis, &outer_num, &mid_num, &inner_num);
+    int is_run_common_broadcast, axis_trim = 0;
+    auto y_dims_trimed = trim_trailing_singular_dims(y_dims);
+    axis_trim = (y_dims_trimed.size() == 0) ? x_dims.size() : axis;
+    get_mid_dims(x_dims,
+                 y_dims_trimed,
+                 axis_trim,
+                 &outer_num,
+                 &mid_num,
+                 &inner_num,
+                 &is_run_common_broadcast);
+    if (is_run_common_broadcast == 1) {
+      CommonElementwiseBroadcastForward<CompareFunctor, DType, bool>(
+          x, y, z, x_dims, y_dims, param.Out->dims(), CompareFunctor(), axis);
+      return;
+    }
+
+    // get_mid_dims(x_dims, y_dims, axis, &outer_num, &mid_num, &inner_num);
     for (int outer_id = 0; outer_id < outer_num; ++outer_id) {
       for (int mid_id = 0; mid_id < mid_num; ++mid_id) {
         auto y_data = y[mid_id];

--- a/lite/kernels/host/flip_compute.cc
+++ b/lite/kernels/host/flip_compute.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/host/flip_compute.h"
+#include "lite/api/paddle_place.h"
+#include "lite/core/op_registry.h"
+
+REGISTER_LITE_KERNEL(flip,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::FlipCompute<float>,
+                     flip_fp32)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFloat))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFloat))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(flip,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::FlipCompute<int64_t>,
+                     flip_i64)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt64))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt64))})
+    .Finalize();

--- a/lite/kernels/host/flip_compute.h
+++ b/lite/kernels/host/flip_compute.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <stdint.h>
+#include <bitset>
+#include <vector>
+#include "lite/core/kernel.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <typename T>
+class FlipCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
+ public:
+  using param_t = operators::FcParam;
+
+  void Run() {
+    constexpr size_t dim_bitset_size = 64;
+    auto& param = this->Param<operators::FlipParam>();
+    auto x = param.X;
+    auto out = param.Out;
+    auto flip_dims = param.axis;
+
+    auto x_dims = x->dims();
+    const int total_dims = x_dims.size();
+    std::bitset<dim_bitset_size> dim_bitset;
+    for (size_t i = 0; i < flip_dims.size(); ++i) {
+      int dim = flip_dims[i];
+      if (flip_dims[i] < 0) {
+        dim += total_dims;
+      }
+      dim_bitset[dim] = true;
+    }
+    auto x_strides = x_dims.Vectorize();
+    auto numel = x->numel();
+    const T* x_data = x->template data<T>();
+    T* out_data = out->template mutable_data<T>();
+#pragma omp parallel for
+    for (int64_t i = 0; i < numel; ++i) {
+      int64_t cur_indices = i;
+      int64_t rem = 0;
+      int64_t dst_offset = 0;
+
+      for (int d = 0; d < total_dims; ++d) {
+        int64_t temp = cur_indices;
+        cur_indices = cur_indices / x_strides[d];
+        rem = temp - cur_indices * x_strides[d];
+        dst_offset += dim_bitset[d]
+                          ? (x_dims[d] - 1 - cur_indices) * x_strides[d]
+                          : cur_indices * x_strides[d];
+        cur_indices = rem;
+      }
+      out_data[i] = x_data[dst_offset];
+    }
+  }
+
+  ~FlipCompute() = default;
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/operators/CMakeLists.txt
+++ b/lite/operators/CMakeLists.txt
@@ -148,6 +148,7 @@ add_operator(meshgrid_op_lite extra SRCS meshgrid_op.cc DEPS ${op_DEPS})
 add_operator(linspace_op extra SRCS linspace_op.cc DEPS ${op_DEPS})
 add_operator(roi_perspective_transform_op extra SRCS roi_perspective_transform_op.cc DEPS ${op_DEPS})
 add_operator(argsort_op extra SRCS argsort_op.cc DEPS ${op_DEPS})
+add_operator(flip_op extra SRCS flip_op.cc DEPS ${op_DEPS})
 
 # for OCR specific
 add_operator(while_op extra SRCS while_op.cc DEPS ${op_DEPS})

--- a/lite/operators/activation_ops.cc
+++ b/lite/operators/activation_ops.cc
@@ -88,6 +88,12 @@ bool ActivationOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
     if (opdesc.HasAttr("approximate")) {
       param_.gelu_approximate = opdesc.GetAttr<bool>("approximate");
     }
+  } else if (opdesc.Type() == "erf") {
+    param_.active_type = lite_api::ActivationType::kErf;
+  } else if (opdesc.Type() == "sign") {
+    param_.active_type = lite_api::ActivationType::kSign;
+  } else if (opdesc.Type() == "softplus") {
+    param_.active_type = lite_api::ActivationType::kSoftPlus;
   }
 
   VLOG(4) << "opdesc.Type():" << opdesc.Type();
@@ -109,3 +115,5 @@ REGISTER_LITE_OP(relu6, paddle::lite::operators::ActivationOp);
 REGISTER_LITE_OP(prelu, paddle::lite::operators::ActivationOp);
 REGISTER_LITE_OP(thresholded_relu, paddle::lite::operators::ActivationOp);
 REGISTER_LITE_OP(elu, paddle::lite::operators::ActivationOp);
+REGISTER_LITE_OP(erf, paddle::lite::operators::ActivationOp);
+REGISTER_LITE_OP(softplus, paddle::lite::operators::ActivationOp);

--- a/lite/operators/activation_ops.h
+++ b/lite/operators/activation_ops.h
@@ -95,6 +95,12 @@ class ActivationOp : public OpLite {
       case lite_api::ActivationType::kGelu:
         ch->macs = param_.X->numel();
         break;
+      case lite_api::ActivationType::kErf:
+        ch->macs = param_.X->numel();
+        break;
+      case lite_api::ActivationType::kSign:
+        ch->macs = param_.X->numel();
+        break;
       default:
         LOG(FATAL) << "This Type of Activation:"
                    << static_cast<int>(param_.active_type)

--- a/lite/operators/flip_op.cc
+++ b/lite/operators/flip_op.cc
@@ -1,0 +1,90 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/flip_op.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+bool FlipOp::CheckShape() const {
+  CHECK_OR_FALSE(param_.X);
+  CHECK_OR_FALSE(param_.Out);
+  return true;
+}
+
+bool FlipOp::InferShapeImpl() const {
+  auto x_dims = param_.X->dims();
+  auto flip_dims = param_.axis;
+  auto flip_dims_size = flip_dims.size();
+  CHECK_GT_OR_FALSE(flip_dims_size, 0);
+
+  auto min_max_d = std::minmax_element(flip_dims.begin(), flip_dims.end());
+  CHECK_LT(*min_max_d.first, static_cast<int32_t>(x_dims.size()))
+      << "min(axes) should be less than the input tensor X's "
+         "axes of FlipOp. But received min(axes) = "
+      << *min_max_d.first << ",  X's axes = " << x_dims.size()
+      << ", X's shape = [" << x_dims << "]";
+
+  CHECK_GE(*min_max_d.first, static_cast<int32_t>(x_dims.size() * -1))
+      << "min(axes) should be greater than the input tensor X's "
+         "axes of FlipOp times -1. But received min(axes) = "
+      << *min_max_d.first << ",  X's axes = " << x_dims.size()
+      << ", X's shape = [" << x_dims << "]";
+
+  CHECK_GE(*min_max_d.second, static_cast<int32_t>(x_dims.size() * -1))
+      << "max(axes) should be greater than the input tensor X's "
+         "axes of FlipOp times -1. But received max(axes) = "
+      << *min_max_d.second << ",  X's axes = " << x_dims.size()
+      << ", X's shape = [" << x_dims << "]";
+
+  CHECK_LT(*min_max_d.second, static_cast<int32_t>(x_dims.size()))
+      << "min(axes) should be less than the input tensor X's "
+         "axes of FlipOp. But received min(axes) = "
+      << *min_max_d.second << ",  X's axes = " << x_dims.size()
+      << ", X's shape = [" << x_dims << "]";
+
+  flip_dims.erase(std::unique(flip_dims.begin(), flip_dims.end()),
+                  flip_dims.end());
+  CHECK_EQ(flip_dims.size(), flip_dims_size)
+      << "axes has duplicates, original flip axes size=" << flip_dims_size
+      << ", but unique flip axes size=" << flip_dims.size() << ".";
+  std::vector<int64_t> output_dims(x_dims.size());
+  for (int i = 0; i < x_dims.size(); ++i) {
+    output_dims[i] = x_dims[i];
+  }
+
+  param_.Out->Resize(output_dims);
+
+  return true;
+}
+
+bool FlipOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
+  auto x_var = scope->FindVar(opdesc.Input("X").front());
+  auto output_var = scope->FindVar(opdesc.Output("Out").front());
+  CHECK(x_var);
+  CHECK(output_var);
+  param_.X = const_cast<lite::Tensor *>(&(x_var->Get<lite::Tensor>()));
+  param_.Out = output_var->GetMutable<lite::Tensor>();
+  param_.axis = opdesc.GetAttr<std::vector<int>>("axis");
+
+  return true;
+}
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_OP(flip, paddle::lite::operators::FlipOp)

--- a/lite/operators/flip_op.h
+++ b/lite/operators/flip_op.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+#include "lite/core/op_lite.h"
+#include "lite/core/scope.h"
+#include "lite/utils/all.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+class FlipOp : public OpLite {
+ public:
+  FlipOp() {}
+  explicit FlipOp(const std::string &op_type) : OpLite(op_type) {}
+
+  bool CheckShape() const override;
+
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+
+  bool InferShapeImpl() const override;
+
+  bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+  std::string DebugString() const override { return "flip"; }
+
+ protected:
+  mutable FlipParam param_;
+  int axis_;
+};
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -2393,6 +2393,13 @@ struct ArgsortParam : ParamBase {
   bool descending{false};
 };
 
+struct FlipParam : ParamBase {
+  const lite::Tensor* X{};
+  lite::Tensor* Out{};
+
+  std::vector<int> axis;
+};
+
 }  // namespace operators
 }  // namespace lite
 }  // namespace paddle


### PR DESCRIPTION
- add ops: erf, sign , softplus, flip
- add kernels: elementwise_sub<int64_t>, reduce_prod<int64_t>, 
- fix bugs: 
    - slice op的StartsTensor和EndsTensor这一输入，paddle可以支持int32和int64,具体是在运行时做precision检查然后根据不同precision来取数据，最后统一static_cast到int64， 之前跑的模型都是int64的StartsTensor和EndsTensor，现在模型里有int32的没办法跑，这一点和paddle做了对齐。
    - compare op里没有做fast broadcast，对于Tensor([1])和Tensor([0,1)]这样的两个tensor的compare结果无法对齐paddle，做了修复
  