### PR TITLE
[CUDA] Fix compile error on cuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,8 +282,8 @@ include(external/mkldnn)    # download, build, install mkldnn
 include(external/eigen)     # download eigen3
 include(external/xxhash)    # download install xxhash needed for x86 jit
 
-include(configure)          # add paddle env configuration
 include(cudnn)
+include(configure)          # add paddle env configuration
 
 if(LITE_WITH_CUDA)
   include(cuda)

--- a/lite/backends/cuda/math/gemm.cc
+++ b/lite/backends/cuda/math/gemm.cc
@@ -139,7 +139,7 @@ class cublasTypeWrapper<half> {
   static const cudaDataType_t type = CUDA_R_16F;
 };
 
-#if (CUBLAS_VER_MAJOR * 10 + CUBLAS_VER_MINOR) >= 101
+#if (CUBLAS_VER_MAJOR * 10 + CUBLAS_VER_MINOR) == 101
 
 template <typename PTypeIn, typename PTypeOut>
 bool LtGemm<PTypeIn, PTypeOut>::init(const bool trans_a,

--- a/lite/backends/cuda/math/gemm.h
+++ b/lite/backends/cuda/math/gemm.h
@@ -69,7 +69,7 @@ class Gemm {
   int ldc_{-1};
 };
 
-#if (CUBLAS_VER_MAJOR * 10 + CUBLAS_VER_MINOR) >= 101
+#if (CUBLAS_VER_MAJOR * 10 + CUBLAS_VER_MINOR) == 101
 
 template <typename PtypeIn, typename PtypeOut>
 class LtGemm {


### PR DESCRIPTION
- 修复编译cuda，cmake阶段找不到cudnn的问题
- cuda11之后，cublasLt接口发生变化，编译会失败，目前Lite没有用到cublasLt接口，临时解决方案，只在cuda10.1的时候编译cublasLt