### PR TITLE
Enhance opt python API capability : count the operators supported by the new hardware

### DIFF
--- a/cmake/lite.cmake
+++ b/cmake/lite.cmake
@@ -620,6 +620,22 @@ function(add_kernel TARGET device level)
     endif()
 endfunction()
 
+# file to record subgraph bridges for new hardware
+set(subgraph_bridges_src_list "${CMAKE_BINARY_DIR}/subgraph_bridges_src_list.txt")
+file(WRITE ${subgraph_bridges_src_list} "") # clean
+
+# add a subgraph bridge for some new hardware which support some op by subgraph
+# device: such as npu, rknpu, apu, huawei_ascend_npu, imagination_nna, nnadapter
+function(add_subgraph_bridge)
+  set(options "")
+  set(oneValueArgs "")
+  set(multiValueArgs SRCS)
+  cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  foreach(src ${args_SRCS})
+    file(APPEND ${subgraph_bridges_src_list} "${CMAKE_CURRENT_SOURCE_DIR}/${src}\n")
+  endforeach()
+endfunction(add_subgraph_bridge)
+
 set(ops CACHE INTERNAL "ops")
 set(ops_src_list "${CMAKE_BINARY_DIR}/ops_src_list.txt")
 file(WRITE ${ops_src_list} "") # clean

--- a/lite/api/opt_base.cc
+++ b/lite/api/opt_base.cc
@@ -369,30 +369,31 @@ void OptBase::PrintOpsInfo(const std::set<std::string>& valid_ops) {
                                 ? it->first.size()
                                 : maximum_optype_length;
   }
-  std::cout << std::setiosflags(std::ios::internal);
   // Print the first row: OP_nam taget1 target2 ...
   std::cout << std::setw(maximum_optype_length) << "OP_name";
   for (size_t i = 0; i < lite_supported_targets.size(); i++) {
-    std::cout << std::setw(10) << lite_supported_targets[i].substr(1);
+    std::string i_th_substr = lite_supported_targets[i].substr(1);
+    std::cout << std::setw(i_th_substr.size() + 5) << i_th_substr;
   }
   std::cout << std::endl;
   // Print the name of supported ops and mark if it's supported by each target
   // print the support info of inputed ops: valid_ops
   for (auto op = valid_ops.begin(); op != valid_ops.end(); op++) {
-    std::cout << std::setw(maximum_optype_length) << *op;
     // Check: If this kernel doesn't match any operator, we will skip it.
     if (supported_ops.find(*op) == supported_ops.end()) {
       continue;
     }
+    std::cout << std::setw(maximum_optype_length) << *op;
     // Print OP info.
     auto ops_valid_places = supported_ops.at(*op);
     for (size_t i = 0; i < lite_supported_targets.size(); i++) {
+      std::string i_th_substr = lite_supported_targets[i].substr(1);
       if (std::find(ops_valid_places.begin(),
                     ops_valid_places.end(),
                     lite_supported_targets[i]) != ops_valid_places.end()) {
-        std::cout << std::setw(10) << "Y";
+        std::cout << std::setw(i_th_substr.size() + 5) << "Y";
       } else {
-        std::cout << std::setw(10) << " ";
+        std::cout << std::setw(i_th_substr.size() + 5) << " ";
       }
     }
     std::cout << std::endl;

--- a/lite/core/CMakeLists.txt
+++ b/lite/core/CMakeLists.txt
@@ -134,6 +134,7 @@ execute_process(
     ${kernels_src_list}
     ${fake_kernels_src_list}
     ${ops_src_list}
+    ${subgraph_bridges_src_list}
     ${CMAKE_BINARY_DIR}/supported_kernel_op_info.h
     RESULT_VARIABLE result)
 #----------------------------------------------- NOT CHANGE -----------------------------------------------

--- a/lite/kernels/apu/bridges/CMakeLists.txt
+++ b/lite/kernels/apu/bridges/CMakeLists.txt
@@ -1,3 +1,14 @@
+add_subgraph_bridge(SRCS act_op.cc
+                    concat_op.cc
+                    conv_op.cc
+                    conv_transpose_op.cc
+                    elementwise_ops.cc
+                    fc_op.cc
+                    graph.cc
+                    pool_op.cc
+                    softmax_op.cc
+                    utility.cc)
+
 if(NOT LITE_WITH_APU)
   return()
 endif()

--- a/lite/kernels/huawei_ascend_npu/bridges/CMakeLists.txt
+++ b/lite/kernels/huawei_ascend_npu/bridges/CMakeLists.txt
@@ -1,3 +1,30 @@
+add_subgraph_bridge(SRCS act_op.cc
+                    argmax_op.cc
+                    batch_norm_op.cc
+                    cast_op.cc
+                    concat_op.cc
+                    conv_op.cc
+                    dropout_op.cc
+                    elementwise_ops.cc
+                    fc_op.cc
+                    flatten_op.cc
+                    gather_op.cc
+                    graph.cc
+                    interpolate_op.cc
+                    layer_norm_op.cc
+                    matmul_op.cc
+                    pool_op.cc
+                    prior_box_op.cc
+                    reduce_mean_op.cc
+                    reshape_op.cc
+                    scale_op.cc
+                    shape_op.cc
+                    slice_op.cc
+                    softmax_op.cc
+                    transpose_op.cc
+                    unsqueeze_op.cc
+                    utility.cc)
+
 if(NOT LITE_WITH_HUAWEI_ASCEND_NPU)
   return()
 endif()

--- a/lite/kernels/imagination_nna/bridges/CMakeLists.txt
+++ b/lite/kernels/imagination_nna/bridges/CMakeLists.txt
@@ -1,3 +1,12 @@
+add_subgraph_bridge(SRCS act_op.cc
+                    batch_norm_op.cc
+                    conv_op.cc
+                    fc_op.cc
+                    graph.cc
+                    pool_op.cc
+                    softmax_op.cc
+                    utility.cc)
+
 if(NOT LITE_WITH_IMAGINATION_NNA)
   return()
 endif()

--- a/lite/kernels/nnadapter/bridges/CMakeLists.txt
+++ b/lite/kernels/nnadapter/bridges/CMakeLists.txt
@@ -1,3 +1,17 @@
+add_subgraph_bridge(SRCS act_op.cc
+                    concat_op.cc
+                    conv_op.cc
+                    converter.cc
+                    elementwise_ops.cc
+                    fc_op.cc
+                    flatten_op.cc
+                    pool_op.cc
+                    reshape_op.cc
+                    scale_op.cc
+                    softmax_op.cc
+                    transpose_op.cc
+                    utility.cc)
+
 if(NOT LITE_WITH_NNADAPTER)
   return()
 endif()

--- a/lite/kernels/npu/bridges/CMakeLists.txt
+++ b/lite/kernels/npu/bridges/CMakeLists.txt
@@ -1,3 +1,42 @@
+add_subgraph_bridge(SRCS act_op.cc
+                    argmax_op.cc
+                    argmax_op_test.cc
+                    batch_norm_op.cc
+                    compare_op.cc
+                    concat_op.cc
+                    conv_op.cc
+                    conv_transpose_op.cc
+                    dropout_op.cc
+                    elementwise_ops.cc
+                    expand_op.cc
+                    fc_op.cc
+                    fill_constant_batch_size_like_op.cc
+                    fill_constant_op.cc
+                    gather_op.cc
+                    graph.cc
+                    increment_op.cc
+                    instance_norm_op.cc
+                    interpolate_op.cc
+                    layer_norm_op.cc
+                    lookup_table_op.cc
+                    matmul_op.cc
+                    mul_op.cc
+                    pad2d_op.cc
+                    pool_op.cc
+                    reduce_mean_op.cc
+                    reduce_mean_op_test.cc
+                    reshape_op.cc
+                    scale_op.cc
+                    shape_op.cc
+                    shuffle_channel_op.cc
+                    softmax_op.cc
+                    split_op.cc
+                    split_op_test.cc
+                    topk_op.cc
+                    transpose_op.cc
+                    unsqueeze_op.cc
+                    utility.cc)
+
 if(NOT LITE_WITH_NPU)
   return()
 endif()

--- a/lite/kernels/rknpu/bridges/CMakeLists.txt
+++ b/lite/kernels/rknpu/bridges/CMakeLists.txt
@@ -1,3 +1,20 @@
+add_subgraph_bridge(SRCS act_op.cc
+                    batch_norm_op.cc
+                    concat_op.cc
+                    conv_op.cc
+                    elementwise_ops.cc
+                    fc_op.cc
+                    flatten_op.cc
+                    graph.cc
+                    norm_op.cc
+                    pad2d_op.cc
+                    pool_op.cc
+                    reshape2_op.cc
+                    scale_op.cc
+                    softmax_op.cc
+                    transpose2_op.cc
+                    utility.cc)
+
 if(NOT LITE_WITH_RKNPU)
   return()
 endif()

--- a/lite/tools/cmake_tools/ast.py
+++ b/lite/tools/cmake_tools/ast.py
@@ -189,6 +189,12 @@ class KernelRegistry:
         return str
 
 
+class SubgraphBridgeRegistry:
+    def __init__(self):
+        self.op_type = ''
+        self.target = ''
+
+
 class RegisterLiteKernelParser(SyntaxParser):
 
     KEYWORD = 'REGISTER_LITE_KERNEL'
@@ -514,6 +520,52 @@ class RegisterLiteOpParser(SyntaxParser):
         
         self.eat_word()
         return self.token
+
+
+class RegisterSubgraphBridgeParser(SyntaxParser):
+    KEYWORD = 'REGISTER_SUBGRAPH_BRIDGE'
+
+    def __init__(self, str):
+        super(RegisterSubgraphBridgeParser, self).__init__(str)
+        self.subgraph_bridge = []
+
+    def parse(self):
+        self.cur_pos = 0
+        while self.cur_pos < len(self.str):
+            start = self.str.find(self.KEYWORD, self.cur_pos)
+            if start != -1:
+                #print 'str ', start, self.str[start-2: start]
+                if start != 0 and '/' in self.str[start-2: start]:
+                    '''
+                    skip commented code
+                    '''
+                    self.cur_pos = start + 1
+                    continue
+                self.cur_pos = start
+                k = SubgraphBridgeRegistry()
+                self.subgraph_bridge.append(self.parse_register(k))
+            else:
+                break
+
+    def parse_register(self, k):
+        self.eat_word()
+        assert self.token == self.KEYWORD
+        self.eat_spaces()
+
+        self.eat_left_parentheses()
+        self.eat_spaces()
+
+        self.eat_word()
+        k.op_type = self.token
+        self.eat_comma()
+        self.eat_spaces()
+
+        self.eat_word()
+        k.target = self.token
+        self.eat_comma()
+        self.eat_spaces()
+
+        return k
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Enhance opt python API capability :Some new hardware(such as HuaweiAscendNPU) supports operators in the form of subgraph access. We need to count these operators in the python interface of opt