### PR TITLE
[Pass] Fix No attributes called axis found for softmax

### DIFF
--- a/lite/core/mir/opencl_kernel_place_correct_pass.h
+++ b/lite/core/mir/opencl_kernel_place_correct_pass.h
@@ -62,7 +62,10 @@ class OpenCLKernelPlaceCorrectPass : public ProgramPass {
 
         const auto& tensor = var->Get<Tensor>();
         const auto dims = tensor.dims();
-        int axis = op_info->GetAttr<int>("axis");
+        int axis = -1;
+        if (op_info->HasAttr("axis")) {
+          axis = op_info->GetAttr<int>("axis");
+        }
         axis = axis >= 0 ? axis : axis + dims.size();
         VLOG(4) << "dims: " << dims << "\t dims[axis]: " << dims[axis];
 


### PR DESCRIPTION
`axis`是`softmax`的一个可选 attribute，因此在访问时需要先执行`HasAttr("axis")`，返回 true 后才可以执行`GetAttr<int>("axis")`.