### PR TITLE
[Pass]Delete redundant layout_cast links when there are multiple outputs on the same node

### DIFF
--- a/lite/core/mir/type_layout_cast_pass.cc
+++ b/lite/core/mir/type_layout_cast_pass.cc
@@ -234,18 +234,17 @@ void TypeLayoutTransformPass::AddLayoutInst(
     inst_node->AsStmt().kernels().clear();
     inst_node->AsStmt().kernels().emplace_back(
         std::move(original_selected_kernel));
-
-    std::string tmp;
-    if (inst_node->AsStmt().op_info()->GetInputArgname("a", &tmp)) {
-      CHECK(false) << "get old a " << tmp;
-    }
-
-    for (auto& kernel : inst_node->AsStmt().kernels()) {
-      inst_node->AsStmt().op()->AttachKernel(kernel.get());
-    }
-
-    graph->CheckValid();
   }
+  std::string tmp;
+  if (inst_node->AsStmt().op_info()->GetInputArgname("a", &tmp)) {
+    CHECK(false) << "get old a " << tmp;
+  }
+
+  for (auto& kernel : inst_node->AsStmt().kernels()) {
+    inst_node->AsStmt().op()->AttachKernel(kernel.get());
+  }
+
+  graph->CheckValid();
 }
 
 void TypeLayoutTransformPass::SetValidPlaces(

--- a/lite/core/mir/type_layout_cast_pass.h
+++ b/lite/core/mir/type_layout_cast_pass.h
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 #include "lite/core/mir/pass.h"
 #include "lite/core/op_registry.h"
-
 namespace paddle {
 namespace lite {
 namespace mir {
@@ -28,13 +28,17 @@ class TypeLayoutTransformPass : public ProgramPass {
  public:
   void Apply(const std::unique_ptr<SSAGraph>& graph) override;
 
-  void ComplementInputs(SSAGraph* graph, Node* inst_node, Node* in);
+  void ComplementInputs(SSAGraph* graph,
+                        Node* inst_node,
+                        Node* in,
+                        std::map<std::string, Node*>* copied_nodes);
 
   void AddLayoutInst(const Type& from,
                      const Type& to,
                      Node* in,
                      SSAGraph* graph,
                      Node* inst_node,
+                     std::map<std::string, Node*>* copied_nodes,
                      const std::vector<Place>& valid_places);
 
   void SetValidPlaces(const std::vector<Place>& valid_places);


### PR DESCRIPTION
主要作用是当node有多个输出时去除多余的layout转换
其效果如下(第一张图变第二张图）：
<img width="309" alt="0bbf7de26061e17dd65aad5f3d667ce8" src="https://user-images.githubusercontent.com/28774670/127466676-0f33796b-7b3c-42dc-b431-692e795c3f76.png">

![8baf2ae210e4919f5e921bf2e74dcd9b](https://user-images.githubusercontent.com/28774670/127466591-673db152-e448-431b-9d0c-60229419938f.png)