### PR TITLE
refine public symbol

### DIFF
--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -41,7 +41,7 @@ std::vector<std::string> GetAllOps();
 /*
  * Predictor for inference, input a model, it will optimize and execute it.
  */
-class LITE_API Predictor {
+class Predictor {
  public:
   // Create an empty predictor.
   Predictor() {

--- a/lite/api/light_api.h
+++ b/lite/api/light_api.h
@@ -38,7 +38,7 @@ namespace lite {
  * The light weight predictor, mainly for mobile. It loads an optimized model,
  * and will not depend on the MIR or perform latter optimization.
  */
-class LITE_API LightPredictor {
+class LightPredictor {
  public:
   // constructor function of LightPredictor, `lite_model_file` refers to data in
   // model file or buffer,`model_from_memory` refers to whther to load model

--- a/lite/core/memory.h
+++ b/lite/core/memory.h
@@ -54,13 +54,11 @@ namespace lite {
 
 // Malloc memory for a specific Target. All the targets should be an element in
 // the `switch` here.
-LITE_API void* TargetMalloc(TargetType target, size_t size);
+void* TargetMalloc(TargetType target, size_t size);
 
 // Free memory for a specific Target. All the targets should be an element in
 // the `switch` here.
-void LITE_API TargetFree(TargetType target,
-                         void* data,
-                         std::string free_flag = "");
+void TargetFree(TargetType target, void* data, std::string free_flag = "");
 
 // Copy a buffer from host to another target.
 void TargetCopy(TargetType target, void* dst, const void* src, size_t size);

--- a/lite/core/program.h
+++ b/lite/core/program.h
@@ -196,7 +196,7 @@ struct Instruction {
 /*
  * A program contains kernels for runtime.
  */
-class LITE_API RuntimeProgram {
+class RuntimeProgram {
  public:
   explicit RuntimeProgram(std::vector<std::vector<Instruction>>&& insts)
       : instructions_(std::move(insts)) {


### PR DESCRIPTION
- clean public symbols：only APIs can be compiled as public symbols

- Effect of Current PR：reduce the lib size by 4kb
``` shell
# version: v2.9.1, compiling command
cd Paddle-Lite && ./lite/tools/build_android.sh --toolchain=clang --with_log=OFF

# BEFORE: 2055K
# AFTER MERGING THIS PR: 2051K
```