### PR TITLE
[Pass][OpenCL] Add restrict to conv_elementwise_tree_fuser

### DIFF
--- a/lite/kernels/opencl/fc_image_compute.cc
+++ b/lite/kernels/opencl/fc_image_compute.cc
@@ -31,7 +31,7 @@ class FcImageCompute : public KernelLite<TARGET(kOpenCL),
     const auto bias_t = param.bias;
     has_bias_ = (bias_t == nullptr) ? false : true;
 
-    // Runtime precision can be forced to fp32 to avoid the loss of accuracy
+    // Runtime precision can be forced to fp32 to avoid precision loss
     // when K is larger than thres_k.
     // But this will increase the running time of fc because running time under
     // fp32 is two time longer than that under fp16.


### PR DESCRIPTION
**【问题】**
在该 pass 中，需要限制 conv1x1 的输出 VarNode 只能有一个输出。当该 VarNode 有多个输出时，由于该 VarNode 被标记为了AsIntermediate，进而该 VarNode 被删除，导致该与该 VarNode 有连接关系的节点出现输入悬空状态，因此这时经 opt 转换输出的模型结构会出现问题。在 EfficientNetB0 模型上可以复现这个问题。

**【解决方法】**
对 conv1x1 的输出 VarNode 加上`assert_only_one_output`限制。

**【效果】**
可解决 EfficientNetB0 模型转换问题。