### PR TITLE
[OpenCL][Bugfix] Support fp32 on pool_local

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         description: Check C++ code style using cpplint.py.
         entry: bash ./tools/codestyle/cpplint_pre_commit.hook
         language: system
-        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx)$
+        files: \.(c|cc|cxx|cpp|cu|cl|h|hpp|hxx)$
         exclude: ^(third-party/) | ^(metal/) | ^(web/) | ^(lite/kernels/metal/|lite/backends/metal/)
 #-   repo: local
     #hooks:

--- a/lite/backends/opencl/cl_kernel/image/pool_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/pool_kernel.cl
@@ -46,6 +46,7 @@ __kernel void pool(__read_only image2d_t input,
 
 #ifdef POOL_AVG
 
+  CL_DTYPE4 res = (CL_DTYPE4)(0.0f);
   int div;
 #ifdef EXCLUSIVE
   div = (end_h - start_h) * (end_w - start_w);
@@ -63,10 +64,14 @@ __kernel void pool(__read_only image2d_t input,
     }
   }
   res_f32 /= (float)div;
-  CL_DTYPE4 res = CONVERT_TYPE_TO(res_f32, CL_COMPUTE_DTYPE4);
+#ifdef CL_DTYPE_half
+  res = convert_half4(res_f32);
+#else
+  res = res_f32;
+#endif
+
 #else
   // pool_avg: use default precision
-  CL_DTYPE4 res = (CL_DTYPE4)(0.0f);
   for (int y = start_h; y < end_h; ++y) {
     for (int x = start_w; x < end_w; ++x) {
       res += READ_IMG_TYPE(
@@ -187,10 +192,13 @@ __kernel void pool_local(__read_only image2d_t input,
     avg_output[local_id] = avg_output[local_id] / (float)block_size;
 
     const int output_channel_width_idx = mad24(out_c, out_width, out_w);
-    WRITE_IMG_TYPE(CL_DTYPE_CHAR,
-                   output,
-                   (int2)(output_channel_width_idx, out_nh),
-                   CONVERT_TYPE_TO(avg_output[local_id], CL_COMPUTE_DTYPE4));
+#ifdef CL_DTYPE_half
+    CL_DTYPE4 res = convert_half(avg_output[local_id]);
+#else
+    CL_DTYPE4 res = avg_output[local_id];
+#endif
+    WRITE_IMG_TYPE(
+        CL_DTYPE_CHAR, output, (int2)(output_channel_width_idx, out_nh), res);
   }
 #else
   local_output[local_id] = (CL_DTYPE4)(-FLT_MAX);
@@ -383,7 +391,10 @@ __kernel void pool_avg_global(__read_only image2d_t input,
   }
   const float global_size_div = 1.0f / (in_height * in_width);
   CL_DTYPE4 avg;
-  avg = CONVERT_TYPE_TO((sum * global_size_div), CL_COMPUTE_DTYPE4);
+  avg.x = CONVERT_TYPE_TO((sum.x * global_size_div), CL_COMPUTE_DTYPE);
+  avg.y = CONVERT_TYPE_TO((sum.y * global_size_div), CL_COMPUTE_DTYPE);
+  avg.z = CONVERT_TYPE_TO((sum.z * global_size_div), CL_COMPUTE_DTYPE);
+  avg.w = CONVERT_TYPE_TO((sum.w * global_size_div), CL_COMPUTE_DTYPE);
 
 #ifdef DEBUG
   if (out_c == 0) {

--- a/lite/demo/cxx/mobile_full/mobilenetv1_full_api.cc
+++ b/lite/demo/cxx/mobile_full/mobilenetv1_full_api.cc
@@ -58,17 +58,22 @@ void RunModel() {
   config.set_model_dir(FLAGS_model_dir);
   config.set_power_mode((paddle::lite_api::PowerMode)FLAGS_power_mode);
   config.set_threads(FLAGS_threads);
-  if (FLAGS_use_gpu) {
-    std::vector<Place> valid_places{
-        Place{TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault)},
-        Place{TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNCHW)},
-        Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kImageDefault)},
-        Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW)},
-        Place{TARGET(kOpenCL), PRECISION(kInt32), DATALAYOUT(kNCHW)},
-        Place{TARGET(kARM)}};
 
+  std::vector<Place> valid_places;
+  if (FLAGS_use_gpu) {
+    valid_places.emplace_back(
+        Place{TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault)});
+    valid_places.emplace_back(
+        Place{TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNCHW)});
+    valid_places.emplace_back(
+        Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kImageDefault)});
+    valid_places.emplace_back(
+        Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW)});
+    valid_places.emplace_back(
+        Place{TARGET(kOpenCL), PRECISION(kInt32), DATALAYOUT(kNCHW)});
+    valid_places.emplace_back(Place{TARGET(kARM)});
   } else {
-    std::vector<Place> valid_places{Place{TARGET(kARM), PRECISION(kFloat)}};
+    valid_places.emplace_back(Place{TARGET(kARM), PRECISION(kFloat)});
   }
 
   if (FLAGS_prefer_int8_kernel) {


### PR DESCRIPTION
在macOS上以fp32精度运行模型时，报错：opencl Compile Server Error；在手机端fp32运行正常。
经定位发现是在执行`CONVERT_TYPE_TO(avg_output[local_id], CL_COMPUTE_DTYPE4)`这段代码时报错。