### PR TITLE
fix some bugs, test=develop

### DIFF
--- a/lite/core/mir/pattern_matcher.h
+++ b/lite/core/mir/pattern_matcher.h
@@ -195,7 +195,7 @@ struct PMNode {
   PMPattern* pattern_;
   std::string name_;
   std::string op_type_;
-  Type type_;
+  Type type_{};
   Role role_{Role::kUnknown};
 };
 

--- a/lite/model_parser/base/var_desc.h
+++ b/lite/model_parser/base/var_desc.h
@@ -59,5 +59,9 @@ class VarDescAPI : public VarDescReadAPI, public VarDescWriteAPI {
   virtual ~VarDescAPI() = default;
 };
 
+inline bool IsParamVarDesc(const VarDescReadAPI& var) {
+  return var.GetType() == VarDataType::LOD_TENSOR && var.Persistable();
+}
+
 }  // namespace lite
 }  // namespace paddle

--- a/lite/model_parser/compatible_pb_test.cc
+++ b/lite/model_parser/compatible_pb_test.cc
@@ -314,7 +314,7 @@ CHECK_BLOCK_DESC(pb, framework::proto);
 
 template <>
 void CheckBlockDesc<cpp::BlockDesc>(const cpp::BlockDesc& some_desc) {
-  auto desc = some_desc;
+  auto& desc = some_desc;
   ASSERT_EQ(desc.Idx(), 1);
   ASSERT_EQ(desc.ParentIdx(), -1);
   ASSERT_EQ(desc.ForwardBlockIdx(), 2);

--- a/lite/model_parser/flatbuffers/block_desc.cc
+++ b/lite/model_parser/flatbuffers/block_desc.cc
@@ -34,13 +34,13 @@ proto::OpDesc const* BlockDescView::GetOp<proto::OpDesc>(int32_t idx) const {
 template <>
 VarDescView const* BlockDescView::GetVar<VarDescView>(int32_t idx) const {
   CHECK_LT(idx, static_cast<int32_t>(VarsSize())) << "idx >= vars.size()";
-  return &vars_[idx];
+  return vars_[idx].get();
 }
 
 template <>
 OpDescView const* BlockDescView::GetOp<OpDescView>(int32_t idx) const {
   CHECK_LT(idx, static_cast<int32_t>(OpsSize())) << "idx >= ops.size()";
-  return &ops_[idx];
+  return ops_[idx].get();
 }
 
 #ifdef LITE_WITH_FLATBUFFERS_DESC

--- a/lite/model_parser/flatbuffers/block_desc.h
+++ b/lite/model_parser/flatbuffers/block_desc.h
@@ -28,6 +28,10 @@ namespace fbs {
 
 class BlockDescView : public BlockDescAPI {
  public:
+  BlockDescView() = default;
+
+  BlockDescView(const BlockDescView&) = delete;
+
   explicit BlockDescView(proto::BlockDesc const* desc) : desc_(desc) {
     CHECK(desc_);
     vars_.resize(VarsSize());
@@ -78,8 +82,6 @@ class BlockDescView : public BlockDescAPI {
     return desc_->forward_block_idx();
   }
 
-  BlockDescView() = default;
-
  private:
   proto::BlockDesc const* desc_;  // not_own
   std::vector<std::unique_ptr<VarDescView>> vars_;
@@ -90,6 +92,9 @@ class BlockDescView : public BlockDescAPI {
 class BlockDesc : public BlockDescAPI {
  public:
   BlockDesc() : owned_(true), desc_(new proto::BlockDescT()) {}
+
+  BlockDesc(const BlockDesc&) = delete;
+
   explicit BlockDesc(proto::BlockDescT* desc) : desc_(desc) {
     CHECK(desc_);
     SyncVars();

--- a/lite/model_parser/flatbuffers/block_desc.h
+++ b/lite/model_parser/flatbuffers/block_desc.h
@@ -33,10 +33,10 @@ class BlockDescView : public BlockDescAPI {
     vars_.resize(VarsSize());
     ops_.resize(OpsSize());
     for (size_t idx = 0; idx < VarsSize(); ++idx) {
-      vars_[idx] = VarDescView(desc_->vars()->Get(idx));
+      vars_[idx].reset(new VarDescView(desc_->vars()->Get(idx)));
     }
     for (size_t idx = 0; idx < OpsSize(); ++idx) {
-      ops_[idx] = OpDescView(desc_->ops()->Get(idx));
+      ops_[idx].reset(new OpDescView(desc_->ops()->Get(idx)));
     }
   }
 
@@ -70,7 +70,9 @@ class BlockDescView : public BlockDescAPI {
     return nullptr;
   }
 
-  const std::vector<VarDescView>& GetVars() const { return vars_; }
+  const std::vector<std::unique_ptr<VarDescView>>& GetVars() const {
+    return vars_;
+  }
 
   int32_t ForwardBlockIdx() const override {
     return desc_->forward_block_idx();
@@ -80,8 +82,8 @@ class BlockDescView : public BlockDescAPI {
 
  private:
   proto::BlockDesc const* desc_;  // not_own
-  std::vector<VarDescView> vars_;
-  std::vector<OpDescView> ops_;
+  std::vector<std::unique_ptr<VarDescView>> vars_;
+  std::vector<std::unique_ptr<OpDescView>> ops_;
 };
 
 #ifdef LITE_WITH_FLATBUFFERS_DESC

--- a/lite/model_parser/flatbuffers/program_desc.cc
+++ b/lite/model_parser/flatbuffers/program_desc.cc
@@ -29,7 +29,7 @@ template <>
 BlockDescView const* ProgramDescView::GetBlock<BlockDescView>(
     int32_t idx) const {
   CHECK_LT(idx, static_cast<int32_t>(BlocksSize())) << "idx >= blocks.size()";
-  return &blocks_[idx];
+  return blocks_[idx].get();
 }
 
 template <>

--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -51,7 +51,7 @@ class ProgramDescView : public ProgramDescAPI {
     desc_ = proto::GetProgramDesc(buf_.data());
     blocks_.resize(desc_->blocks()->size());
     for (size_t idx = 0; idx < BlocksSize(); ++idx) {
-      blocks_[idx] = BlockDescView(desc_->blocks()->Get(idx));
+      blocks_[idx].reset(new BlockDescView(desc_->blocks()->Get(idx)));
     }
   }
 
@@ -77,7 +77,9 @@ class ProgramDescView : public ProgramDescAPI {
     return nullptr;
   }
 
-  const std::vector<BlockDescView>& GetBlocks() const { return blocks_; }
+  const std::vector<std::unique_ptr<BlockDescView>>& GetBlocks() const {
+    return blocks_;
+  }
 
   bool HasVersion() const override { return desc_->version() != nullptr; }
 
@@ -100,7 +102,7 @@ class ProgramDescView : public ProgramDescAPI {
  private:
   proto::ProgramDesc const* desc_;
   model_parser::Buffer buf_;
-  std::vector<BlockDescView> blocks_;
+  std::vector<std::unique_ptr<BlockDescView>> blocks_;
 
  private:
   ProgramDescView& operator=(const ProgramDescView&) = delete;

--- a/lite/model_parser/flatbuffers/program_desc.h
+++ b/lite/model_parser/flatbuffers/program_desc.h
@@ -33,6 +33,9 @@ namespace fbs {
 class ProgramDescView : public ProgramDescAPI {
  public:
   ProgramDescView() = default;
+
+  ProgramDescView(const ProgramDescView&) = delete;
+
   explicit ProgramDescView(model_parser::Buffer&& buf) {
     Init(std::forward<model_parser::Buffer>(buf));
   }
@@ -103,16 +106,14 @@ class ProgramDescView : public ProgramDescAPI {
   proto::ProgramDesc const* desc_;
   model_parser::Buffer buf_;
   std::vector<std::unique_ptr<BlockDescView>> blocks_;
-
- private:
-  ProgramDescView& operator=(const ProgramDescView&) = delete;
-  ProgramDescView(const ProgramDescView&) = delete;
 };
 
 #ifdef LITE_WITH_FLATBUFFERS_DESC
 class ProgramDesc : public ProgramDescAPI {
  public:
   ProgramDesc() = default;
+
+  ProgramDesc(const ProgramDesc&) = delete;
 
   explicit ProgramDesc(const model_parser::Buffer& buf) {
     const auto* raw_buf = proto::GetProgramDesc(buf.data());

--- a/lite/model_parser/general/block_desc.cc
+++ b/lite/model_parser/general/block_desc.cc
@@ -55,6 +55,8 @@ OpDesc* BlockDesc::AddOp<OpDesc>() {
 }
 
 void BlockDesc::CopyFrom(const BlockDesc& desc) {
+  ops_.clear();
+  vars_.clear();
   SetIdx(desc.Idx());
   SetParentIdx(desc.ParentIdx());
   SetForwardBlockIdx(desc.ForwardBlockIdx());

--- a/lite/model_parser/general/block_desc.cc
+++ b/lite/model_parser/general/block_desc.cc
@@ -21,37 +21,56 @@ namespace general {
 template <>
 VarDesc* BlockDesc::GetVar<VarDesc>(int32_t idx) {
   CHECK_LT(idx, VarsSize()) << "idx >= vars.size()";
-  return &vars_[idx];
+  return vars_[idx].get();
 }
 
 template <>
 VarDesc const* BlockDesc::GetVar<VarDesc>(int32_t idx) const {
   CHECK_LT(idx, VarsSize()) << "idx >= vars.size()";
-  return &vars_[idx];
+  return vars_[idx].get();
 }
 
 template <>
 VarDesc* BlockDesc::AddVar<VarDesc>() {
-  vars_.emplace_back();
-  return &vars_.back();
+  vars_.emplace_back(new VarDesc);
+  return vars_.back().get();
 }
 
 template <>
 OpDesc* BlockDesc::GetOp<OpDesc>(int32_t idx) {
   CHECK_LT(idx, OpsSize()) << "idx >= ops.size()";
-  return &ops_[idx];
+  return ops_[idx].get();
 }
 
 template <>
 OpDesc const* BlockDesc::GetOp<OpDesc>(int32_t idx) const {
   CHECK_LT(idx, OpsSize()) << "idx >= ops.size()";
-  return &ops_[idx];
+  return ops_[idx].get();
 }
 
 template <>
 OpDesc* BlockDesc::AddOp<OpDesc>() {
-  ops_.emplace_back();
-  return &ops_.back();
+  ops_.emplace_back(new OpDesc);
+  return ops_.back().get();
+}
+
+void BlockDesc::CopyFrom(const BlockDesc& desc) {
+  SetIdx(desc.Idx());
+  SetParentIdx(desc.ParentIdx());
+  SetForwardBlockIdx(desc.ForwardBlockIdx());
+  for (size_t i = 0; i < desc.OpsSize(); ++i) {
+    ops_.emplace_back(new OpDesc(*desc.GetOp<OpDesc>(i)));
+  }
+  for (size_t i = 0; i < desc.VarsSize(); ++i) {
+    vars_.emplace_back(new VarDesc(*desc.GetVar<VarDesc>(i)));
+  }
+}
+
+BlockDesc::BlockDesc(const BlockDesc& desc) { CopyFrom(desc); }
+
+BlockDesc& BlockDesc::operator=(const BlockDesc& desc) {
+  CopyFrom(desc);
+  return *this;
 }
 
 }  // namespace general

--- a/lite/model_parser/general/block_desc.h
+++ b/lite/model_parser/general/block_desc.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <memory>
 #include <vector>
 #include "lite/model_parser/base/apis.h"
 #include "lite/model_parser/general/op_desc.h"
@@ -30,6 +31,12 @@ namespace general {
 class BlockDesc : public BlockDescAPI {
  public:
   BlockDesc() = default;
+
+  BlockDesc(const BlockDesc& desc);
+
+  BlockDesc& operator=(const BlockDesc& desc);
+
+  BlockDesc(BlockDesc&& desc) = default;
 
   int32_t Idx() const override { return idx_; }
 
@@ -49,7 +56,7 @@ class BlockDesc : public BlockDescAPI {
   template <typename T>
   T const* GetVar(int32_t idx) const;
 
-  std::vector<VarDesc>& GetVars() { return vars_; }
+  std::vector<std::unique_ptr<VarDesc>>& GetVars() { return vars_; }
 
   template <typename T>
   T* AddVar();
@@ -71,11 +78,14 @@ class BlockDesc : public BlockDescAPI {
 
   void SetForwardBlockIdx(int32_t idx) override { forward_block_idx_ = idx; }
 
+ protected:
+  void CopyFrom(const BlockDesc& desc);
+
  private:
   int32_t idx_;
   int32_t parent_idx_;
-  std::vector<OpDesc> ops_;
-  std::vector<VarDesc> vars_;
+  std::vector<std::unique_ptr<OpDesc>> ops_;
+  std::vector<std::unique_ptr<VarDesc>> vars_;
   int32_t forward_block_idx_;
 };
 

--- a/lite/model_parser/general/program_desc.cc
+++ b/lite/model_parser/general/program_desc.cc
@@ -18,22 +18,30 @@ namespace paddle {
 namespace lite {
 namespace general {
 
+void ProgramDesc::CopyFrom(const ProgramDesc& other) {
+  version_ = other.Version();
+  blocks_.clear();
+  for (const auto& block : other.blocks()) {
+    blocks_.emplace_back(new BlockDesc(*block));
+  }
+}
+
 template <>
 BlockDesc* ProgramDesc::GetBlock<BlockDesc>(int32_t idx) {
   CHECK_LT(idx, BlocksSize()) << "idx >= blocks.size()";
-  return &blocks_[idx];
+  return blocks_[idx].get();
 }
 
 template <>
 BlockDesc const* ProgramDesc::GetBlock<BlockDesc>(int32_t idx) const {
   CHECK_LT(idx, BlocksSize()) << "idx >= blocks.size()";
-  return &blocks_[idx];
+  return blocks_[idx].get();
 }
 
 template <>
 BlockDesc* ProgramDesc::AddBlock<BlockDesc>() {
-  blocks_.emplace_back();
-  return &blocks_.back();
+  blocks_.emplace_back(new BlockDesc);
+  return blocks_.back().get();
 }
 
 template <>

--- a/lite/model_parser/general/program_desc.h
+++ b/lite/model_parser/general/program_desc.h
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 #include "lite/model_parser/base/apis.h"
@@ -33,12 +34,11 @@ class ProgramDesc : public ProgramDescAPI {
  public:
   ProgramDesc() = default;
 
-  void CopyFrom(const ProgramDesc& other) {
-    version_ = other.Version();
-    blocks_ = other.blocks();
-  }
+  void CopyFrom(const ProgramDesc& other);
 
-  const std::vector<BlockDesc>& blocks() const { return blocks_; }
+  const std::vector<std::unique_ptr<BlockDesc>>& blocks() const {
+    return blocks_;
+  }
 
   size_t BlocksSize() const override { return blocks_.size(); }
 
@@ -50,7 +50,7 @@ class ProgramDesc : public ProgramDescAPI {
   template <typename T>
   T const* GetBlock(int32_t idx) const;
 
-  std::vector<BlockDesc>& GetBlocks() { return blocks_; }
+  std::vector<std::unique_ptr<BlockDesc>>& GetBlocks() { return blocks_; }
 
   template <typename T>
   T* AddBlock();
@@ -79,7 +79,7 @@ class ProgramDesc : public ProgramDescAPI {
  private:
   int64_t version_;
   OpVersionMap op_version_map_;
-  std::vector<BlockDesc> blocks_;
+  std::vector<std::unique_ptr<BlockDesc>> blocks_;
 };
 
 }  // namespace general

--- a/lite/model_parser/general/var_desc.h
+++ b/lite/model_parser/general/var_desc.h
@@ -53,8 +53,8 @@ class VarDesc : public VarDescAPI {
 
  private:
   std::string name_;
-  Type type_;
-  Type data_type_;
+  Type type_{};
+  Type data_type_{Type::FP32};
   bool persistable_;
   std::vector<int64_t> shape_;
 };

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -181,14 +181,14 @@ void LoadNonCombinedParamsPb(const std::string &model_dir,
   // Check param files format
   // default format: non-combined params
   for (auto &var : main_block->GetVars()) {
-    if (var.Name() != "feed" && var.Name() != "fetch" && var.Persistable()) {
-      if (IsFileExists(model_dir + "/" + var.Name())) {
-        VLOG(4) << "reading weight " << var.Name();
-        model_parser::BinaryFileReader reader(model_dir + "/" + var.Name());
+    if (var->Name() != "feed" && var->Name() != "fetch" && var->Persistable()) {
+      if (IsFileExists(model_dir + "/" + var->Name())) {
+        VLOG(4) << "reading weight " << var->Name();
+        model_parser::BinaryFileReader reader(model_dir + "/" + var->Name());
         model_parser::pb::LoDTensorDeserializer loader;
-        switch (var.GetType()) {
+        switch (var->GetType()) {
           case VarDescAPI::Type::LOD_TENSOR:
-            LoadLoDTensor(&loader, &reader, scope->Var(var.Name()));
+            LoadLoDTensor(&loader, &reader, scope->Var(var->Name()));
             break;
           default:
             CHECK(false) << "unknown weight type";

--- a/lite/model_parser/pb/utils.h
+++ b/lite/model_parser/pb/utils.h
@@ -27,6 +27,12 @@ lite::VarDataType ConvertVarType(
 ::paddle::framework::proto::VarType_Type ConvertVarType(
     lite::VarDataType var_type);
 
+inline bool IsParamVarDesc(const paddle::framework::proto::VarDesc& var) {
+  return var.type().type() ==
+             paddle::framework::proto::VarType_Type_LOD_TENSOR &&
+         var.persistable();
+}
+
 }  // namespace pb
 }  // namespace lite
 }  // namespace paddle


### PR DESCRIPTION
1、获取 `vector` 内的对象指针是不安全的，改为获取指针对象。
2、`enum class` 继承自基本类型时，需要显式初始化，否则取值没有意义。
3、保存权重时，应区分变量类型而非变量名，否则可能会错误获取非权重变量。