### PR TITLE
fix compiling scripts

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -149,6 +149,10 @@ function make_tiny_publish_so {
 
   cur_dir=$(pwd)
   build_dir=$cur_dir/build.lite.${os}.${abi}.${lang}
+  if [ ! -d third-party ]; then
+    git checkout third-party
+  fi
+
   if [ -d $build_dir ]
   then
     rm -rf $build_dir

--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -164,6 +164,11 @@ function set_android_api_level {
 # 4.1 function of tiny_publish compiling
 # here we only compile light_api lib
 function make_tiny_publish_so {
+
+  if [ ! -d third-party ]; then
+     git checkout third-party
+  fi
+
   # Step1. Create directory for compiling.
   build_dir=$workspace/build.lite.android.$ARCH.$TOOLCHAIN
   if [ "${WITH_OPENCL}" == "ON" ]; then

--- a/lite/tools/build_ios.sh
+++ b/lite/tools/build_ios.sh
@@ -40,6 +40,9 @@ fi
 # 3. compiling functions
 ####################################################################################################
 function make_ios {
+    if [ ! -d third-party ]; then
+      git checkout third-party
+    fi
     local arch=$1
 
     if [ ${arch} == "armv8" ]; then

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -234,6 +234,10 @@ function make_publish_so {
 
     if [ "$WITH_TINY_PUBLISH" = "OFF" ]; then
         prepare_thirdparty
+    else
+        if [ ! -d third-party ] ; then
+            git checkout third-party
+        fi
     fi
 
     build_dir=$workspace/build.lite.linux.$ARCH.$TOOLCHAIN


### PR DESCRIPTION
### BUG FIX
 `full_publish` 支持第三库下载加速：删除 third-party文件夹后、将启动从百度云加速下载第三库压缩文件
但是这种第三方库加速再tiny_publish上不支持，因为tiny_publish不使用第三方库

- 问题： 当tiny_publish编译下、删除third-party 文件夹、编译会报错
### Effect of Current PR

解决当前BUG 
- 解决方法： tiny_publish下检查third-party 文件夹、如果不存在、就git checkout third-party ，恢复这个文件夹