### PR TITLE
[API]add TryShrinkMemory API 

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -468,16 +468,37 @@ void Predictor::CheckPaddleOpVersions(
     }
   }
 }
-// #ifdef LITE_WITH_TRAIN
-// void Predictor::FeedVars(const std::vector<framework::Tensor> &tensors) {
-//   auto var = scope_->FindVar("feed");
-//   auto &feed_list = *(var->GetMutable<std::vector<lite::Tensor>>());
-//   feed_list.resize(tensors.size());
 
-//   for (size_t i = 0; i < tensors.size(); ++i)
-//     feed_list[i].ShareDataWith(tensors[i]);
-// }
-// #endif
+bool Predictor::TryShrinkMemory() {
+#ifdef LITE_WITH_ARM
+  // Clear ArmL3Cache
+  lite::DeviceInfo::Global().ClearArmL3Cache();
+#endif
+  const std::vector<std::string> &local_var_names =
+      program_->exec_scope()->LocalVarNames();
+  for (auto &var_name : local_var_names) {
+    Variable *var = program_->exec_scope()->FindLocalVar(var_name);
+    if (var->IsType<lite::Tensor>()) {
+      // Clear unpersistable tensors
+      auto *tensor = program_->exec_scope()->FindMutableTensor(var_name);
+      if (!tensor->persistable()) {
+        tensor->clear();
+      }
+    } else if (var->IsType<std::vector<Tensor>>()) {
+      // Clear unpersistable tensor vector
+      auto *tensor_array =
+          program_->exec_scope()->FindMutableTensorList(var_name);
+      for (auto &tensor : *tensor_array) {
+        if (!tensor.persistable()) {
+          tensor.clear();
+        }
+      }
+    } else {
+      continue;
+    }
+  }
+  return true;
+}
 
 void Predictor::CheckInputValid() {
   for (size_t idx = 0; idx < input_precisions_.size(); ++idx) {

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -174,6 +174,13 @@ class LITE_API Predictor {
 #endif
   }
 
+  /// \brief Release all tmp tensor to compress the size of the memory pool.
+  /// The memory pool is considered to be composed of a list of chunks, if
+  /// the chunk is not occupied, it can be released.
+  ///
+  /// \return a boolean variable.
+  bool TryShrinkMemory();
+
   // Get offset-th col of feed inputs.
   lite::Tensor* GetInput(size_t offset);
   // get input by name.
@@ -260,6 +267,13 @@ class CxxPaddleApiImpl : public lite_api::PaddlePredictor {
   std::unique_ptr<const lite_api::Tensor> GetOutput(int i) const override;
 
   void Run() override;
+
+  /// \brief Release all tmp tensor to compress the size of the memory pool.
+  /// The memory pool is considered to be composed of a list of chunks, if
+  /// the chunk is not occupied, it can be released.
+  ///
+  /// \return a boolean variable.
+  bool TryShrinkMemory() override;
 
   std::shared_ptr<lite_api::PaddlePredictor> Clone() override;
 

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -262,6 +262,10 @@ void CxxPaddleApiImpl::SaveOptimizedModel(const std::string &model_dir,
   raw_predictor_->SaveModel(model_dir, model_type, record_info);
 }
 
+bool CxxPaddleApiImpl::TryShrinkMemory() {
+  return raw_predictor_->TryShrinkMemory();
+}
+
 }  // namespace lite
 
 namespace lite_api {

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -319,5 +319,36 @@ void LightPredictor::CheckInputValid() {
   }
 }
 
+bool LightPredictor::TryShrinkMemory() {
+#ifdef LITE_WITH_ARM
+  // Clear ArmL3Cache
+  lite::DeviceInfo::Global().ClearArmL3Cache();
+#endif
+  const std::vector<std::string>& local_var_names =
+      program_->exec_scope()->LocalVarNames();
+  for (auto& var_name : local_var_names) {
+    Variable* var = program_->exec_scope()->FindLocalVar(var_name);
+    if (var->IsType<lite::Tensor>()) {
+      // Clear unpersistable tensors
+      auto* tensor = program_->exec_scope()->FindMutableTensor(var_name);
+      if (!tensor->persistable()) {
+        tensor->clear();
+      }
+    } else if (var->IsType<std::vector<Tensor>>()) {
+      // Clear unpersistable tensor vector
+      auto* tensor_array =
+          program_->exec_scope()->FindMutableTensorList(var_name);
+      for (auto& tensor : *tensor_array) {
+        if (!tensor.persistable()) {
+          tensor.clear();
+        }
+      }
+    } else {
+      continue;
+    }
+  }
+  return true;
+}
+
 }  // namespace lite
 }  // namespace paddle

--- a/lite/api/light_api.h
+++ b/lite/api/light_api.h
@@ -67,6 +67,13 @@ class LITE_API LightPredictor {
     program_->Run();
   }
 
+  /// \brief Release all tmp tensor to compress the size of the memory pool.
+  /// The memory pool is considered to be composed of a list of chunks, if
+  /// the chunk is not occupied, it can be released.
+  ///
+  /// \return a boolean variable.
+  bool TryShrinkMemory();
+
   // Get offset-th col of feed inputs.
   Tensor* GetInput(size_t offset);
   // get input by name.
@@ -145,6 +152,13 @@ class LightPredictorImpl : public lite_api::PaddlePredictor {
       const std::string& name) override;
 
   void Init(const lite_api::MobileConfig& config);
+
+  /// \brief Release all tmp tensor to compress the size of the memory pool.
+  /// The memory pool is considered to be composed of a list of chunks, if
+  /// the chunk is not occupied, it can be released.
+  ///
+  /// \return a boolean variable.
+  bool TryShrinkMemory() override;
 
  private:
   std::unique_ptr<lite::LightPredictor> raw_predictor_;

--- a/lite/api/light_api_impl.cc
+++ b/lite/api/light_api_impl.cc
@@ -140,6 +140,10 @@ std::vector<std::string> LightPredictorImpl::GetOutputNames() {
   return raw_predictor_->GetOutputNames();
 }
 
+bool LightPredictorImpl::TryShrinkMemory() {
+  return raw_predictor_->TryShrinkMemory();
+}
+
 }  // namespace lite
 
 namespace lite_api {

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -111,6 +111,9 @@ class LITE_API PaddlePredictor {
   // Get output names
   virtual std::vector<std::string> GetParamNames();
 
+  /// Release all tmp tensor to compress the size of the memory pool.
+  virtual bool TryShrinkMemory() = 0;
+
   // Get Input by name
   virtual std::unique_ptr<Tensor> GetInputByName(const std::string& name) = 0;
 

--- a/lite/api/paddle_api_test.cc
+++ b/lite/api/paddle_api_test.cc
@@ -53,6 +53,14 @@ TEST(CxxApi, run) {
 
   predictor->Run();
 
+  predictor->TryShrinkMemory();
+  input_tensor->Resize(std::vector<int64_t>({100, 100}));
+  data = input_tensor->mutable_data<float>();
+  for (int i = 0; i < 100 * 100; i++) {
+    data[i] = i;
+  }
+
+  predictor->Run();
   auto output = predictor->GetTensor(outputs[0]);
   auto* out = output->data<float>();
   LOG(INFO) << out[0];
@@ -132,6 +140,14 @@ TEST(LightApi, run) {
 
   predictor->Run();
 
+  predictor->TryShrinkMemory();
+  input_tensor->Resize(std::vector<int64_t>({100, 100}));
+  data = input_tensor->mutable_data<float>();
+  for (int i = 0; i < 100 * 100; i++) {
+    data[i] = i;
+  }
+
+  predictor->Run();
   auto output = predictor->GetOutput(0);
   auto* out = output->data<float>();
   LOG(INFO) << out[0];

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -85,6 +85,8 @@ class DeviceInfo {
     workspace_.mutable_data<int8_t>();
   }
 
+  void ClearArmL3Cache() { workspace_.clear(); }
+
   int llc_size() const {
     auto size = absolute_l3cache_size_;
     switch (l3_cache_method_) {


### PR DESCRIPTION
cherry-pick from #6235
- Add API : `TryShrinkMemory `
```
API NAME: TryShrinkMemory
DESCRIPTION:
 - input :  null
 - return : void 
 - Effect:  release memory usage consumed by intermediate temporary tensors and L3ArmCache.
[Inputs and Outputs Tensor will also be released, if you have called TryShrinkMemory API but want to rerun this predictor, you need to fill the input tensor again ]

``` 

- &eg. MobileNetV1

``` 
auto predictor = lite_api::CreatePaddlePredictor(config);
// Status1. Predictor is created, memory usage is 22M
...
predictor->Run();
// Status2. Predictor has inference successfully, memory usage is 44M
...
predictor->TryShrinkMemory();
// Status3. Release memory that used by intermediate tensors and ArmL3Cache, memory usage is reduced to 37M
//                warning: inputs and outputs tensors data will be null after this API is applied
...

// if you want to rerun this model, you need to feed model inputs again
  auto* in_data = in_tensor->mutable_data<float>();
...
```