### PR TITLE
fix bug in naive_buffer to support compile on windows vs_2017

### DIFF
--- a/lite/model_parser/naive_buffer/naive_buffer.h
+++ b/lite/model_parser/naive_buffer/naive_buffer.h
@@ -292,7 +292,7 @@ class StructBuilder : public FieldBuilder {
  */
 template <typename Builder>
 class ListBuilder : public FieldBuilder {
-  std::vector<Builder> builders_;
+  std::deque<Builder> builders_;
 
  public:
   explicit ListBuilder(BinaryTable* table) : FieldBuilder(table) {}
@@ -314,15 +314,15 @@ class ListBuilder : public FieldBuilder {
     return &builders_[i];
   }
 
-  typename std::vector<Builder>::iterator begin() { return builders_.begin(); }
+  typename std::deque<Builder>::iterator begin() { return builders_.begin(); }
 
-  typename std::vector<Builder>::iterator end() { return builders_.end(); }
+  typename std::deque<Builder>::iterator end() { return builders_.end(); }
 
-  typename std::vector<Builder>::const_iterator begin() const {
+  typename std::deque<Builder>::const_iterator begin() const {
     return builders_.begin();
   }
 
-  typename std::vector<Builder>::const_iterator end() const {
+  typename std::deque<Builder>::const_iterator end() const {
     return builders_.end();
   }
 


### PR DESCRIPTION
There is a vector container in the class ”ListBuilder“ member. When the vector container needs to be expanded, it will call the copy constructor of the container element, but the elements in this container are forbidden to be copied. Therefore, we use the container “std:: deque” to avoid calling the copy constructor when expanding.