### PR TITLE
[opt]accelerate the process of opt compile,test=develop

### DIFF
--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -15,7 +15,7 @@ if ((NOT LITE_ON_TINY_PUBLISH) AND (LITE_WITH_CUDA OR LITE_WITH_X86 OR LITE_WITH
     #full api dynamic library
     lite_cc_library(paddle_full_api_shared SHARED SRCS paddle_api.cc light_api.cc cxx_api.cc cxx_api_impl.cc light_api_impl.cc
                   DEPS paddle_api paddle_api_light  paddle_api_full)
-    add_dependencies(paddle_full_api_shared op_list_h kernel_list_h framework_proto op_registry fbs_headers)
+    add_dependencies(paddle_full_api_shared framework_proto op_registry fbs_headers)
     target_link_libraries(paddle_full_api_shared framework_proto op_registry)
     if(LITE_WITH_X86)
         add_dependencies(paddle_full_api_shared xxhash)
@@ -51,7 +51,6 @@ if ((NOT LITE_ON_TINY_PUBLISH) AND (LITE_WITH_CUDA OR LITE_WITH_X86 OR LITE_WITH
                   HUAWEI_ASCEND_NPU_DEPS ${huawei_ascend_npu_kernels}
                   )
 
-    add_dependencies(paddle_light_api_shared op_list_h kernel_list_h)
     if(WIN32)
         target_link_libraries(paddle_light_api_shared shlwapi.lib)
     endif()
@@ -99,7 +98,7 @@ else()
     # Compiling steps in tiny_publish format:
     # 1. compile all source files into .object `PADDLELITE_OBJS`
     add_library(PADDLELITE_OBJS OBJECT ${__lite_cc_files} paddle_api.cc light_api.cc light_api_impl.cc)
-    add_dependencies(PADDLELITE_OBJS op_list_h kernel_list_h fbs_headers)
+    add_dependencies(PADDLELITE_OBJS fbs_headers)
     if (IOS)
         # only sttaic lib is produced for IOS platform.
         add_library(paddle_api_light_bundled STATIC $<TARGET_OBJECTS:PADDLELITE_OBJS>)
@@ -527,8 +526,9 @@ endif()
 if (LITE_WITH_PYTHON)
     add_subdirectory(python)
     # add library for opt_base
-    lite_cc_library(opt_base SRCS opt_base.cc cxx_api_impl.cc paddle_api.cc cxx_api.cc DEPS kernel op optimizer mir_passes utils)
-    add_dependencies(opt_base supported_kernel_op_info_h framework_proto all_kernel_faked_cc kernel_list_h)
+    lite_cc_library(opt_base SRCS opt_base.cc cxx_api_impl.cc paddle_api.cc cxx_api.cc
+        DEPS kernel op optimizer mir_passes utils)
+    add_dependencies(opt_base framework_proto)
 endif()
 
 if (LITE_ON_TINY_PUBLISH)
@@ -539,9 +539,9 @@ endif()
 
 if (LITE_ON_MODEL_OPTIMIZE_TOOL)
     message(STATUS "Compiling opt")
-    lite_cc_binary(opt SRCS opt.cc cxx_api_impl.cc paddle_api.cc cxx_api.cc
+    lite_cc_binary(opt SRCS opt.cc cxx_api_impl.cc paddle_api.cc cxx_api.cc $<TARGET_OBJECTS:all_kernel_faked>
         DEPS gflags kernel op optimizer mir_passes utils ${host_kernels})
-    add_dependencies(opt op_list_h kernel_list_h all_kernel_faked_cc supported_kernel_op_info_h)
+    add_dependencies(opt all_kernel_faked)
 endif(LITE_ON_MODEL_OPTIMIZE_TOOL)
 
 if(NOT WITH_COVERAGE)

--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -20,8 +20,7 @@
 // are created automatically during opt's compiling period
 #include <algorithm>
 #include <iomanip>
-#include "all_kernel_faked.cc"  // NOLINT
-#include "kernel_src_map.h"     // NOLINT
+#include "kernel_src_map.h"  // NOLINT
 #include "lite/api/cxx_api.h"
 #include "lite/api/paddle_api.h"
 #include "lite/api/paddle_use_kernels.h"

--- a/lite/core/CMakeLists.txt
+++ b/lite/core/CMakeLists.txt
@@ -82,51 +82,52 @@ configure_file (version.h.in version.h)
 #  OUTPUT opencl_kernels_source.cc # not a real path to the output to force it execute every time.
 #  )
 # A trick to generate the paddle_use_kernels.h
-add_custom_command (
-  COMMAND python ${CMAKE_SOURCE_DIR}/lite/tools/cmake_tools/parse_kernel_registry.py
-  ${kernels_src_list}
-  ${CMAKE_SOURCE_DIR}/lite/api/paddle_use_kernels.h
-  "${LITE_OPTMODEL_DIR}/.tailored_kernels_list"
-  ${LITE_BUILD_TAILOR}
-  ${LITE_BUILD_EXTRA}
-  ${LITE_WITH_ARM82_FP16}
-  OUTPUT kernels.h # not a real path to the output to force it execute every time.
-)
+execute_process(
+    COMMAND python ${CMAKE_SOURCE_DIR}/lite/tools/cmake_tools/parse_kernel_registry.py
+    ${kernels_src_list}
+    ${CMAKE_SOURCE_DIR}/lite/api/paddle_use_kernels.h
+    "${LITE_OPTMODEL_DIR}/.tailored_kernels_list"
+    ${LITE_BUILD_TAILOR}
+    ${LITE_BUILD_EXTRA}
+    ${LITE_WITH_ARM82_FP16}
+    RESULT_VARIABLE result)
 # A trick to generate the paddle_use_ops.h
-add_custom_command (
-  COMMAND python ${CMAKE_SOURCE_DIR}/lite/tools/cmake_tools/parse_op_registry.py
-  ${ops_src_list}
-  ${CMAKE_SOURCE_DIR}/lite/api/paddle_use_ops.h
-  "${LITE_OPTMODEL_DIR}/.tailored_ops_list"
-  ${LITE_BUILD_TAILOR}
-  OUTPUT ops.h # not a real path to the output to force it execute every time.
-  )
-# generate fake kernels for memory_optimize_tool
+execute_process(
+    COMMAND python ${CMAKE_SOURCE_DIR}/lite/tools/cmake_tools/parse_op_registry.py
+    ${ops_src_list}
+    ${CMAKE_SOURCE_DIR}/lite/api/paddle_use_ops.h
+    "${LITE_OPTMODEL_DIR}/.tailored_ops_list"
+    ${LITE_BUILD_TAILOR}
+    RESULT_VARIABLE result
+    )
 
 #-------------------------------opt----------------------------------------------------------------
 # tricks to create headfiles for opt
-add_custom_command (
-  COMMAND python ${CMAKE_SOURCE_DIR}/lite/tools/cmake_tools/create_fake_kernel_registry.py
-  ${kernels_src_list}
-  ${fake_kernels_src_list}
-  ${CMAKE_BINARY_DIR}/all_kernel_faked.cc
-  ${CMAKE_BINARY_DIR}/kernel_src_map.h
-  OUTPUT all_kernel_faked.cc # not a real path to the output to force it execute every time.
-)
-add_custom_target (op_list_h DEPENDS ops.h)
-add_custom_target (kernel_list_h DEPENDS kernels.h)
-add_custom_target (all_kernel_faked_cc DEPENDS all_kernel_faked.cc)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/all_kernel_faked_dir)
+execute_process(
+    COMMAND python ${CMAKE_SOURCE_DIR}/lite/tools/cmake_tools/create_fake_kernel_registry.py
+    ${kernels_src_list}
+    ${fake_kernels_src_list}
+    ${CMAKE_BINARY_DIR}/all_kernel_faked_dir
+    ${CMAKE_BINARY_DIR}/all_kernel_faked.h
+    ${CMAKE_BINARY_DIR}/all_kernel_faked.cc
+    ${CMAKE_BINARY_DIR}/kernel_src_map.h
+    RESULT_VARIABLE result)
+
+file(GLOB all_kernel_faked_src ${CMAKE_BINARY_DIR}/all_kernel_faked_dir/*.cc)
+if (LITE_ON_MODEL_OPTIMIZE_TOOL)
+  add_library(all_kernel_faked OBJECT ${all_kernel_faked_src})
+  add_dependencies(all_kernel_faked op kernel type_system)
+endif()
 
 # create headfile to restore ops info sorted by suppported platforms
-add_custom_command (
-  COMMAND python ${CMAKE_SOURCE_DIR}/lite/tools/cmake_tools/record_supported_kernel_op.py
-  ${kernels_src_list}
-  ${fake_kernels_src_list}
-  ${ops_src_list}
-  ${CMAKE_BINARY_DIR}/supported_kernel_op_info.h
-  OUTPUT supported_kernel_op_info.h # not a real path to the output to force it execute every time.
-)
-add_custom_target (supported_kernel_op_info_h DEPENDS supported_kernel_op_info.h)
+execute_process(
+    COMMAND python ${CMAKE_SOURCE_DIR}/lite/tools/cmake_tools/record_supported_kernel_op.py
+    ${kernels_src_list}
+    ${fake_kernels_src_list}
+    ${ops_src_list}
+    ${CMAKE_BINARY_DIR}/supported_kernel_op_info.h
+    RESULT_VARIABLE result)
 #----------------------------------------------- NOT CHANGE -----------------------------------------------
 lite_cc_library (kernel SRCS kernel.cc
   DEPS context type_system target_wrapper any op_params tensor
@@ -136,8 +137,6 @@ lite_cc_library (op SRCS op_lite.cc
   DEPS scope op_registry target_wrapper kernel cpp_op_desc tensor utils
 )
 
-add_dependencies (kernel kernel_list_h)
-add_dependencies (op op_list_h)
 
 
 lite_cc_library (type_system SRCS type_system.cc DEPS tensor target_wrapper)


### PR DESCRIPTION
背景：opt工具编译过慢，严重影响RD同学和业务部门使用lite的开发效率；
问题描述：
all_kernel_faked.c中添加的全局算子类的注册数目超过了编译器对同一编译单元内的编译设置，导致卡住很久；
实现方法：
（1）把原来在cmake中用add_custom_target在make编译阶段执行python脚本的部分统统换成使用execute_process()的方式在cmake构建阶段执行（这里仔细确认过修改地方的python脚本的输入都是在cmake构建阶段使用cmake file()命令得到的结果），然后去除了不必要的target依赖提速编译；
（2）把原来编译opt预处理生成的all_faked_kernel.cc拆解成all_faked_kernel.h和若干个kernel两大部分，拆解出的若干个kernel单独编译成.o后再完成链接，提速比较明显；
结果：
在默认make -j8设置下编译opt从原来21min提速到8min。
本PR影响：
暂无。