### PR TITLE
[arm-fp16] add seq_conv and seq_pool fp16 implementation

### DIFF
--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -298,8 +298,12 @@ void LightPredictor::DequantizeWeight() {
 typedef __fp16 float16_t;
 void LightPredictor::WeightFP32ToFP16() {
   std::shared_ptr<const cpp::ProgramDesc> program_desc = program_desc_;
-  std::vector<std::string> fp16_ops{
-      "conv2d", "depthwise_conv2d", "fc", "sequence_conv"};
+  std::vector<std::string> fp16_ops{"conv2d",
+                                    "depthwise_conv2d",
+                                    "fc",
+                                    "sequence_conv",
+                                    "elementwise_add",
+                                    "elementwise_mul"};
   for (size_t i = 0; i < program_desc->BlocksSize(); i++) {
     auto* block = program_desc->GetBlock<cpp::BlockDesc>(i);
     for (size_t k = 0; k < block->OpsSize(); ++k) {

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -298,7 +298,8 @@ void LightPredictor::DequantizeWeight() {
 typedef __fp16 float16_t;
 void LightPredictor::WeightFP32ToFP16() {
   std::shared_ptr<const cpp::ProgramDesc> program_desc = program_desc_;
-  std::vector<std::string> fp16_ops{"conv2d", "depthwise_conv2d", "fc"};
+  std::vector<std::string> fp16_ops{
+      "conv2d", "depthwise_conv2d", "fc", "sequence_conv"};
   for (size_t i = 0; i < program_desc->BlocksSize(); i++) {
     auto* block = program_desc->GetBlock<cpp::BlockDesc>(i);
     for (size_t k = 0; k < block->OpsSize(); ++k) {

--- a/lite/api/model_test.cc
+++ b/lite/api/model_test.cc
@@ -133,7 +133,6 @@ void Run(const std::vector<std::vector<int64_t>>& input_shapes,
     for (int i = 0; i < input_num; ++i) {
       if (flag_in) {
         fscanf(fp_r, "%f\n", &input_data[i]);
-        if (j == 1) VLOG(4) << "data: " << input_data[i];
       } else {
         input_data[i] = 1.f;
       }

--- a/lite/api/model_test.cc
+++ b/lite/api/model_test.cc
@@ -102,7 +102,7 @@ void Run(const std::vector<std::vector<int64_t>>& input_shapes,
          const int repeat,
          const int warmup_times = 0) {
   lite_api::MobileConfig config;
-  config.set_model_from_file(model_dir + ".nb");
+  config.set_model_from_file(model_dir);
   config.set_power_mode(power_mode);
   config.set_threads(thread_num);
 
@@ -127,11 +127,13 @@ void Run(const std::vector<std::vector<int64_t>>& input_shapes,
     }
     FILE* fp_r = nullptr;
     if (flag_in) {
-      fp_r = fopen(FLAGS_in_txt.c_str(), "r");
+      std::string in_txt = FLAGS_in_txt + std::to_string(j + 1) + ".txt";
+      fp_r = fopen(in_txt.c_str(), "r");
     }
     for (int i = 0; i < input_num; ++i) {
       if (flag_in) {
         fscanf(fp_r, "%f\n", &input_data[i]);
+        if (j == 1) VLOG(4) << "data: " << input_data[i];
       } else {
         input_data[i] = 1.f;
       }
@@ -184,7 +186,8 @@ void Run(const std::vector<std::vector<int64_t>>& input_shapes,
         out_data, output_tensor_numel, true, out_mean);
     FILE* fp1 = nullptr;
     if (flag_out) {
-      fp1 = fopen(FLAGS_out_txt.c_str(), "w");
+      std::string out_txt = FLAGS_out_txt + std::to_string(tidx + 1) + ".txt";
+      fp1 = fopen(out_txt.c_str(), "w");
     }
     double sum1 = 0.f;
     for (int i = 0; i < output_tensor_numel; ++i) {

--- a/lite/api/model_test.cc
+++ b/lite/api/model_test.cc
@@ -301,6 +301,7 @@ int main(int argc, char** argv) {
     // Output optimized model
     paddle::lite_api::OutputOptModel(
         FLAGS_model_dir, save_optimized_model_dir, input_shapes);
+    save_optimized_model_dir += ".nb";
   }
 
 #ifdef LITE_WITH_LIGHT_WEIGHT_FRAMEWORK

--- a/lite/backends/arm/math/sequence_pool.cc
+++ b/lite/backends/arm/math/sequence_pool.cc
@@ -27,14 +27,14 @@ namespace lite {
 namespace arm {
 namespace math {
 
-template <>
-void seq_pool_sum<float>(const float* din,
-                         float* dout,
-                         const std::vector<uint64_t> lod,
-                         int64_t width) {
+template <typename T>
+void seq_pool_sum(const T* din,
+                  T* dout,
+                  const std::vector<uint64_t> lod,
+                  int64_t width) {
   for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
-    const float* din_ptr = din + lod[i] * width;
-    float* dout_ptr = dout + i * width;
+    const T* din_ptr = din + lod[i] * width;
+    T* dout_ptr = dout + i * width;
     int64_t height = static_cast<int64_t>(lod[i + 1] - lod[i]);
     if (height > 0) {
       if (width == 1) {
@@ -44,7 +44,7 @@ void seq_pool_sum<float>(const float* din,
         }
         *dout_ptr = sum;
       } else {
-        memcpy(dout_ptr, din_ptr, width * sizeof(float));
+        memcpy(dout_ptr, din_ptr, width * sizeof(T));
         din_ptr += width;
         height = height - 1;
         for (int h = 0; h < height; h++) {
@@ -58,24 +58,24 @@ void seq_pool_sum<float>(const float* din,
   }
 }
 
-template <>
-void seq_pool_average<float>(const float* din,
-                             float* dout,
-                             const std::vector<uint64_t> lod,
-                             int64_t width) {
+template <typename T>
+void seq_pool_average(const T* din,
+                      T* dout,
+                      const std::vector<uint64_t> lod,
+                      int64_t width) {
   for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
-    const float* din_ptr = din + lod[i] * width;
-    float* dout_ptr = dout + i * width;
+    const T* din_ptr = din + lod[i] * width;
+    T* dout_ptr = dout + i * width;
     int64_t height = static_cast<int64_t>(lod[i + 1] - lod[i]);
     if (height > 0) {
       if (width == 1) {
-        float sum = 0.f;
+        T sum = 0.f;
         for (int h = 0; h < height; ++h) {
           sum += din_ptr[h];
         }
         *dout_ptr = sum / height;
       } else {
-        memcpy(dout_ptr, din_ptr, width * sizeof(float));
+        memcpy(dout_ptr, din_ptr, width * sizeof(T));
         din_ptr += width;
         int remain_h = height - 1;
         for (int h = 0; h < remain_h; h++) {
@@ -92,25 +92,25 @@ void seq_pool_average<float>(const float* din,
   }
 }
 
-template <>
-void seq_pool_sqrt<float>(const float* din,
-                          float* dout,
-                          const std::vector<uint64_t> lod,
-                          int64_t width) {
+template <typename T>
+void seq_pool_sqrt(const T* din,
+                   T* dout,
+                   const std::vector<uint64_t> lod,
+                   int64_t width) {
   for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
-    const float* din_ptr = din + lod[i] * width;
-    float* dout_ptr = dout + i * width;
+    const T* din_ptr = din + lod[i] * width;
+    T* dout_ptr = dout + i * width;
     int64_t height = static_cast<int64_t>(lod[i + 1] - lod[i]);
     if (height > 0) {
-      float sqrt_len = sqrtf(height);
+      T sqrt_len = sqrtf(height);
       if (width == 1) {
-        float sum = 0.f;
+        T sum = 0.f;
         for (int h = 0; h < height; ++h) {
           sum += din_ptr[h];
         }
         *dout_ptr = sum / sqrt_len;
       } else {
-        memcpy(dout_ptr, din_ptr, width * sizeof(float));
+        memcpy(dout_ptr, din_ptr, width * sizeof(T));
         din_ptr += width;
         int remain_h = height - 1;
         for (int h = 0; h < remain_h; h++) {
@@ -127,20 +127,20 @@ void seq_pool_sqrt<float>(const float* din,
   }
 }
 
-template <>
-void seq_pool_max<float>(const float* din,
-                         float* dout,
-                         int64_t* index,
-                         const std::vector<uint64_t> lod,
-                         int64_t width) {
+template <typename T>
+void seq_pool_max(const T* din,
+                  T* dout,
+                  int64_t* index,
+                  const std::vector<uint64_t> lod,
+                  int64_t width) {
   for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
-    const float* din_ptr = din + lod[i] * width;
-    float* dout_ptr = dout + i * width;
+    const T* din_ptr = din + lod[i] * width;
+    T* dout_ptr = dout + i * width;
     int64_t* index_ptr = index + i * width;
     int64_t height = static_cast<int64_t>(lod[i + 1] - lod[i]);
     if (height > 0) {
       if (width == 1) {
-        float max = -std::numeric_limits<float>::max();
+        T max = -std::numeric_limits<T>::max();
         int64_t max_index = -1;
         for (int h = 0; h < height; ++h) {
           max = std::max(max, din_ptr[h]);
@@ -149,7 +149,7 @@ void seq_pool_max<float>(const float* din,
         *dout_ptr = max;
         *index_ptr = max_index;
       } else {
-        memcpy(dout_ptr, din_ptr, width * sizeof(float));
+        memcpy(dout_ptr, din_ptr, width * sizeof(T));
         memset(index_ptr, 0, width * sizeof(int64_t));
         din_ptr += width;
         int remain_h = height - 1;
@@ -165,20 +165,20 @@ void seq_pool_max<float>(const float* din,
   }
 }
 
-template <>
-void seq_pool_min<float>(const float* din,
-                         float* dout,
-                         int64_t* index,
-                         const std::vector<uint64_t> lod,
-                         int64_t width) {
+template <typename T>
+void seq_pool_min(const T* din,
+                  T* dout,
+                  int64_t* index,
+                  const std::vector<uint64_t> lod,
+                  int64_t width) {
   for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
-    const float* din_ptr = din + lod[i] * width;
-    float* dout_ptr = dout + i * width;
+    const T* din_ptr = din + lod[i] * width;
+    T* dout_ptr = dout + i * width;
     int64_t* index_ptr = index + i * width;
     int64_t height = static_cast<int64_t>(lod[i + 1] - lod[i]);
     if (height > 0) {
       if (width == 1) {
-        float min = std::numeric_limits<float>::max();
+        T min = std::numeric_limits<T>::max();
         int64_t min_index = -1;
         for (int h = 0; h < height; ++h) {
           min = std::min(min, din_ptr[h]);
@@ -187,7 +187,7 @@ void seq_pool_min<float>(const float* din,
         *dout_ptr = min;
         *index_ptr = min_index;
       } else {
-        memcpy(dout_ptr, din_ptr, width * sizeof(float));
+        memcpy(dout_ptr, din_ptr, width * sizeof(T));
         memset(index_ptr, 0, width * sizeof(int64_t));
         din_ptr += width;
         int remain_h = height - 1;
@@ -203,37 +203,99 @@ void seq_pool_min<float>(const float* din,
   }
 }
 
-template <>
-void seq_pool_first<float>(const float* din,
-                           float* dout,
-                           const std::vector<uint64_t> lod,
-                           int64_t width) {
+template <typename T>
+void seq_pool_first(const T* din,
+                    T* dout,
+                    const std::vector<uint64_t> lod,
+                    int64_t width) {
   for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
     int64_t height = lod[i + 1] - lod[i];
-    const float* din_ptr = din + width * lod[i];
-    float* dout_ptr = dout + i * width;
+    const T* din_ptr = din + width * lod[i];
+    T* dout_ptr = dout + i * width;
     if (height > 0) {
-      memcpy(dout_ptr, din_ptr, width * sizeof(float));
+      memcpy(dout_ptr, din_ptr, width * sizeof(T));
     }
   }
 }
 
-template <>
-void seq_pool_last<float>(const float* din,
-                          float* dout,
-                          const std::vector<uint64_t> lod,
-                          int64_t width) {
+template <typename T>
+void seq_pool_last(const T* din,
+                   T* dout,
+                   const std::vector<uint64_t> lod,
+                   int64_t width) {
   for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
     int64_t height = lod[i + 1] - lod[i];
     int64_t seq_len = static_cast<int64_t>(lod[i + 1] - lod[0]);
-    const float* din_ptr = din + width * seq_len;
-    float* dout_ptr = dout + i * width;
+    const T* din_ptr = din + width * seq_len;
+    T* dout_ptr = dout + i * width;
     if (height > 0) {
-      memcpy(dout_ptr, din_ptr - width, width * sizeof(float));
+      memcpy(dout_ptr, din_ptr - width, width * sizeof(T));
     }
   }
 }
 
+template void seq_pool_sum<float>(const float* din,
+                                  float* dout,
+                                  const std::vector<uint64_t> lod,
+                                  int64_t width);
+template void seq_pool_average<float>(const float* din,
+                                      float* dout,
+                                      const std::vector<uint64_t> lod,
+                                      int64_t width);
+template void seq_pool_sqrt<float>(const float* din,
+                                   float* dout,
+                                   const std::vector<uint64_t> lod,
+                                   int64_t width);
+template void seq_pool_max<float>(const float* din,
+                                  float* dout,
+                                  int64_t* index,
+                                  const std::vector<uint64_t> lod,
+                                  int64_t width);
+template void seq_pool_min<float>(const float* din,
+                                  float* dout,
+                                  int64_t* index,
+                                  const std::vector<uint64_t> lod,
+                                  int64_t width);
+template void seq_pool_first<float>(const float* din,
+                                    float* dout,
+                                    const std::vector<uint64_t> lod,
+                                    int64_t width);
+template void seq_pool_last<float>(const float* din,
+                                   float* dout,
+                                   const std::vector<uint64_t> lod,
+                                   int64_t width);
+#ifdef ENABLE_ARM_FP16
+template void seq_pool_sum<float16_t>(const float16_t* din,
+                                      float16_t* dout,
+                                      const std::vector<uint64_t> lod,
+                                      int64_t width);
+template void seq_pool_average<float16_t>(const float16_t* din,
+                                          float16_t* dout,
+                                          const std::vector<uint64_t> lod,
+                                          int64_t width);
+template void seq_pool_sqrt<float16_t>(const float16_t* din,
+                                       float16_t* dout,
+                                       const std::vector<uint64_t> lod,
+                                       int64_t width);
+template void seq_pool_max<float16_t>(const float16_t* din,
+                                      float16_t* dout,
+                                      int64_t* index,
+                                      const std::vector<uint64_t> lod,
+                                      int64_t width);
+template void seq_pool_min<float16_t>(const float16_t* din,
+                                      float16_t* dout,
+                                      int64_t* index,
+                                      const std::vector<uint64_t> lod,
+                                      int64_t width);
+template void seq_pool_first<float16_t>(const float16_t* din,
+                                        float16_t* dout,
+                                        const std::vector<uint64_t> lod,
+                                        int64_t width);
+template void seq_pool_last<float16_t>(const float16_t* din,
+                                       float16_t* dout,
+                                       const std::vector<uint64_t> lod,
+                                       int64_t width);
+#endif
 }  // namespace math
 }  // namespace arm
 }  // namespace lite

--- a/lite/core/mir/fp16_attribute_pass.h
+++ b/lite/core/mir/fp16_attribute_pass.h
@@ -35,8 +35,12 @@ class FP16AttributePass : public ProgramPass {
   void Apply(const std::unique_ptr<SSAGraph>& graph) override;
 
  private:
-  std::vector<std::string> fp16_ops_{
-      "conv2d", "depthwise_conv2d", "fc", "sequence_conv"};
+  std::vector<std::string> fp16_ops_{"conv2d",
+                                     "depthwise_conv2d",
+                                     "fc",
+                                     "sequence_conv",
+                                     "elementwise_add",
+                                     "elementwise_mul"};
 };
 
 }  // namespace mir

--- a/lite/core/mir/fp16_attribute_pass.h
+++ b/lite/core/mir/fp16_attribute_pass.h
@@ -35,7 +35,8 @@ class FP16AttributePass : public ProgramPass {
   void Apply(const std::unique_ptr<SSAGraph>& graph) override;
 
  private:
-  std::vector<std::string> fp16_ops_{"conv2d", "depthwise_conv2d", "fc"};
+  std::vector<std::string> fp16_ops_{
+      "conv2d", "depthwise_conv2d", "fc", "sequence_conv"};
 };
 
 }  // namespace mir

--- a/lite/kernels/arm/sequence_conv_compute.cc
+++ b/lite/kernels/arm/sequence_conv_compute.cc
@@ -192,6 +192,7 @@ void SequenceConvCompute<PRECISION(kFP16), PRECISION(kFP16)>::Run() {
   // [sequence_len, kernel_size * hidden_dim] * [kernel_size * hidden_dim,
   // kernel_num]
   // = [sequence_len, kernel_num]
+  paddle::lite::operators::ActivationParam act_param;
   paddle::lite::arm::math::fp16::sgemm_fp16(false,
                                             false,         // is_transB,
                                             sequence_len,  // M

--- a/lite/kernels/arm/sequence_conv_compute.cc
+++ b/lite/kernels/arm/sequence_conv_compute.cc
@@ -24,6 +24,9 @@ limitations under the License. */
 #include "lite/core/tensor.h"
 #include "lite/core/type_system.h"
 #include "lite/operators/op_params.h"
+#ifdef ENABLE_ARM_FP16
+#include "lite/backends/arm/math/fp16/funcs_fp16.h"
+#endif
 
 namespace paddle {
 namespace lite {
@@ -31,21 +34,13 @@ namespace kernels {
 namespace arm {
 
 template <typename Dtype>
-void local_naive_transpose(const Dtype* din, Dtype* dout, int m, int n) {
-  int k = 0;
-  for (int i = 0; i < n; ++i) {
-    for (int j = 0; j < m; ++j) {
-      dout[k++] = din[j * n + i];
-    }
-  }
-}
-void data_padding(const float* data_in,
+void data_padding(const Dtype* data_in,
                   int up_pad,
                   int down_pad,
                   int width,
                   int hidden_dim,
                   int kernel_size,
-                  float* out,
+                  Dtype* out,
                   int stride) {
   int len = hidden_dim;
   for (int i = 0; i <= (width + up_pad + down_pad) - kernel_size; i += stride) {
@@ -65,9 +60,12 @@ void data_padding(const float* data_in,
     }
   }
 }
-void SequenceConvCompute::PrepareForRun() {}
+template <>
+void SequenceConvCompute<PRECISION(kFloat),
+                         PRECISION(kFloat)>::PrepareForRun() {}
 
-void SequenceConvCompute::Run() {
+template <>
+void SequenceConvCompute<PRECISION(kFloat), PRECISION(kFloat)>::Run() {
   // param.X is in shape: [sequence_len, hidden_dim];
   // param.Filter is in shape: [kernel_size * hidden_dim, kernel_num]
   // param.contextLength : kernel_size
@@ -103,14 +101,14 @@ void SequenceConvCompute::Run() {
       auto* sub_in_data = in_data + input_row_begin * hidden_dim;
       auto* sub_col_data =
           col_data + input_row_begin * kernel_size * hidden_dim;
-      data_padding(sub_in_data,
-                   up_pad,
-                   down_pad,
-                   input_row_end - input_row_begin,
-                   hidden_dim,
-                   kernel_size,
-                   sub_col_data,
-                   stride);
+      data_padding<float>(sub_in_data,
+                          up_pad,
+                          down_pad,
+                          input_row_end - input_row_begin,
+                          hidden_dim,
+                          kernel_size,
+                          sub_col_data,
+                          stride);
     }
   }
   // SGDMM C := alpha * A * B + beta * C
@@ -138,18 +136,105 @@ void SequenceConvCompute::Run() {
                                  &ctx);                     // ctx
 }
 
+#ifdef ENABLE_ARM_FP16
+template <>
+void SequenceConvCompute<PRECISION(kFP16), PRECISION(kFP16)>::PrepareForRun() {}
+
+template <>
+void SequenceConvCompute<PRECISION(kFP16), PRECISION(kFP16)>::Run() {
+  // param.X is in shape: [sequence_len, hidden_dim];
+  // param.Filter is in shape: [kernel_size * hidden_dim, kernel_num]
+  // param.contextLength : kernel_size
+  // param.contextStart: for padding idx
+  // param.Out is in shape [new_sequence_len, kernel_num]
+  auto& param = this->Param<operators::SequenceConvParam>();
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  const auto* in_data = param.X->data<float16_t>();
+  const auto* filter_data = param.Filter->data<float16_t>();
+  float16_t* out_data = param.Out->mutable_data<float16_t>();
+  int pad_start = param.contextStart;
+  int kernel_size = param.contextLength;
+  int stride = param.contextStride;
+  int kernel_num = param.Filter->dims()[1];
+  int up_pad = std::max(0, -pad_start);
+  int down_pad = std::max(0, pad_start + kernel_size - 1);
+  auto hidden_dim = static_cast<int64_t>(param.X->dims()[1]);
+  auto sequence_len = static_cast<int64_t>(param.X->dims()[0]);
+  auto lod = param.X->lod();
+  lite::Tensor col;
+  col.Resize({sequence_len, kernel_size * hidden_dim});
+  auto* col_data = col.mutable_data<float16_t>();
+  auto lod_level_0 = lod[0];
+  int input_row_begin, input_row_end;
+  for (int i = 0; i < static_cast<int>(lod_level_0.size()) - 1; i++) {
+    if (lod_level_0[i] == lod_level_0[i + 1]) continue;
+    input_row_begin = (pad_start > 0)
+                          ? static_cast<int>(lod_level_0[i]) + pad_start
+                          : static_cast<int>(lod_level_0[i]);
+    input_row_end = static_cast<int>(lod_level_0[i + 1]);
+
+    if (input_row_begin < input_row_end) {
+      auto* sub_in_data = in_data + input_row_begin * hidden_dim;
+      auto* sub_col_data =
+          col_data + input_row_begin * kernel_size * hidden_dim;
+      data_padding<float16_t>(sub_in_data,
+                              up_pad,
+                              down_pad,
+                              input_row_end - input_row_begin,
+                              hidden_dim,
+                              kernel_size,
+                              sub_col_data,
+                              stride);
+    }
+  }
+  // SGDMM C := alpha * A * B + beta * C
+  // matmul: col * filter_data
+  // [sequence_len, kernel_size * hidden_dim] * [kernel_size * hidden_dim,
+  // kernel_num]
+  // = [sequence_len, kernel_num]
+  paddle::lite::arm::math::fp16::sgemm_fp16(false,
+                                            false,         // is_transB,
+                                            sequence_len,  // M
+                                            kernel_num,    // N
+                                            kernel_size * hidden_dim,  // K
+                                            1.0f,                      // alpha
+                                            col_data,                  // A
+                                            kernel_size * hidden_dim,  // lda: k
+                                            filter_data,               // B
+                                            kernel_num,                // ldb: n
+                                            0.f,                       // beta
+                                            out_data,                  // C
+                                            kernel_num,                // ldc: n
+                                            NULL,                      // bias
+                                            false,      // is_bias
+                                            act_param,  // act_param
+                                            &ctx);      // ctx
+}
+#endif
+
 }  // namespace arm
 }  // namespace kernels
 }  // namespace lite
 }  // namespace paddle
+typedef paddle::lite::kernels::arm::SequenceConvCompute<PRECISION(kFloat),
+                                                        PRECISION(kFloat)>
+    SeqConvFp32;
+#ifdef ENABLE_ARM_FP16
+typedef paddle::lite::kernels::arm::SequenceConvCompute<PRECISION(kFP16),
+                                                        PRECISION(kFP16)>
+    SeqConvFp16;
 
-REGISTER_LITE_KERNEL(sequence_conv,
-                     kARM,
-                     kFloat,
-                     kNCHW,
-                     paddle::lite::kernels::arm::SequenceConvCompute,
-                     def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindInput("Filter", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+REGISTER_LITE_KERNEL(sequence_conv, kARM, kFP16, kNCHW, SeqConvFp16, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
+    .BindInput("Filter",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
+    .Finalize();
+#endif  // ENABLE_ARM_FP16
+
+REGISTER_LITE_KERNEL(sequence_conv, kARM, kFloat, kNCHW, SeqConvFp32, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .BindInput("Filter",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
     .Finalize();

--- a/lite/kernels/arm/sequence_conv_compute.h
+++ b/lite/kernels/arm/sequence_conv_compute.h
@@ -22,7 +22,8 @@ namespace lite {
 namespace kernels {
 namespace arm {
 
-class SequenceConvCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+template <PrecisionType Ptype, PrecisionType OutType>
+class SequenceConvCompute : public KernelLite<TARGET(kARM), Ptype> {
  public:
   void PrepareForRun() override;
 

--- a/lite/kernels/arm/sequence_pool_compute.h
+++ b/lite/kernels/arm/sequence_pool_compute.h
@@ -22,8 +22,8 @@ namespace paddle {
 namespace lite {
 namespace kernels {
 namespace arm {
-
-class SequencePoolCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+template <PrecisionType Ptype, typename Dtype>
+class SequencePoolCompute : public KernelLite<TARGET(kARM), Ptype> {
  public:
   void PrepareForRun() override;
 

--- a/lite/tests/kernels/sequence_pool_grad_compute_test.cc
+++ b/lite/tests/kernels/sequence_pool_grad_compute_test.cc
@@ -26,7 +26,7 @@ namespace arm {
 
 using param_t = operators::SequencePoolParam;
 using grad_param_t = operators::SequencePoolGradParam;
-using kernel_t = SequencePoolCompute;
+using kernel_t = SequencePoolCompute<PRECISION(kFloat), float>;
 using grad_kernel_t = SequencePoolGradCompute;
 
 void sequence_pool_grad_common(grad_param_t* param,


### PR DESCRIPTION
855-v8-1-thread

  |   |   | add seq_conv/pool fp16 | old | now | improve
-- | -- | -- | -- | -- | -- | --
input_shape | fp32 | old-fp16 | now-fp16 | fp32/fp16-1 | fp32/fp16-1 | old-fp16/now-fp16-1
128,1 | 1.38329 | 1.36761 | 1.04651 | 1.147% | 32.181% | 30.683%
224,1 | 2.35686 | 2.33994 | 1.76861 | 0.723% | 33.261% | 32.304%
256,1 | 2.61528 | 2.61705 | 2.0006 | -0.068% | 30.725% | 30.813%



