### PR TITLE
process the read_from_array op, test=develop

### DIFF
--- a/lite/kernels/host/read_from_array_compute.cc
+++ b/lite/kernels/host/read_from_array_compute.cc
@@ -46,6 +46,10 @@ REGISTER_LITE_KERNEL(read_from_array,
                {LiteType::GetTensorListTy(TARGET(kHost),
                                           PRECISION(kAny),
                                           DATALAYOUT(kAny))})
+    .BindInput("FakeAssociatedX",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
     .BindInput("I",
                {LiteType::GetTensorTy(TARGET(kHost),
                                       PRECISION(kInt64),

--- a/lite/kernels/host/write_to_array_compute.cc
+++ b/lite/kernels/host/write_to_array_compute.cc
@@ -53,7 +53,7 @@ REGISTER_LITE_KERNEL(write_to_array,
                 {LiteType::GetTensorListTy(TARGET(kHost),
                                            PRECISION(kAny),
                                            DATALAYOUT(kAny))})
-    .BindOutput("AssociatedOut",
+    .BindOutput("FakeAssociatedOut",
                 {LiteType::GetTensorListTy(TARGET(kHost),
                                            PRECISION(kAny),
                                            DATALAYOUT(kAny))})

--- a/lite/kernels/xpu/read_from_array_compute.cc
+++ b/lite/kernels/xpu/read_from_array_compute.cc
@@ -57,6 +57,10 @@ REGISTER_LITE_KERNEL(read_from_array,
                {LiteType::GetTensorListTy(TARGET(kXPU),
                                           PRECISION(kAny),
                                           DATALAYOUT(kAny))})
+    .BindInput("FakeAssociatedX",
+               {LiteType::GetTensorTy(TARGET(kXPU),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
     .BindInput("I",
                {LiteType::GetTensorTy(TARGET(kXPU),
                                       PRECISION(kInt64),

--- a/lite/kernels/xpu/write_to_array_compute.cc
+++ b/lite/kernels/xpu/write_to_array_compute.cc
@@ -70,7 +70,7 @@ REGISTER_LITE_KERNEL(write_to_array,
                 {LiteType::GetTensorListTy(TARGET(kXPU),
                                            PRECISION(kAny),
                                            DATALAYOUT(kAny))})
-    .BindOutput("AssociatedOut",
+    .BindOutput("FakeAssociatedOut",
                 {LiteType::GetTensorListTy(TARGET(kXPU),
                                            PRECISION(kAny),
                                            DATALAYOUT(kAny))})

--- a/lite/model_parser/ssa/block_desc.cc
+++ b/lite/model_parser/ssa/block_desc.cc
@@ -24,7 +24,7 @@ BlockDesc::BlockDesc(const general::BlockDesc& current, BlockDesc* parent) {
   if (parent) {
     scope_.reset(new RootVarScope{current, parent->mutable_scope()});
     parent_ = parent;
-    parent_->SetKid(this);
+    parent_->AddKid(this);
   } else {
     scope_.reset(new RootVarScope{current, nullptr});
   }

--- a/lite/model_parser/ssa/block_desc.h
+++ b/lite/model_parser/ssa/block_desc.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <set>
 #include <utility>
+#include <vector>
 
 #include "lite/model_parser/general/block_desc.h"
 #include "lite/model_parser/ssa/op_desc.h"
@@ -52,9 +53,9 @@ class BlockDesc {
 
   const BlockDesc* parent() const { return parent_; }
 
-  const BlockDesc* kid() const { return kid_; }
+  const std::vector<BlockDesc*>& kids() const { return kids_; }
 
-  void SetKid(BlockDesc* desc) { kid_ = desc; }
+  void AddKid(BlockDesc* desc) { kids_.emplace_back(desc); }
 
   void SetBlockOpDesc(BlockOpDesc* op) {
     CHECK(op);
@@ -90,7 +91,7 @@ class BlockDesc {
   }
 
  private:
-  BlockDesc* kid_{nullptr};
+  std::vector<BlockDesc*> kids_;
   BlockDesc* parent_{nullptr};
   // The root variable scope serves as a symbol table here.
   std::unique_ptr<RootVarScope> scope_;

--- a/lite/model_parser/ssa/op_desc.cc
+++ b/lite/model_parser/ssa/op_desc.cc
@@ -92,7 +92,7 @@ void WriteToArrayOpDesc::ProcessTensorArrayOp(const general::OpDesc& raw_desc,
     mutable_scope->AddRootVar(block_idx, std::move(asso_var));
   }
   auto root_var = mutable_scope->GetRootVarDesc(asso_var_name).lock();
-  const auto& var_desc = AddOutput("AssociatedOut", root_var->latest());
+  const auto& var_desc = AddOutput("FakeAssociatedOut", root_var->latest());
   UpdateVarBlockIdx(var_desc, block_idx);
 }
 
@@ -106,7 +106,7 @@ void ReadFromArrayOpDesc::ProcessTensorArrayOp(const general::OpDesc& raw_desc,
   const std::string asso_var_name{var_name + ".AssociatedVar"};
   CHECK(scope->HasRootVarDesc(asso_var_name));
   auto root_var = scope->GetRootVarDesc(asso_var_name).lock();
-  const auto& var_desc = AddInput("FakeAssociatedIn", root_var->latest());
+  const auto& var_desc = AddInput("FakeAssociatedX", root_var->latest());
   UpdateVarBlockIdx(var_desc, block_idx);
 }
 

--- a/lite/model_parser/ssa/op_desc.cc
+++ b/lite/model_parser/ssa/op_desc.cc
@@ -96,6 +96,20 @@ void WriteToArrayOpDesc::ProcessTensorArrayOp(const general::OpDesc& raw_desc,
   UpdateVarBlockIdx(var_desc, block_idx);
 }
 
+void ReadFromArrayOpDesc::ProcessTensorArrayOp(const general::OpDesc& raw_desc,
+                                               const RootVarScope* scope,
+                                               int32_t block_idx) {
+  CHECK(scope);
+  CHECK_EQ(raw_desc.inputs().at("X").size(), 1);
+  const auto& var_name = raw_desc.inputs().at("X").at(0);
+
+  const std::string asso_var_name{var_name + ".AssociatedVar"};
+  CHECK(scope->HasRootVarDesc(asso_var_name));
+  auto root_var = scope->GetRootVarDesc(asso_var_name).lock();
+  const auto& var_desc = AddInput("FakeAssociatedIn", root_var->latest());
+  UpdateVarBlockIdx(var_desc, block_idx);
+}
+
 constexpr char const WriteBackOp::type_[];
 constexpr char const WriteBackOp::input_lod_deps_[];
 constexpr char const WriteBackOp::input_lod_array_deps_[];

--- a/lite/model_parser/ssa/op_desc.h
+++ b/lite/model_parser/ssa/op_desc.h
@@ -75,7 +75,7 @@ class OpDesc : public OpDescBase {
  public:
   OpDesc() = default;
   OpDesc(const general::OpDesc& raw_desc,
-         const RootVarScope* scope,
+         const RootVarScope& scope,
          int32_t block_idx);
 
  protected:
@@ -94,15 +94,15 @@ class WriteToArrayOpDesc : public OpDesc {
  public:
   WriteToArrayOpDesc() = default;
   WriteToArrayOpDesc(const general::OpDesc& raw_desc,
-                     RootVarScope* mutable_scope,
+                     const RootVarScope& scope,
                      int32_t block_idx)
-      : OpDesc(raw_desc, mutable_scope, block_idx) {
-    ProcessTensorArrayOp(raw_desc, mutable_scope, block_idx);
+      : OpDesc(raw_desc, scope, block_idx) {
+    ProcessTensorArrayOp(raw_desc, scope, block_idx);
   }
 
  private:
   void ProcessTensorArrayOp(const general::OpDesc& raw_desc,
-                            RootVarScope* mutable_scope,
+                            const RootVarScope& scope,
                             int32_t block_idx);
 };
 
@@ -110,7 +110,7 @@ class ReadFromArrayOpDesc : public OpDesc {
  public:
   ReadFromArrayOpDesc() = default;
   ReadFromArrayOpDesc(const general::OpDesc& raw_desc,
-                      const RootVarScope* scope,
+                      const RootVarScope& scope,
                       int32_t block_idx)
       : OpDesc(raw_desc, scope, block_idx) {
     ProcessTensorArrayOp(raw_desc, scope, block_idx);
@@ -118,7 +118,7 @@ class ReadFromArrayOpDesc : public OpDesc {
 
  private:
   void ProcessTensorArrayOp(const general::OpDesc& raw_desc,
-                            const RootVarScope* scope,
+                            const RootVarScope& scope,
                             int32_t block_idx);
 };
 

--- a/lite/model_parser/ssa/op_desc.h
+++ b/lite/model_parser/ssa/op_desc.h
@@ -106,6 +106,22 @@ class WriteToArrayOpDesc : public OpDesc {
                             int32_t block_idx);
 };
 
+class ReadFromArrayOpDesc : public OpDesc {
+ public:
+  ReadFromArrayOpDesc() = default;
+  ReadFromArrayOpDesc(const general::OpDesc& raw_desc,
+                      const RootVarScope* scope,
+                      int32_t block_idx)
+      : OpDesc(raw_desc, scope, block_idx) {
+    ProcessTensorArrayOp(raw_desc, scope, block_idx);
+  }
+
+ private:
+  void ProcessTensorArrayOp(const general::OpDesc& raw_desc,
+                            const RootVarScope* scope,
+                            int32_t block_idx);
+};
+
 // In order to modify the block operator, we need to know the specific
 // input name. Because its format is not uniform, so register here.
 

--- a/lite/model_parser/ssa/program_desc.cc
+++ b/lite/model_parser/ssa/program_desc.cc
@@ -81,13 +81,13 @@ void PlainProgramDesc::InsertOpOfBlock(const general::BlockDesc& block_desc) {
     } else {
       std::unique_ptr<OpDescBase> op;
       if (raw_op->Type() == "write_to_array") {
-        op.reset(new WriteToArrayOpDesc(
-            *raw_op, dst_block->mutable_scope(), block_idx));
+        op.reset(
+            new WriteToArrayOpDesc(*raw_op, *dst_block->scope(), block_idx));
       } else if (raw_op->Type() == "read_from_array") {
         op.reset(
-            new ReadFromArrayOpDesc(*raw_op, dst_block->scope(), block_idx));
+            new ReadFromArrayOpDesc(*raw_op, *dst_block->scope(), block_idx));
       } else {
-        op.reset(new OpDesc(*raw_op, dst_block->scope(), block_idx));
+        op.reset(new OpDesc(*raw_op, *dst_block->scope(), block_idx));
       }
       const auto& inputs = ConvertToSet(op->inputs());
       const auto& outputs = ConvertToSet(op->outputs());
@@ -208,8 +208,8 @@ void ProgramDescConverter::InitBlocks() {
     if (block->parent()) {
       dst_block->SetParentIdx(block->parent()->idx());
     }
-    if (block->kid()) {
-      dst_block->SetForwardBlockIdx(block->kid()->idx());
+    if (block->kids().size()) {
+      dst_block->SetForwardBlockIdx(block->kids().front()->idx());
     }
   }
   for (auto& block : src_desc_->blocks()) {

--- a/lite/model_parser/ssa/program_desc.cc
+++ b/lite/model_parser/ssa/program_desc.cc
@@ -83,6 +83,9 @@ void PlainProgramDesc::InsertOpOfBlock(const general::BlockDesc& block_desc) {
       if (raw_op->Type() == "write_to_array") {
         op.reset(new WriteToArrayOpDesc(
             *raw_op, dst_block->mutable_scope(), block_idx));
+      } else if (raw_op->Type() == "read_from_array") {
+        op.reset(
+            new ReadFromArrayOpDesc(*raw_op, dst_block->scope(), block_idx));
       } else {
         op.reset(new OpDesc(*raw_op, dst_block->scope(), block_idx));
       }

--- a/lite/model_parser/ssa/var_desc.h
+++ b/lite/model_parser/ssa/var_desc.h
@@ -136,14 +136,23 @@ class RootVarScope {
 
   const RootVarScope* parent() const { return parent_; }
 
-  const RootVarScope* kid() const { return kid_; }
+  const std::vector<RootVarScope*>& kids() const { return kids_; }
 
  protected:
-  void SetKidScope(const RootVarScope& kid) { kid_ = &kid; }
+  void AddKidScope(RootVarScope* kid) {
+    CHECK(kid);
+    kids_.emplace_back(kid);
+  }
+
+  RootVarScope* GetMutableScopeOfRootVar(const std::string& name);
+
+  const std::map<std::string, std::shared_ptr<VarDesc>>& GetRootVarsMap() {
+    return root_vars_;
+  }
 
  private:
-  const RootVarScope* kid_{nullptr};
-  const RootVarScope* parent_{nullptr};
+  std::vector<RootVarScope*> kids_;
+  RootVarScope* parent_{nullptr};
   std::map<std::string, std::shared_ptr<VarDesc>> root_vars_;
 };
 


### PR DESCRIPTION
1、Paddle 主框架 `framework::proto::BlockDesc::forward_block_idx` 可能为反向计算专用；所以将原先与其耦合的变量解耦，类型修改为 `std::vector`；
2、增加 `WriteToArray` 后继 `ReadFromArray` 的拓扑支持；
3、调整代码逻辑，消除 `ssa::Scope` 不同层级同名 `LOD_TENSOR_ARRAY` 变量的混淆风险。