### PR TITLE
modify the io_copy operator, test=develop

### DIFF
--- a/lite/operators/io_copy_op.cc
+++ b/lite/operators/io_copy_op.cc
@@ -60,6 +60,9 @@ bool IoCopyOp::AttachImpl(const cpp::OpDesc &opdesc,
   if (opdesc.HasInput("InputArray")) {
     param_.x_array = scope->FindTensorList(opdesc.Input("InputArray").front());
   }
+  if (opdesc.HasInput("WriteBack")) {
+    param_.y = scope->FindMutableTensor(opdesc.Input("WriteBack").front());
+  }
   if (opdesc.HasOutput("Out")) {
     param_.y = scope->FindMutableTensor(opdesc.Output("Out").front());
   }

--- a/lite/operators/io_copy_op.cc
+++ b/lite/operators/io_copy_op.cc
@@ -62,8 +62,8 @@ bool IoCopyOp::AttachImpl(const cpp::OpDesc &opdesc,
   }
   // In order to support static single assignment, the output variable needs to
   // be passed in as input.
-  if (opdesc.HasInput("WriteBack")) {
-    param_.y = scope->FindMutableTensor(opdesc.Input("WriteBack").front());
+  if (opdesc.HasInput("WriteBack_Out")) {
+    param_.y = scope->FindMutableTensor(opdesc.Input("WriteBack_Out").front());
   }
   if (opdesc.HasOutput("Out")) {
     param_.y = scope->FindMutableTensor(opdesc.Output("Out").front());

--- a/lite/operators/io_copy_op.cc
+++ b/lite/operators/io_copy_op.cc
@@ -60,6 +60,8 @@ bool IoCopyOp::AttachImpl(const cpp::OpDesc &opdesc,
   if (opdesc.HasInput("InputArray")) {
     param_.x_array = scope->FindTensorList(opdesc.Input("InputArray").front());
   }
+  // In order to support static single assignment, the output variable needs to
+  // be passed in as input.
   if (opdesc.HasInput("WriteBack")) {
     param_.y = scope->FindMutableTensor(opdesc.Input("WriteBack").front());
   }


### PR DESCRIPTION
修改 `io_copy` 算子输入：增加输入属性 `WriteBack_Out` 作为回写输出，以支持静态图拓扑排序不确定问题的修复。

<img src="https://user-images.githubusercontent.com/39303645/123051885-cc8b4800-d434-11eb-969a-546fef8b6611.png" width="400">

如上图，(a) 带来的有向环将使框架无法仅根据图的节点依赖确定执行顺序，所以将其变换为 (b)。为了不再产生环，所以使其输出参数移到输入。

兼容性说明：
`io_copy` 为 Paddle-Lite 框架内部算子，仅产出于 opt 目标模型，与其它框架无耦合。此修改向后兼容，原本可以正常运行的模型不会因此修改受到影响。