### PR TITLE
add the write_back operator, test=develop

### DIFF
--- a/lite/core/mir/type_target_cast_pass.cc
+++ b/lite/core/mir/type_target_cast_pass.cc
@@ -39,7 +39,8 @@ void TypeTargetTransformPass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 
   // record the copied node.
   std::map<std::string, Node*> copied_nodes;
-  std::vector<std::string> skip_ops = {"while", "conditional_block"};
+  std::vector<std::string> skip_ops = {
+      "while", "conditional_block", "write_back"};
 
   for (auto& node : nodes) {
     auto op_type = node->AsStmt().op_type();

--- a/lite/kernels/host/CMakeLists.txt
+++ b/lite/kernels/host/CMakeLists.txt
@@ -20,6 +20,7 @@ add_kernel(unbind_compute_host Host basic SRCS unbind_compute.cc DEPS ${lite_ker
 add_kernel(argmax_compute_host Host basic SRCS argmax_compute.cc DEPS ${lite_kernel_deps} math_host)
 add_kernel(assign_value_compute_host Host basic SRCS assign_value_compute.cc DEPS ${lite_kernel_deps})
 add_kernel(yolo_box_compute_host Host basic SRCS yolo_box_compute.cc DEPS ${lite_kernel_deps} math_host)
+add_kernel(write_back_compute_host Host basic SRCS write_back_compute.cc DEPS ${lite_kernel_deps})
 
 # extra kernels
 add_kernel(deformable_conv_compute_host Host extra SRCS deformable_conv_compute.cc DEPS ${lite_kernel_deps})

--- a/lite/kernels/host/write_back_compute.cc
+++ b/lite/kernels/host/write_back_compute.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/host/write_back_compute.h"
+#include "lite/core/target_wrapper.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+void WriteBackCompute::Run() {
+  auto& param = this->template Param<operators::WriteBackParam>();
+  CHECK(param.x->target() == param.y->target());
+  param.y->CopyDataFrom(*param.x);
+}
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(write_back,
+                     kHost,
+                     kAny,
+                     kAny,
+                     paddle::lite::kernels::host::WriteBackCompute,
+                     tensor_copy)
+    .BindInput("Src_LoDTensor",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindInput("Dst_LoDTensor",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindInput("Dep_LoDTensor",
+               {LiteType::GetTensorTy(TARGET(kAny),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindInput("Dep_LoDTensorArray",
+               {LiteType::GetTensorListTy(TARGET(kAny),
+                                          PRECISION(kAny),
+                                          DATALAYOUT(kAny))})
+    .Finalize();

--- a/lite/kernels/host/write_back_compute.cc
+++ b/lite/kernels/host/write_back_compute.cc
@@ -23,7 +23,7 @@ namespace host {
 void WriteBackCompute::Run() {
   auto& param = this->template Param<operators::WriteBackParam>();
   CHECK(param.x->target() == param.y->target());
-  param.y->CopyDataFrom(*param.x);
+  param.y->ShareDataWith(*param.x);
 }
 
 }  // namespace host

--- a/lite/kernels/host/write_back_compute.h
+++ b/lite/kernels/host/write_back_compute.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+class WriteBackCompute
+    : public KernelLite<TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny)> {
+ public:
+  void Run() override;
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/operators/CMakeLists.txt
+++ b/lite/operators/CMakeLists.txt
@@ -2,7 +2,7 @@ set(op_DEPS tensor op op_params scope memory)
 
 lite_cc_library(op_params SRCS op_params.cc DEPS tensor any)
 
-# 1.baisc ops used in basic models
+# 1.basic ops used in basic models
 add_operator(conv_op basic SRCS conv_op.cc DEPS ${op_DEPS})
 add_operator(pool_op basic SRCS pool_op.cc DEPS ${op_DEPS})
 add_operator(fc_op basic SRCS fc_op.cc DEPS ${op_DEPS})
@@ -55,11 +55,12 @@ add_operator(instance_norm_op basic SRCS instance_norm_op.cc DEPS ${op_DEPS})
 add_operator(subgraph_op basic SRCS subgraph_op.cc DEPS ${op_DEPS})
 add_operator(grid_sampler_op basic SRCS grid_sampler_op.cc DEPS ${op_DEPS})
 add_operator(flatten_op basic SRCS flatten_op.cc DEPS ${op_DEPS})
+add_operator(write_back_op basic SRCS write_back_op.cc DEPS ${op_DEPS})
+add_operator(lod_array_length_op basic SRCS lod_array_length_op.cc DEPS ${op_DEPS})
+
 add_operator(pow_op extra SRCS pow_op.cc DEPS ${op_DEPS})
 add_operator(sign_op extra SRCS sign_op.cc DEPS ${op_DEPS})
-add_operator(lod_array_length_op basic SRCS lod_array_length_op.cc DEPS ${op_DEPS})
 add_operator(rnn_op extra SRCS rnn_op.cc DEPS ${op_DEPS})
-add_operator(write_back_op extra SRCS write_back_op.cc DEPS ${op_DEPS})
 
 # 2.basic ops not used in basic models
 add_operator(negative_op extra SRCS negative_op.cc DEPS ${op_DEPS})

--- a/lite/operators/CMakeLists.txt
+++ b/lite/operators/CMakeLists.txt
@@ -59,6 +59,7 @@ add_operator(pow_op extra SRCS pow_op.cc DEPS ${op_DEPS})
 add_operator(sign_op extra SRCS sign_op.cc DEPS ${op_DEPS})
 add_operator(lod_array_length_op basic SRCS lod_array_length_op.cc DEPS ${op_DEPS})
 add_operator(rnn_op extra SRCS rnn_op.cc DEPS ${op_DEPS})
+add_operator(write_back_op extra SRCS write_back_op.cc DEPS ${op_DEPS})
 
 # 2.basic ops not used in basic models
 add_operator(negative_op extra SRCS negative_op.cc DEPS ${op_DEPS})

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -2438,6 +2438,11 @@ struct FlipParam : ParamBase {
   std::vector<int> axis;
 };
 
+struct WriteBackParam : ParamBase {
+  const lite::Tensor* x{};
+  lite::Tensor* y{};
+};
+
 }  // namespace operators
 }  // namespace lite
 }  // namespace paddle

--- a/lite/operators/write_back_op.cc
+++ b/lite/operators/write_back_op.cc
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/write_back_op.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+bool WriteBackOp::CheckShape() const {
+  CHECK(param_.x);
+  CHECK(param_.y);
+  return true;
+}
+
+bool WriteBackOp::InferShapeImpl() const {
+  param_.y->Resize(param_.x->dims());
+  param_.y->set_lod(param_.x->lod());
+  param_.y->set_precision(param_.x->precision());
+  param_.y->set_persistable(param_.x->persistable());
+  return true;
+}
+
+bool WriteBackOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
+  param_.x = scope->FindTensor(opdesc.Input("Src_LoDTensor").front());
+  param_.y = scope->FindMutableTensor(opdesc.Input("Dst_LoDTensor").front());
+  return true;
+}
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_OP(write_back, paddle::lite::operators::WriteBackOp);

--- a/lite/operators/write_back_op.h
+++ b/lite/operators/write_back_op.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include "lite/core/op_lite.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+class WriteBackOp : public OpLite {
+ public:
+  using OpLite::OpLite;
+
+  bool CheckShape() const override;
+
+  bool InferShapeImpl() const override;
+
+  bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+
+  std::string DebugString() const override { return "write_back"; }
+
+ private:
+  mutable WriteBackParam param_;
+};
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle


### PR DESCRIPTION
为解决上游给出静态图存在有向环的问题，给出一个 WriteBack 算子。其作用等价于 IOCopy，区别仅为其输出用输入表示，且有依赖参数指明哪些变量需在其调用之前准备完毕。

本提交与 https://github.com/PaddlePaddle/Paddle-Lite/pull/6291 相互配合。