### PR TITLE
[Metal] fix compile, winograde, memory manage bugs;   add new kernel: pad2d, mat_mul;

### DIFF
--- a/lite/backends/metal/CMakeLists.txt
+++ b/lite/backends/metal/CMakeLists.txt
@@ -29,8 +29,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/lite.metallib
 find_library(METAL_LIBRARY Metal REQUIRED)
 find_library(FOUNDATION_LIBRARY Foundation)
 
-add_library(
-        metal_target_wrapper
+lite_cc_library(metal_target_wrapper SRCS
         context.mm
         metal_buffer.mm
         metal_context.mm

--- a/lite/backends/metal/metal_context_imp.mm
+++ b/lite/backends/metal/metal_context_imp.mm
@@ -198,8 +198,8 @@ extern NSString* cString2NSString(std::string cStr) {
         width = MIN(width, outTexture.width);
         height = pipline.threadExecutionWidth / width;
         height = MIN(height, outTexture.height);
-        groupWidth = (outTexture.width / 4 + width - 1) / width;
-        groupHeight = (outTexture.height / 1 + height - 1) / height;
+        groupWidth = (outTexture.width / 2 + width - 1) / width;
+        groupHeight = (outTexture.height / 2 + height - 1) / height;
     } else {
         width = pipline.threadExecutionWidth;
         width = MIN(width, outTexture.width);

--- a/lite/backends/metal/metal_kernel/texture/Pad2d.metal
+++ b/lite/backends/metal/metal_kernel/texture/Pad2d.metal
@@ -17,58 +17,19 @@
 #include "Common.metal"
 using namespace metal;
 
-kernel void pad2d_half(texture2d_array<half, access::read> inTexture
-                       [[texture(0)]],
-                       texture2d_array<half, access::write> outTexture
-                       [[texture(1)]],
-                       constant Pad2dParam &pm [[buffer(0)]],
-                       uint3 gid [[thread_position_in_grid]]) {
-  if (gid.x >= outTexture.get_width() || gid.y >= outTexture.get_height() ||
-      gid.z >= outTexture.get_array_size())
-    return;
-  int x = gid.x - pm.paddingLeft;
-  int y = gid.y - pm.paddingTop;
-  if (pm.mode == 0) {
-    if (x < 0 || y < 0 || x >= inTexture.get_width() ||
-        y >= inTexture.get_height()) {
-      outTexture.write(half4(pm.padValue), uint2(gid.xy), gid.z);
-    } else {
-      outTexture.write(
-          inTexture.read(uint2(x, y), gid.z), uint2(gid.xy), gid.z);
-    }
-  } else if (pm.mode == 1) {
-    x = abs(x);
-    y = abs(y);
-    int w = inTexture.get_width();
-    int h = inTexture.get_height();
-    x = x < w ? x : 2 * w - 2 - x;
-    y = y < h ? y : 2 * h - 2 - y;
-    outTexture.write(inTexture.read(uint2(x, y), gid.z), uint2(gid.xy), gid.z);
-  } else if (pm.mode == 2) {
-    int w = inTexture.get_width();
-    int h = inTexture.get_height();
-    x = x > 0 ? x : 0;
-    x = x < w ? x : w - 1;
-    y = y > 0 ? y : 0;
-    y = y < h ? y : h - 1;
-    outTexture.write(inTexture.read(uint2(x, y), gid.z), uint2(gid.xy), gid.z);
-  }
-}
-
-kernel void pad2d(texture2d_array<float, access::read> inTexture [[texture(0)]],
-                  texture2d_array<float, access::write> outTexture
-                  [[texture(1)]],
+kernel void pad2d(texture2d_array<ftype, access::read> inTexture [[texture(0)]],
+                  texture2d_array<ftype, access::write> outTexture [[texture(1)]],
                   constant Pad2dParam &pm [[buffer(0)]],
                   uint3 gid [[thread_position_in_grid]]) {
   if (gid.x >= outTexture.get_width() || gid.y >= outTexture.get_height() ||
       gid.z >= outTexture.get_array_size())
     return;
-  int x = gid.x - pm.paddingLeft;
-  int y = gid.y - pm.paddingTop;
+  uint x = gid.x - pm.paddingLeft;
+  uint y = gid.y - pm.paddingTop;
   if (pm.mode == 0) {
     if (x < 0 || y < 0 || x >= inTexture.get_width() ||
         y >= inTexture.get_height()) {
-      outTexture.write(float4(pm.padValue), uint2(gid.xy), gid.z);
+      outTexture.write(ftype4(pm.padValue), uint2(gid.xy), gid.z);
     } else {
       outTexture.write(
           inTexture.read(uint2(x, y), gid.z), uint2(gid.xy), gid.z);
@@ -76,14 +37,14 @@ kernel void pad2d(texture2d_array<float, access::read> inTexture [[texture(0)]],
   } else if (pm.mode == 1) {
     x = abs(x);
     y = abs(y);
-    int w = inTexture.get_width();
-    int h = inTexture.get_height();
+    uint w = inTexture.get_width();
+    uint h = inTexture.get_height();
     x = x < w ? x : 2 * w - 2 - x;
     y = y < h ? y : 2 * h - 2 - y;
     outTexture.write(inTexture.read(uint2(x, y), gid.z), uint2(gid.xy), gid.z);
   } else if (pm.mode == 2) {
-    int w = inTexture.get_width();
-    int h = inTexture.get_height();
+    uint w = inTexture.get_width();
+    uint h = inTexture.get_height();
     x = x > 0 ? x : 0;
     x = x < w ? x : w - 1;
     y = y > 0 ? y : 0;

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -307,9 +307,14 @@ RuntimeProgram::RuntimeProgram(
           ContextScheduler::Global().NewContext(kernel->target()));
     }
 #elif LITE_WITH_METAL
-    std::unique_ptr<KernelContext> ctx(new KernelContext());
-    (*metal_ctx_).As<MTLContext>().CopySharedTo(&ctx->As<MTLContext>());
-    kernel->SetContext(std::move(ctx));
+    if (kernel->target() == TARGET(kMetal)) {
+      std::unique_ptr<KernelContext> ctx(new KernelContext());
+      (*metal_ctx_).As<MTLContext>().CopySharedTo(&ctx->As<MTLContext>());
+      kernel->SetContext(std::move(ctx));
+    } else {
+      kernel->SetContext(
+          ContextScheduler::Global().NewContext(kernel->target()));
+    }
 #else
     if (kernel != nullptr) {
       kernel->SetContext(

--- a/lite/kernels/metal/CMakeLists.txt
+++ b/lite/kernels/metal/CMakeLists.txt
@@ -44,6 +44,8 @@ add_kernel(exp_metal_image APPLE_METAL basic SRCS image_op/exp_image_compute.mm 
 # add_kernel(box_coder_metal_image APPLE_METAL basic SRCS image_op/box_coder_image_compute.mm DEPS metal_target_wrapper)
 add_kernel(fetch_metal_image APPLE_METAL basic SRCS image_op/fetch_image_compute.mm DEPS metal_target_wrapper)
 add_kernel(slice_metal_compute APPLE_METAL basic SRCS image_op/slice_image_compute.mm DEPS metal_target_wrapper)
+add_kernel(matmul_metal_compute APPLE_METAL basic SRCS image_op/matmul_image_compute.mm DEPS metal_target_wrapper)
+add_kernel(pad2d_metal_compute APPLE_METAL basic SRCS image_op/pad2d_image_compute.mm DEPS metal_target_wrapper)
 
 
 add_library(METAL_BASE STATIC IMPORTED )

--- a/lite/kernels/metal/image_op/concat_image_compute.h
+++ b/lite/kernels/metal/image_op/concat_image_compute.h
@@ -53,7 +53,7 @@ class ConcatImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
     std::string v_ = "normal";

--- a/lite/kernels/metal/image_op/concat_image_compute.mm
+++ b/lite/kernels/metal/image_op/concat_image_compute.mm
@@ -44,8 +44,8 @@ void ConcatImageCompute::PrepareForRun() {
 }
 
 void ConcatImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     int idx = 0;
@@ -139,7 +139,7 @@ void ConcatImageCompute::setup_without_mps() {
     function_name_ = "concat_" + std::to_string(orank) + "_" + std::to_string(num) + "_" + v_;
 #endif
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 }  // namespace metal

--- a/lite/kernels/metal/image_op/conv2d_image_compute.h
+++ b/lite/kernels/metal/image_op/conv2d_image_compute.h
@@ -42,10 +42,10 @@ class Conv2dImageCompute
    public:
     void PrepareForRun() override;
     void Run() override;
-    void SaveOutput() override;
-    //  void SaveOutput() override {
-    //    MetalDebug::SaveOutput("conv2d", output_buffer_);
-    //  };
+    void SaveOutput() override {
+        MetalDebug::SaveOutput(
+            (use_mps_ ? ("MPS_" + function_name_) : function_name_), output_buffer_);
+    };
     virtual ~Conv2dImageCompute();
 
    private:
@@ -76,7 +76,7 @@ class Conv2dImageCompute
     uint16_t activate_type_ = 0;
     std::string name_param_out_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 

--- a/lite/kernels/metal/image_op/elementwise_add_image_compute.h
+++ b/lite/kernels/metal/image_op/elementwise_add_image_compute.h
@@ -63,7 +63,7 @@ class ElementwiseAddImageCompute
     const MetalImage* input_buffer_y_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/elementwise_add_image_compute.mm
+++ b/lite/kernels/metal/image_op/elementwise_add_image_compute.mm
@@ -90,8 +90,8 @@ void ElementwiseAddImageCompute::Run() {
 #pragma mark - SELF
 
 void ElementwiseAddImageCompute::run_without_mps() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -132,7 +132,7 @@ void ElementwiseAddImageCompute::setup_without_mps() {
     if (input_buffer_y_->tensor_dim_.size() == 1 &&
         (axis == 1 ||
             (axis == -1 &&
-                input_buffer_y_->tensor_dim_[0] == input_buffer_x_->pad_to_four_dim_[1]))) {
+                input_buffer_y_->tensor_dim_[0] == input_buffer_x_->dim_[3]))) {
         add_by_channel = 1;
     }
     if (add_by_channel == 1 || params_fast == 1) {
@@ -162,7 +162,7 @@ void ElementwiseAddImageCompute::setup_without_mps() {
 
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 #pragma mark - MPS

--- a/lite/kernels/metal/image_op/elementwise_mul_image_compute.h
+++ b/lite/kernels/metal/image_op/elementwise_mul_image_compute.h
@@ -52,7 +52,7 @@ class ElementwiseMulImageCompute
     const MetalImage* input_buffer_y_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/elementwise_mul_image_compute.mm
+++ b/lite/kernels/metal/image_op/elementwise_mul_image_compute.mm
@@ -44,8 +44,8 @@ void ElementwiseMulImageCompute::PrepareForRun() {
 }
 
 void ElementwiseMulImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -108,7 +108,7 @@ void ElementwiseMulImageCompute::setup_without_mps() {
     function_name_ = "elementwise_mul";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 }  // namespace metal

--- a/lite/kernels/metal/image_op/exp_image_compute.h
+++ b/lite/kernels/metal/image_op/exp_image_compute.h
@@ -48,7 +48,7 @@ class ExpImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> param_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/exp_image_compute.mm
+++ b/lite/kernels/metal/image_op/exp_image_compute.mm
@@ -38,12 +38,12 @@ void ExpImageCompute::PrepareForRun() {
     function_name_ = "exp";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 void ExpImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];

--- a/lite/kernels/metal/image_op/fc_image_compute.h
+++ b/lite/kernels/metal/image_op/fc_image_compute.h
@@ -54,7 +54,7 @@ class FCImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 

--- a/lite/kernels/metal/image_op/fc_image_compute.mm
+++ b/lite/kernels/metal/image_op/fc_image_compute.mm
@@ -45,8 +45,8 @@ void FCImageCompute::PrepareForRun() {
 }
 
 void FCImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -84,7 +84,7 @@ void FCImageCompute::setup_without_mps() {
     function_name_ = "mul_add";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 }
 }

--- a/lite/kernels/metal/image_op/feed_image_compute.h
+++ b/lite/kernels/metal/image_op/feed_image_compute.h
@@ -50,7 +50,7 @@ class FeedImageCompute
     std::shared_ptr<MetalBuffer> param_buffer_;
     MetalImage* output_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/feed_image_compute.mm
+++ b/lite/kernels/metal/image_op/feed_image_compute.mm
@@ -50,12 +50,12 @@ void FeedImageCompute::PrepareForRun() {
     }
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 void FeedImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     const auto& param = this->Param<param_t>();

--- a/lite/kernels/metal/image_op/fetch_image_compute.h
+++ b/lite/kernels/metal/image_op/fetch_image_compute.h
@@ -52,7 +52,7 @@ class FetchImageCompute
     std::shared_ptr<MetalBuffer> output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/fetch_image_compute.mm
+++ b/lite/kernels/metal/image_op/fetch_image_compute.mm
@@ -56,8 +56,8 @@ void FetchImageCompute::PrepareForRun() {
 }
 
 void FetchImageCompute::Run() {
+    auto pipline = pipline_;
     auto inTexture = input_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -99,7 +99,7 @@ void FetchImageCompute::setup_without_mps() {
 
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 }  // namespace metal

--- a/lite/kernels/metal/image_op/io_copy_image_compute.mm
+++ b/lite/kernels/metal/image_op/io_copy_image_compute.mm
@@ -104,7 +104,7 @@ class IoCopyHostToMetalTexture
     MetalImage* output_buffer_ = nullptr;
     std::shared_ptr<MetalBuffer> src_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/matmul_image_compute.h
+++ b/lite/kernels/metal/image_op/matmul_image_compute.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "lite/core/kernel.h"
+#include "lite/core/tensor.h"
+#include "lite/operators/op_params.h"
+
+#ifdef LITE_WITH_PROFILE
+#include "lite/core/profile/profiler.h"
+#endif
+
+#include "lite/backends/metal/metal_context.h"
+#include "lite/backends/metal/metal_debug.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace metal {
+
+class MatMulImageCompute
+    : public KernelLite<TARGET(kMetal), PRECISION(kFloat), DATALAYOUT(kMetalTexture2DArray)> {
+    using param_t = operators::MatMulParam;
+
+   public:
+    void PrepareForRun() override;
+    void Run() override;
+    void SaveOutput() override {
+        MetalDebug::SaveOutput(function_name_, output_buffer_);
+    };
+
+   private:
+    void setup_without_mps();
+
+    MetalImage* output_buffer_;
+    const MetalImage* input_buffer_x_;
+    const MetalImage* input_buffer_y_;
+
+    id<MTLComputePipelineState> pipline_;
+    std::string function_name_;
+    MetalContext* metal_context_;
+};
+
+}  // namespace metal
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/metal/image_op/matmul_image_compute.mm
+++ b/lite/kernels/metal/image_op/matmul_image_compute.mm
@@ -1,0 +1,121 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/metal/image_op/matmul_image_compute.h"
+#include "lite/backends/metal/metal_context_imp.h"
+#include "lite/core/op_registry.h"
+#include "lite/core/tensor.h"
+#include "lite/kernels/metal/image_op/metal_params.h"
+
+using namespace std;
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace metal {
+
+void MatMulImageCompute::PrepareForRun() {
+    auto& context = ctx_->As<MTLContext>();
+    metal_context_ = (MetalContext*)context.context();
+
+    const auto& param = this->Param<param_t>();
+    auto output_dims = param.Out->dims();
+    auto input_dims = param.X->dims();
+
+#ifdef LITE_WITH_METAL_FULL
+#else
+    input_buffer_x_ = param.X->data<MetalHalf, MetalImage>();
+    input_buffer_y_ = param.Y->data<MetalHalf, MetalImage>();
+    output_buffer_ = param.Out->mutable_data<MetalHalf, MetalImage>(metal_context_, output_dims);
+#endif
+
+    setup_without_mps();
+}
+
+void MatMulImageCompute::Run() {
+    auto pipline = pipline_;
+    auto outTexture = output_buffer_->image();
+    auto backend = (__bridge MetalContextImp*)metal_context_->backend();
+
+    auto encoder = [backend commandEncoder];
+    [encoder setTexture:input_buffer_x_->image() atIndex:(0)];
+    [encoder setTexture:input_buffer_y_->image() atIndex:(1)];
+    [encoder setTexture:output_buffer_->image() atIndex:(2)];
+
+    [backend dispatchEncoder:encoder pipline:pipline outTexture:outTexture];
+    [backend commit];
+}
+
+void MatMulImageCompute::setup_without_mps() {
+    auto valid = false;
+    if (input_buffer_y_->tensor_dim_.size() == 4) {
+        
+    } else if (input_buffer_y_->tensor_dim_.size() == 3) {
+        
+    } else {
+        //tensor.size = 1, 2
+        if(input_buffer_x_->dim_[0] == 1 &&
+           input_buffer_x_->dim_[1] == 1 && input_buffer_x_->dim_[2] == 1) {
+            valid = true;
+        }
+    }
+    if (!valid) {
+        LOG(FATAL) << "mat_mul: only supports : 1.same shapes 2.by channel.";
+    }
+
+    // inputy来源：4维-参数来自于上一个输入 3维-参数来自于外部tensor
+    function_name_ = "mat_mul";
+    // pipline
+    auto backend = (__bridge MetalContextImp*)metal_context_->backend();
+    pipline_ = [backend pipline:function_name_];
+}
+
+}  // namespace metal
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(matmul,
+    kMetal,
+    kFloat,
+    kMetalTexture2DArray,
+    paddle::lite::kernels::metal::MatMulImageCompute,
+    def)
+    .BindInput("X",
+        {LiteType::GetTensorTy(TARGET(kMetal),
+            PRECISION(kFloat),
+            DATALAYOUT(kMetalTexture2DArray))})
+    .BindInput("Y",
+        {LiteType::GetTensorTy(TARGET(kMetal),
+            PRECISION(kFloat),
+            DATALAYOUT(kMetalTexture2DArray))})
+    .BindOutput("Out",
+        {LiteType::GetTensorTy(TARGET(kMetal),
+            PRECISION(kFloat),
+            DATALAYOUT(kMetalTexture2DArray))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(matmul,
+    kMetal,
+    kFP16,
+    kMetalTexture2DArray,
+    paddle::lite::kernels::metal::MatMulImageCompute,
+    def)
+    .BindInput("X",
+        {LiteType::GetTensorTy(TARGET(kMetal), PRECISION(kFP16), DATALAYOUT(kMetalTexture2DArray))})
+    .BindInput("Y",
+        {LiteType::GetTensorTy(TARGET(kMetal), PRECISION(kFP16), DATALAYOUT(kMetalTexture2DArray))})
+    .BindOutput("Out",
+        {LiteType::GetTensorTy(TARGET(kMetal), PRECISION(kFP16), DATALAYOUT(kMetalTexture2DArray))})
+    .Finalize();

--- a/lite/kernels/metal/image_op/matmul_image_compute.mm
+++ b/lite/kernels/metal/image_op/matmul_image_compute.mm
@@ -74,7 +74,7 @@ void MatMulImageCompute::setup_without_mps() {
         LOG(FATAL) << "mat_mul: only supports : 1.same shapes 2.by channel.";
     }
 
-    // inputy来源：4维-参数来自于上一个输入 3维-参数来自于外部tensor
+    // input y：4-dims come from last output; 3-dims come from tensor input;
     function_name_ = "mat_mul";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();

--- a/lite/kernels/metal/image_op/metal_params.h
+++ b/lite/kernels/metal/image_op/metal_params.h
@@ -242,4 +242,13 @@ struct FetchMetalParam {
     int idim[4];
 };
 
+struct Pad2dParam {
+    uint16_t paddingTop;
+    uint16_t paddingBottom;
+    uint16_t paddingLeft;
+    uint16_t paddingRight;
+    float padValue;
+    uint16_t mode;
+};
+
 #endif  // LITE_KERNELS_METAL_IMAGE_OP_METAL_PARAMS_H_

--- a/lite/kernels/metal/image_op/nearest_interp_image_compute.h
+++ b/lite/kernels/metal/image_op/nearest_interp_image_compute.h
@@ -50,7 +50,7 @@ class NearestInterpImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/nearest_interp_image_compute.mm
+++ b/lite/kernels/metal/image_op/nearest_interp_image_compute.mm
@@ -42,8 +42,8 @@ void NearestInterpImageCompute::PrepareForRun() {
 }
 
 void NearestInterpImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -83,7 +83,7 @@ void NearestInterpImageCompute::setup_without_mps() {
     function_name_ = "nearest_interp";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 }  // namespace metal

--- a/lite/kernels/metal/image_op/pad2d_image_compute.h
+++ b/lite/kernels/metal/image_op/pad2d_image_compute.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "lite/core/kernel.h"
+#include "lite/core/tensor.h"
+#include "lite/operators/op_params.h"
+
+#ifdef LITE_WITH_PROFILE
+#include "lite/core/profile/profiler.h"
+#endif
+
+#include "lite/backends/metal/metal_context.h"
+#include "lite/backends/metal/metal_debug.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace metal {
+
+class Pad2dImageCompute
+    : public KernelLite<TARGET(kMetal), PRECISION(kFloat), DATALAYOUT(kMetalTexture2DArray)> {
+    using param_t = operators::Pad2dParam;
+
+   public:
+    void PrepareForRun() override;
+    void Run() override;
+    void SaveOutput() override {
+        MetalDebug::SaveOutput(function_name_, output_buffer_);
+    };
+
+   private:
+    void setup_without_mps();
+
+    MetalImage* output_buffer_;
+    const MetalImage* input_buffer_x_;
+    std::shared_ptr<MetalBuffer> params_buffer_;
+
+    id<MTLComputePipelineState> pipline_;
+    std::string function_name_;
+    MetalContext* metal_context_;
+};
+
+}  // namespace metal
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/metal/image_op/pad2d_image_compute.mm
+++ b/lite/kernels/metal/image_op/pad2d_image_compute.mm
@@ -1,0 +1,121 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/metal/image_op/pad2d_image_compute.h"
+#include "lite/backends/metal/metal_context_imp.h"
+#include "lite/core/op_registry.h"
+#include "lite/core/tensor.h"
+#include "lite/kernels/metal/image_op/metal_params.h"
+
+using namespace std;
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace metal {
+
+void Pad2dImageCompute::PrepareForRun() {
+    auto& context = ctx_->As<MTLContext>();
+    metal_context_ = (MetalContext*)context.context();
+
+    const auto& param = this->Param<param_t>();
+    auto output_dims = param.Out->dims();
+
+#ifdef LITE_WITH_METAL_FULL
+#else
+    input_buffer_x_ = param.X->data<MetalHalf, MetalImage>();
+    output_buffer_ = param.Out->mutable_data<MetalHalf, MetalImage>(metal_context_, output_dims);
+#endif
+
+    setup_without_mps();
+}
+
+void Pad2dImageCompute::Run() {
+    auto pipline = pipline_;
+    auto outTexture = output_buffer_->image();
+    auto backend = (__bridge MetalContextImp*)metal_context_->backend();
+
+    auto encoder = [backend commandEncoder];
+    [encoder setTexture:input_buffer_x_->image() atIndex:(0)];
+    [encoder setTexture:output_buffer_->image() atIndex:(1)];
+    [encoder setBuffer:params_buffer_->buffer() offset:(0) atIndex:(0)];
+
+    [backend dispatchEncoder:encoder pipline:pipline outTexture:outTexture];
+    [backend commit];
+}
+
+void Pad2dImageCompute::setup_without_mps() {
+    const auto& param = this->Param<param_t>();
+
+    short mode = 0;
+    if (param.mode == "reflect") {
+        mode = 1;
+    } else if (param.mode == "edge") {
+        mode = 2;
+    } else if (param.mode == "constant") {
+        mode = 0;
+    } else {
+        LOG(FATAL) << "pad2d: only supports : 1.same shapes 2.by channel.";
+    }
+    
+    Pad2dParam pad_params = {
+        static_cast<uint16_t>(param.paddings[0]),
+        static_cast<uint16_t>(param.paddings[1]),
+        static_cast<uint16_t>(param.paddings[2]),
+        static_cast<uint16_t>(param.paddings[3]),
+        param.pad_value,
+        static_cast<uint16_t>(mode)
+    };
+    params_buffer_ =
+        std::make_shared<MetalBuffer>(metal_context_, sizeof(pad_params), &pad_params);
+
+    // input y：4-dims come from last output; 3-dims come from tensor input;
+    function_name_ = "pad2d";
+    // pipline
+    auto backend = (__bridge MetalContextImp*)metal_context_->backend();
+    pipline_ = [backend pipline:function_name_];
+}
+
+}  // namespace metal
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(pad2d,
+    kMetal,
+    kFloat,
+    kMetalTexture2DArray,
+    paddle::lite::kernels::metal::Pad2dImageCompute,
+    def)
+    .BindInput("X",
+        {LiteType::GetTensorTy(TARGET(kMetal),
+            PRECISION(kFloat),
+            DATALAYOUT(kMetalTexture2DArray))})
+    .BindOutput("Out",
+        {LiteType::GetTensorTy(TARGET(kMetal),
+            PRECISION(kFloat),
+            DATALAYOUT(kMetalTexture2DArray))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(pad2d,
+    kMetal,
+    kFP16,
+    kMetalTexture2DArray,
+    paddle::lite::kernels::metal::Pad2dImageCompute,
+    def)
+    .BindInput("X",
+        {LiteType::GetTensorTy(TARGET(kMetal), PRECISION(kFP16), DATALAYOUT(kMetalTexture2DArray))})
+    .BindOutput("Out",
+        {LiteType::GetTensorTy(TARGET(kMetal), PRECISION(kFP16), DATALAYOUT(kMetalTexture2DArray))})
+    .Finalize();

--- a/lite/kernels/metal/image_op/pool_image_compute.h
+++ b/lite/kernels/metal/image_op/pool_image_compute.h
@@ -62,7 +62,7 @@ class PoolImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/pool_image_compute.mm
+++ b/lite/kernels/metal/image_op/pool_image_compute.mm
@@ -73,8 +73,8 @@ void PoolImageCompute::Run() {
 #pragma mark - SELF
 void PoolImageCompute::run_without_mps() {
     const auto& param = this->Param<param_t>();
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -144,7 +144,7 @@ void PoolImageCompute::setup_without_mps() {
     }
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 #pragma mark - MPS

--- a/lite/kernels/metal/image_op/relu_image_compute.h
+++ b/lite/kernels/metal/image_op/relu_image_compute.h
@@ -48,7 +48,7 @@ class ReluImageCompute
     const MetalImage* input_buffer_;
     MetalImage* output_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };
@@ -69,7 +69,7 @@ class Relu6ImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };
@@ -90,7 +90,7 @@ class LeakyReluImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/relu_image_compute.mm
+++ b/lite/kernels/metal/image_op/relu_image_compute.mm
@@ -40,12 +40,12 @@ void ReluImageCompute::PrepareForRun() {
     function_name_ = "relu";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 void ReluImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -73,12 +73,12 @@ void Relu6ImageCompute::PrepareForRun() {
     function_name_ = "relu6";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 void Relu6ImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -107,12 +107,12 @@ void LeakyReluImageCompute::PrepareForRun() {
     function_name_ = "leaky_relu";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 void LeakyReluImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];

--- a/lite/kernels/metal/image_op/reshape_image_compute.h
+++ b/lite/kernels/metal/image_op/reshape_image_compute.h
@@ -52,7 +52,7 @@ class ReshapeImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/reshape_image_compute.mm
+++ b/lite/kernels/metal/image_op/reshape_image_compute.mm
@@ -39,8 +39,8 @@ void ReshapeImageCompute::PrepareForRun() {
 }
 
 void ReshapeImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -91,14 +91,11 @@ void ReshapeImageCompute::setup_without_mps() {
 #endif
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 ReshapeImageCompute::~ReshapeImageCompute() {
-    if (pipline_) {
-        CFRelease(pipline_);
-        pipline_ = nullptr;
-    }
+
 }
 
 }  // namespace metal

--- a/lite/kernels/metal/image_op/sigmoid_image_compute.h
+++ b/lite/kernels/metal/image_op/sigmoid_image_compute.h
@@ -49,7 +49,7 @@ class SigmoidImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> param_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/sigmoid_image_compute.mm
+++ b/lite/kernels/metal/image_op/sigmoid_image_compute.mm
@@ -41,12 +41,12 @@ void SigmoidImageCompute::PrepareForRun() {
     function_name_ = "sigmoid";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 void SigmoidImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];

--- a/lite/kernels/metal/image_op/slice_image_compute.h
+++ b/lite/kernels/metal/image_op/slice_image_compute.h
@@ -52,7 +52,7 @@ class SliceImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/slice_image_compute.mm
+++ b/lite/kernels/metal/image_op/slice_image_compute.mm
@@ -41,8 +41,8 @@ void SliceImageCompute::PrepareForRun() {
 }
 
 void SliceImageCompute::Run() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -102,7 +102,7 @@ void SliceImageCompute::setup_without_mps() {
     function_name_ = "slice";
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 }
 
 }  // namespace metal

--- a/lite/kernels/metal/image_op/softmax_image_compute.h
+++ b/lite/kernels/metal/image_op/softmax_image_compute.h
@@ -63,7 +63,7 @@ class SoftmaxImageCompute
     MetalImage* output_buffer_;
     std::shared_ptr<MetalBuffer> params_buffer_;
 
-    void* pipline_;
+    id<MTLComputePipelineState> pipline_;
     std::string function_name_;
     MetalContext* metal_context_;
 };

--- a/lite/kernels/metal/image_op/softmax_image_compute.mm
+++ b/lite/kernels/metal/image_op/softmax_image_compute.mm
@@ -67,8 +67,8 @@ void SoftmaxImageCompute::Run() {
 #pragma mark - SELF
 
 void SoftmaxImageCompute::run_without_mps() {
+    auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
-    auto pipline = (__bridge id<MTLComputePipelineState>)pipline_;
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
 
     auto encoder = [backend commandEncoder];
@@ -117,7 +117,7 @@ void SoftmaxImageCompute::setup_without_mps() {
 
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
-    pipline_ = (__bridge_retained void*)[backend pipline:function_name_];
+    pipline_ = [backend pipline:function_name_];
 
     SoftmaxMetalParam2 metal_param{
         (int)input_buffer_->pad_to_four_dim_[0],


### PR DESCRIPTION
fix shell compile;  fix wrong winograde result;  add new kernel: pad2d, mat_mul; fix memory crash；

修复：build_ios_with_metal.sh脚本编译时，/lite/backends/metal/xxx.mm 文件未编译到library问题；
修复：conv-winograde实现结果未对齐问题；（即：threadgroup设置不正确）
添加：新kernel：pad2d、mat_mul
修复：预测对象释放时崩溃问题；由于C++持有OC对象方式不正确导致；（即：由void*指针持有改为实际对象类型持有，这样OC对象引用计数才会+1）