### PR TITLE
[OpenCL] Support leaky_relu/shuffle_channel/split

### DIFF
--- a/lite/backends/opencl/cl_kernel/cl_common.h
+++ b/lite/backends/opencl/cl_kernel/cl_common.h
@@ -88,6 +88,20 @@ inline CL_DTYPE activation(CL_DTYPE in
 #ifdef RELU6
   output = clamp(in, (CL_DTYPE)0, (CL_DTYPE)6);
 #endif
+
+#ifdef LEAKY_RELU
+#ifdef CL_DTYPE_float
+  output = select((CL_DTYPE)(LEAKY_RELU_ALPHA)*in,
+                  in,
+                  (int)(isgreaterequal(in, 0)));  // NOLINT
+#endif
+
+#ifdef CL_DTYPE_half
+  output = select(
+      (CL_DTYPE)(LEAKY_RELU_ALPHA)*in, in, (ushort)(isgreaterequal(in, 0)));
+#endif
+#endif
+
   return output;
 }
 
@@ -110,5 +124,11 @@ inline CL_DTYPE4 activation_type4(CL_DTYPE4 in
   in = fmax((CL_DTYPE4)(0.0f, 0.0f, 0.0f, 0.0f), in);
   output = fmin((CL_DTYPE4)(6.0f, 6.0f, 6.0f, 6.0f), in);
 #endif
+
+#ifdef LEAKY_RELU
+  output = select(
+      (CL_DTYPE4)(LEAKY_RELU_ALPHA)*in, in, isgreaterequal(in, (CL_DTYPE4)0));
+#endif
+
   return output;
 }

--- a/lite/backends/opencl/cl_kernel/image/shuffle_channel_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/shuffle_channel_kernel.cl
@@ -1,0 +1,70 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cl_common.h>
+ 
+__kernel void shuffle_channel(__read_only  image2d_t input,
+                             __write_only image2d_t output,
+                             __private const int group,
+                             __private const int group_size,
+                             __private const int channels,
+                             __private const int out_W) {
+    const int w_idx      = get_global_id(0);
+    const int c4_idx     = get_global_id(1);
+    const int nh_idx     = get_global_id(2);
+
+    const sampler_t sampler =
+        CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
+    int2 output_pos;
+    output_pos.x = c4_idx * out_W + w_idx;
+    output_pos.y = nh_idx;
+
+    CL_DTYPE4 output_data;
+    for(int i = 0; i < 4; i++){
+        int outc_idx = (c4_idx << 2) + i;
+        if(outc_idx >= channels){
+            break;
+        }
+        int inc_idx  = outc_idx % group * group_size + outc_idx / group;
+        int inc4_idx = inc_idx >> 2;
+        int2 input_pos;
+        input_pos.x = inc4_idx * out_W + w_idx;
+        input_pos.y = nh_idx;
+        CL_DTYPE4 input_data;
+        input_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, input_pos);
+        CL_DTYPE value;
+        int sub_idx = inc_idx % 4;
+        if (sub_idx == 0) {
+          value = input_data.x;
+        } else if (sub_idx == 1) {
+          value = input_data.y;
+        } else if (sub_idx == 2) {
+          value = input_data.z;
+        } else if (sub_idx == 3) {
+          value = input_data.w;
+        }
+        if (i == 0) {
+          output_data.x = value;
+        } else if (i == 1) {
+          output_data.y = value;
+        } else if (i == 2) {
+          output_data.z = value;
+        } else if (i == 3) {
+          output_data.w = value;
+        }
+    }
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, output_pos, output_data);
+}
+

--- a/lite/backends/opencl/cl_kernel/image/split_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/split_kernel.cl
@@ -1,0 +1,151 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cl_common.h>
+
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
+__kernel void SplitBatch(__read_only image2d_t input,
+                         __write_only image2d_t output0,
+                         __write_only image2d_t output1,
+                         __private const int axis,
+                         __private const int out0_dims_axis,
+                         __private const int in_dims_second,
+                         __private const int in_dims_last,
+                         __private const int width) {
+  const int channel_blk_idx = get_global_id(0);
+  const int width_idx = get_global_id(1);
+  const int hb_idx = get_global_id(2);
+
+  const int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
+  const CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, in_pos);
+  const int n = hb_idx / width;
+
+  int2 out_pos;
+  if (n < out0_dims_axis) {
+    out_pos = in_pos;
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output0, out_pos, in_data);
+  } else {
+    out_pos.y = hb_idx - out0_dims_axis;
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, in_data);
+  }
+}
+
+__kernel void SplitChannel(__read_only image2d_t input,
+                           __write_only image2d_t output0,
+                           __write_only image2d_t output1,
+                           __private const int axis,
+                           __private const int out0_dims_axis,
+                           __private const int in_dims_second,
+                           __private const int in_dims_last,
+                           __private const int width) {
+  const int channel_blk_idx = get_global_id(0);
+  const int width_idx = get_global_id(1);
+  const int hb_idx = get_global_id(2);
+
+  const int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
+  const CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, in_pos);
+  const int c = channel_blk_idx * 4;
+
+  // write all data to output0 directly
+  if (c < out0_dims_axis) {
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output0, in_pos, in_data);
+  }
+
+  // deal with the last channel of output0
+  int channel_offset = out0_dims_axis % 4;
+  if (channel_blk_idx == out0_dims_axis / 4) { // only the last channel_blk of output0 hits this
+    if (channel_offset != 0) {
+      CL_DTYPE4 out0_last_val;
+      if (channel_offset == 1) {
+        out0_last_val = (CL_DTYPE4)(in_data.x, 0, 0, 0);
+      } else if (channel_offset == 2) {
+        out0_last_val = (CL_DTYPE4)(in_data.x, in_data.y, 0, 0);
+      } else if (channel_offset == 3) {
+        out0_last_val = (CL_DTYPE4)(in_data.x, in_data.y, in_data.z, 0);
+      }
+      WRITE_IMG_TYPE(CL_DTYPE_CHAR, output0, in_pos, out0_last_val);
+    }
+  }
+
+  // deal with output1
+  if (c + 4 >= out0_dims_axis) { // only theads for output1 hit this
+    const int2 out_pos = (int2)((channel_blk_idx - out0_dims_axis / 4) * in_dims_last + width_idx, hb_idx);
+    if (channel_offset == 0) { // write all data to output1 directly
+      WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, in_data);
+    } else {
+      CL_DTYPE4 combined_val;
+      CL_DTYPE4 latter = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, (int2)(in_pos.x + in_dims_last, in_pos.y));
+      if (channel_offset == 1) {
+        combined_val = (CL_DTYPE4)(in_data.y, in_data.z, in_data.w, latter.x);
+      } else if (channel_offset == 2) {
+        combined_val = (CL_DTYPE4)(in_data.z, in_data.w, latter.x, latter.y);
+      } else if (channel_offset == 3) {
+        combined_val = (CL_DTYPE4)(in_data.w, latter.x, latter.y, latter.z);
+      }
+      WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, combined_val);
+    }
+  }
+}
+
+__kernel void SplitHeight(__read_only image2d_t input,
+                          __write_only image2d_t output0,
+                          __write_only image2d_t output1,
+                          __private const int axis,
+                          __private const int out0_dims_axis,
+                          __private const int in_dims_second,
+                          __private const int in_dims_last,
+                          __private const int width) {
+  const int channel_blk_idx = get_global_id(0);
+  const int width_idx = get_global_id(1);
+  const int hb_idx = get_global_id(2);
+
+  const int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
+  const CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, in_pos);
+  const int h = hb_idx % width;
+
+  int2 out_pos;
+  if (h < out0_dims_axis) {
+    out_pos = in_pos;
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output0, out_pos, in_data);
+  } else {
+    out_pos.y = hb_idx - out0_dims_axis;
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, in_data);
+  }
+}
+
+__kernel void SplitWidth(__read_only image2d_t input,
+                         __write_only image2d_t output0,
+                         __write_only image2d_t output1,
+                         __private const int axis,
+                         __private const int out0_dims_axis,
+                         __private const int in_dims_second,
+                         __private const int in_dims_last,
+                         __private const int width) {
+  const int channel_blk_idx = get_global_id(0);
+  const int width_idx = get_global_id(1);
+  const int hb_idx = get_global_id(2);
+
+  const int2 in_pos = (int2)(channel_blk_idx * in_dims_last + width_idx, hb_idx);
+  const CL_DTYPE4 in_data = READ_IMG_TYPE(CL_DTYPE_CHAR, input, sampler, in_pos);
+
+  int2 out_pos;
+  if (width_idx < out0_dims_axis) {
+    out_pos = in_pos;
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output0, out_pos, in_data);
+  } else {
+    out_pos.x = width_idx - out0_dims_axis;
+    WRITE_IMG_TYPE(CL_DTYPE_CHAR, output1, out_pos, in_data);
+  }
+}

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -37,6 +37,9 @@ add_kernel(pad2d_opencl_image OPENCL basic SRCS pad2d_image_compute.cc DEPS ${cl
 add_kernel(box_coder_opencl_image OPENCL basic SRCS box_coder_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(pixel_shuffle_opencl_image OPENCL basic SRCS pixel_shuffle_image_compute.cc DEPS ${cl_kernel_deps})
 add_kernel(expand_opencl_image OPENCL basic SRCS expand_image_compute.cc DEPS ${cl_kernel_deps})
+add_kernel(shuffle_channel_opencl_image OPENCL basic SRCS shuffle_channel_image_compute.cc DEPS ${cl_kernel_deps})
+add_kernel(split_opencl_image OPENCL basic SRCS split_image_compute.cc DEPS ${cl_kernel_deps})
+
 
 # extra
 # wait to add ...

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -319,6 +319,12 @@ void ConvImageCompute::PrepareForRun() {
     } else if (conv_param_->activation_param.active_type ==
                lite_api::ActivationType::kRelu6) {
       build_options_single += " -DRELU6";
+    } else if (conv_param_->activation_param.active_type ==
+               lite_api::ActivationType::kLeakyRelu) {
+      std::string leaky_relu_alpha_str =
+          std::to_string(conv_param_->activation_param.Leaky_relu_alpha);
+      build_options_single +=
+          " -DLEAKY_RELU -DLEAKY_RELU_ALPHA=" + leaky_relu_alpha_str + "f";
     } else {
       LOG(FATAL) << "Unsupported activation type:"
                  << static_cast<int>(conv_param_->activation_param.active_type);

--- a/lite/kernels/opencl/shuffle_channel_image_compute.cc
+++ b/lite/kernels/opencl/shuffle_channel_image_compute.cc
@@ -1,0 +1,139 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "lite/backends/opencl/cl_half.h"
+#include "lite/backends/opencl/cl_include.h"
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+#include "lite/kernels/opencl/image_helper.h"
+#include "lite/operators/op_params.h"
+#include "lite/utils/replace_stl/stream.h"
+#include "lite/utils/string.h"
+#ifdef LITE_WITH_PROFILE
+#include "lite/core/profile/profiler.h"
+#endif
+#include "lite/backends/opencl/cl_utility.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace opencl {
+
+class ShuffleChannelComputeImage2D
+    : public KernelLite<TARGET(kOpenCL),
+                        PRECISION(kFP16),
+                        DATALAYOUT(kImageDefault)> {
+ public:
+  using param_t = operators::ShuffleChannelParam;
+
+  std::string doc() const override {
+    return "ShuffleChannel using cl::Image2D, kFP16";
+  }
+
+  void PrepareForRun() override {
+    auto& context = ctx_->As<OpenCLContext>();
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
+    context.cl_context()->AddKernel(kernel_func_name_,
+                                    "image/shuffle_channel_kernel.cl",
+                                    build_options_,
+                                    time_stamp_);
+  }
+
+  void Run() override {
+    const auto& param = *param_.get_mutable<param_t>();
+    const auto& in_dims = param.X->dims();
+    const auto& out_dims = param.Out->dims();
+    int out_W = in_dims[3];
+    int channels = in_dims[1];
+    int group = param.group;
+    int group_size = channels / group;
+
+    auto* x_img = param.X->data<half_t, cl::Image2D>();
+
+    auto out_image_shape = InitImageDimInfoWith(out_dims);
+    auto* out_img = param.Out->mutable_data<half_t, cl::Image2D>(
+        out_image_shape["width"], out_image_shape["height"]);
+
+    auto& context = ctx_->As<OpenCLContext>();
+    CHECK(context.cl_context() != nullptr);
+    cl_int status;
+    STL::stringstream kernel_key;
+    kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
+    auto kernel = context.cl_context()->GetKernel(kernel_key.str());
+    int arg_idx = 0;
+    status = kernel.setArg(arg_idx, *x_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, *out_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, group);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, group_size);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, channels);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, out_W);
+    CL_CHECK_FATAL(status);
+
+    auto global_work_size =
+        cl::NDRange{static_cast<cl::size_type>(out_dims[out_dims.size() - 1]),
+                    static_cast<cl::size_type>(out_image_shape["width"] /
+                                               out_dims[out_dims.size() - 1]),
+                    static_cast<cl::size_type>(out_image_shape["height"])};
+
+    status = EnqueueNDRangeKernel(context,
+                                  kernel,
+                                  cl::NullRange,
+                                  global_work_size,
+                                  cl::NullRange,
+                                  nullptr,
+                                  event_);
+    CL_CHECK_FATAL(status);
+  }
+
+#ifdef LITE_WITH_PROFILE
+  void SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
+    ch->kernel_func_name = kernel_func_name_;
+    ch->cl_event =
+        event_;  // `event_` defined in `kernel.h`, valid after kernel::Run
+  }
+#endif
+
+ private:
+  std::string kernel_func_name_{"shuffle_channel"};
+  std::string build_options_{" -DCL_DTYPE_half"};
+  std::string time_stamp_{GetTimeStamp()};
+};
+
+}  // namespace opencl
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(
+    shuffle_channel,
+    kOpenCL,
+    kFP16,
+    kImageDefault,
+    paddle::lite::kernels::opencl::ShuffleChannelComputeImage2D,
+    def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kFP16),
+                                      DATALAYOUT(kImageDefault))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kFP16),
+                                       DATALAYOUT(kImageDefault))})
+    .Finalize();

--- a/lite/kernels/opencl/split_image_compute.cc
+++ b/lite/kernels/opencl/split_image_compute.cc
@@ -1,0 +1,230 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "lite/backends/opencl/cl_half.h"
+#include "lite/backends/opencl/cl_include.h"
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+#include "lite/kernels/opencl/image_helper.h"
+#include "lite/operators/op_params.h"
+#include "lite/utils/replace_stl/stream.h"
+#include "lite/utils/string.h"
+#ifdef LITE_WITH_PROFILE
+#include "lite/core/profile/profiler.h"
+#endif
+#include "lite/backends/opencl/cl_utility.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace opencl {
+
+/* Pick kernel and assign width & flag */
+static void HelperFunc(const DDimLite& in_dims,
+                       const int axis,
+                       std::string* kernel_func_name,
+                       int* width,
+                       int* flag) {
+  if (in_dims.size() < 4) {
+    if (in_dims.size() - axis == 1) {
+      *width = in_dims[1];
+      *flag = 3;
+    } else {
+      *width = in_dims[0];
+      *flag = 2;
+    }
+  } else {
+    switch (axis) {
+      case 0:
+        *kernel_func_name = "SplitBatch";
+        *width = in_dims[2];
+        break;
+      case 1:
+        *kernel_func_name = "SplitChannel";
+        *width = in_dims[3];
+        break;
+      case 2:
+        *kernel_func_name = "SplitHeight";
+        *width = in_dims[0];
+        break;
+      case 3:
+        *kernel_func_name = "SplitWidth";
+        *width = in_dims[1];
+        break;
+      default:
+        LOG(FATAL) << "Unsupported axis: " << axis;
+    }
+    *flag = axis;
+  }
+}
+
+class SplitComputeImage2D : public KernelLite<TARGET(kOpenCL),
+                                              PRECISION(kFP16),
+                                              DATALAYOUT(kImageDefault)> {
+ public:
+  using param_t = operators::SplitParam;
+
+  std::string doc() const override { return "Split using cl::Image2D, kFP16"; }
+
+  void PrepareForRun() override {
+    auto& context = ctx_->As<OpenCLContext>();
+    split_param_ = param_.get_mutable<param_t>();
+    auto& x_dims = split_param_->x->dims();
+    auto& outs = split_param_->output;
+    axis_ = split_param_->axis;
+    if (axis_ < 0) {
+      axis_ += x_dims.size() - 1;
+    }
+
+    if (outs.size() != 2) {
+      LOG(FATAL) << "NOT imple yet!";
+    }
+    HelperFunc(x_dims, axis_, &kernel_func_name_, &width_, &flag_);
+
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
+    context.cl_context()->AddKernel(kernel_func_name_,
+                                    "image/split_kernel.cl",
+                                    build_options_,
+                                    time_stamp_);
+
+    STL::stringstream kernel_key;
+    kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
+    kernel_ = context.cl_context()->GetKernel(kernel_key.str());
+  }
+
+  void ReInitWhenNeeded() override {
+    split_param_ = param_.get_mutable<param_t>();
+    auto& x_dims = split_param_->x->dims();
+
+    if ((!first_epoch_for_reinit_ && x_dims != last_x_dims_) ||
+        first_epoch_for_reinit_) {
+      last_x_dims_ = x_dims;
+      first_epoch_for_reinit_ = false;
+
+      // compute global work size
+      auto x_img_shape = InitImageDimInfoWith(x_dims);
+      const auto& default_work_size =
+          DefaultWorkSize(x_dims,
+                          DDim(std::vector<DDim::value_type>{
+                              static_cast<int64_t>(x_img_shape["width"]),
+                              static_cast<int64_t>(x_img_shape["height"])}));
+      gws_ = cl::NDRange{static_cast<cl::size_type>(default_work_size[0]),
+                         static_cast<cl::size_type>(default_work_size[1]),
+                         static_cast<cl::size_type>(default_work_size[2])};
+
+      HelperFunc(x_dims, axis_, &kernel_func_name_, &width_, &flag_);
+    }
+  }
+
+  void Run() override {
+    const auto& x_dims = split_param_->x->dims();
+    const int out0_dims_axis = split_param_->output[0]->dims()[axis_];
+    const auto out_num = split_param_->output.size();
+    const auto* x_img = split_param_->x->data<half_t, cl::Image2D>();
+
+    std::vector<cl::Image2D*> out_img{out_num};
+    for (auto i = 0; i < split_param_->output.size(); i++) {
+      auto image_shape = InitImageDimInfoWith(split_param_->output[i]->dims());
+      out_img[i] = split_param_->output[i]->mutable_data<half_t, cl::Image2D>(
+          image_shape["width"], image_shape["height"]);
+    }
+
+    auto& context = ctx_->As<OpenCLContext>();
+    CHECK(context.cl_context() != nullptr);
+
+    if (out_num == 2) {
+      cl_int status;
+      int arg_idx = 0;
+      status = kernel_.setArg(arg_idx++, *x_img);
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, *(out_img[0]));
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, *(out_img[1]));
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, flag_);
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, out0_dims_axis);
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, static_cast<int>(x_dims[1]));
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++,
+                              static_cast<int>(x_dims[x_dims.size() - 1]));
+      CL_CHECK_FATAL(status);
+      status = kernel_.setArg(arg_idx++, width_);
+      CL_CHECK_FATAL(status);
+
+      status = EnqueueNDRangeKernel(context,
+                                    kernel_,
+                                    cl::NullRange,
+                                    gws_,
+                                    cl::NullRange,
+                                    nullptr,
+                                    event_);
+      CL_CHECK_FATAL(status);
+    } else {
+      LOG(FATAL) << "NOT imple yet!";
+    }
+  }
+
+#ifdef LITE_WITH_PROFILE
+  void SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
+    ch->kernel_func_name = kernel_func_name_;
+    ch->cl_event =
+        event_;  // `event_` defined in `kernel.h`, valid after kernel::Run
+  }
+#endif
+
+ private:
+  int axis_{-1};
+  int flag_{-1};   // the axis after expanding input tensor to 4 dims
+  int width_{-1};  // this var and `flag_` form the one OpenCL image dim
+  param_t* split_param_{nullptr};
+  bool first_epoch_for_reinit_{true};
+  DDim last_x_dims_;
+  std::string kernel_func_name_{""};
+  std::string build_options_{" -DCL_DTYPE_half"};
+  std::string time_stamp_{GetTimeStamp()};
+  cl::Kernel kernel_;
+  cl::NDRange gws_;
+};
+
+}  // namespace opencl
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(split,
+                     kOpenCL,
+                     kFP16,
+                     kImageDefault,
+                     paddle::lite::kernels::opencl::SplitComputeImage2D,
+                     def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kFP16),
+                                      DATALAYOUT(kImageDefault))})
+    .BindInput("AxisTensor",
+               {LiteType::GetTensorTy(TARGET(kARM),
+                                      PRECISION(kInt32),
+                                      DATALAYOUT(kNCHW))})
+    .BindInput("SectionsTensorList",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kInt32),
+                                      DATALAYOUT(kNCHW))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kFP16),
+                                       DATALAYOUT(kImageDefault))})
+    .Finalize();

--- a/lite/operators/shuffle_channel_op.h
+++ b/lite/operators/shuffle_channel_op.h
@@ -42,6 +42,13 @@ class ShuffleChannelOpLite : public OpLite {
   std::string DebugString() const override { return "shuffle_channel"; }
 
  private:
+#ifdef LITE_WITH_PROFILE
+  void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
+    ch->input_shape = ch->DimToStr(param_.X->dims());
+    ch->output_shape = ch->DimToStr(param_.Out->dims());
+    ch->remark = "group" + std::to_string(param_.group);
+  }
+#endif
   mutable ShuffleChannelParam param_;
 };
 


### PR DESCRIPTION
添加本PR后，opencl 可正常运行且精度与arm fp32结果基本一致；
运行 ttfnet，845上 opencl 50ms；855上 opencl 42ms；mate30 上 opencl 43ms。