### PR TITLE
Add opt argument spmm

### DIFF
--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -20,6 +20,7 @@
 #include "lite/core/device_info.h"
 #include "lite/core/mir/pass_manager.h"
 #include "lite/core/mir/post_quant_dynamic_pass.h"
+#include "lite/core/mir/sparse_conv_pass.h"
 #include "lite/core/version.h"
 
 #ifndef LITE_ON_TINY_PUBLISH
@@ -101,6 +102,7 @@ void CxxPaddleApiImpl::Init(const lite_api::CxxConfig &config) {
       CHECK(pass);
       pass->SetQuantType(config.quant_type());
     }
+    pass->SetSparseThreshold(config.sparse_threshold());
     raw_predictor_->Build(config, places, passes);
   } else {
     raw_predictor_->PrepareFeedFetch();

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -20,7 +20,7 @@
 #include "lite/core/device_info.h"
 #include "lite/core/mir/pass_manager.h"
 #include "lite/core/mir/post_quant_dynamic_pass.h"
-#include "lite/core/mir/sparse_conv_pass.h"
+#include "lite/core/mir/sparse_conv_detect_pass.h"
 #include "lite/core/version.h"
 
 #ifndef LITE_ON_TINY_PUBLISH
@@ -102,7 +102,10 @@ void CxxPaddleApiImpl::Init(const lite_api::CxxConfig &config) {
       CHECK(pass);
       pass->SetQuantType(config.quant_type());
     }
-    pass->SetSparseThreshold(config.sparse_threshold());
+    auto *sparse_detect_pass = mir::PassManager::Global().LookUp<mir::SparseConvDetectPass>(
+          "sparse_conv_detect_pass");
+    CHECK(sparse_detect_pass);
+    sparse_detect_pass->SetSparseThreshold(config.sparse_threshold());
     raw_predictor_->Build(config, places, passes);
   } else {
     raw_predictor_->PrepareFeedFetch();

--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -66,6 +66,9 @@ DEFINE_string(quant_type,
               "Set the quant_type for post_quant_dynamic, "
               "and it should be QUANT_INT8 or QUANT_INT16 for now.");
 DEFINE_bool(enable_fp16, false, "Set kernel_type run in FP16.");
+DEFINE_float(sparse_threshold,
+             0.5,
+             "Set 0.5 as the lower bound for the sparse conv pass.")
 DEFINE_bool(record_tailoring_info,
             false,
             "Record kernels and operators information of the optimized model "
@@ -217,7 +220,8 @@ void RunOptimize(const std::string& model_dir,
                  const std::vector<std::string>& nnadapter_device_names,
                  bool record_tailoring_info,
                  bool quant_model,
-                 const std::string& quant_type) {
+                 const std::string& quant_type,
+                 float sparse_threshold) {
   if (!model_file.empty() && !param_file.empty()) {
     LOG(WARNING)
         << "Load combined-param model. Option model_dir will be ignored";
@@ -239,6 +243,7 @@ void RunOptimize(const std::string& model_dir,
   } else {
     OPT_LOG_FATAL << "Unsupported quant type: " << quant_type;
   }
+  config.set_sparse_threshold(sparse_threshold);
   auto predictor = lite_api::CreatePaddlePredictor(config);
 
   LiteModelType model_type;
@@ -524,7 +529,8 @@ void Main() {
                 valid_places.second,
                 FLAGS_record_tailoring_info,
                 FLAGS_quant_model,
-                FLAGS_quant_type);
+                FLAGS_quant_type,
+                FLAGS_sparse_threshold);
     return;
   }
 
@@ -567,7 +573,8 @@ void Main() {
                 valid_places.second,
                 FLAGS_record_tailoring_info,
                 FLAGS_quant_model,
-                FLAGS_quant_type);
+                FLAGS_quant_type,
+                FLAGS_sparse_threshold);
     OPT_LOG << "Transformation done. ";
   }
 

--- a/lite/api/opt.cc
+++ b/lite/api/opt.cc
@@ -66,9 +66,9 @@ DEFINE_string(quant_type,
               "Set the quant_type for post_quant_dynamic, "
               "and it should be QUANT_INT8 or QUANT_INT16 for now.");
 DEFINE_bool(enable_fp16, false, "Set kernel_type run in FP16.");
-DEFINE_float(sparse_threshold,
+DEFINE_double(sparse_threshold,
              0.5,
-             "Set 0.5 as the lower bound for the sparse conv pass.")
+             "Set 0.5 as the lower bound for the sparse conv pass.");
 DEFINE_bool(record_tailoring_info,
             false,
             "Record kernels and operators information of the optimized model "
@@ -371,6 +371,8 @@ void PrintHelpInfo() {
       "  Arguments of mode quantization in opt:\n"
       "        `--quant_model=(true|false)`\n"
       "        `--quant_type=(QUANT_INT8|QUANT_INT16)`\n"
+      "  Arguments of sparse convolution:\n"
+      "        `--sparse_threshold=(float)`\n"
       "  Arguments of enable_fp16 in opt: \n"
       "        `--enable_fp16=(true|false)`\n"
       "  Arguments of model checking and ops information:\n"

--- a/lite/api/opt_base.cc
+++ b/lite/api/opt_base.cc
@@ -54,6 +54,10 @@ void OptBase::SetQuantType(const std::string& quant_type) {
   }
 }
 
+void OptBase::SetSparseThreshold(float sparse_threshold) {
+  opt_config_.set_sparse_threshold(sparse_threshold);
+} 
+
 void OptBase::SetPassesInternal(
     const std::vector<std::string>& passes_internal) {
   opt_config_.set_passes_internal(passes_internal);

--- a/lite/api/opt_base.h
+++ b/lite/api/opt_base.h
@@ -53,6 +53,7 @@ class LITE_API OptBase {
   void RecordModelInfo(bool record_strip_info = true);
   void SetQuantModel(bool quant_model);
   void SetQuantType(const std::string &quant_type);
+  void SetSparseThreshold(float sparse_threshold=0.5);
   // set optimized_model type
   void SetModelType(std::string model_type = "naive_buffer");
   // internal inference for developer, not recommanded.

--- a/lite/api/opt_base.h
+++ b/lite/api/opt_base.h
@@ -53,7 +53,7 @@ class LITE_API OptBase {
   void RecordModelInfo(bool record_strip_info = true);
   void SetQuantModel(bool quant_model);
   void SetQuantType(const std::string &quant_type);
-  void SetSparseThreshold(float sparse_threshold=0.5);
+  void SetSparseThreshold(float sparse_threshold=0.5f);
   // set optimized_model type
   void SetModelType(std::string model_type = "naive_buffer");
   // internal inference for developer, not recommanded.

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -406,6 +406,9 @@ class LITE_API CxxConfig : public ConfigBase {
   bool quant_model() const { return quant_model_; }
   void set_quant_type(QuantType quant_type) { quant_type_ = quant_type; }
   QuantType quant_type() const { return quant_type_; }
+
+  void set_sparse_threshold(float threshold) { threshold_ = threshold; }
+  float sparse_threshold const { return threshold; }
 };
 
 /// MobileConfig is the config for the light weight predictor, it will skip

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -293,6 +293,7 @@ class LITE_API CxxConfig : public ConfigBase {
   std::vector<std::string> passes_internal_{};
   bool quant_model_{false};  // Enable post_quant_dynamic in opt
   QuantType quant_type_{QuantType::QUANT_INT16};
+  float sparse_threshold_{0.5f};
   std::map<int, std::vector<std::shared_ptr<void>>>
       preferred_inputs_for_warmup_;
 #ifdef LITE_WITH_CUDA
@@ -407,8 +408,8 @@ class LITE_API CxxConfig : public ConfigBase {
   void set_quant_type(QuantType quant_type) { quant_type_ = quant_type; }
   QuantType quant_type() const { return quant_type_; }
 
-  void set_sparse_threshold(float threshold) { threshold_ = threshold; }
-  float sparse_threshold const { return threshold; }
+  void set_sparse_threshold(float sparse_threshold) { sparse_threshold_ = sparse_threshold; }
+  float sparse_threshold() const { return sparse_threshold_; }
 };
 
 /// MobileConfig is the config for the light weight predictor, it will skip

--- a/lite/core/mir/sparse_conv_detect_pass.cc
+++ b/lite/core/mir/sparse_conv_detect_pass.cc
@@ -212,10 +212,10 @@ void SparseConvDetectPass::Apply(const std::unique_ptr<SSAGraph>& graph) {
       float sparse_zero_percent =
           static_cast<float>(zero_num) / static_cast<float>(weight_num);
       VLOG(4) << "sparse zero num percent: " << sparse_zero_percent;
-      if (sparse_zero_percent < thread_hold_) {
+      if (sparse_zero_percent < sparse_threshold_) {
         VLOG(4) << "The sparse degree of the sparse conv must be greater than "
-                   "thread_hold: "
-                << thread_hold_;
+                   "sparse_threshold_: "
+                << sparse_threshold_;
         continue;
       }
       auto nonzeros_output_name =

--- a/lite/core/mir/sparse_conv_detect_pass.h
+++ b/lite/core/mir/sparse_conv_detect_pass.h
@@ -51,12 +51,12 @@ class SparseConvDetectPass : public ProgramPass {
   void CopyOutputScaleFromOpInfo(cpp::OpDesc* op_desc,
                                  OpInfo* op_info,
                                  const std::string& name);
-  void SetSparseThreshold(float threshold) {
+  void SetSparseThreshold(float sparse_threshold) {
     sparse_threshold_ = sparse_threshold;
   }
 
  private:
-  float thread_hold_;
+  float sparse_threshold_{0.5f};
 };
 
 }  // namespace mir

--- a/lite/core/mir/sparse_conv_detect_pass.h
+++ b/lite/core/mir/sparse_conv_detect_pass.h
@@ -51,9 +51,12 @@ class SparseConvDetectPass : public ProgramPass {
   void CopyOutputScaleFromOpInfo(cpp::OpDesc* op_desc,
                                  OpInfo* op_info,
                                  const std::string& name);
+  void SetSparseThreshold(float threshold) {
+    sparse_threshold_ = sparse_threshold;
+  }
 
  private:
-  float thread_hold_{0.4f};
+  float thread_hold_;
 };
 
 }  // namespace mir


### PR DESCRIPTION
暴露sparse_threshold为opt的参数，避免了每次修改都要重新编译opt的繁琐过程。默认取0.5。
相关文档和tests待和sparse_conv_pass的一起写。