### PR TITLE
[Framework]add kernel vartype StepScope and add vartype transformation

### DIFF
--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -132,6 +132,10 @@ void RuntimeProgram::SaveToProgram(
             // Set persistable=false for tensor array
             v->SetType(cpp::VarDesc::Type::LOD_TENSOR_ARRAY);
             v->SetPersistable(false);
+          } else if (decl_type->IsStepScope() &&
+                     var->IsType<std::vector<lite::Scope*>>()) {
+            v->SetType(cpp::VarDesc::Type::STEP_SCOPES);
+            v->SetPersistable(false);
           } else {
             LOG(WARNING) << "Unsupported decl type " << *decl_type
                          << " for var " << var_name << " in op " << op_type;
@@ -544,7 +548,11 @@ void Program::PrepareWorkspace(
         } else if (var_type == lite::VarDescAPI::Type::LOD_TENSOR_ARRAY) {
           var_type_map_[var_name] = LiteType::GetTensorListTy(
               TARGET(kUnk), PRECISION(kUnk), DATALAYOUT(kUnk));
+        } else if (var_type == lite::VarDescAPI::Type::STEP_SCOPES) {
+          var->GetMutable<std::vector<lite::Scope*>>();
+          LOG(WARNING) << " var_name :  lite::VarDescAPI::Type::STEP_SCOPES";
         }
+
       } else {
         if (var_name == "feed" || var_name == "fetch") continue;
         weights_.push_back(var_name);

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -550,11 +550,7 @@ void Program::PrepareWorkspace(
               TARGET(kUnk), PRECISION(kUnk), DATALAYOUT(kUnk));
         } else if (var_type == lite::VarDescAPI::Type::STEP_SCOPES) {
           var->GetMutable<std::vector<lite::Scope*>>();
-        } else {
-          LOG(FATAL) << "Error: Unsupported data type for variable "
-                     << var_name;
         }
-
       } else {
         if (var_name == "feed" || var_name == "fetch") continue;
         weights_.push_back(var_name);

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -137,8 +137,8 @@ void RuntimeProgram::SaveToProgram(
             v->SetType(cpp::VarDesc::Type::STEP_SCOPES);
             v->SetPersistable(false);
           } else {
-            LOG(WARNING) << "Unsupported decl type " << *decl_type
-                         << " for var " << var_name << " in op " << op_type;
+            LOG(FATAL) << "Unsupported decl type " << *decl_type << " for var "
+                       << var_name << " in op " << op_type;
           }
         }
         already_added_vars.insert(var_name);
@@ -550,7 +550,9 @@ void Program::PrepareWorkspace(
               TARGET(kUnk), PRECISION(kUnk), DATALAYOUT(kUnk));
         } else if (var_type == lite::VarDescAPI::Type::STEP_SCOPES) {
           var->GetMutable<std::vector<lite::Scope*>>();
-          LOG(WARNING) << " var_name :  lite::VarDescAPI::Type::STEP_SCOPES";
+        } else {
+          LOG(FATAL) << "Error: Unsupported data type for variable "
+                     << var_name;
         }
 
       } else {

--- a/lite/core/type_system.cc
+++ b/lite/core/type_system.cc
@@ -103,6 +103,20 @@ const Type *Type::GetTensorListTy(TargetType target,
   return type_repo[v];
 }
 
+const Type *Type::GetStepScopeTy() {
+  static std::map<size_t, const Type *> type_repo;
+  std::hash<int> hasher;
+  size_t v = hasher(static_cast<int>(DataType::ID::StepScope));
+  if (!type_repo[v])
+    type_repo[v] = new Type(DataType::ID::StepScope,
+                            "StepScope",
+                            TARGET(kUnk),
+                            PRECISION(kUnk),
+                            DATALAYOUT(kUnk),
+                            -1);
+  return type_repo[v];
+}
+
 const Type *Type::GetUnsupportedTy() {
   static std::map<size_t, const Type *> type_repo;
   std::hash<int> hasher;

--- a/lite/core/type_system.h
+++ b/lite/core/type_system.h
@@ -90,6 +90,9 @@ class DataType {
     Tensor,
     // A tensor list, but all the elements should have the same type.
     TensorList,
+    // A vector of local scope, which size equals the step number of While Op.
+    // The i'th scope storages temporary variables generated in the i'th step.
+    StepScope,
     // ---------
     NumTypes,  // Must remains as last defined ID.
   };
@@ -101,6 +104,7 @@ class DataType {
   bool IsUnsupported() const { return id_ == ID::Unsupported; }
   bool IsTensor() const { return id_ == ID::Tensor; }
   bool IsTensorList() const { return id_ == ID::TensorList; }
+  bool IsStepScope() const { return id_ == ID::StepScope; }
   // Get number of types.
   int num_types() const { return static_cast<int>(ID::NumTypes); }
 
@@ -132,6 +136,8 @@ class Type : public DataType {
       PrecisionType precision = PRECISION(kFloat),
       DataLayoutType layout = DATALAYOUT(kNCHW),
       int device = 0);
+  /// Get a StepScope type.
+  static const Type* GetStepScopeTy();
   /// Get an Unsupported type.
   static const Type* GetUnsupportedTy();
   /// Get an Void type.

--- a/lite/kernels/host/while_compute.cc
+++ b/lite/kernels/host/while_compute.cc
@@ -54,8 +54,5 @@ REGISTER_LITE_KERNEL(
                 {LiteType::GetTensorTy(TARGET(kHost),
                                        PRECISION(kAny),
                                        DATALAYOUT(kAny))})
-    .BindOutput("StepScopes",
-                {LiteType::GetTensorTy(TARGET(kHost),
-                                       PRECISION(kAny),
-                                       DATALAYOUT(kAny))})
+    .BindOutput("StepScopes", {LiteType::GetStepScopeTy()})
     .Finalize();

--- a/lite/model_parser/compatible_pb.cc
+++ b/lite/model_parser/compatible_pb.cc
@@ -49,6 +49,7 @@ namespace lite {
       if (type == VarDataType::LOD_TENSOR ||                       \
           type == VarDataType::SELECTED_ROWS ||                    \
           type == VarDataType::LOD_TENSOR_ARRAY) {                 \
+        any_desc->SetDataType(cpp_desc.GetDataType());             \
         any_desc->SetShape(cpp_desc.GetShape());                   \
       }                                                            \
     }                                                              \
@@ -68,6 +69,7 @@ void TransformVarDescAnyToCpp<pb::VarDesc>(const pb::VarDesc &any_desc,
     }
     if (type == VarDataType::LOD_TENSOR || type == VarDataType::SELECTED_ROWS ||
         type == VarDataType::LOD_TENSOR_ARRAY) {
+      cpp_desc->SetDataType(any_desc.GetDataType());
       cpp_desc->SetShape(any_desc.GetShape());
     }
   }


### PR DESCRIPTION
### issue 
- Inputs and outputs can not be registered as StepScope type 
  - currently can only be registered as Tensor or TensorArray

``` c++
// Example
REGISTER_LITE_KERNEL(
    while, kHost, kAny, kAny, paddle::lite::kernels::host::WhileCompute, def)
    .BindInput("X",
               {LiteType::GetTensorTy(TARGET(kHost),
                                      PRECISION(kAny),
                                      DATALAYOUT(kAny))})
    .BindInput("Condition",
               {LiteType::GetTensorTy(TARGET(kHost),
                                      PRECISION(kBool),
                                      DATALAYOUT(kAny))})
    .BindOutput("Out",
                {LiteType::GetTensorTy(TARGET(kHost),
                                       PRECISION(kAny),
                                       DATALAYOUT(kAny))})
    .Finalize();
```


### Effect of Current PR
-  （1）`StepScope` type is supported in Lite kernel registry
   - `StepScope` refers to `Vector<Scope*>`
``` c++
// Example
REGISTER_LITE_KERNEL(
    while, kHost, kAny, kAny, paddle::lite::kernels::host::WhileCompute, def)
    .BindInput("X",
               {LiteType::GetTensorTy(TARGET(kHost),
                                      PRECISION(kAny),
                                      DATALAYOUT(kAny))})
    .BindInput("Condition",
               {LiteType::GetTensorTy(TARGET(kHost),
                                      PRECISION(kBool),
                                      DATALAYOUT(kAny))})
    .BindOutput("Out",
                {LiteType::GetTensorTy(TARGET(kHost),
                                       PRECISION(kAny),
                                       DATALAYOUT(kAny))})
    .BindOutput("StepScopes", {LiteType::GetStepScopeTy()})
    .Finalize();
```

- （2）Forbidden type transformation of unknown datatype
![image](https://user-images.githubusercontent.com/45189361/123049459-26d6d980-d432-11eb-8eb7-5df88ec02c8f.png)
