### PR TITLE
[x86] move roi_align and box_clip to host test=develop

### DIFF
--- a/lite/kernels/arm/CMakeLists.txt
+++ b/lite/kernels/arm/CMakeLists.txt
@@ -67,8 +67,6 @@ add_kernel(reduce_sum_compute_arm ARM extra SRCS reduce_sum_compute.cc DEPS ${li
 add_kernel(split_lod_tensor_compute_arm ARM extra SRCS split_lod_tensor_compute.cc DEPS ${lite_kernel_deps} math_arm)
 add_kernel(merge_lod_tensor_compute_arm ARM extra SRCS merge_lod_tensor_compute.cc DEPS ${lite_kernel_deps} math_arm)
 add_kernel(generate_proposals_v2_compute_arm ARM extra SRCS generate_proposals_v2_compute.cc DEPS ${lite_kernel_deps} math_arm)
-add_kernel(roi_align_compute_arm ARM extra SRCS roi_align_compute.cc DEPS ${lite_kernel_deps} math_arm)
-add_kernel(box_clip_compute_arm ARM extra SRCS box_clip_compute.cc DEPS ${lite_kernel_deps} math_arm)
 add_kernel(clip_compute_arm ARM extra SRCS clip_compute.cc DEPS ${lite_kernel_deps} math_arm)
 add_kernel(pixel_shuffle_compute_arm ARM extra SRCS pixel_shuffle_compute.cc DEPS ${lite_kernel_deps} math_arm)
 add_kernel(scatter_compute_arm ARM extra SRCS scatter_compute.cc DEPS ${lite_kernel_deps} math_arm)

--- a/lite/kernels/host/CMakeLists.txt
+++ b/lite/kernels/host/CMakeLists.txt
@@ -96,6 +96,8 @@ add_kernel(distribute_fpn_proposals_compute_host Host extra SRCS distribute_fpn_
 add_kernel(collect_fpn_proposals_compute_host Host extra SRCS collect_fpn_proposals_compute.cc DEPS ${lite_kernel_deps})
 add_kernel(flip_compute_host Host extra SRCS flip_compute.cc DEPS ${lite_kernel_deps})
 add_kernel(unique_with_counts_compute  Host extra SRCS unique_with_counts_compute.cc DEPS ${lite_kernel_deps})
+add_kernel(roi_align_compute Host extra SRCS roi_align_compute.cc DEPS ${lite_kernel_deps})
+add_kernel(box_clip_compute Host extra SRCS box_clip_compute.cc DEPS ${lite_kernel_deps})
 
 if(LITE_BUILD_EXTRA AND LITE_WITH_x86)
   lite_cc_test(test_where_index_compute_host SRCS where_index_compute.cc DEPS where_index_compute_host)

--- a/lite/kernels/host/box_clip_compute.cc
+++ b/lite/kernels/host/box_clip_compute.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/arm/box_clip_compute.h"
+#include "lite/kernels/host/box_clip_compute.h"
+#include <cmath>
 #include <string>
 #include <vector>
-#include "lite/backends/arm/math/funcs.h"
 #include "lite/core/op_registry.h"
 #include "lite/core/tensor.h"
 #include "lite/core/type_system.h"
@@ -23,7 +23,7 @@
 namespace paddle {
 namespace lite {
 namespace kernels {
-namespace arm {
+namespace host {
 
 template <class T>
 void ClipTiledBoxes(const Tensor& im_info,
@@ -62,7 +62,6 @@ void BoxClipCompute::Run() {
   int64_t n = static_cast<int64_t>(box_lod.size() - 1);
   for (int i = 0; i < n; ++i) {
     Tensor im_info_slice = im_info->Slice<float>(i, i + 1);
-    auto* im_info_slice_data = im_info_slice.data<float>();
     Tensor box_slice = input->Slice<float>(box_lod[i], box_lod[i + 1]);
     Tensor output_slice = output->Slice<float>(box_lod[i], box_lod[i + 1]);
     ClipTiledBoxes<float>(im_info_slice, box_slice, &output_slice);
@@ -70,18 +69,18 @@ void BoxClipCompute::Run() {
   return;
 }
 
-}  // namespace arm
+}  // namespace host
 }  // namespace kernels
 }  // namespace lite
 }  // namespace paddle
 
 REGISTER_LITE_KERNEL(box_clip,
-                     kARM,
+                     kHost,
                      kFloat,
                      kNCHW,
-                     paddle::lite::kernels::arm::BoxClipCompute,
+                     paddle::lite::kernels::host::BoxClipCompute,
                      def)
-    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindInput("ImInfo", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindOutput("Output", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindInput("ImInfo", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindOutput("Output", {LiteType::GetTensorTy(TARGET(kHost))})
     .Finalize();

--- a/lite/kernels/host/box_clip_compute.h
+++ b/lite/kernels/host/box_clip_compute.h
@@ -15,23 +15,23 @@
 #pragma once
 #include <algorithm>
 #include "lite/core/kernel.h"
-#include "lite/operators/roi_align_op.h"
+#include "lite/operators/box_clip_op.h"
 
 namespace paddle {
 namespace lite {
 namespace kernels {
-namespace arm {
+namespace host {
 
-class RoiAlignCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class BoxClipCompute : public KernelLite<TARGET(kHost), PRECISION(kFloat)> {
  public:
-  using param_t = operators::RoiAlignParam;
+  using param_t = operators::BoxClipParam;
 
   void Run() override;
 
-  virtual ~RoiAlignCompute() = default;
+  virtual ~BoxClipCompute() = default;
 };
 
-}  // namespace arm
+}  // namespace host
 }  // namespace kernels
 }  // namespace lite
 }  // namespace paddle

--- a/lite/kernels/host/roi_align_compute.cc
+++ b/lite/kernels/host/roi_align_compute.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lite/kernels/arm/roi_align_compute.h"
+#include "lite/kernels/host/roi_align_compute.h"
+#include <cmath>
 #include <string>
 #include <vector>
-#include "lite/backends/arm/math/funcs.h"
 #include "lite/core/op_registry.h"
 #include "lite/core/tensor.h"
 #include "lite/core/type_system.h"
@@ -23,7 +23,7 @@
 namespace paddle {
 namespace lite {
 namespace kernels {
-namespace arm {
+namespace host {
 static constexpr int kROISize = 4;
 
 template <class T>
@@ -112,7 +112,6 @@ void RoiAlignCompute::Run() {
   int sampling_ratio = param.sampling_ratio;
 
   auto in_dims = in->dims();
-  int batch_size = in_dims[0];
   int channels = in_dims[1];
   int height = in_dims[2];
   int width = in_dims[3];
@@ -237,23 +236,23 @@ void RoiAlignCompute::Run() {
   }
 }
 
-}  // namespace arm
+}  // namespace host
 }  // namespace kernels
 }  // namespace lite
 }  // namespace paddle
 
 REGISTER_LITE_KERNEL(roi_align,
-                     kARM,
+                     kHost,
                      kFloat,
                      kNCHW,
-                     paddle::lite::kernels::arm::RoiAlignCompute,
+                     paddle::lite::kernels::host::RoiAlignCompute,
                      def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
-    .BindInput("ROIs", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindInput("ROIs", {LiteType::GetTensorTy(TARGET(kHost))})
     .BindInput("RoisLod",
-               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt64))})
     .BindInput("RoisNum",
-               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost))})
     .BindPaddleOpVersion("roi_align", 1)
     .Finalize();

--- a/lite/kernels/host/roi_align_compute.h
+++ b/lite/kernels/host/roi_align_compute.h
@@ -15,23 +15,23 @@
 #pragma once
 #include <algorithm>
 #include "lite/core/kernel.h"
-#include "lite/operators/box_clip_op.h"
+#include "lite/operators/roi_align_op.h"
 
 namespace paddle {
 namespace lite {
 namespace kernels {
-namespace arm {
+namespace host {
 
-class BoxClipCompute : public KernelLite<TARGET(kARM), PRECISION(kFloat)> {
+class RoiAlignCompute : public KernelLite<TARGET(kHost), PRECISION(kFloat)> {
  public:
-  using param_t = operators::BoxClipParam;
+  using param_t = operators::RoiAlignParam;
 
   void Run() override;
 
-  virtual ~BoxClipCompute() = default;
+  virtual ~RoiAlignCompute() = default;
 };
 
-}  // namespace arm
+}  // namespace host
 }  // namespace kernels
 }  // namespace lite
 }  // namespace paddle


### PR DESCRIPTION
roi_align and box_clip were naive implementation in arm , so move roi_align and box_clip to host for supporting x86 