### PR TITLE
[arm] improve int8 winograd profiler

### DIFF
--- a/lite/kernels/arm/conv_compute.cc
+++ b/lite/kernels/arm/conv_compute.cc
@@ -97,7 +97,7 @@ void ConvCompute<PRECISION(kInt8), PRECISION(kFloat)>::PrepareForRun() {
     impl_ = new DirectConv<PRECISION(kInt8), PRECISION(kFloat)>;
     // VLOG(3) << "Run DirectConv Int8";
   } else if (param.groups == 1 && kw == 3 && sw == 1 && no_dilation &&
-             pads_equal) {
+             pads_equal && !ctx.has_dot()) {
     impl_ = new WinogradConv<PRECISION(kInt8), PRECISION(kFloat)>;
     // VLOG(3) << "Run WinogradConv Int8";
   } else {
@@ -122,7 +122,7 @@ void ConvCompute<PRECISION(kInt8), PRECISION(kInt8)>::PrepareForRun() {
     impl_ = new DirectConv<PRECISION(kInt8), PRECISION(kInt8)>;
     // VLOG(3) << "Run DirectConv Int8";
   } else if (param.groups == 1 && kw == 3 && sw == 1 && no_dilation &&
-             pads_equal) {
+             pads_equal && !ctx.has_dot()) {
     impl_ = new WinogradConv<PRECISION(kInt8), PRECISION(kInt8)>;
     // VLOG(3) << "Run WinogradConv Int8";
   } else {

--- a/lite/kernels/arm/conv_compute.cc
+++ b/lite/kernels/arm/conv_compute.cc
@@ -207,6 +207,7 @@ REGISTER_LITE_KERNEL(depthwise_conv2d, kARM, kFP16, kNCHW, ConvFp16, def)
                 {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindPaddleOpVersion("depthwise_conv2d", 1)
     .Finalize();
+
 #endif  // ENABLE_ARM_FP16
 
 REGISTER_LITE_KERNEL(conv2d, kARM, kFloat, kNCHW, ConvFp32, def)

--- a/lite/tests/math/conv_int8_compute_test.cc
+++ b/lite/tests/math/conv_int8_compute_test.cc
@@ -43,7 +43,7 @@ DEFINE_int32(in_height, 112, "input height");
 DEFINE_int32(in_width, 112, "input width");
 
 DEFINE_int32(out_channel, 32, "output channel");
-DEFINE_int32(group, 1, "group");
+DEFINE_int32(group, 32, "group");
 DEFINE_int32(kernel_h, 3, "kernel height");
 DEFINE_int32(kernel_w, 3, "kernel width");
 DEFINE_int32(pad_h, 1, "pad height");


### PR DESCRIPTION
winograd. int8 改用SDOT实现，性能有大幅提升
855 | old | now | improve
-- | -- | -- | --
resnet50-int8-v8 | 111.776 | 82.831 | 34.94%
resnet50-int8-v7 | 123.553 | 91.3715 | 35.22%

