### PR TITLE
Modify cmake function bundle_static_library

### DIFF
--- a/cmake/lite.cmake
+++ b/cmake/lite.cmake
@@ -805,6 +805,7 @@ function(bundle_static_library tgt_name bundled_tgt_name fake_target)
       COMMAND ${ar_tool} -M < ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
       OUTPUT ${bundled_tgt_full_name}
       COMMENT "Bundling ${bundled_tgt_name}"
+      DEPENDS ${tgt_name}
       VERBATIM)
   else()
     foreach(lib ${static_libs})
@@ -812,6 +813,7 @@ function(bundle_static_library tgt_name bundled_tgt_name fake_target)
     endforeach()
     add_custom_command(
       COMMAND /usr/bin/libtool -static -o ${bundled_tgt_full_name} ${libfiles}
+      DEPENDS ${tgt_name}
       OUTPUT ${bundled_tgt_full_name}
     )
   endif()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/63448337/129129998-08774f1b-f643-46b4-95f8-a114f654cc32.png)
自定义命令通过打包${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar文件里记录的所有文件，生成静态库${bundled_tgt_full_name}，但由于该命令产出的${bundled_tgt_full_name}不依赖于任何其他target，这样output ${bundled_tgt_full_name}只会被执行一次。