### PR TITLE
[OpenCL] Support leaky_relu/shuffle_channel/split

### DIFF
--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -88,6 +88,20 @@ inline CL_DTYPE activation(CL_DTYPE in
 #ifdef RELU6
   output = clamp(in, (CL_DTYPE)0, (CL_DTYPE)6);
 #endif
+
+#ifdef LEAKY_RELU
+#ifdef CL_DTYPE_float
+  output = select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in,
+                  in,
+                  (int)(isgreaterequal(in, 0)));  // NOLINT
+#endif
+
+#ifdef CL_DTYPE_half
+  output = select(
+      (CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, (ushort)(isgreaterequal(in, 0)));
+#endif
+#endif
+
   return output;
 }
 
@@ -110,5 +124,11 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
   in = fmax((CL_DTYPE4)(0.0f, 0.0f, 0.0f, 0.0f), in);
   output = fmin((CL_DTYPE4)(6.0f, 6.0f, 6.0f, 6.0f), in);
 #endif
+
+#ifdef LEAKY_RELU
+  output = select(
+      (CL_DTYPE4)(LEAKY_RELU_ALPHA)*in, in, isgreaterequal(in, (CL_DTYPE4)0));
+#endif
+
   return output;
 }

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -37,6 +37,9 @@ add_kernel(pad2d_opencl_image OPENCL basic SRCS pad2d_image_compute.cc DEPS ${cl
 add_kernel(box_coder_opencl_image OPENCL basic SRCS box_coder_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(pixel_shuffle_opencl_image OPENCL basic SRCS pixel_shuffle_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(expand_opencl_image OPENCL basic SRCS expand_image_compute.cc DEPS ${cl_kernel_deps})
+add_kernel(shuffle_channel_opencl_image OPENCL basic SRCS shuffle_channel_image_compute.cc DEPS ${cl_kernel_deps})
+add_kernel(split_opencl_image OPENCL basic SRCS split_image_compute.cc DEPS ${cl_kernel_deps})
+
 
 # extra
 # wait to add ...

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -319,6 +319,12 @@ void ConvImageCompute::PrepareForRun() {
     } else if (conv_param_->activation_param.active_type ==
                lite_api::ActivationType::kRelu6) {
       build_options_single += " -DRELU6";
+    } else if (conv_param_->activation_param.active_type ==
+               lite_api::ActivationType::kLeakyRelu) {
+      std::string leaky_relu_alpha_str =
+          std::to_string(conv_param_->activation_param.Leaky_relu_alpha);
+      build_options_single +=
+          " -DLEAKY_RELU -DLEAKY_RELU_ALPHA=" + leaky_relu_alpha_str + "f";
     } else {
       LOG(FATAL) << "Unsupported activation type:"
                  << static_cast<int>(conv_param_->activation_param.active_type);

--- a/lite/operators/shuffle_channel_op.h
+++ b/lite/operators/shuffle_channel_op.h
@@ -42,6 +42,13 @@ class ShuffleChannelOpLite : public OpLite {
   std::string DebugString() const override { return "shuffle_channel"; }
 
  private:
+#ifdef LITE_WITH_PROFILE
+  void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
+    ch->input_shape = ch->DimToStr(param_.X->dims());
+    ch->output_shape = ch->DimToStr(param_.Out->dims());
+    ch->remark = "group" + std::to_string(param_.group);
+  }
+#endif
   mutable ShuffleChannelParam param_;
 };
 


### PR DESCRIPTION
添加本PR后，opencl 可正常运行且精度与arm fp32结果基本一致；
运行 ttfnet，845上 opencl 50ms；855上 opencl 42ms；mate30 上 opencl 43ms。