### PR TITLE
[compatible] add patch code to suppport old opt model to select correct kernel,test=develop

### DIFF
--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -351,6 +351,10 @@ RuntimeProgram::RuntimeProgram(
 #endif
 
       auto kernels = op->CreateKernels({place});
+      if (kernels.size() == 0 && place.target == TargetType::kARM) {
+        place.target = TargetType::kHost;
+        kernels = op->CreateKernels({place});
+      }
       CHECK_GT(kernels.size(), 0) << kernels_error_message;
       auto it = std::find_if(
           kernels.begin(), kernels.end(), [&](std::unique_ptr<KernelBase>& it) {


### PR DESCRIPTION
在runtime加入patch，处理老版本arm/host kernel同名并存老版本opt pass选择arm kernel导致在新版本预测库只剩host kernel的情况下无法正常运行的问题，该修改不会对现有预测库的稳定性和性能造成冲击