### PR TITLE
[utils] Fix Timer utest

### DIFF
--- a/lite/utils/timer_test.cc
+++ b/lite/utils/timer_test.cc
@@ -43,7 +43,7 @@ TEST(timer, basic) {
   };
 
   paddle::lite::Timer timer;
-  for (float base = 10.f; base < 100.f; base += 25.f) {
+  for (float base = 60.f; base < 100.f; base += 25.f) {
     timer.Start();
     timer.SleepInMs(base);
     float duration_ms = timer.Stop();


### PR DESCRIPTION
在 android 部分机器上运行 test_timer 时，会有如下报错：当设定 sleep 10ms时，gettimeofday 返回 12ms，Timer 返回 10ms，gettimeofday 的耗时与 Timer 相差大于设定阈值。因此修改了单测测试范围。

![image](https://user-images.githubusercontent.com/24290792/127951321-aa2d276a-4ea8-4f41-9da2-f5924371b12f.png)
