### PR TITLE
[arm] fix v7 model profiler greater than v2.8

### DIFF
--- a/lite/backends/arm/math/packed_sgemm.cc
+++ b/lite/backends/arm/math/packed_sgemm.cc
@@ -3280,8 +3280,8 @@ void loadb_trans(
 
 #define X_BLOCK_COMPUTE(l2_cache, MBLOCK, NBLOCK, M, N, K)                  \
   int x_block = (l2_cache - (MBLOCK * K)) / (sizeof(float) * (K + MBLOCK)); \
-  x_block /= NBLOCK;                                                        \
   x_block = (x_block == 0) ? 1 : x_block;                                   \
+  x_block /= NBLOCK;                                                        \
   x_block *= NBLOCK;                                                        \
   int x_num = (N + (x_block - 1)) / x_block;                                \
   x_block = (N + x_num - 1) / x_num;                                        \


### PR DESCRIPTION

625-v7-1-thread

  | x_block==0 | swamp place | delete x_block==0
-- | -- | -- | --
mobilenetv1 | 151.285 | 146.581 | 146.638
mv2 | 129.907 | 129.53 | 129.678
mv3_small | 35.5235 | 34.8905 | 34.7109

