### PR TITLE
[Pass][OpenCL] fix conv_elementwise_tree_fuse_pass bugs

### DIFF
--- a/lite/core/optimizer/mir/fusion/conv_elementwise_tree_fuse_pass.h
+++ b/lite/core/optimizer/mir/fusion/conv_elementwise_tree_fuse_pass.h
@@ -56,6 +56,8 @@ namespace mir {
 //   fusion_elementwise_add_activation.
 // * The input tensor dims of elementwise_add/fusion_elementwise_add_activation
 //   must be equal to that of conv2d_1x1.
+// * The output tensor of conv2d_1x1 must be Y of
+//   elementwise_add/fusion_elementwise_add_activation.
 // * Only support opencl target by now.
 
 class ConvElementwiseTreeFusePass : public ProgramPass {

--- a/lite/core/optimizer/mir/fusion/conv_elementwise_tree_fuser.h
+++ b/lite/core/optimizer/mir/fusion/conv_elementwise_tree_fuser.h
@@ -16,7 +16,7 @@
 
 #include <memory>
 #include <string>
-#include "lite/core/mir/pattern_matcher_high_api.h"
+#include "lite/core/optimizer/mir/pattern_matcher_high_api.h"
 
 namespace paddle {
 namespace lite {

--- a/lite/core/optimizer/mir/fusion/conv_elementwise_tree_fuser.h
+++ b/lite/core/optimizer/mir/fusion/conv_elementwise_tree_fuser.h
@@ -16,7 +16,7 @@
 
 #include <memory>
 #include <string>
-#include "lite/core/optimizer/mir/pattern_matcher_high_api.h"
+#include "lite/core/mir/pattern_matcher_high_api.h"
 
 namespace paddle {
 namespace lite {
@@ -45,6 +45,9 @@ class ConvElementwiseTreeFuser : public FuseBase {
   bool conv_has_bias_{false};
   bool conv_has_prelu_alpha_{false};
   std::string elementwise_type_{""};
+  PMNode* conv_output_;
+  PMNode* conv_;
+  PMNode* elementwise_;
 };
 
 }  // namespace fusion


### PR DESCRIPTION
【问题1】
当对 resnet18 模型进行 opt 转换时，输出的 .nb 模型结构错误。原因为对已经应用了该 pass 的 conv_1x1 第二次应用该 pass 时，图结构错误。

解决方法：增加对 conv_1x1 的限制，当该 conv_1x1 已经被应用该 pass 后，就不满足当前 pattern 了。

【问题2】
对如下模型结构进行 opt 转换时，输出的 .nb 模型结果错误。原因为在`BuildPattern`环节时，无法确定 conv 的 filter 信息，因而认为原始结构图中存在符合该 pass 的 pattern，并且相关 node 被标记为了 Intermediate，然而在执行`InsertNewNode`时，发现 conv 不是 1x1，因而 return，但是并没有重置之前被标记为 Intermediate 的 node，最后导致 opt 产出的结果有误。

解决方法：将标记 Intermediate 的操作后移到`InsertNewNode`函数中。

原始结构图：
![image](https://user-images.githubusercontent.com/24290792/129856682-307ab3bc-bb21-4917-8721-bceede29b707.png)
opt 转换后的错误结构图：
![image](https://user-images.githubusercontent.com/24290792/129856703-99d3055b-6906-44ac-b817-58e8e2fe9b27.png)
