### PR TITLE
add TryShrinkMemory API

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -464,9 +464,10 @@ void Predictor::CheckPaddleOpVersions(
 }
 
 bool Predictor::TryShrinkMemory() {
+#ifdef LITE_WITH_ARM
   // Clear ArmL3Cache
   lite::DeviceInfo::Global().ClearArmL3Cache();
-
+#endif
   std::vector<std::string> local_var_names =
       program_->exec_scope()->LocalVarNames();
   for (auto var_name : local_var_names) {

--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -468,9 +468,9 @@ bool Predictor::TryShrinkMemory() {
   // Clear ArmL3Cache
   lite::DeviceInfo::Global().ClearArmL3Cache();
 #endif
-  std::vector<std::string> local_var_names =
+  const std::vector<std::string> &local_var_names =
       program_->exec_scope()->LocalVarNames();
-  for (auto var_name : local_var_names) {
+  for (auto &var_name : local_var_names) {
     Variable *var = program_->exec_scope()->FindLocalVar(var_name);
     if (var->IsType<lite::Tensor>()) {
       // Clear unpersistable tensors
@@ -480,7 +480,7 @@ bool Predictor::TryShrinkMemory() {
       }
     } else if (var->IsType<std::vector<Tensor>>()) {
       // Clear unpersistable tensor vector
-      auto tensor_array =
+      auto *tensor_array =
           program_->exec_scope()->FindMutableTensorList(var_name);
       for (auto &tensor : *tensor_array) {
         if (!tensor.persistable()) {

--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -464,18 +464,27 @@ void Predictor::CheckPaddleOpVersions(
 }
 
 bool Predictor::TryShrinkMemory() {
-  std::vector<std::string> local_var_names = scope_->LocalVarNames();
+  // Clear ArmL3Cache
+  lite::DeviceInfo::Global().ClearArmL3Cache();
+
+  std::vector<std::string> local_var_names =
+      program_->exec_scope()->LocalVarNames();
   for (auto var_name : local_var_names) {
-    Variable *var = scope_->FindLocalVar(var_name);
+    Variable *var = program_->exec_scope()->FindLocalVar(var_name);
     if (var->IsType<lite::Tensor>()) {
-      auto *tensor = scope_->FindMutableTensor(var_name);
+      // Clear unpersistable tensors
+      auto *tensor = program_->exec_scope()->FindMutableTensor(var_name);
       if (!tensor->persistable()) {
         tensor->clear();
       }
     } else if (var->IsType<std::vector<Tensor>>()) {
-      auto tensor_array = scope_->FindMutableTensorList(var_name);
+      // Clear unpersistable tensor vector
+      auto tensor_array =
+          program_->exec_scope()->FindMutableTensorList(var_name);
       for (auto &tensor : *tensor_array) {
-        tensor.clear();
+        if (!tensor.persistable()) {
+          tensor.clear();
+        }
       }
     } else {
       continue;

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -174,6 +174,13 @@ class LITE_API Predictor {
 #endif
   }
 
+  /// \brief Release all tmp tensor to compress the size of the memory pool.
+  /// The memory pool is considered to be composed of a list of chunks, if
+  /// the chunk is not occupied, it can be released.
+  ///
+  /// \return a boolean variable.
+  bool TryShrinkMemory();
+
   // Get offset-th col of feed inputs.
   lite::Tensor* GetInput(size_t offset);
   // get input by name.
@@ -259,6 +266,13 @@ class CxxPaddleApiImpl : public lite_api::PaddlePredictor {
   std::unique_ptr<const lite_api::Tensor> GetOutput(int i) const override;
 
   void Run() override;
+
+  /// \brief Release all tmp tensor to compress the size of the memory pool.
+  /// The memory pool is considered to be composed of a list of chunks, if
+  /// the chunk is not occupied, it can be released.
+  ///
+  /// \return a boolean variable.
+  bool TryShrinkMemory() override;
 
   std::shared_ptr<lite_api::PaddlePredictor> Clone() override;
 

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -262,6 +262,10 @@ void CxxPaddleApiImpl::SaveOptimizedModel(const std::string &model_dir,
   raw_predictor_->SaveModel(model_dir, model_type, record_info);
 }
 
+bool CxxPaddleApiImpl::TryShrinkMemory() {
+  return raw_predictor_->TryShrinkMemory();
+}
+
 }  // namespace lite
 
 namespace lite_api {

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -347,9 +347,9 @@ bool LightPredictor::TryShrinkMemory() {
   // Clear ArmL3Cache
   lite::DeviceInfo::Global().ClearArmL3Cache();
 #endif
-  std::vector<std::string> local_var_names =
+  const std::vector<std::string>& local_var_names =
       program_->exec_scope()->LocalVarNames();
-  for (auto var_name : local_var_names) {
+  for (auto& var_name : local_var_names) {
     Variable* var = program_->exec_scope()->FindLocalVar(var_name);
     if (var->IsType<lite::Tensor>()) {
       // Clear unpersistable tensors
@@ -359,7 +359,7 @@ bool LightPredictor::TryShrinkMemory() {
       }
     } else if (var->IsType<std::vector<Tensor>>()) {
       // Clear unpersistable tensor vector
-      auto tensor_array =
+      auto* tensor_array =
           program_->exec_scope()->FindMutableTensorList(var_name);
       for (auto& tensor : *tensor_array) {
         if (!tensor.persistable()) {

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -342,13 +342,6 @@ void LightPredictor::CheckInputValid() {
   }
 }
 
-///
-/// \brief Release all tmp tensor to compress the size of the memory pool.
-/// The memory pool is considered to be composed of a list of chunks, if
-/// the chunk is not occupied, it can be released.
-///
-/// \return a boolean variable.
-///
 bool LightPredictor::TryShrinkMemory() {
   std::vector<std::string> local_var_names = scope_->LocalVarNames();
   for (auto var_name : local_var_names) {

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -343,9 +343,10 @@ void LightPredictor::CheckInputValid() {
 }
 
 bool LightPredictor::TryShrinkMemory() {
+#ifdef LITE_WITH_ARM
   // Clear ArmL3Cache
   lite::DeviceInfo::Global().ClearArmL3Cache();
-
+#endif
   std::vector<std::string> local_var_names =
       program_->exec_scope()->LocalVarNames();
   for (auto var_name : local_var_names) {

--- a/lite/api/light_api.h
+++ b/lite/api/light_api.h
@@ -67,6 +67,13 @@ class LITE_API LightPredictor {
     program_->Run();
   }
 
+  /// \brief Release all tmp tensor to compress the size of the memory pool.
+  /// The memory pool is considered to be composed of a list of chunks, if
+  /// the chunk is not occupied, it can be released.
+  ///
+  /// \return a boolean variable.
+  bool TryShrinkMemory();
+
   // Get offset-th col of feed inputs.
   Tensor* GetInput(size_t offset);
   // get input by name.
@@ -153,6 +160,13 @@ class LightPredictorImpl : public lite_api::PaddlePredictor {
       const std::string& name) override;
 
   void Init(const lite_api::MobileConfig& config);
+
+  /// \brief Release all tmp tensor to compress the size of the memory pool.
+  /// The memory pool is considered to be composed of a list of chunks, if
+  /// the chunk is not occupied, it can be released.
+  ///
+  /// \return a boolean variable.
+  bool TryShrinkMemory() override;
 
  private:
   std::unique_ptr<lite::LightPredictor> raw_predictor_;

--- a/lite/api/light_api_impl.cc
+++ b/lite/api/light_api_impl.cc
@@ -144,6 +144,10 @@ std::vector<std::string> LightPredictorImpl::GetOutputNames() {
   return raw_predictor_->GetOutputNames();
 }
 
+bool LightPredictorImpl::TryShrinkMemory() {
+  return raw_predictor_->TryShrinkMemory();
+}
+
 }  // namespace lite
 
 namespace lite_api {

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -111,6 +111,9 @@ class LITE_API PaddlePredictor {
   // Get output names
   virtual std::vector<std::string> GetParamNames();
 
+  /// Release all tmp tensor to compress the size of the memory pool.
+  virtual bool TryShrinkMemory() = 0;
+
   // Get Input by name
   virtual std::unique_ptr<Tensor> GetInputByName(const std::string& name) = 0;
 

--- a/lite/api/paddle_api_test.cc
+++ b/lite/api/paddle_api_test.cc
@@ -55,7 +55,6 @@ TEST(CxxApi, run) {
 
   predictor->TryShrinkMemory();
   input_tensor->Resize(std::vector<int64_t>({100, 100}));
-  auto* data = input_tensor->mutable_data<float>();
   for (int i = 0; i < 100 * 100; i++) {
     data[i] = i;
   }
@@ -141,7 +140,6 @@ TEST(LightApi, run) {
 
   predictor->TryShrinkMemory();
   input_tensor->Resize(std::vector<int64_t>({100, 100}));
-  auto* data = input_tensor->mutable_data<float>();
   for (int i = 0; i < 100 * 100; i++) {
     data[i] = i;
   }

--- a/lite/api/paddle_api_test.cc
+++ b/lite/api/paddle_api_test.cc
@@ -53,6 +53,13 @@ TEST(CxxApi, run) {
 
   predictor->Run();
 
+  predictor->TryShrinkMemory();
+  input_tensor->Resize(std::vector<int64_t>({100, 100}));
+  auto* data = input_tensor->mutable_data<float>();
+  for (int i = 0; i < 100 * 100; i++) {
+    data[i] = i;
+  }
+
   auto output = predictor->GetTensor(outputs[0]);
   auto* out = output->data<float>();
   LOG(INFO) << out[0];
@@ -130,6 +137,14 @@ TEST(LightApi, run) {
     data[i] = i;
   }
 
+  predictor->Run();
+
+  predictor->TryShrinkMemory();
+  input_tensor->Resize(std::vector<int64_t>({100, 100}));
+  auto* data = input_tensor->mutable_data<float>();
+  for (int i = 0; i < 100 * 100; i++) {
+    data[i] = i;
+  }
   predictor->Run();
 
   auto output = predictor->GetOutput(0);

--- a/lite/api/paddle_api_test.cc
+++ b/lite/api/paddle_api_test.cc
@@ -55,10 +55,12 @@ TEST(CxxApi, run) {
 
   predictor->TryShrinkMemory();
   input_tensor->Resize(std::vector<int64_t>({100, 100}));
+  data = input_tensor->mutable_data<float>();
   for (int i = 0; i < 100 * 100; i++) {
     data[i] = i;
   }
 
+  predictor->Run();
   auto output = predictor->GetTensor(outputs[0]);
   auto* out = output->data<float>();
   LOG(INFO) << out[0];
@@ -140,11 +142,12 @@ TEST(LightApi, run) {
 
   predictor->TryShrinkMemory();
   input_tensor->Resize(std::vector<int64_t>({100, 100}));
+  data = input_tensor->mutable_data<float>();
   for (int i = 0; i < 100 * 100; i++) {
     data[i] = i;
   }
-  predictor->Run();
 
+  predictor->Run();
   auto output = predictor->GetOutput(0);
   auto* out = output->data<float>();
   LOG(INFO) << out[0];

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -90,6 +90,8 @@ class DeviceInfo {
     workspace_.mutable_data<int8_t>();
   }
 
+  void ClearArmL3Cache() { workspace_.clear(); }
+
   int llc_size() const {
     auto size = absolute_l3cache_size_;
     switch (l3_cache_method_) {


### PR DESCRIPTION
- Add API : `TryShrinkMemory `
```
API NAME: TryShrinkMemory
DESCRIPTION:
 - input :  null
 - return : void 
 - Effect:  release memory usage consumed by intermediate temporary tensors and L3ArmCache.
[Inputs and Outputs Tensor will also be released, if you have called TryShrinkMemory API but want to rerun this predictor, you need to fill the input tensor again ]

``` 

- &eg. MobileNetV1

``` 
auto predictor = lite_api::CreatePaddlePredictor(config);
// Status1. Predictor is created, memory usage is 22M
...
predictor->Run();
// Status2. Predictor has inference successfully, memory usage is 44M
...
predictor->TryShrinkMemory();
// Status3. Release memory that used by intermediate tensors and ArmL3Cache, memory usage is reduced to 37M
//                warning: inputs and outputs tensors data will be null after this API is applied
...

// if you want to rerun this model, you need to feed model inputs again
  auto* in_data = in_tensor->mutable_data<float>();
...
```