### PR TITLE
[host][kernel] align gather to paddle2.1.1

### DIFF
--- a/lite/kernels/host/gather_compute.cc
+++ b/lite/kernels/host/gather_compute.cc
@@ -53,7 +53,6 @@ void GatherV2Func(const operators::GatherParam& param, const int axis) {
   const int axis_index = axis;
   int input_index_dim_size = input_dim[axis_index];
   for (int i = 0; i < index_size; i++) {
-    LOG(INFO) << lite::string_format("index_data[%d]: %lld", i, index_data[i]);
     CHECK_LT(index_data[i], input_index_dim_size)
         << "The element of Index must be less than the size of "
         << "dim size of axis dim";
@@ -88,7 +87,6 @@ void GatherCompute<IndexType, AxisType>::Run() {
   int axis = param.axis;
   // get axis from tensor
   if (param.Axis != nullptr) {
-    LOG(INFO) << "param.Axis is not nullptr";
     const Tensor* axis_tensor = param.Axis;
     const auto& axis_type = axis_tensor->precision();
     if (axis_type == PRECISION(kInt32)) {
@@ -100,11 +98,6 @@ void GatherCompute<IndexType, AxisType>::Run() {
                  << lite_api::PrecisionToStr(axis_type);
     }
   }
-
-  LOG(INFO) << "axis: " << axis;
-  LOG(INFO) << "in dims: " << param.X->dims();
-  LOG(INFO) << "index dims: " << param.Index->dims();
-  LOG(INFO) << "out dims: " << param.Out->dims();
 
   const auto& data_type = param.X->precision();
   if (axis != 0) {

--- a/lite/kernels/host/gather_compute.cc
+++ b/lite/kernels/host/gather_compute.cc
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "lite/kernels/host/gather_compute.h"
 #include <vector>
 
@@ -22,7 +23,8 @@ namespace host {
 template <typename IndexType, typename DataType>
 void GatherFunc(const operators::GatherParam& param) {
   auto src_dims = param.X->dims();
-  auto index_size = param.Index->dims()[0];
+  auto index_dims = param.Index->dims();
+  auto index_size = index_dims[0];
   auto* p_src = param.X->data<DataType>();
   const IndexType* p_index = param.Index->data<IndexType>();
   auto* p_output = param.Out->mutable_data<DataType>();
@@ -40,24 +42,26 @@ void GatherFunc(const operators::GatherParam& param) {
 }
 
 template <typename IndexType, typename AxisType, typename DataType>
-void GatherV2Func(const operators::GatherParam& param) {
-  auto* axis_data = param.Axis->data<AxisType>();
+void GatherV2Func(const operators::GatherParam& param, const int axis) {
   auto* index_data = param.Index->data<IndexType>();
   auto* input_data = param.X->data<DataType>();
   auto* out_data = param.Out->mutable_data<DataType>();
 
   int index_size = param.Index->numel();
   int input_size = param.X->numel();
+  if (input_size == 0) return;
   auto input_dim = param.X->dims();
-  int axis_index = axis_data[0];
-  int inner_dim_size = 1;
-  int outer_dim_size = 1;
+  const int axis_index = axis;
   int input_index_dim_size = input_dim[axis_index];
   for (int i = 0; i < index_size; i++) {
+    LOG(INFO) << lite::string_format("index_data[%d]: %lld", i, index_data[i]);
     CHECK_LT(index_data[i], input_index_dim_size)
-        << "The element of Index must be less than the size of"
+        << "The element of Index must be less than the size of "
         << "dim size of axis dim";
   }
+
+  int inner_dim_size = 1;
+  int outer_dim_size = 1;
   for (int i = 0; i < axis_index; i++) {
     inner_dim_size *= input_dim[i];
   }
@@ -81,60 +85,44 @@ void GatherV2Func(const operators::GatherParam& param) {
 template <typename IndexType, typename AxisType>
 void GatherCompute<IndexType, AxisType>::Run() {
   auto& param = this->template Param<operators::GatherParam>();
+
+  int axis = param.axis;
+  // get axis from tensor
   if (param.Axis != nullptr) {
-    switch (param.X->precision()) {
-      case PRECISION(kFloat):
-        GatherV2Func<IndexType, AxisType, float>(param);
-        break;
-#ifdef ENABLE_ARM_FP16
-      case PRECISION(kFP16):
-        GatherV2Func<IndexType, AxisType, lite_api::float16_t>(param);
-        break;
-#endif
-      case PRECISION(kInt8):
-        GatherV2Func<IndexType, AxisType, int8_t>(param);
-        break;
-      case PRECISION(kInt16):
-        GatherV2Func<IndexType, AxisType, int16_t>(param);
-        break;
-      case PRECISION(kInt32):
-        GatherV2Func<IndexType, AxisType, int32_t>(param);
-        break;
-      case PRECISION(kInt64):
-        GatherV2Func<IndexType, AxisType, int64_t>(param);
-        break;
-      default:
-        LOG(FATAL) << "unsupport data type: "
-                   << lite_api::PrecisionToStr(param.X->precision());
+    LOG(INFO) << "param.Axis is not nullptr";
+    const Tensor* axis_tensor = param.Axis;
+    const auto& axis_type = axis_tensor->precision();
+    if (axis_type == PRECISION(kInt32)) {
+      axis = static_cast<int>(axis_tensor->data<int32_t>()[0]);
+    } else if (axis_type == PRECISION(kInt64)) {
+      axis = static_cast<int>(axis_tensor->data<int64_t>()[0]);
+    } else {
+      LOG(FATAL) << "unsupport data type of Axis tensor: "
+                 << lite_api::PrecisionToStr(axis_type);
+    }
+  }
+
+  LOG(INFO) << "axis: " << axis;
+
+  const auto& index_type = param.Index->precision();
+  if (axis != 0) {
+    if (index_type == PRECISION(kInt32)) {
+      GatherV2Func<IndexType, AxisType, int32_t>(param, axis);
+    } else if (index_type == PRECISION(kInt64)) {
+      LOG(INFO) << "index type: int64";
+      GatherV2Func<IndexType, AxisType, int64_t>(param, axis);
+    } else {
+      LOG(FATAL) << "unsupport data type of Index tensor: "
+                 << lite_api::PrecisionToStr(index_type);
     }
     return;
-  } else {
-    switch (param.X->precision()) {
-      case PRECISION(kFloat):
-        GatherFunc<IndexType, float>(param);
-        break;
-#ifdef ENABLE_ARM_FP16
-      case PRECISION(kFP16):
-        GatherFunc<IndexType, lite_api::float16_t>(param);
-        break;
-#endif
-      case PRECISION(kInt8):
-        GatherFunc<IndexType, int8_t>(param);
-        break;
-      case PRECISION(kInt16):
-        GatherFunc<IndexType, int16_t>(param);
-        break;
-      case PRECISION(kInt32):
-        GatherFunc<IndexType, int32_t>(param);
-        break;
-      case PRECISION(kInt64):
-        GatherFunc<IndexType, int64_t>(param);
-        break;
-      default:
-        LOG(FATAL) << "unsupport data type: "
-                   << lite_api::PrecisionToStr(param.X->precision());
-    }
-    return;
+  }
+
+  if (param.X->numel() == 0) return;
+  if (index_type == PRECISION(kInt32)) {
+    GatherFunc<IndexType, int32_t>(param);
+  } else if (index_type == PRECISION(kInt64)) {
+    GatherFunc<IndexType, int64_t>(param);
   }
 }
 

--- a/lite/kernels/host/gather_compute.cc
+++ b/lite/kernels/host/gather_compute.cc
@@ -23,8 +23,7 @@ namespace host {
 template <typename IndexType, typename DataType>
 void GatherFunc(const operators::GatherParam& param) {
   auto src_dims = param.X->dims();
-  auto index_dims = param.Index->dims();
-  auto index_size = index_dims[0];
+  auto index_size = param.Index->dims()[0];
   auto* p_src = param.X->data<DataType>();
   const IndexType* p_index = param.Index->data<IndexType>();
   auto* p_output = param.Out->mutable_data<DataType>();

--- a/lite/kernels/host/gather_compute.cc
+++ b/lite/kernels/host/gather_compute.cc
@@ -44,7 +44,6 @@ template <typename IndexType, typename AxisType, typename DataType>
 void GatherV2Func(const operators::GatherParam& param, const int axis) {
   auto* index_data = param.Index->data<IndexType>();
   auto* input_data = param.X->data<DataType>();
-  auto* out_data = param.Out->mutable_data<DataType>();
 
   int index_size = param.Index->numel();
   int input_size = param.X->numel();
@@ -60,12 +59,19 @@ void GatherV2Func(const operators::GatherParam& param, const int axis) {
 
   int inner_dim_size = 1;
   int outer_dim_size = 1;
+  std::vector<int64_t> out_dim_vec;
   for (int i = 0; i < axis_index; i++) {
     inner_dim_size *= input_dim[i];
+    out_dim_vec.push_back(input_dim[i]);
   }
+  out_dim_vec.push_back(index_size);
   for (size_t i = axis_index + 1; i < input_dim.size(); i++) {
     outer_dim_size *= input_dim[i];
+    out_dim_vec.push_back(input_dim[i]);
   }
+
+  param.Out->Resize(DDim(out_dim_vec));
+  auto* out_data = param.Out->mutable_data<DataType>();
 
   int out_index = 0;
   for (int i = 0; i < inner_dim_size; i++) {

--- a/lite/kernels/host/gather_compute.h
+++ b/lite/kernels/host/gather_compute.h
@@ -16,13 +16,15 @@
 #include <stdint.h>
 #include "lite/core/kernel.h"
 #include "lite/core/op_registry.h"
+
 namespace paddle {
 namespace lite {
 namespace kernels {
 namespace host {
 
 template <typename IndexType, typename AxisType>
-class GatherCompute : public KernelLite<TARGET(kHost), PRECISION(kFloat)> {
+class GatherCompute
+    : public KernelLite<TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny)> {
  public:
   void Run() override;
 

--- a/lite/operators/gather_op.cc
+++ b/lite/operators/gather_op.cc
@@ -62,7 +62,7 @@ bool GatherOp::InferShapeImpl() const {
     for (int i = axis + 1; i < input_dim.size(); i++) {
       out_dim_vec.push_back(input_dim[i]);
     }
-    param_.Out->Resize(DDims(out_dim_vec));
+    param_.Out->Resize(DDim(out_dim_vec));
   }
 
   return true;

--- a/lite/operators/gather_op.cc
+++ b/lite/operators/gather_op.cc
@@ -21,7 +21,6 @@ namespace lite {
 namespace operators {
 
 bool GatherOp::CheckShape() const {
-  LOG(INFO) << "check shape";
   CHECK_OR_FALSE(param_.X);
   CHECK_OR_FALSE(param_.Index);
   CHECK_OR_FALSE(param_.Out);
@@ -41,8 +40,6 @@ bool GatherOp::CheckShape() const {
 }
 
 bool GatherOp::InferShapeImpl() const {
-  LOG(INFO) << "InferShapeImpl";
-
   auto axis = param_.axis;
   auto input_dim = param_.X->dims();
   auto index_dims = param_.Index->dims();
@@ -69,14 +66,12 @@ bool GatherOp::InferShapeImpl() const {
 }
 
 bool GatherOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  LOG(INFO) << "AttachImpl";
   param_.X = scope->FindTensor(opdesc.Input("X").front());
   param_.Index = scope->FindTensor(opdesc.Input("Index").front());
   param_.Out = scope->FindMutableTensor(opdesc.Output("Out").front());
   if (opdesc.HasInput("Axis") && !opdesc.Input("Axis").empty()) {
-    LOG(INFO) << "AXIS exist";
+    LOG(INFO) << "Axis exist";
     auto axis = opdesc.Input("Axis").front();
-    LOG(INFO) << "xxx";
     param_.Axis = scope->FindTensor(axis);
   }
   param_.axis = opdesc.GetAttr<int>("axis");

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -1666,6 +1666,7 @@ struct GatherParam : ParamBase {
   const lite::Tensor* X{};
   const lite::Tensor* Index{};
   const lite::Tensor* Axis{nullptr};
+  int axis{0};
   lite::Tensor* Out{};
 };
 

--- a/lite/tests/kernels/gather_compute_test.cc
+++ b/lite/tests/kernels/gather_compute_test.cc
@@ -304,7 +304,7 @@ TEST(Gather, precision) {
 
   for (auto x_dims : std::vector<std::vector<int64_t>>{{5, 7, 10, 12}}) {
     for (auto index_dims : std::vector<std::vector<int64_t>>{{3}, {7}, {10}}) {
-      for (auto has_axis_tensor : {false, true}) {
+      for (auto has_axis_tensor : {false}) {
         lite_api::shape_t axis_dims{{1}};
         for (auto axis : {0, 1, 2}) {
 #if ((defined(LITE_WITH_XPU) && defined(LITE_WITH_XTCL)) || \

--- a/lite/tests/kernels/gather_compute_test.cc
+++ b/lite/tests/kernels/gather_compute_test.cc
@@ -21,7 +21,68 @@
 namespace paddle {
 namespace lite {
 
-template <class T = float, class R = int64_t, class A = int32_t>
+template <typename IndexType, typename DataType>
+void GatherFunc(const operators::GatherParam& param) {
+  auto src_dims = param.X->dims();
+  auto index_size = param.Index->dims()[0];
+  auto* p_src = param.X->data<DataType>();
+  const IndexType* p_index = param.Index->data<IndexType>();
+  auto* p_output = param.Out->mutable_data<DataType>();
+
+  int slice_size = 1;
+  for (size_t i = 1; i < src_dims.size(); ++i) {
+    slice_size *= src_dims[i];
+  }
+  for (int i = 0; i < index_size; ++i) {
+    IndexType index_ = p_index[i];
+    memcpy(p_output + i * slice_size,
+           p_src + index_ * slice_size,
+           slice_size * sizeof(DataType));
+  }
+}
+
+template <typename IndexType, typename AxisType, typename DataType>
+void GatherV2Func(const operators::GatherParam& param, const int axis) {
+  auto* index_data = param.Index->data<IndexType>();
+  auto* input_data = param.X->data<DataType>();
+  auto* out_data = param.Out->mutable_data<DataType>();
+
+  int index_size = param.Index->numel();
+  int input_size = param.X->numel();
+  if (input_size == 0) return;
+  auto input_dim = param.X->dims();
+  const int axis_index = axis;
+  int input_index_dim_size = input_dim[axis_index];
+  for (int i = 0; i < index_size; i++) {
+    LOG(INFO) << lite::string_format("index_data[%d]: %lld", i, index_data[i]);
+    CHECK_LT(index_data[i], input_index_dim_size)
+        << "The element of Index must be less than the size of "
+        << "dim size of axis dim";
+  }
+
+  int inner_dim_size = 1;
+  int outer_dim_size = 1;
+  for (int i = 0; i < axis_index; i++) {
+    inner_dim_size *= input_dim[i];
+  }
+  for (size_t i = axis_index + 1; i < input_dim.size(); i++) {
+    outer_dim_size *= input_dim[i];
+  }
+
+  int out_index = 0;
+  for (int i = 0; i < inner_dim_size; i++) {
+    for (int j = 0; j < index_size; j++) {
+      for (int k = 0; k < outer_dim_size; k++) {
+        int index = k + index_data[j] * outer_dim_size +
+                    (i * input_size / inner_dim_size);
+        out_data[out_index] = input_data[index];
+        out_index++;
+      }
+    }
+  }
+}
+
+template <class T = float, class IndexType = int64_t, class AxisType = int32_t>
 class GatherComputeTest : public arena::TestCase {
  protected:
   // common attributes for this op.
@@ -29,12 +90,12 @@ class GatherComputeTest : public arena::TestCase {
   std::string x_ = "x";
   std::string index_ = "index";
   std::string axis_tensor_ = "Axis";
-  std::string axis_ = "axis";
   std::string out_ = "out";
   DDim x_dims_{{5, 4, 2, 3}};
   DDim index_dims_{{2, 1}};
   DDim axis_dims_{{1}};
-  bool is_use_axis_tensor_ = false;
+  int axis_{0};
+  bool is_use_axis_tensor_{false};
 
  public:
   GatherComputeTest(const Place& place,
@@ -43,83 +104,124 @@ class GatherComputeTest : public arena::TestCase {
                     const DDim& index_dims,
                     const DDim& axis_dims,
                     const bool use_axis_tensor,
-                    const int axis)
+                    const int axis_data)
       : TestCase(place, alias),
         x_dims_(x_dims),
         index_dims_(index_dims),
-        axis_dims_(axis_dims) is_use_axis_tensor(use_axis_tensor) axis_(axis) {}
+        axis_dims_(axis_dims),
+        is_use_axis_tensor_(use_axis_tensor),
+        axis_(axis_data) {}
 
   void RunBaseline(Scope* scope) override {
+    operators::GatherParam param;
     auto x = scope->FindTensor(x_);
     auto index = scope->FindTensor(index_);
-    auto axis_tensor = scope->FindTensor(axis_tensor_);
-    auto x_dims = x->dims();
-    auto index_dims = index->dims();
-    CHECK(index_dims.size() == 1 ||
-          (index_dims.size() == 2 && index_dims[1] == 1));
-    CHECK_EQ(index_dims.size(), 1);
-    if (axis_dims_.production() == 1) {
-      auto* axis_data = axis_tensor->template data<A>();
-      auto* index_data = index->template data<R>();
-      auto* input_data = x->template data<T>();
+    param.X = x;
+    param.Index = index;
+    param.axis = axis_;
+    if (is_use_axis_tensor_) {
+      param.Axis = scope->FindTensor(axis_tensor_);
+    }
 
-      int index_size = index->numel();
-      int input_size = x->numel();
-      auto input_dim = x->dims();
-      int axis_index = axis_data[0];
-      int inner_dim_size = 1;
-      int outer_dim_size = 1;
+    auto index_dims = param.Index->dims();
+    auto axis = param.axis;
+    auto input_dim = param.X->dims();
+    DDim output_dims(input_dim);
+    if (param.Axis != nullptr || axis == 0) {
+      // if has Axis, we can not obtain correct shape of output
+      int batch_size = index_dims[0];
+      output_dims[0] = batch_size;
+    } else {
+      int index_size = index_dims[0];
       std::vector<int64_t> out_dim_vec;
-      for (int i = 0; i < axis_index; i++) {
-        inner_dim_size *= input_dim[i];
+      for (int i = 0; i < axis; i++) {
         out_dim_vec.push_back(input_dim[i]);
       }
       out_dim_vec.push_back(index_size);
-      for (int i = axis_index + 1; i < input_dim.size(); i++) {
-        outer_dim_size *= input_dim[i];
+      for (int i = axis + 1; i < input_dim.size(); i++) {
         out_dim_vec.push_back(input_dim[i]);
       }
-      auto out = scope->NewTensor(out_);
-      CHECK(out);
-      out->Resize(out_dim_vec);
-      auto* out_data = out->template mutable_data<T>();
+      output_dims = DDim(out_dim_vec);
+    }
+    auto out = scope->NewTensor(out_);
+    out->Resize(output_dims);
+    param.Out = out;
 
-      int out_index = 0;
-      for (int i = 0; i < inner_dim_size; i++) {
-        for (int j = 0; j < index_size; j++) {
-          for (int k = 0; k < outer_dim_size; k++) {
-            int index = k + index_data[j] * outer_dim_size +
-                        (i * input_size / inner_dim_size);
-            out_data[out_index] = input_data[index];
-            out_index++;
-          }
-        }
+    // get axis from tensor
+    if (param.Axis != nullptr) {
+      LOG(INFO) << "param.Axis is not nullptr";
+      const Tensor* axis_tensor = param.Axis;
+      const auto& axis_type = axis_tensor->precision();
+      if (axis_type == PRECISION(kInt32)) {
+        axis = static_cast<int>(axis_tensor->data<int32_t>()[0]);
+      } else if (axis_type == PRECISION(kInt64)) {
+        axis = static_cast<int>(axis_tensor->data<int64_t>()[0]);
+      } else {
+        LOG(FATAL) << "unsupport data type of Axis tensor: "
+                   << lite_api::PrecisionToStr(axis_type);
+      }
+    }
+
+    LOG(INFO) << "axis: " << axis;
+    LOG(INFO) << "in dims: " << param.X->dims();
+    LOG(INFO) << "index dims: " << param.Index->dims();
+    LOG(INFO) << "out dims: " << param.Out->dims();
+
+    const auto& data_type = param.X->precision();
+    if (axis != 0) {
+      switch (data_type) {
+        case PRECISION(kFloat):
+          GatherV2Func<IndexType, AxisType, float>(param, axis);
+          break;
+#ifdef ENABLE_ARM_FP16
+        case PRECISION(kFP16):
+          GatherV2Func<IndexType, AxisType, lite_api::float16_t>(param, axis);
+          break;
+#endif
+        case PRECISION(kInt8):
+          GatherV2Func<IndexType, AxisType, int8_t>(param, axis);
+          break;
+        case PRECISION(kInt16):
+          GatherV2Func<IndexType, AxisType, int16_t>(param, axis);
+          break;
+        case PRECISION(kInt32):
+          GatherV2Func<IndexType, AxisType, int32_t>(param, axis);
+          break;
+        case PRECISION(kInt64):
+          GatherV2Func<IndexType, AxisType, int64_t>(param, axis);
+          break;
+        default:
+          LOG(FATAL) << "unsupport data type: "
+                     << lite_api::PrecisionToStr(data_type);
       }
       return;
-    } else {
-      auto out = scope->NewTensor(out_);
-      CHECK(out);
-      int batch_size = index_dims[0];
-      DDim out_dims = x_dims;
-      out_dims[0] = batch_size;
-      out->Resize(out_dims);
+    }
 
-      auto x_data = x->template data<T>();
-      auto index_data = index->template data<R>();
-      auto out_data = out->template mutable_data<T>();
-
-      auto slice_num = x_dims[0];
-      auto slice_size = x_dims.Slice(1, x_dims.size()).production();
-      for (int i = 0; i < batch_size; i++) {
-        auto index = index_data[i];
-        CHECK_LT(index, slice_num) << "gather index[i] expected < " << slice_num
-                                   << " but got " << index;
-        CHECK_GE(index, 0) << "gather ids[i] expected >= 0 but got " << index;
-        memcpy(out_data + i * slice_size,
-               x_data + index * slice_size,
-               slice_size * sizeof(T));
-      }
-      return;
+    if (param.X->numel() == 0) return;
+    switch (data_type) {
+      case PRECISION(kFloat):
+        GatherFunc<IndexType, float>(param);
+        break;
+#ifdef ENABLE_ARM_FP16
+      case PRECISION(kFP16):
+        GatherFunc<IndexType, lite_api::float16_t>(param);
+        break;
+#endif
+      case PRECISION(kInt8):
+        GatherFunc<IndexType, int8_t>(param);
+        break;
+      case PRECISION(kInt16):
+        GatherFunc<IndexType, int16_t>(param);
+        break;
+      case PRECISION(kInt32):
+        GatherFunc<IndexType, int32_t>(param);
+        break;
+      case PRECISION(kInt64):
+        GatherFunc<IndexType, int64_t>(param);
+        break;
+      default:
+        LOG(FATAL) << "unsupport data type: "
+                   << lite_api::PrecisionToStr(data_type);
     }
   }
 
@@ -139,12 +241,12 @@ class GatherComputeTest : public arena::TestCase {
     fill_data_rand(
         x.data(), static_cast<T>(-1), static_cast<T>(1), x_dims_.production());
 
-    std::vector<R> index(index_dims_.production());
-    fill_data_rand<R>(
+    std::vector<IndexType> index(index_dims_.production());
+    fill_data_rand<IndexType>(
         index.data(), 0, x_dims_[0] - 1, index_dims_.production());
-    std::vector<A> axis(axis_dims_.production());
-    if (axis_dims_.production() == 1) {
-      fill_data_rand<A>(
+    std::vector<AxisType> axis(axis_dims_.production());
+    if (is_use_axis_tensor_) {
+      fill_data_rand<AxisType>(
           axis.data(), 0, x_dims_.size() - 1, axis_dims_.production());
     }
     SetCommonTensor(x_, x_dims_, x.data());
@@ -155,15 +257,23 @@ class GatherComputeTest : public arena::TestCase {
   }
 };
 
-template <class T = float, class R = int32_t, class A = int32_t>
+template <class T = float, class IndexType = int32_t, class AxisType = int32_t>
 void TestGather(const std::vector<int64_t>& x_dims,
                 const std::vector<int64_t>& index_dims,
                 const std::vector<int64_t>& axis_dims,
+                const bool use_axis_tensor,
+                const int axis,
                 Place place,
                 float abs_error = 1e-5,
                 const std::string& alias = "def") {
-  std::unique_ptr<arena::TestCase> tester(new GatherComputeTest<T, R, A>(
-      place, alias, DDim(x_dims), DDim(index_dims), DDim(axis_dims)));
+  std::unique_ptr<arena::TestCase> tester(
+      new GatherComputeTest<T, IndexType, AxisType>(place,
+                                                    alias,
+                                                    DDim(x_dims),
+                                                    DDim(index_dims),
+                                                    DDim(axis_dims),
+                                                    use_axis_tensor,
+                                                    axis));
   arena::Arena arena(std::move(tester), place, abs_error);
   arena.TestPrecision();
 }
@@ -192,19 +302,25 @@ TEST(Gather, precision) {
   return;
 #endif
 
-  for (auto x_dims :
-       std::vector<std::vector<int64_t>>{{5, 7, 10, 12}, {8, 12, 16}}) {
+  for (auto x_dims : std::vector<std::vector<int64_t>>{{5, 7, 10, 12}}) {
     for (auto index_dims : std::vector<std::vector<int64_t>>{{3}, {7}, {10}}) {
       for (auto has_axis_tensor : {false, true}) {
+        lite_api::shape_t axis_dims{{1}};
         for (auto axis : {0, 1, 2}) {
 #if ((defined(LITE_WITH_XPU) && defined(LITE_WITH_XTCL)) || \
      defined(LITE_WITH_NPU) || defined(LITE_WITH_HUAWEI_ASCEND_NPU))
-          axis_dims = {{0}};
-          TestGather<float, int32_t, int32_t>(
-              x_dims, index_dims, axis_dims, place, abs_error, "def");
+          TestGather<float, int32_t, int32_t>(x_dims,
+                                              index_dims,
+                                              axis_dims,
+                                              has_axis_tensor,
+                                              axis,
+                                              place,
+                                              abs_error,
+                                              "def");
 #else
           TestGather<float, int64_t, int64_t>(x_dims,
                                               index_dims,
+                                              axis_dims,
                                               has_axis_tensor,
                                               axis,
                                               place,
@@ -212,23 +328,60 @@ TEST(Gather, precision) {
                                               "int64int64");
           TestGather<float, int32_t, int32_t>(x_dims,
                                               index_dims,
+                                              axis_dims,
                                               has_axis_tensor,
                                               axis,
                                               place,
                                               abs_error,
                                               "int32int32");
-          TestGather<float, int32_t, int64_t>(
-              x_dims, index_dims, axis_dims, place, abs_error, "int32int64");
-          TestGather<float, int64_t, int32_t>(
-              x_dims, index_dims, axis_dims, place, abs_error, "int64int32");
-          TestGather<int64_t, int64_t, int64_t>(
-              x_dims, index_dims, axis_dims, place, abs_error, "int64int64");
-          TestGather<int64_t, int32_t, int32_t>(
-              x_dims, index_dims, axis_dims, place, abs_error, "int32int32");
-          TestGather<int64_t, int32_t, int64_t>(
-              x_dims, index_dims, axis_dims, place, abs_error, "int32int64");
-          TestGather<int64_t, int64_t, int32_t>(
-              x_dims, index_dims, axis_dims, place, abs_error, "int64int32");
+          TestGather<float, int32_t, int64_t>(x_dims,
+                                              index_dims,
+                                              axis_dims,
+                                              has_axis_tensor,
+                                              axis,
+                                              place,
+                                              abs_error,
+                                              "int32int64");
+          TestGather<float, int64_t, int32_t>(x_dims,
+                                              index_dims,
+                                              axis_dims,
+                                              has_axis_tensor,
+                                              axis,
+                                              place,
+                                              abs_error,
+                                              "int64int32");
+          TestGather<int64_t, int64_t, int64_t>(x_dims,
+                                                index_dims,
+                                                axis_dims,
+                                                has_axis_tensor,
+                                                axis,
+                                                place,
+                                                abs_error,
+                                                "int64int64");
+          TestGather<int64_t, int32_t, int32_t>(x_dims,
+                                                index_dims,
+                                                axis_dims,
+                                                has_axis_tensor,
+                                                axis,
+                                                place,
+                                                abs_error,
+                                                "int32int32");
+          TestGather<int64_t, int32_t, int64_t>(x_dims,
+                                                index_dims,
+                                                axis_dims,
+                                                has_axis_tensor,
+                                                axis,
+                                                place,
+                                                abs_error,
+                                                "int32int64");
+          TestGather<int64_t, int64_t, int32_t>(x_dims,
+                                                index_dims,
+                                                axis_dims,
+                                                has_axis_tensor,
+                                                axis,
+                                                place,
+                                                abs_error,
+                                                "int64int32");
 #endif
         }
       }

--- a/lite/tests/kernels/gather_compute_test.cc
+++ b/lite/tests/kernels/gather_compute_test.cc
@@ -94,8 +94,8 @@ class GatherComputeTest : public arena::TestCase {
   DDim x_dims_{{5, 4, 2, 3}};
   DDim index_dims_{{2, 1}};
   DDim axis_dims_{{1}};
-  int axis_{0};
   bool is_use_axis_tensor_{false};
+  int axis_{0};
 
  public:
   GatherComputeTest(const Place& place,

--- a/lite/tests/kernels/gather_compute_test.cc
+++ b/lite/tests/kernels/gather_compute_test.cc
@@ -41,11 +41,13 @@ class GatherComputeTest : public arena::TestCase {
                     const std::string& alias,
                     const DDim& x_dims,
                     const DDim& index_dims,
-                    const DDim& axis_dims)
+                    const DDim& axis_dims,
+                    const bool use_axis_tensor,
+                    const int axis)
       : TestCase(place, alias),
         x_dims_(x_dims),
         index_dims_(index_dims),
-        axis_dims_(axis_dims) {}
+        axis_dims_(axis_dims) is_use_axis_tensor(use_axis_tensor) axis_(axis) {}
 
   void RunBaseline(Scope* scope) override {
     auto x = scope->FindTensor(x_);
@@ -193,30 +195,42 @@ TEST(Gather, precision) {
   for (auto x_dims :
        std::vector<std::vector<int64_t>>{{5, 7, 10, 12}, {8, 12, 16}}) {
     for (auto index_dims : std::vector<std::vector<int64_t>>{{3}, {7}, {10}}) {
-      for (auto axis_dims : std::vector<std::vector<int64_t>>{{2}, {0}}) {
+      for (auto has_axis_tensor : {false, true}) {
+        for (auto axis : {0, 1, 2}) {
 #if ((defined(LITE_WITH_XPU) && defined(LITE_WITH_XTCL)) || \
      defined(LITE_WITH_NPU) || defined(LITE_WITH_HUAWEI_ASCEND_NPU))
-        axis_dims = {{0}};
-        TestGather<float, int32_t, int32_t>(
-            x_dims, index_dims, axis_dims, place, abs_error, "def");
+          axis_dims = {{0}};
+          TestGather<float, int32_t, int32_t>(
+              x_dims, index_dims, axis_dims, place, abs_error, "def");
 #else
-        TestGather<float, int64_t, int64_t>(
-            x_dims, index_dims, axis_dims, place, abs_error, "int64int64");
-        TestGather<float, int32_t, int32_t>(
-            x_dims, index_dims, axis_dims, place, abs_error, "int32int32");
-        TestGather<float, int32_t, int64_t>(
-            x_dims, index_dims, axis_dims, place, abs_error, "int32int64");
-        TestGather<float, int64_t, int32_t>(
-            x_dims, index_dims, axis_dims, place, abs_error, "int64int32");
-        TestGather<int64_t, int64_t, int64_t>(
-            x_dims, index_dims, axis_dims, place, abs_error, "int64int64");
-        TestGather<int64_t, int32_t, int32_t>(
-            x_dims, index_dims, axis_dims, place, abs_error, "int32int32");
-        TestGather<int64_t, int32_t, int64_t>(
-            x_dims, index_dims, axis_dims, place, abs_error, "int32int64");
-        TestGather<int64_t, int64_t, int32_t>(
-            x_dims, index_dims, axis_dims, place, abs_error, "int64int32");
+          TestGather<float, int64_t, int64_t>(x_dims,
+                                              index_dims,
+                                              has_axis_tensor,
+                                              axis,
+                                              place,
+                                              abs_error,
+                                              "int64int64");
+          TestGather<float, int32_t, int32_t>(x_dims,
+                                              index_dims,
+                                              has_axis_tensor,
+                                              axis,
+                                              place,
+                                              abs_error,
+                                              "int32int32");
+          TestGather<float, int32_t, int64_t>(
+              x_dims, index_dims, axis_dims, place, abs_error, "int32int64");
+          TestGather<float, int64_t, int32_t>(
+              x_dims, index_dims, axis_dims, place, abs_error, "int64int32");
+          TestGather<int64_t, int64_t, int64_t>(
+              x_dims, index_dims, axis_dims, place, abs_error, "int64int64");
+          TestGather<int64_t, int32_t, int32_t>(
+              x_dims, index_dims, axis_dims, place, abs_error, "int32int32");
+          TestGather<int64_t, int32_t, int64_t>(
+              x_dims, index_dims, axis_dims, place, abs_error, "int32int64");
+          TestGather<int64_t, int64_t, int32_t>(
+              x_dims, index_dims, axis_dims, place, abs_error, "int64int32");
 #endif
+        }
       }
     }
   }


### PR DESCRIPTION
Paddle 2.1.1 中对 gather 算子进行了修改，因此 Paddle 2.1.1 训练出的模型 gather0 在当前版本的 Paddle-Lite 下运行的输出结果与 Paddle 无法对齐。

使用 gather0 模型：
```
未加入本 PR 时 arm cpu 输出：


加入本 PR 后 arm cpu 输出：
======= benchmark summary =======
input_shape(s) (NCHW):1,3,256,256, :
model_dir:arm.nb
warmup:1
repeats:2
power_mode:0
thread_num:1
*** time info(ms) ***
1st_duration:134.12
max_duration:86.089
min_duration:86.037
avg_duration:86.063

====== output summary ======
output tensor num:6

--- output tensor 0 ---
output shape(NCHW):1 100
output tensor 0 elem num:100
output tensor 0 standard deviation:1.1803
output tensor 0 mean value:1.63

--- output tensor 1 ---
output shape(NCHW):1 100
output tensor 1 elem num:100
output tensor 1 standard deviation:0.00344564
output tensor 1 mean value:0.00551195

--- output tensor 2 ---
output shape(NCHW):1 100
output tensor 2 elem num:100
output tensor 2 standard deviation:26.2481
output tensor 2 mean value:27.24

--- output tensor 3 ---
output shape(NCHW):1 100
output tensor 3 elem num:100
output tensor 3 standard deviation:24.9138
output tensor 3 mean value:30.94

--- output tensor 4 ---
output shape(NCHW):100 2
output tensor 4 elem num:200
output tensor 4 standard deviation:0.279051
output tensor 4 mean value:0.414975

--- output tensor 5 ---
output shape(NCHW):100 2
output tensor 5 elem num:200
output tensor 5 standard deviation:3.37574
output tensor 5 mean value:4.28627

# paddle 2.1.1 输出：
[Predict result] shape: [1, 100] , max_val: 3.0 , min_val: 0.0 , max_arg: 4 , mean:  1.63 , std:  1.1802965
[Predict result] shape: [1, 100] , max_val: 0.023129357 , min_val: 0.0023462577 , max_arg: 0 , mean:  0.005511984 , std:  0.0034456651
[Predict result] shape: [1, 100] , max_val: 63.0 , min_val: 0.0 , max_arg: 13 , mean:  27.24 , std:  26.248093
[Predict result] shape: [1, 100] , max_val: 63.0 , min_val: 0.0 , max_arg: 28 , mean:  30.94 , std:  24.91378
[Predict result] shape: [100, 2] , max_val: 1.0015359 , min_val: -0.12530077 , max_arg: 26 , mean:  0.41497493 , std:  0.2790508
[Predict result] shape: [100, 2] , max_val: 12.629872 , min_val: -0.5976058 , max_arg: 5 , mean:  4.2862644 , std:  3.3757362
```