### PR TITLE
[OpenCL] Fix cl_context gen_lwss bugs

### DIFF
--- a/lite/backends/opencl/cl_context.cc
+++ b/lite/backends/opencl/cl_context.cc
@@ -269,7 +269,7 @@ CLContext::DefaultLocalWorkSize(const cl::NDRange &gws,
   } while (ly_src > 1);
   if (tune_type == lite_api::CL_TUNE_NONE && lws_set.empty()) {
     lws_set.insert(
-          (reverse ? cl::NDRange{lz, ly, lx} : cl::NDRange{lx, ly, lz}));
+        (reverse ? cl::NDRange{lz, ly, lx} : cl::NDRange{lx, ly, lz}));
   }
   return lws_set;
 }

--- a/lite/backends/opencl/cl_context.h
+++ b/lite/backends/opencl/cl_context.h
@@ -76,6 +76,7 @@ class CLContext {
   std::set<cl::NDRange, CompareByRange> DefaultLocalWorkSize(
       const cl::NDRange &global_work_size,
       register size_t max_work_size,
+      size_t tune_type = 0,
       const int &divitor = 2,
       const bool &tune_reverse = false,
       const size_t &user_defined_max_work_size = 0);


### PR DESCRIPTION
在现在当local_work_size的生成函数中，目前没有覆盖没有auto-tuning情况下生成空的候选项的判断后处理，导致后面kernel run的时候参数出现不合法随机值挂死问题。