### PR TITLE
[x86 OpenCL] Fix compiling err of gettimeofday

### DIFF
--- a/lite/api/benchmark.cc
+++ b/lite/api/benchmark.cc
@@ -224,7 +224,7 @@ void Run(const std::string& model_path,
   std::vector<float> perf_vct;
   lite::Timer timer;
   for (int i = 0; i < repeats; ++i) {
-    auto start = timer.Start();
+    timer.Start();
     predictor->Run();
     float elapsed_time_ms = timer.Stop();
     perf_vct.push_back(elapsed_time_ms);

--- a/lite/api/benchmark.cc
+++ b/lite/api/benchmark.cc
@@ -226,8 +226,8 @@ void Run(const std::string& model_path,
   for (int i = 0; i < repeats; ++i) {
     timer.Start();
     predictor->Run();
-    float elapsed_time_ms = timer.Stop();
-    perf_vct.push_back(elapsed_time_ms);
+    float duration_ms = timer.Stop();
+    perf_vct.push_back(duration_ms);
   }
 
   std::stable_sort(perf_vct.begin(), perf_vct.end());

--- a/lite/api/test_helper.h
+++ b/lite/api/test_helper.h
@@ -19,7 +19,7 @@
 #include <sys/time.h>
 #else
 #include "lite/backends/x86/port.h"
-#endif
+#endif  // !_WIN32
 #include <time.h>
 #include <cmath>
 #include <fstream>
@@ -50,6 +50,20 @@ DEFINE_bool(int8, false, "is run int8");
 
 namespace paddle {
 namespace lite {
+
+#if defined(_WIN32)
+extern struct timeval;
+static int gettimeofday(struct timeval* tp, void* tzp) {
+  LARGE_INTEGER now, freq;
+  QueryPerformanceCounter(&now);
+  QueryPerformanceFrequency(&freq);
+  tp->tv_sec = now.QuadPart / freq.QuadPart;
+  tp->tv_usec = (now.QuadPart % freq.QuadPart) * 1000000 / freq.QuadPart;
+  // uint64_t duration_us = sec * 1000000 + usec;
+
+  return (0);
+}
+#endif  // _WIN32
 
 inline double GetCurrentUS() {
   struct timeval time;

--- a/lite/api/test_helper.h
+++ b/lite/api/test_helper.h
@@ -15,12 +15,6 @@
 #pragma once
 
 #include <gflags/gflags.h>
-#if !defined(_WIN32)
-#include <sys/time.h>
-#else
-#include "lite/backends/x86/port.h"
-#endif  // !_WIN32
-#include <time.h>
 #include <cmath>
 #include <fstream>
 #include <memory>
@@ -28,6 +22,7 @@
 #include <vector>
 #include "lite/api/cxx_api.h"
 #include "lite/utils/cp_logging.h"
+#include "lite/utils/timer.h"
 
 // for eval
 DEFINE_string(model_dir, "", "model dir");
@@ -51,24 +46,8 @@ DEFINE_bool(int8, false, "is run int8");
 namespace paddle {
 namespace lite {
 
-#if defined(_WIN32)
-extern struct timeval;
-static int gettimeofday(struct timeval* tp, void* tzp) {
-  LARGE_INTEGER now, freq;
-  QueryPerformanceCounter(&now);
-  QueryPerformanceFrequency(&freq);
-  tp->tv_sec = now.QuadPart / freq.QuadPart;
-  tp->tv_usec = (now.QuadPart % freq.QuadPart) * 1000000 / freq.QuadPart;
-  // uint64_t duration_us = sec * 1000000 + usec;
-
-  return (0);
-}
-#endif  // _WIN32
-
 inline double GetCurrentUS() {
-  struct timeval time;
-  gettimeofday(&time, NULL);
-  return 1e+6 * time.tv_sec + time.tv_usec;
+  return static_cast<double>(lite::Timer::GetCurrentUS());
 }
 
 template <typename T>

--- a/lite/kernels/opencl/conv_image_compute.h
+++ b/lite/kernels/opencl/conv_image_compute.h
@@ -19,9 +19,6 @@
 #include <string>
 #include <vector>
 
-#if defined(_MSC_VER)
-#include "lite/backends/x86/port.h"
-#endif
 #include "lite/backends/opencl/cl_half.h"
 #include "lite/backends/opencl/cl_include.h"
 #include "lite/core/kernel.h"

--- a/lite/kernels/opencl/image_helper.h
+++ b/lite/kernels/opencl/image_helper.h
@@ -14,14 +14,10 @@
 
 #pragma once
 
+#include <chrono>  // NOLINT(build/c++11)
 #include <map>
 #include <string>
 #include <vector>
-#if defined(_MSC_VER)
-#include "lite/backends/x86/port.h"
-#else
-#include <sys/time.h>
-#endif
 #include "lite/core/tensor.h"
 #include "lite/utils/cp_logging.h"
 
@@ -80,9 +76,10 @@ static std::vector<size_t> DefaultGlobalWorkSize(const DDim& tensor_dim,
 }
 
 static const std::string GetTimeStamp() {
-  struct timeval time;
-  gettimeofday(&time, NULL);
-  return std::to_string(time.tv_usec);
+  uint64_t usec = std::chrono::duration_cast<std::chrono::microseconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count();
+  return std::to_string(usec);
 }
 
 }  // namespace opencl

--- a/lite/kernels/opencl/image_helper.h
+++ b/lite/kernels/opencl/image_helper.h
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <chrono>  // NOLINT(build/c++11)
 #include <map>
 #include <string>
 #include <vector>
 #include "lite/core/tensor.h"
 #include "lite/utils/cp_logging.h"
+#include "lite/utils/timer.h"
 
 namespace paddle {
 namespace lite {
@@ -76,9 +76,7 @@ static std::vector<size_t> DefaultGlobalWorkSize(const DDim& tensor_dim,
 }
 
 static const std::string GetTimeStamp() {
-  uint64_t usec = std::chrono::duration_cast<std::chrono::microseconds>(
-                      std::chrono::system_clock::now().time_since_epoch())
-                      .count();
+  uint64_t usec = lite::Timer::GetCurrentUS();
   return std::to_string(usec);
 }
 

--- a/lite/utils/CMakeLists.txt
+++ b/lite/utils/CMakeLists.txt
@@ -35,3 +35,7 @@ if (WITH_TESTING)
     endif ()
     lite_cc_test(float16_test SRCS float16_test.cc)
 endif()
+
+# timer
+lite_cc_library(timer SRCS timer.cc DEPS ${utils_DEPS})
+lite_cc_test(test_timer SRCS timer_test.cc DEPS ${utils_DEPS})

--- a/lite/utils/CMakeLists.txt
+++ b/lite/utils/CMakeLists.txt
@@ -38,4 +38,4 @@ endif()
 
 # timer
 lite_cc_library(timer SRCS timer.cc DEPS ${utils_DEPS})
-lite_cc_test(test_timer SRCS timer_test.cc DEPS ${utils_DEPS})
+lite_cc_test(test_timer SRCS timer_test.cc DEPS ${utils_DEPS} timer)

--- a/lite/utils/CMakeLists.txt
+++ b/lite/utils/CMakeLists.txt
@@ -38,4 +38,4 @@ endif()
 
 # timer
 lite_cc_library(timer SRCS timer.cc DEPS ${utils_DEPS})
-lite_cc_test(test_timer SRCS timer_test.cc DEPS ${utils_DEPS} timer)
+lite_cc_test(test_timer SRCS timer_test.cc DEPS ${utils_DEPS})

--- a/lite/utils/timer.cc
+++ b/lite/utils/timer.cc
@@ -13,70 +13,7 @@
 // limitations under the License.
 
 #include "lite/utils/timer.h"
-#include <cmath>
-#include <ctime>
-#include <string>
-#include <thread>  // NOLINT(build/c++11)
-#include "lite/utils/cp_logging.h"
-#include "lite/utils/macros.h"
 
 namespace paddle {
-namespace lite {
-
-using std::chrono::duration_cast;
-using std::chrono::microseconds;
-
-Timer::Timer(const std::string timer_info) {
-  timer_info_ = timer_info;
-  Reset();
-}
-
-void Timer::Start() { Reset(); }
-
-float Timer::Stop() {
-  stop_ = system_clock::now();
-  float ms_delta =
-      duration_cast<microseconds>(stop_ - start_).count() / 1000.0f;
-  min_ = static_cast<float>(fmin(min_, ms_delta));
-  max_ = static_cast<float>(fmax(max_, ms_delta));
-  sum_ += ms_delta;
-  count_++;
-  return ms_delta;
-}
-
-void Timer::Reset() {
-  min_ = FLT_MAX;
-  max_ = FLT_MIN;
-  sum_ = 0.0f;
-  count_ = 0;
-  stop_ = start_ = system_clock::now();
-}
-
-void Timer::SleepInMs(const float milliseconds) {
-  // Early return on non-positive input
-  if (milliseconds <= 0.f) {
-    return;
-  }
-
-  const int64_t ms = static_cast<int64_t>(milliseconds);
-  std::this_thread::sleep_for(std::chrono::milliseconds(ms));
-}
-
-void Timer::Print() {
-  char min_str[16];
-  snprintf(min_str, sizeof(min_str), "%6.3f", min_);
-  char max_str[16];
-  snprintf(max_str, sizeof(max_str), "%6.3f", max_);
-  char avg_str[16];
-  snprintf(
-      avg_str, sizeof(avg_str), "%6.3f", sum_ / static_cast<float>(count_));
-  LOG(INFO) << lite::string_format(
-      "time cost: min = %-8s ms  |  max = %-8s ms  |  avg = %-8s ms \n",
-      timer_info_.c_str(),
-      min_str,
-      max_str,
-      avg_str);
-}
-
-}  // namespace lite
+namespace lite {}  // namespace lite
 }  // namespace paddle

--- a/lite/utils/timer.cc
+++ b/lite/utils/timer.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/utils/timer.h"
+#include <cmath>
+#include <ctime>
+#include <string>
+#include <thread>  // NOLINT(build/c++11)
+#include "lite/utils/cp_logging.h"
+#include "lite/utils/macros.h"
+
+namespace paddle {
+namespace lite {
+
+using std::chrono::duration_cast;
+using std::chrono::microseconds;
+
+Timer::Timer(const std::string timer_info = "benchmark") {
+  timer_info_ = timer_info;
+  Reset();
+}
+
+void Timer::Start() { Reset(); }
+
+float Timer::Stop() {
+  stop_ = system_clock::now();
+  float ms_delta =
+      duration_cast<microseconds>(stop_ - start_).count() / 1000.0f;
+  min_ = static_cast<float>(fmin(min_, ms_delta));
+  max_ = static_cast<float>(fmax(max_, ms_delta));
+  sum_ += ms_delta;
+  count_++;
+  return ms_delta;
+}
+
+void Timer::Reset() {
+  min_ = FLT_MAX;
+  max_ = FLT_MIN;
+  sum_ = 0.0f;
+  count_ = 0;
+  stop_ = start_ = system_clock::now();
+}
+
+void Timer::SleepInMs(const float milliseconds) {
+  // Early return on non-positive input
+  if (milliseconds <= 0.f) {
+    return;
+  }
+
+  const int64_t ms = static_cast<int64_t>(milliseconds);
+  std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+void Timer::Print() {
+  char min_str[16];
+  snprintf(min_str, sizeof(min_str), "%6.3f", min_);
+  char max_str[16];
+  snprintf(max_str, sizeof(max_str), "%6.3f", max_);
+  char avg_str[16];
+  snprintf(
+      avg_str, sizeof(avg_str), "%6.3f", sum_ / static_cast<float>(count_));
+  LOG(INFO) << lite::string_format(
+      "time cost: min = %-8s ms  |  max = %-8s ms  |  avg = %-8s ms \n",
+      timer_info_.c_str(),
+      min_str,
+      max_str,
+      avg_str);
+}
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/utils/timer.cc
+++ b/lite/utils/timer.cc
@@ -26,7 +26,7 @@ namespace lite {
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 
-Timer::Timer(const std::string timer_info = "benchmark") {
+Timer::Timer(const std::string timer_info) {
   timer_info_ = timer_info;
   Reset();
 }

--- a/lite/utils/timer.h
+++ b/lite/utils/timer.h
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 #pragma once
+#include <float.h>
 #include <chrono>  // NOLINT(build/c++11)
 #include <cmath>
 #include <string>
 #include <thread>  // NOLINT(build/c++11)
 #include "lite/utils/cp_logging.h"
-#include "lite/utils/macros.h"
+#include "lite/utils/string.h"
 
 namespace paddle {
 namespace lite {
@@ -63,7 +64,7 @@ class Timer {
     char avg_str[16];
     snprintf(
         avg_str, sizeof(avg_str), "%6.3f", sum_ / static_cast<float>(count_));
-    LOG(INFO) << lite::string_format(
+    LOG(INFO) << string_format(
         "time cost: min = %-8s ms | max = %-8s ms | avg = %-8s ms \n",
         timer_info_.c_str(),
         min_str,

--- a/lite/utils/timer.h
+++ b/lite/utils/timer.h
@@ -47,7 +47,14 @@ class Timer {
     return ms_delta;
   }
 
-  void SleepInMs(const float ms) {
+  static uint64_t GetCurrentUS() {
+    uint64_t usec = std::chrono::duration_cast<std::chrono::microseconds>(
+                        std::chrono::system_clock::now().time_since_epoch())
+                        .count();
+    return usec;
+  }
+
+  static void SleepInMs(const float ms) {
     if (ms <= 0.f) {
       return;
     }

--- a/lite/utils/timer.h
+++ b/lite/utils/timer.h
@@ -27,12 +27,12 @@ namespace lite {
 // thread-safe timer impl
 class Timer {
  public:
-  explicit Timer(const std::string timer_info = "benchmark") {
+  explicit Timer(const std::string timer_info = "") {
     timer_info_ = timer_info;
     Reset();
   }
 
-  void Start() { Reset(); }
+  void Start() { start_ = std::chrono::system_clock::now(); }
 
   float Stop() {
     stop_ = std::chrono::system_clock::now();
@@ -65,7 +65,7 @@ class Timer {
     snprintf(
         avg_str, sizeof(avg_str), "%6.3f", sum_ / static_cast<float>(count_));
     LOG(INFO) << string_format(
-        "%10s time cost: min = %8s ms | max = %8s ms | avg = %8s ms \n",
+        "%s time cost: min = %8s ms | max = %8s ms | avg = %8s ms",
         timer_info_.c_str(),
         min_str,
         max_str,

--- a/lite/utils/timer.h
+++ b/lite/utils/timer.h
@@ -65,7 +65,7 @@ class Timer {
     snprintf(
         avg_str, sizeof(avg_str), "%6.3f", sum_ / static_cast<float>(count_));
     LOG(INFO) << string_format(
-        "%-45s time cost: min = %-8s ms | max = %-8s ms | avg = %-8s ms \n",
+        "%10s time cost: min = %8s ms | max = %8s ms | avg = %8s ms \n",
         timer_info_.c_str(),
         min_str,
         max_str,

--- a/lite/utils/timer.h
+++ b/lite/utils/timer.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <chrono>  // NOLINT(build/c++11)
+#include <string>
+
+namespace paddle {
+namespace lite {
+
+using std::chrono::time_point;
+using std::chrono::system_clock;
+
+// thread-safe timer impl
+class Timer {
+ public:
+  explicit Timer(const std::string timer_info = "benchmark");
+  void Start();
+  float Stop();
+  void SleepInMs(const float milliseconds);
+  void Print();
+
+ private:
+  void Reset();
+
+ private:
+  float min_;
+  float max_;
+  float sum_;
+  std::string timer_info_;
+  time_point<system_clock> start_;
+  time_point<system_clock> stop_;
+  int count_;
+};
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/utils/timer.h
+++ b/lite/utils/timer.h
@@ -14,33 +14,79 @@
 
 #pragma once
 #include <chrono>  // NOLINT(build/c++11)
+#include <cmath>
 #include <string>
+#include <thread>  // NOLINT(build/c++11)
+#include "lite/utils/cp_logging.h"
+#include "lite/utils/macros.h"
 
 namespace paddle {
 namespace lite {
 
-using std::chrono::time_point;
-using std::chrono::system_clock;
-
 // thread-safe timer impl
 class Timer {
  public:
-  explicit Timer(const std::string timer_info = "benchmark");
-  void Start();
-  float Stop();
-  void SleepInMs(const float milliseconds);
-  void Print();
+  explicit Timer(const std::string timer_info = "benchmark") {
+    timer_info_ = timer_info;
+    Reset();
+  }
+
+  void Start() { Reset(); }
+
+  float Stop() {
+    stop_ = std::chrono::system_clock::now();
+    float ms_delta =
+        std::chrono::duration_cast<std::chrono::microseconds>(stop_ - start_)
+            .count() /
+        1000.0f;
+    min_ = static_cast<float>(fmin(min_, ms_delta));
+    max_ = static_cast<float>(fmax(max_, ms_delta));
+    sum_ += ms_delta;
+    count_++;
+    return ms_delta;
+  }
+
+  void SleepInMs(const float ms) {
+    if (ms <= 0.f) {
+      return;
+    }
+
+    const int64_t ms_int = static_cast<int64_t>(ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms_int));
+  }
+
+  void Print() {
+    char min_str[16];
+    snprintf(min_str, sizeof(min_str), "%6.3f", min_);
+    char max_str[16];
+    snprintf(max_str, sizeof(max_str), "%6.3f", max_);
+    char avg_str[16];
+    snprintf(
+        avg_str, sizeof(avg_str), "%6.3f", sum_ / static_cast<float>(count_));
+    LOG(INFO) << lite::string_format(
+        "time cost: min = %-8s ms | max = %-8s ms | avg = %-8s ms \n",
+        timer_info_.c_str(),
+        min_str,
+        max_str,
+        avg_str);
+  }
 
  private:
-  void Reset();
+  void Reset() {
+    min_ = FLT_MAX;
+    max_ = FLT_MIN;
+    sum_ = 0.0f;
+    count_ = 0;
+    stop_ = start_ = std::chrono::system_clock::now();
+  }
 
  private:
   float min_;
   float max_;
   float sum_;
   std::string timer_info_;
-  time_point<system_clock> start_;
-  time_point<system_clock> stop_;
+  std::chrono::time_point<std::chrono::system_clock> start_;
+  std::chrono::time_point<std::chrono::system_clock> stop_;
   int count_;
 };
 

--- a/lite/utils/timer.h
+++ b/lite/utils/timer.h
@@ -65,7 +65,7 @@ class Timer {
     snprintf(
         avg_str, sizeof(avg_str), "%6.3f", sum_ / static_cast<float>(count_));
     LOG(INFO) << string_format(
-        "time cost: min = %-8s ms | max = %-8s ms | avg = %-8s ms \n",
+        "%-45s time cost: min = %-8s ms | max = %-8s ms | avg = %-8s ms \n",
         timer_info_.c_str(),
         min_str,
         max_str,

--- a/lite/utils/timer_test.cc
+++ b/lite/utils/timer_test.cc
@@ -48,7 +48,6 @@ TEST(timer, basic) {
     timer.SleepInMs(base);
     float duration_ms = timer.Stop();
     timer.Print();
-    EXPECT_EQ(static_cast<int>(duration_ms), static_cast<int>(base));
 
     auto start = GetCurrentUS();
     timer.SleepInMs(base);
@@ -56,6 +55,7 @@ TEST(timer, basic) {
     float t = (end - start) * 1e-3;
     LOG(INFO) << "Base time: " << base << "  gettimeofday: " << t
               << "  Timer: " << duration_ms;
+    EXPECT_EQ(static_cast<int>(duration_ms), static_cast<int>(t));
   }
 }
 

--- a/lite/utils/timer_test.cc
+++ b/lite/utils/timer_test.cc
@@ -29,11 +29,11 @@ static int gettimeofday(struct timeval* tp, void* tzp) {
   QueryPerformanceFrequency(&freq);
   tp->tv_sec = now.QuadPart / freq.QuadPart;
   tp->tv_usec = (now.QuadPart % freq.QuadPart) * 1000000 / freq.QuadPart;
-  // uint64_t elapsed_time = sec * 1000000 + usec;
+  // uint64_t duration_us = sec * 1000000 + usec;
 
   return (0);
 }
-#endif // !_WIN32
+#endif  // !_WIN32
 
 TEST(timer, basic) {
   auto GetCurrentUS = []() -> double {
@@ -42,31 +42,21 @@ TEST(timer, basic) {
     return 1e+6 * time.tv_sec + time.tv_usec;
   };
 
-  const float scale = 0.1f;
   paddle::lite::Timer timer;
-  for (float ms = 0.f; ms < 100.f; ms += 25.f) {
+  for (float base = 0.f; base < 100.f; base += 25.f) {
     timer.Start();
-    timer.SleepInMs(ms);
-    float elapsed_time_ms = timer.Stop();
+    timer.SleepInMs(base);
+    float duration_ms = timer.Stop();
     timer.Print();
-    EXPECT_NEAR(elapsed_time_ms, ms, ms * scale);
+    EXPECT_EQ(static_cast<int>(duration_ms), static_cast<int>(base));
 
     auto start = GetCurrentUS();
-    timer.SleepInMs(ms);
+    timer.SleepInMs(base);
     auto end = GetCurrentUS();
-    float base = (end - start) * 1e-3;
-    LOG(INFO) << "Base time: " << ms
-              << "  gettimeofday: " << base
-              << "  Timer: " << elapsed_time_ms;
-    EXPECT_NEAR(elapsed_time_ms, base, base * scale);
+    float t = (end - start) * 1e-3;
+    LOG(INFO) << "Base time: " << base << "  gettimeofday: " << t
+              << "  Timer: " << duration_ms;
   }
-
-  const float ms = 123.f;
-  timer.Start();
-  timer.SleepInMs(ms);
-  float elapsed_time_ms = timer.Stop();
-  timer.Print();
-  EXPECT_NEAR(elapsed_time_ms, ms, ms * scale);
 }
 
 }  // namespace lite

--- a/lite/utils/timer_test.cc
+++ b/lite/utils/timer_test.cc
@@ -25,14 +25,15 @@ TEST(timer, basic) {
     timer.SleepInMs(i);
     float elapsed_time_ms = timer.Stop();
     timer.Print();
-    CHECK_EQ(elapsed_time_ms, i);
+    EXPECT_EQ(elapsed_time_ms, i);
   }
 
-  const float ms = 1000.f timer.Start();
+  const float ms = 1000.f;
+  timer.Start();
   timer.SleepInMs(ms);
   float elapsed_time_ms = timer.Stop();
   timer.Print();
-  CHECK_EQ(elapsed_time_ms, ms);
+  EXPECT_EQ(elapsed_time_ms, ms);
 }
 
 }  // namespace lite

--- a/lite/utils/timer_test.cc
+++ b/lite/utils/timer_test.cc
@@ -43,7 +43,7 @@ TEST(timer, basic) {
   };
 
   paddle::lite::Timer timer;
-  for (float base = 0.f; base < 100.f; base += 25.f) {
+  for (float base = 10.f; base < 100.f; base += 25.f) {
     timer.Start();
     timer.SleepInMs(base);
     float duration_ms = timer.Stop();
@@ -55,7 +55,7 @@ TEST(timer, basic) {
     float t = (end - start) * 1e-3;
     LOG(INFO) << "Base time: " << base << "  gettimeofday: " << t
               << "  Timer: " << duration_ms;
-    EXPECT_EQ(static_cast<int>(duration_ms), static_cast<int>(t));
+    EXPECT_NEAR(duration_ms, t, t * 0.1);
   }
 }
 

--- a/lite/utils/timer_test.cc
+++ b/lite/utils/timer_test.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/utils/timer.h"
+#include <gtest/gtest.h>
+
+namespace paddle {
+namespace lite {
+
+TEST(timer, basic) {
+  paddle::lite::Timer timer;
+  for (float i = 0.f; i < 100.f; i += 10.f) {
+    timer.Start();
+    timer.SleepInMs(i);
+    float elapsed_time_ms = timer.Stop();
+    timer.Print();
+    CHECK_EQ(elapsed_time_ms, i);
+  }
+
+  const float ms = 1000.f timer.Start();
+  timer.SleepInMs(ms);
+  float elapsed_time_ms = timer.Stop();
+  timer.Print();
+  CHECK_EQ(elapsed_time_ms, ms);
+}
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/utils/timer_test.cc
+++ b/lite/utils/timer_test.cc
@@ -33,7 +33,7 @@ static int gettimeofday(struct timeval* tp, void* tzp) {
 
   return (0);
 }
-#endif
+#endif // !_WIN32
 
 TEST(timer, basic) {
   auto GetCurrentUS = []() -> float {

--- a/lite/utils/timer_test.cc
+++ b/lite/utils/timer_test.cc
@@ -36,7 +36,7 @@ static int gettimeofday(struct timeval* tp, void* tzp) {
 #endif // !_WIN32
 
 TEST(timer, basic) {
-  auto GetCurrentUS = []() -> float {
+  auto GetCurrentUS = []() -> double {
     struct timeval time;
     gettimeofday(&time, NULL);
     return 1e+6 * time.tv_sec + time.tv_usec;
@@ -44,7 +44,7 @@ TEST(timer, basic) {
 
   const float scale = 0.1f;
   paddle::lite::Timer timer;
-  for (float ms = 0.f; ms < 1000.f; ms += 25.f) {
+  for (float ms = 0.f; ms < 100.f; ms += 25.f) {
     timer.Start();
     timer.SleepInMs(ms);
     float elapsed_time_ms = timer.Stop();


### PR DESCRIPTION
在`lite/utils/`下增加CPU端统一计时管理类`Timer`，舍弃使用非跨平台函数`gettimeofday`。