### PR TITLE
【arm-fp16】fix concat error when input tensor type is different

### DIFF
--- a/lite/kernels/arm/concat_compute.cc
+++ b/lite/kernels/arm/concat_compute.cc
@@ -19,6 +19,9 @@
 #include "lite/core/op_registry.h"
 #include "lite/core/tensor.h"
 #include "lite/core/type_system.h"
+#ifdef ENABLE_ARM_FP16
+#include "lite/backends/arm/math/fp16/funcs_fp16.h"
+#endif
 
 namespace paddle {
 namespace lite {
@@ -77,6 +80,25 @@ void ConcatCompute::Run() {
       if (type == PRECISION(kUnk)) {
         type = tensor->precision();
       } else {
+        VLOG(4) << "type: " << PrecisionRepr(type)
+                << ", tensor: " << PrecisionRepr(tensor->precision());
+#ifdef ENABLE_ARM_FP16
+        if (type != tensor->precision() &&
+            tensor->precision() == PrecisionType::kFP16 &&
+            type == PrecisionType::kFloat) {
+          // fp16 ==> flaot
+          Tensor tmp;
+          auto shape = tensor->dims();
+          tmp.Resize(shape);
+          tmp.set_precision(PrecisionType::kFloat);
+          auto dout = tmp.mutable_data<float>();
+          auto din = tensor->data<float16_t>();
+          auto size = tmp.numel();
+          lite::arm::math::fp16::fp16_to_fp32(din, dout, tensor->numel());
+          tensor->CopyDataFrom(tmp);
+          continue;
+        }
+#endif
         CHECK(type == tensor->precision()) << "The precision of "
                                            << "concat inputs should be same.";
       }


### PR DESCRIPTION
<img width="682" alt="image" src="https://user-images.githubusercontent.com/38650344/120957139-b1a7ab00-c787-11eb-8b89-510b63466293.png">
修复此类FP16 模型中concat计算crash