### PR TITLE
[Framework] Fix rockchip_npu and imagination_nna ci problems

### DIFF
--- a/lite/kernels/imagination_nna/bridges/CMakeLists.txt
+++ b/lite/kernels/imagination_nna/bridges/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT LITE_WITH_IMAGINATION_NNA)
   return()
 endif()
 
-lite_cc_library(subgraph_bridge_utility_imagination_nna SRCS utility.cc DEPS ${imagination_nna_builder_libs} ${imagination_nna_runtime_libs} tensor)
+lite_cc_library(subgraph_bridge_utility_imagination_nna SRCS utility.cc DEPS ${imagination_nna_builder_libs} ${imagination_nna_runtime_libs} core)
 lite_cc_library(subgraph_bridge_graph_imagination_nna SRCS graph.cc DEPS subgraph_bridge_utility_imagination_nna)
 
 set(imagination_nna_subgraph_bridge_deps core subgraph_bridge_utility_imagination_nna subgraph_bridge_graph_imagination_nna)

--- a/lite/kernels/rknpu/bridges/CMakeLists.txt
+++ b/lite/kernels/rknpu/bridges/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT LITE_WITH_RKNPU)
   return()
 endif()
 
-lite_cc_library(subgraph_bridge_utility_rknpu SRCS utility.cc DEPS ${rknpu_builder_libs} tensor)
+lite_cc_library(subgraph_bridge_utility_rknpu SRCS utility.cc DEPS ${rknpu_builder_libs} core)
 lite_cc_library(subgraph_bridge_graph_rknpu SRCS graph.cc DEPS subgraph_bridge_utility_rknpu)
 
 set(rknpu_subgraph_bridge_deps core subgraph_bridge_utility_rknpu subgraph_bridge_graph_rknpu)


### PR DESCRIPTION
A new library '**core**' has been established and the old library '**tensor**', '**memory**' and '**target_wrapper**' have been deleted. Symbols are contained in '**core**'.

![image](https://user-images.githubusercontent.com/29272811/130934120-9535038b-4814-49b5-a37b-5a9d05afdf78.png)


**The following devices have been checked:**
1. MediatekAPU
2. RockchipNPU
3. ImaginationNNA
4. HuaweiAscendNPU
5. HuaweiKirinNPU