### PR TITLE
[lib_size] refactor OpLite InferShapeWithCache interface,test=develop

### DIFF
--- a/lite/operators/__xpu__bigru_op.cc
+++ b/lite/operators/__xpu__bigru_op.cc
@@ -90,7 +90,6 @@ bool XPUBiGRUOp::InferShapeImpl() const {
 }
 
 bool XPUBiGRUOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
-  AttachParam(&param_);
   bool has_mul_b = op_desc.GetAttr<bool>("has_mul_b");
   bool has_gru_b = op_desc.GetAttr<bool>("has_gru_b");
 

--- a/lite/operators/__xpu__block_fuse_op.cc
+++ b/lite/operators/__xpu__block_fuse_op.cc
@@ -1,0 +1,128 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/__xpu__block_fuse_op.h"
+#include <memory>
+#include <vector>
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+bool XPUBlockFuseOp::CheckShape() const {
+  CHECK(param_.input) << "Input(input) of XPUBlockFuseOp should not be null.";
+  CHECK(param_.output)
+      << "Output(output) of XPUBlockFuseOp should not be null.";
+  return true;
+}
+
+bool XPUBlockFuseOp::InferShapeImpl() const {
+  param_.output_max->Resize({4});
+  param_.output->set_lod(param_.input->lod());
+  return true;
+}
+
+bool XPUBlockFuseOp::AttachImpl(const cpp::OpDesc& op_desc,
+                                lite::Scope* scope) {
+  CHECK(scope->FindVar(op_desc.Input("Input").front()));
+  CHECK(scope->FindVar(op_desc.Output("Output").front()));
+  CHECK(scope->FindVar(op_desc.Output("OutputMax").front()));
+
+  param_.input =
+      scope->FindVar(op_desc.Input("Input").front())->GetMutable<Tensor>();
+  param_.output =
+      scope->FindVar(op_desc.Output("Output").front())->GetMutable<Tensor>();
+  param_.filter =
+      scope->FindVar(op_desc.Input("Filter").front())->GetMutable<Tensor>();
+  param_.output_max =
+      scope->FindVar(op_desc.Output("OutputMax").front())->GetMutable<Tensor>();
+
+  param_.op_type = op_desc.GetAttr<std::vector<int>>("op_type");
+  param_.place_x = op_desc.GetAttr<std::vector<int>>("place_x");
+  param_.place_y = op_desc.GetAttr<std::vector<int>>("place_y");
+  param_.place_z = op_desc.GetAttr<std::vector<int>>("place_z");
+  param_.filter_dims = op_desc.GetAttr<std::vector<int>>("filter_dims");
+  param_.strides = op_desc.GetAttr<std::vector<int>>("strides");
+  auto paddings = op_desc.GetAttr<std::vector<int>>("paddings");
+  param_.paddings = std::make_shared<std::vector<int>>(paddings);
+  auto dilations = op_desc.GetAttr<std::vector<int>>("dilations");
+  param_.dilations = std::make_shared<std::vector<int>>(dilations);
+  param_.groups = op_desc.GetAttr<std::vector<int>>("groups");
+  param_.act_type = op_desc.GetAttr<std::vector<int>>("act_type");
+  param_.act_param = op_desc.GetAttr<std::vector<float>>("act_param");
+  param_.block_lod = op_desc.GetAttr<std::vector<int>>("block_lod");
+  param_.conv_bias = op_desc.GetAttr<std::vector<int>>("conv_bias");
+  param_.has_bias = op_desc.GetAttr<bool>("has_bias");
+
+  // optional params
+  if (op_desc.HasAttr("has_input_max") &&
+      op_desc.GetAttr<bool>("has_input_max")) {
+    CHECK(scope->FindVar(op_desc.Input("InputMax").front()));
+    param_.input_max =
+        scope->FindVar(op_desc.Input("InputMax").front())->GetMutable<Tensor>();
+  }
+  if (op_desc.GetAttr<bool>("has_bias")) {
+    CHECK(scope->FindVar(op_desc.Input("Bias").front()));
+    param_.bias =
+        scope->FindVar(op_desc.Input("Bias").front())->GetMutable<Tensor>();
+  }
+
+  // shape check
+  int op_num = param_.op_type.size();
+  CHECK_EQ(op_num, param_.place_x.size());
+  CHECK_EQ(op_num, param_.place_y.size());
+  CHECK_EQ(op_num, param_.place_z.size());
+  int f_n = 0, s_n = 0, p_n = 0, d_n = 0, g_n = 0, act_n = 0, act_param_n = 0,
+      bias_n = 0;
+  for (size_t i = 0; i < op_num; i++) {
+    if (param_.op_type[i] == 0) {
+      f_n += 4;
+      s_n += 2;
+      p_n += 4;
+      d_n += 2;
+      g_n += 1;
+      act_n += 1;
+      act_param_n += 1;
+      bias_n += 1;
+    } else if (param_.op_type[i] <= 3) {
+      f_n += 2;
+      s_n += 2;
+      p_n += 4;
+    } else if (param_.op_type[i] == 4) {
+      f_n += 2;
+      act_n += 3;
+      act_param_n += 3;
+      bias_n += 1;
+    } else if (param_.op_type[i] == 10) {
+      act_n += 1;
+      act_param_n += 1;
+    }
+  }
+  CHECK_EQ(f_n, param_.filter_dims.size());
+  CHECK_EQ(s_n, param_.strides.size());
+  CHECK_EQ(p_n, paddings.size());
+  CHECK_EQ(d_n, dilations.size());
+  CHECK_EQ(g_n, param_.groups.size());
+  CHECK_EQ(act_n, param_.act_type.size());
+  CHECK_EQ(act_param_n, param_.act_param.size());
+  CHECK_EQ(bias_n, param_.conv_bias.size());
+  return true;
+}
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_OP(__xpu__block_fuse_op, paddle::lite::operators::XPUBlockFuseOp);

--- a/lite/operators/__xpu__conv2d_op.cc
+++ b/lite/operators/__xpu__conv2d_op.cc
@@ -98,7 +98,6 @@ bool XPUConv2dOp::InferShapeImpl() const {
 }
 
 bool XPUConv2dOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
-  AttachParam(&param_);
   CHECK(scope->FindVar(op_desc.Input("Input").front()));
   CHECK(scope->FindVar(op_desc.Input("Filter").front()));
   CHECK(scope->FindVar(op_desc.Output("Output").front()));

--- a/lite/operators/__xpu__conv_pixel_shuffle_fuse_op.cc
+++ b/lite/operators/__xpu__conv_pixel_shuffle_fuse_op.cc
@@ -1,0 +1,241 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/__xpu__conv_pixel_shuffle_fuse_op.h"
+#include <memory>
+#include <vector>
+#include "lite/core/op_registry.h"
+#include "lite/operators/conv_op.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+std::string padding_algorithm_0_ = "";  // NOLINT
+std::string padding_algorithm_1_ = "";  // NOLINT
+
+bool XPUConvPixelShuffleOp::CheckShape() const {
+  CHECK(param_.input) << "Input(Input) of ConvXPUOp should not be null.";
+  CHECK(param_.output) << "Input(Filter) of ConvXPUOp should not be null.";
+  CHECK(param_.filter_0) << "Output(Output) of ConvXPUOp should not be null.";
+  CHECK(param_.filter_1) << "Output(Output) of ConvXPUOp should not be null.";
+
+  const auto in_dims = param_.input->dims();
+  const auto filter_0_dims = param_.filter_0->dims();
+  const auto filter_1_dims = param_.filter_1->dims();
+  const auto upscale_factor = param_.upscale_factor;
+  int groups_0 = param_.groups_0.front();
+  int groups_1 = param_.groups_1.front();
+
+  CHECK_EQ(in_dims.size(), 4UL) << "Conv intput should be 4-D tensor.";
+  CHECK_EQ(filter_0_dims.size(), 4UL) << "Conv filter should be 4-D tensor.";
+  CHECK_EQ(filter_1_dims.size(), 4UL) << "Conv filter should be 4-D tensor.";
+  CHECK_EQ(in_dims[1], filter_0_dims[1] * groups_0)
+      << "The number of input channels should be equal to filter channels * "
+         "groups.";
+  CHECK_EQ(filter_0_dims[0] % groups_0, 0)
+      << "The number of output channels should be divided by groups.";
+  CHECK_EQ(filter_1_dims[0] % groups_1, 0)
+      << "The number of output channels should be divided by groups.";
+  CHECK_EQ_OR_FALSE(filter_0_dims[0] % (upscale_factor * upscale_factor), 0);
+  CHECK_EQ(filter_0_dims[0] / upscale_factor / upscale_factor,
+           filter_1_dims[1] * groups_1)
+      << "The number of input channels should be equal to filter channels * "
+         "groups.";
+
+  return true;
+}
+
+inline int ConvOutputSize(int input_size,
+                          int filter_size,
+                          int dilation,
+                          int pad_left,
+                          int pad_right,
+                          int stride) {
+  const int dkernel = dilation * (filter_size - 1) + 1;
+  int output_size =
+      (input_size + (pad_left + pad_right) - dkernel) / stride + 1;
+
+  return output_size;
+}
+
+bool XPUConvPixelShuffleOp::InferShapeImpl() const {
+  const auto in_dims = param_.input->dims();
+  const auto filter_0_dims = param_.filter_0->dims();
+
+  operators::UpdatePaddingAndDilation(param_.paddings_0.get(),
+                                      param_.dilations_0.get(),
+                                      param_.strides_0,
+                                      padding_algorithm_0_,
+                                      in_dims,
+                                      filter_0_dims);
+
+  // get mid shape
+  auto paddings_0 = *param_.paddings_0;
+  auto dilations_0 = *param_.dilations_0;
+  std::vector<int64_t> mid_shape({in_dims[0], filter_0_dims[0]});
+  for (size_t i = 0; i < param_.strides_0.size(); ++i) {
+    mid_shape.push_back(ConvOutputSize(in_dims[i + 2],
+                                       filter_0_dims[i + 2],
+                                       dilations_0[i],
+                                       paddings_0[i * 2],
+                                       paddings_0[i * 2 + 1],
+                                       param_.strides_0[i]));
+  }
+  const auto upscale_factor = param_.upscale_factor;
+  mid_shape = {mid_shape[0],
+               mid_shape[1] / upscale_factor / upscale_factor,
+               mid_shape[2] * upscale_factor,
+               mid_shape[3] * upscale_factor};
+  const auto filter_1_dims = param_.filter_1->dims();
+
+  operators::UpdatePaddingAndDilation(param_.paddings_1.get(),
+                                      param_.dilations_1.get(),
+                                      param_.strides_1,
+                                      padding_algorithm_1_,
+                                      lite::DDim(mid_shape),
+                                      filter_1_dims);
+  std::vector<int64_t> output_shape({mid_shape[0], filter_1_dims[0]});
+  auto paddings_1 = *param_.paddings_1;
+  auto dilations_1 = *param_.dilations_1;
+  for (size_t i = 0; i < param_.strides_1.size(); ++i) {
+    output_shape.push_back(ConvOutputSize(mid_shape[i + 2],
+                                          filter_1_dims[i + 2],
+                                          dilations_1[i],
+                                          paddings_1[i * 2],
+                                          paddings_1[i * 2 + 1],
+                                          param_.strides_1[i]));
+  }
+  // Set output and output max dims
+  param_.output->Resize(lite::DDim(output_shape));
+  param_.output_max->Resize({4});
+  // share LoD
+  param_.output->set_lod(param_.input->lod());
+  return true;
+}
+
+bool XPUConvPixelShuffleOp::AttachImpl(const cpp::OpDesc& op_desc,
+                                       lite::Scope* scope) {
+  CHECK(scope->FindVar(op_desc.Input("Input").front()));
+  CHECK(scope->FindVar(op_desc.Input("Filter_0").front()));
+  CHECK(scope->FindVar(op_desc.Input("Filter_1").front()));
+  CHECK(scope->FindVar(op_desc.Output("Output").front()));
+  CHECK(scope->FindVar(op_desc.Output("OutputMax").front()));
+
+  param_.input =
+      scope->FindVar(op_desc.Input("Input").front())->GetMutable<Tensor>();
+  param_.filter_0 =
+      scope->FindVar(op_desc.Input("Filter_0").front())->GetMutable<Tensor>();
+  param_.filter_1 =
+      scope->FindVar(op_desc.Input("Filter_1").front())->GetMutable<Tensor>();
+  param_.output =
+      scope->FindVar(op_desc.Output("Output").front())->GetMutable<Tensor>();
+  param_.output_max =
+      scope->FindVar(op_desc.Output("OutputMax").front())->GetMutable<Tensor>();
+
+  param_.strides_0 = op_desc.GetAttr<std::vector<int>>("strides_0");
+  CHECK_EQ(param_.strides_0.size(), 2UL);
+  param_.strides_1 = op_desc.GetAttr<std::vector<int>>("strides_1");
+  CHECK_EQ(param_.strides_1.size(), 2UL);
+  std::vector<int> paddings_0 = op_desc.GetAttr<std::vector<int>>("paddings_0");
+  std::vector<int> paddings_1 = op_desc.GetAttr<std::vector<int>>("paddings_1");
+  auto dilations_0 = op_desc.GetAttr<std::vector<int>>("dilations_0");
+  CHECK_EQ(dilations_0.size(), 2UL);
+  param_.dilations_0 = std::make_shared<std::vector<int>>(dilations_0);
+  auto dilations_1 = op_desc.GetAttr<std::vector<int>>("dilations_1");
+  CHECK_EQ(dilations_1.size(), 2UL);
+  param_.dilations_1 = std::make_shared<std::vector<int>>(dilations_1);
+  param_.groups_0 = op_desc.GetAttr<std::vector<int>>("groups_0");
+  CHECK_EQ(param_.groups_0.size(), 1UL);
+  param_.groups_1 = op_desc.GetAttr<std::vector<int>>("groups_1");
+  CHECK_EQ(param_.groups_1.size(), 1UL);
+  param_.act_type_0 = op_desc.GetAttr<std::vector<int>>("act_type_0");
+  CHECK_EQ(param_.act_type_0.size(), 1UL);
+  param_.act_type_1 = op_desc.GetAttr<std::vector<int>>("act_type_1");
+  CHECK_EQ(param_.act_type_1.size(), 1UL);
+  param_.act_param_0 = op_desc.GetAttr<std::vector<float>>("act_param_0");
+  CHECK_EQ(param_.act_param_0.size(), 1UL);
+  param_.act_param_1 = op_desc.GetAttr<std::vector<float>>("act_param_1");
+  CHECK_EQ(param_.act_param_1.size(), 1UL);
+  param_.has_bias_0 = op_desc.GetAttr<bool>("has_bias_0");
+  param_.has_bias_1 = op_desc.GetAttr<bool>("has_bias_1");
+  param_.upscale_factor = op_desc.GetAttr<int>("upscale_factor");
+
+  // optional params
+  std::vector<std::string> input_arg_names = op_desc.InputArgumentNames();
+  if (std::find(input_arg_names.begin(), input_arg_names.end(), "Bias_0") !=
+      input_arg_names.end()) {
+    auto arguments = op_desc.Input("Bias_0");
+    if (arguments.size() > 0) {
+      auto arg_var = scope->FindVar(arguments.front());
+      if (arg_var != nullptr) {
+        param_.bias_0 =
+            const_cast<lite::Tensor*>(&(arg_var->Get<lite::Tensor>()));
+      }
+    }
+  }
+  if (std::find(input_arg_names.begin(), input_arg_names.end(), "Bias_1") !=
+      input_arg_names.end()) {
+    auto arguments = op_desc.Input("Bias_1");
+    if (arguments.size() > 0) {
+      auto arg_var = scope->FindVar(arguments.front());
+      if (arg_var != nullptr) {
+        param_.bias_1 =
+            const_cast<lite::Tensor*>(&(arg_var->Get<lite::Tensor>()));
+      }
+    }
+  }
+  if (op_desc.HasAttr("padding_algorithm_0")) {
+    padding_algorithm_0_ = op_desc.GetAttr<std::string>("padding_algorithm_0");
+  }
+  if (op_desc.HasAttr("padding_algorithm_1")) {
+    padding_algorithm_1_ = op_desc.GetAttr<std::string>("padding_algorithm_1");
+  }
+
+  // 2-pad to 4-pad
+  if (paddings_0.size() == 2L) {
+    for (size_t i = 0; i < param_.strides_0.size(); ++i) {
+      int copy_pad = *(paddings_0.begin() + 2 * i);
+      paddings_0.insert(paddings_0.begin() + 2 * i + 1, copy_pad);
+    }
+  } else {
+    if (paddings_0.size() != 4L) {
+      LOG(FATAL)
+          << "Paddings size should be the same or twice as the input size.";
+    }
+  }
+  param_.paddings_0 = std::make_shared<std::vector<int>>(paddings_0);
+
+  if (paddings_1.size() == 2L) {
+    for (size_t i = 0; i < param_.strides_1.size(); ++i) {
+      int copy_pad = *(paddings_1.begin() + 2 * i);
+      paddings_1.insert(paddings_1.begin() + 2 * i + 1, copy_pad);
+    }
+  } else {
+    if (paddings_1.size() != 4L) {
+      LOG(FATAL)
+          << "Paddings size should be the same or twice as the input size.";
+    }
+  }
+  param_.paddings_1 = std::make_shared<std::vector<int>>(paddings_1);
+
+  return true;
+}
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_OP(__xpu__conv_pixel_shuffle_fuse_op,
+                 paddle::lite::operators::XPUConvPixelShuffleOp);

--- a/lite/operators/__xpu__dynamic_lstm_fuse_op.cc
+++ b/lite/operators/__xpu__dynamic_lstm_fuse_op.cc
@@ -91,7 +91,6 @@ bool XPUDynamicLstmOp::InferShapeImpl() const {
 
 bool XPUDynamicLstmOp::AttachImpl(const cpp::OpDesc& op_desc,
                                   lite::Scope* scope) {
-  AttachParam(&param_);
   CHECK(scope->FindVar(op_desc.Input("Input").front()));
   CHECK(scope->FindVar(op_desc.Input("Weight_0").front()));
   CHECK(scope->FindVar(op_desc.Input("Weight_1").front()));

--- a/lite/operators/__xpu__fc_op.cc
+++ b/lite/operators/__xpu__fc_op.cc
@@ -71,7 +71,6 @@ bool XPUFcOp::InferShapeImpl() const {
 }
 
 bool XPUFcOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
-  AttachParam(&param_);
   CHECK(scope->FindVar(op_desc.Input("Input").front()));
   CHECK(scope->FindVar(op_desc.Input("Filter").front()));
   CHECK(scope->FindVar(op_desc.Output("Output").front()));

--- a/lite/operators/__xpu__generate_sequence_op.cc
+++ b/lite/operators/__xpu__generate_sequence_op.cc
@@ -44,7 +44,6 @@ bool XPUGenerateSequenceOp::InferShapeImpl() const {
 
 bool XPUGenerateSequenceOp::AttachImpl(const cpp::OpDesc &opdesc,
                                        lite::Scope *scope) {
-  AttachParam(&param_);
   param_.input = scope->FindTensor(opdesc.Input("X").front());
   param_.output = scope->FindMutableTensor(opdesc.Output("Out").front());
   param_.axis = opdesc.GetAttr<int>("axis");

--- a/lite/operators/__xpu__logit_op.cc
+++ b/lite/operators/__xpu__logit_op.cc
@@ -35,7 +35,6 @@ bool XPULogitOp::InferShapeImpl() const {
 }
 
 bool XPULogitOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   CHECK(scope->FindVar(opdesc.Input("X").front()));
   CHECK(scope->FindVar(opdesc.Output("Out").front()));
   param_.input = scope->FindTensor(opdesc.Input("X").front());

--- a/lite/operators/__xpu__multi_softmax_op.cc
+++ b/lite/operators/__xpu__multi_softmax_op.cc
@@ -51,7 +51,6 @@ bool XPUMultiSoftmaxOp::InferShapeImpl() const {
 
 bool XPUMultiSoftmaxOp::AttachImpl(const cpp::OpDesc &opdesc,
                                    lite::Scope *scope) {
-  AttachParam(&param_);
   param_.input = scope->FindTensor(opdesc.Input("Input").front());
   param_.output.clear();
   auto Outputs = opdesc.Output("Output");

--- a/lite/operators/__xpu__softmax_topk_op.cc
+++ b/lite/operators/__xpu__softmax_topk_op.cc
@@ -45,7 +45,6 @@ bool XPUSoftmaxTopkOp::InferShapeImpl() const {
 
 bool XPUSoftmaxTopkOp::AttachImpl(const cpp::OpDesc &opdesc,
                                   lite::Scope *scope) {
-  AttachParam(&param_);
   param_.x = scope->FindTensor(opdesc.Input("X").front());
   param_.output = scope->FindMutableTensor(opdesc.Output("Out").front());
   param_.indices = scope->FindMutableTensor(opdesc.Output("Indices").front());

--- a/lite/operators/__xpu__squeeze_excitation_op.cc
+++ b/lite/operators/__xpu__squeeze_excitation_op.cc
@@ -54,7 +54,6 @@ bool XPUSqueezeExcitationOp::InferShapeImpl() const {
 
 bool XPUSqueezeExcitationOp::AttachImpl(const cpp::OpDesc& op_desc,
                                         lite::Scope* scope) {
-  AttachParam(&param_);
   CHECK(scope->FindVar(op_desc.Input("Input").front()));
   CHECK(scope->FindVar(op_desc.Input("Filter").front()));
   CHECK(scope->FindVar(op_desc.Output("Output").front()));

--- a/lite/operators/batch_norm_op.cc
+++ b/lite/operators/batch_norm_op.cc
@@ -73,7 +73,6 @@ bool BatchNormOp::InferShapeImpl() const {
 }
 
 bool BatchNormOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
-  AttachParam(&param_);
   param_.x = scope->FindVar(op_desc.Input("X").front())->GetMutable<Tensor>();
   param_.bias =
       scope->FindVar(op_desc.Input("Bias").front())->GetMutable<Tensor>();

--- a/lite/operators/batch_norm_op.h
+++ b/lite/operators/batch_norm_op.h
@@ -32,6 +32,8 @@ class BatchNormOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/box_coder_op.h
+++ b/lite/operators/box_coder_op.h
@@ -31,6 +31,8 @@ class BoxCoderOpLite : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/concat_op.cc
+++ b/lite/operators/concat_op.cc
@@ -66,7 +66,6 @@ bool ConcatOpLite::InferShapeImpl() const {
 
 // TODO(Superjomn) replace framework::OpDesc with a lite one.
 bool ConcatOpLite::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
-  AttachParam(&param_);
   auto inputs = op_desc.Input("X");
   auto out = op_desc.Output("Out").front();
 

--- a/lite/operators/concat_op.h
+++ b/lite/operators/concat_op.h
@@ -32,6 +32,8 @@ class ConcatOpLite : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -38,6 +38,7 @@ class ConvOpLite : public OpLite {
 
   bool CheckShape() const override;
   bool InferShapeImpl() const override;
+  bool InferShapeWithCache() const override { return true; }
 
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter* ch) {
@@ -69,7 +70,6 @@ class ConvOpLite : public OpLite {
 
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {
-    AttachParam(&param_);
     auto X = op_desc.Input("Input").front();
     auto Filter = op_desc.Input("Filter").front();
     auto Out = op_desc.Output("Output").front();

--- a/lite/operators/deformable_conv_op.h
+++ b/lite/operators/deformable_conv_op.h
@@ -38,6 +38,7 @@ class DeformableConvOpLite : public OpLite {
 
   bool CheckShape() const override;
   bool InferShapeImpl() const override;
+  bool InferShapeWithCache() const override { return true; }
 
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter* ch) {
@@ -66,7 +67,6 @@ class DeformableConvOpLite : public OpLite {
 
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {
-    AttachParam(&param_);
     auto X = op_desc.Input("Input").front();
     auto Filter = op_desc.Input("Filter").front();
     auto Mask = op_desc.Input("Mask").front();

--- a/lite/operators/elementwise_ops.cc
+++ b/lite/operators/elementwise_ops.cc
@@ -87,7 +87,6 @@ bool ElementwiseOp::InferShapeImpl() const {
 }
 
 bool ElementwiseOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
-  AttachParam(&param_);
   auto X_name = opdesc.Input("X").front();
   auto Y_name = opdesc.Input("Y").front();
   auto Out_name = opdesc.Output("Out").front();

--- a/lite/operators/elementwise_ops.h
+++ b/lite/operators/elementwise_ops.h
@@ -29,6 +29,8 @@ class ElementwiseOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) override;
 
   void AttachKernel(KernelBase* kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -75,8 +75,6 @@ bool FcOpLite::InferShapeImpl() const {
 }
 
 bool FcOpLite::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
-  AttachParam(&param_);
-
   auto input = op_desc.Input("Input").front();
   auto W = op_desc.Input("W").front();
   auto out = op_desc.Output("Out").front();

--- a/lite/operators/fc_op.h
+++ b/lite/operators/fc_op.h
@@ -37,6 +37,8 @@ class FcOpLite : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/matmul_op.cc
+++ b/lite/operators/matmul_op.cc
@@ -133,7 +133,6 @@ bool MatMulOpLite::InferShapeImpl() const {
 }
 
 bool MatMulOpLite::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
-  AttachParam(&param_);
   CHECK(!op_desc.Input("X").empty());
   CHECK(!op_desc.Input("Y").empty());
   CHECK(!op_desc.Output("Out").empty());

--- a/lite/operators/matmul_op.h
+++ b/lite/operators/matmul_op.h
@@ -35,6 +35,8 @@ class MatMulOpLite : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override;

--- a/lite/operators/matmul_v2_op.cc
+++ b/lite/operators/matmul_v2_op.cc
@@ -120,7 +120,6 @@ bool MatMulV2OpLite::InferShapeImpl() const {
 
 bool MatMulV2OpLite::AttachImpl(const cpp::OpDesc &op_desc,
                                 lite::Scope *scope) {
-  AttachParam(&param_);
   CHECK(!op_desc.Input("X").empty());
   CHECK(!op_desc.Input("Y").empty());
   CHECK(!op_desc.Output("Out").empty());

--- a/lite/operators/matmul_v2_op.h
+++ b/lite/operators/matmul_v2_op.h
@@ -35,6 +35,8 @@ class MatMulV2OpLite : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
 
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override;

--- a/lite/operators/mul_op.h
+++ b/lite/operators/mul_op.h
@@ -35,11 +35,11 @@ class MulOpLite : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
-    AttachParam(&param_);
-
     CHECK(!op_desc.Input("X").empty());
     CHECK(!op_desc.Input("Y").empty());
     CHECK(!op_desc.Output("Out").empty());

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -33,18 +33,7 @@ namespace paddle {
 namespace lite {
 namespace operators {
 
-struct ParamBase {
- public:
-  virtual ~ParamBase() {}
-  virtual const std::vector<const Tensor*>* input_tensor_ptrs() {
-    return nullptr;
-  }
-  virtual std::vector<Tensor*>* output_tensor_ptrs() { return nullptr; }
-
- protected:
-  std::shared_ptr<std::vector<const Tensor*>> input_tensor_ptrs_cache_{nullptr};
-  std::shared_ptr<std::vector<Tensor*>> output_tensor_ptrs_cache_{nullptr};
-};
+struct ParamBase {};
 
 using param_t = Any;
 #define WITH_INT8_CONFIG             \
@@ -86,21 +75,6 @@ struct CalibParam : ParamBase {
   const lite::Tensor* input{};
   lite::Tensor* output{};
   float scale;
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({input}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct SubgraphParam : ParamBase {
@@ -133,21 +107,6 @@ struct FcParam : ParamBase {
       "channel"};  // prelu param, can be "all", "channel" or "element"
   // for int8
   WITH_INT8_CONFIG
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({input}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct SearchSeqFcParam : ParamBase {
@@ -186,21 +145,6 @@ struct MulParam : ParamBase {
   int y_num_col_dims{1};
   // for int8
   WITH_INT8_CONFIG
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x, y}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct MulGradParam : ParamBase {
@@ -292,21 +236,6 @@ struct ScaleParam : ParamBase {
   bool fuse_scaleact{false};
   float scale1{1.f};
   float bias1{0.f};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 // For Scatter OP
@@ -325,21 +254,6 @@ struct SoftmaxParam : ParamBase {
   lite::Tensor* output{};
   int axis{-1};
   bool use_cudnn{true};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 // For Reshape and Reshape2 Op
@@ -352,21 +266,6 @@ struct ReshapeParam : ParamBase {
 
   lite::Tensor* xshape{};
   bool inplace{false};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 
 #ifdef LITE_WITH_METAL
   std::vector<int> excepted_transpose_;
@@ -379,24 +278,6 @@ struct ConcatParam : ParamBase {
   lite::Tensor* output{};
   int axis{0};
   lite::Tensor* axis_tensor{};
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      std::vector<const Tensor*> vec;
-      for (auto in : x) {
-        vec.push_back(in);
-      }
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>(vec));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 /// ----------------------- activation operators ----------------------
@@ -426,22 +307,6 @@ struct ActivationParam : ParamBase {
   float threshold{6.0f};
   // gelu
   bool gelu_approximate{false};
-
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct ActivationGradParam : ParamBase {
@@ -542,21 +407,6 @@ struct ConvParam : ParamBase {
   WITH_INT8_CONFIG
   // for Conv2d+Scale fusion
   std::string scale_activation_type{""};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 // For BatchNorm op
@@ -576,21 +426,6 @@ struct BatchNormParam : ParamBase {
   float epsilon;
   float momentum;
   DataLayoutType data_layout{DATALAYOUT(kNCHW)};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({y}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 // For Pooling op
@@ -615,21 +450,6 @@ struct PoolParam : ParamBase {
   std::string data_format{"AnyLayout"};
   // for int8
   WITH_INT8_CONFIG
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 #ifdef LITE_WITH_XPU
   bool pad_zero{false};
 #endif
@@ -665,21 +485,6 @@ struct SplitParam : ParamBase {
   int axis{-1};
   int num{0};
   std::vector<int> sections;
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct UnbindParam : ParamBase {
@@ -687,21 +492,6 @@ struct UnbindParam : ParamBase {
   std::vector<lite::Tensor*> output{};
 
   int axis{-1};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 // For Transpose op
@@ -713,21 +503,6 @@ struct TransposeParam : ParamBase {
   std::vector<int> axis;
   bool use_mkldnn{false};
   std::string data_format{"AnyLayout"};
-  ///////////////////////////////////////////////////////////////////////////////////
-  //  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct TrilTriuParam : ParamBase {
@@ -755,22 +530,6 @@ struct ElementwiseParam : ParamBase {
   bool bias_after_scale{true};
   float alpha{6.f};
   std::string activation_type{""};
-
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X, Y}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct ElementwiseGradParam : ParamBase {
@@ -1031,23 +790,6 @@ struct BoxCoderParam : ParamBase {
   bool box_normalized{true};
   int axis{0};
   std::vector<float> variance{};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>(
-          {prior_box, prior_box_var, target_box}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(
-          new std::vector<lite::Tensor*>({proposals}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 /// ----------------------- multiclass_nms operators ----------------------
@@ -1106,23 +848,6 @@ struct PriorBoxParam : ParamBase {
   // priortype: prior_min, prior_max, prior_com
   std::vector<std::string> order;
   bool min_max_aspect_ratios_order{false};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(
-          new std::vector<const Tensor*>({input, image}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(
-          new std::vector<lite::Tensor*>({boxes, variances}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct DensityPriorBoxParam : public PriorBoxParam {
@@ -1219,21 +944,6 @@ struct Im2SequenceParam : ParamBase {
 struct SequenceSoftmaxParam : ParamBase {
   const lite::Tensor* X{};
   lite::Tensor* Out{};
-  ///////////////////////////////////////////////////////////////////////////////////
-  //  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct NormParam : ParamBase {
@@ -1504,21 +1214,6 @@ struct SliceParam : ParamBase {
   std::vector<lite::Tensor*> EndsTensorList{};
   const lite::Tensor* StartsTensor{nullptr};
   const lite::Tensor* EndsTensor{nullptr};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct AffineChannelParam : ParamBase {
@@ -1600,21 +1295,6 @@ struct SqueezeParam : ParamBase {
   lite::Tensor* XShape{};
   std::vector<int> axes{};
   bool inplace{false};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct UnsqueezeParam : ParamBase {
@@ -1625,21 +1305,6 @@ struct UnsqueezeParam : ParamBase {
   const lite::Tensor* axes_tensor{};
   std::vector<const lite::Tensor*> axes_tensor_vct{};
   bool inplace{false};
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 /// ----------------------- expand operators ----------------------
@@ -1676,21 +1341,6 @@ struct MatMulParam : ParamBase {
   bool transpose_Y{false};
   float alpha{1.0f};
   WITH_INT8_CONFIG
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({X, Y}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({Out}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct GatherNdParam : ParamBase {
@@ -2270,21 +1920,6 @@ struct DeformableConvParam : ParamBase {
   bool var_length{false};
   // only used in conv_transpose.
   std::vector<int> output_size;
-  ///////////////////////////////////////////////////////////////////////////////////
-  // get a vector of input tensors
-  const std::vector<const Tensor*>* input_tensor_ptrs() override {
-    if (!input_tensor_ptrs_cache_) {
-      input_tensor_ptrs_cache_.reset(new std::vector<const Tensor*>({x}));
-    }
-    return input_tensor_ptrs_cache_.get();
-  }
-  // get a vector of output tensors
-  std::vector<Tensor*>* output_tensor_ptrs() override {
-    if (!output_tensor_ptrs_cache_) {
-      output_tensor_ptrs_cache_.reset(new std::vector<lite::Tensor*>({output}));
-    }
-    return output_tensor_ptrs_cache_.get();
-  }
 };
 
 struct PixelShuffleParam : ParamBase {

--- a/lite/operators/pool_op.h
+++ b/lite/operators/pool_op.h
@@ -39,9 +39,10 @@ class PoolOpLite : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   // TODO(Superjomn) replace framework::OpDesc with a lite one.
   bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
-    AttachParam(&param_);
     auto x = op_desc.Input("X").front();
     auto out = op_desc.Output("Out").front();
 

--- a/lite/operators/print_op.cc
+++ b/lite/operators/print_op.cc
@@ -31,8 +31,6 @@ bool PrintOp::InferShapeImpl() const {
 }
 
 bool PrintOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
-  AttachParam(&param_);
-
   param_.name = op_desc.Input("In").front();
   param_.in = scope->FindTensor(param_.name);
   param_.out = scope->FindMutableTensor(op_desc.Output("Out").front());

--- a/lite/operators/reshape_op.cc
+++ b/lite/operators/reshape_op.cc
@@ -56,7 +56,6 @@ bool ReshapeOp::InferShapeImpl() const {
 }
 
 bool ReshapeOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   param_.x =
       scope->FindVar(opdesc.Input("X").front())->GetMutable<lite::Tensor>();
   CHECK(param_.x);

--- a/lite/operators/reshape_op.h
+++ b/lite/operators/reshape_op.h
@@ -32,6 +32,8 @@ class ReshapeOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
@@ -63,6 +65,8 @@ class Reshape2Op : public ReshapeOp {
   bool CheckShape() const override;
 
   bool InferShapeImpl() const override;
+
+  bool InferShapeWithCache() const override { return true; }
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 

--- a/lite/operators/scale_op.cc
+++ b/lite/operators/scale_op.cc
@@ -30,7 +30,6 @@ bool ScaleOp::InferShapeImpl() const {
 }
 
 bool ScaleOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
-  AttachParam(&param_);
   auto x = op_desc.Input("X").front();
   auto output = op_desc.Output("Out").front();
   param_.x = scope->FindVar(x)->GetMutable<Tensor>();

--- a/lite/operators/scatter_nd_add_op.cc
+++ b/lite/operators/scatter_nd_add_op.cc
@@ -49,7 +49,6 @@ bool ScatterNdAddOp::InferShapeImpl() const {
 
 bool ScatterNdAddOp::AttachImpl(const cpp::OpDesc &op_desc,
                                 lite::Scope *scope) {
-  AttachParam(&param_);
   auto x = op_desc.Input("X").front();
   auto indexs = op_desc.Input("Index").front();
   auto updates = op_desc.Input("Updates").front();

--- a/lite/operators/scatter_op.cc
+++ b/lite/operators/scatter_op.cc
@@ -37,7 +37,6 @@ bool ScatterOp::InferShapeImpl() const {
 }
 
 bool ScatterOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
-  AttachParam(&param_);
   auto x = op_desc.Input("X").front();
   auto indexs = op_desc.Input("Ids").front();
   auto updates = op_desc.Input("Updates").front();

--- a/lite/operators/select_input_op.cc
+++ b/lite/operators/select_input_op.cc
@@ -42,7 +42,6 @@ bool SelectInputOpLite::InferShapeImpl() const {
 
 bool SelectInputOpLite::AttachImpl(const cpp::OpDesc &op_desc,
                                    lite::Scope *scope) {
-  AttachParam(&param_);
   auto inputs = op_desc.Input("X");
   auto mask = op_desc.Input("Mask").front();
   auto out = op_desc.Output("Out").front();

--- a/lite/operators/sequence_softmax_op.cc
+++ b/lite/operators/sequence_softmax_op.cc
@@ -34,7 +34,6 @@ bool SequenceSoftmaxOp::InferShapeImpl() const {
 
 bool SequenceSoftmaxOp::AttachImpl(const cpp::OpDesc &opdesc,
                                    lite::Scope *scope) {
-  AttachParam(&param_);
   param_.X =
       scope->FindVar(opdesc.Input("X").front())->GetMutable<lite::Tensor>();
   param_.Out =

--- a/lite/operators/slice_op.cc
+++ b/lite/operators/slice_op.cc
@@ -88,7 +88,6 @@ bool SliceOp::InferShapeImpl() const {
 }
 
 bool SliceOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   auto input_var = scope->FindVar(opdesc.Input("Input").front());
   auto output_var = scope->FindVar(opdesc.Output("Out").front());
   bool input_is_array = input_var->IsType<std::vector<lite::Tensor>>();

--- a/lite/operators/slice_op.h
+++ b/lite/operators/slice_op.h
@@ -32,6 +32,8 @@ class SliceOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/softmax_op.cc
+++ b/lite/operators/softmax_op.cc
@@ -38,8 +38,6 @@ bool SoftmaxOp::InferShapeImpl() const {
 }
 
 bool SoftmaxOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
-
   param_.x = const_cast<lite::Tensor *>(
       &scope->FindVar(opdesc.Input("X").front())->Get<lite::Tensor>());
   param_.output =

--- a/lite/operators/sparse_conv_op.h
+++ b/lite/operators/sparse_conv_op.h
@@ -39,7 +39,6 @@ class SparseConvOp : public OpLite {
   bool InferShapeImpl() const override;
 
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {
-    AttachParam(&param_);
     auto X = op_desc.Input("Input").front();
     auto NonZeroWeights = op_desc.Input("NonZeroWeights").front();
     auto OcNonZeros = op_desc.Input("OcNonZeros").front();

--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -82,7 +82,6 @@ bool SplitOp::InferShapeImpl() const {
 }
 
 bool SplitOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   param_.axis = opdesc.GetAttr<int>("axis");
   param_.num = opdesc.GetAttr<int>("num");
   param_.sections = opdesc.GetAttr<std::vector<int>>("sections");

--- a/lite/operators/split_op.h
+++ b/lite/operators/split_op.h
@@ -32,6 +32,8 @@ class SplitOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/squeeze_op.cc
+++ b/lite/operators/squeeze_op.cc
@@ -84,7 +84,6 @@ bool SqueezeOp::InferShapeImpl() const {
 }
 
 bool SqueezeOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   param_.X = scope->FindTensor(opdesc.Input("X").front());
   param_.Out = scope->FindMutableTensor(opdesc.Output("Out").front());
 

--- a/lite/operators/squeeze_op.h
+++ b/lite/operators/squeeze_op.h
@@ -32,6 +32,8 @@ class SqueezeOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/tensor_array_to_tensor_op.cc
+++ b/lite/operators/tensor_array_to_tensor_op.cc
@@ -76,7 +76,6 @@ bool TensorArrayToTensorOpLite::InferShapeImpl() const {
 
 bool TensorArrayToTensorOpLite::AttachImpl(const cpp::OpDesc &op_desc,
                                            lite::Scope *scope) {
-  AttachParam(&param_);
   auto out = op_desc.Output("Out").front();
   auto outIndex = op_desc.Output("OutIndex").front();
 

--- a/lite/operators/tile_op.cc
+++ b/lite/operators/tile_op.cc
@@ -111,7 +111,6 @@ bool TileOp::InferShapeImpl() const {
 }
 
 bool TileOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   param_.X = scope->FindMutableTensor(opdesc.Input("X").front());
   if (opdesc.HasInput("RepeatTimes") && !opdesc.Input("RepeatTimes").empty()) {
     param_.RepeatTimes =

--- a/lite/operators/transpose_op.cc
+++ b/lite/operators/transpose_op.cc
@@ -55,7 +55,6 @@ bool TransposeOp::InferShapeImpl() const {
 }
 
 bool TransposeOp::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
-  AttachParam(&param_);
   auto x = op_desc.Input("X").front();
   auto out = op_desc.Output("Out").front();
 

--- a/lite/operators/transpose_op.h
+++ b/lite/operators/transpose_op.h
@@ -33,6 +33,8 @@ class TransposeOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/unbind_op.cc
+++ b/lite/operators/unbind_op.cc
@@ -48,7 +48,6 @@ bool UnbindOp::InferShapeImpl() const {
 }
 
 bool UnbindOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   param_.axis = opdesc.GetAttr<int>("axis");
   auto input = opdesc.Input("X").front();
   auto outs = opdesc.Output("Out");

--- a/lite/operators/unique_with_counts_op.cc
+++ b/lite/operators/unique_with_counts_op.cc
@@ -34,7 +34,6 @@ bool UniqueWithCountsOp::InferShapeImpl() const {
 
 bool UniqueWithCountsOp::AttachImpl(const cpp::OpDesc &opdesc,
                                     lite::Scope *scope) {
-  AttachParam(&param_);
   param_.X = scope->FindTensor(opdesc.Input("X").front());
   param_.Out = scope->FindMutableTensor(opdesc.Output("Out").front());
   param_.Index = scope->FindMutableTensor(opdesc.Output("Index").front());

--- a/lite/operators/unsqueeze_op.cc
+++ b/lite/operators/unsqueeze_op.cc
@@ -89,7 +89,6 @@ bool UnsqueezeOp::InferShapeImpl() const {
 }
 
 bool UnsqueezeOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   param_.X = scope->FindTensor(opdesc.Input("X").front());
   param_.Out = scope->FindMutableTensor(opdesc.Output("Out").front());
 

--- a/lite/operators/unsqueeze_op.h
+++ b/lite/operators/unsqueeze_op.h
@@ -32,6 +32,8 @@ class UnsqueezeOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
+  bool InferShapeWithCache() const override { return true; }
+
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }

--- a/lite/operators/where_index_op.cc
+++ b/lite/operators/where_index_op.cc
@@ -33,7 +33,6 @@ bool WhereIndexdOp::InferShapeImpl() const {
 }
 
 bool WhereIndexdOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   auto input = opdesc.Input("Condition").front();
   auto output = opdesc.Output("Out").front();
   CHECK(scope->FindVar(input));

--- a/lite/operators/where_op.cc
+++ b/lite/operators/where_op.cc
@@ -43,7 +43,6 @@ bool WhereOp::InferShapeImpl() const {
 }
 
 bool WhereOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  AttachParam(&param_);
   auto x = opdesc.Input("X").front();
   auto y = opdesc.Input("Y").front();
   auto condition = opdesc.Input("Condition").front();

--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -9,7 +9,7 @@ readonly CMAKE_COMMON_OPTIONS="-DWITH_GPU=OFF \
                                -DLITE_WITH_ARM=ON \
                                -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=ON"
 
-readonly NUM_PROC=${LITE_BUILD_THREADS:-32}
+readonly NUM_PROC=${LITE_BUILD_THREADS:-8}
 
 # global variables
 CMAKE_EXTRA_OPTIONS=""


### PR DESCRIPTION
本PR对InferShapeWithCache()部分进行了一些重构：
InferShapeWithCache()原先有两个限制条件：
1）只对输出shape只依赖输入shape,不依赖输入值的op有效，对于nms这种输出shape和输入tensor的数值有关系的op不能使用InferShapeWithCache;
2）之前在op_param.h中的实现限制了使用InferShapeWithCache()的输入/输出variable必须是tensor，不支持tensorlist，在对InferShapeImpl()进行refactor的时候为了不对库体积造成冲击，也保留了之前的限制条件，另外现有框架operator通过op_info从scope中拿variable时没法直接区分拿到的variable是tensor还是tensorlist；

InferShapeWithCache()只对op执行InferShapeImpl()耗时比较多的操作进行cache缓存；对scale op这种计算InferShapeImpl()非常简单的op没必要执行(param_.output->Resize(param_.x->dims()););

之前支持InferShapeWithCache()的op有23个，分别是
1. scale / softmax / activation / sequence_softmax / calib / prior_box

2. Reshape / concat / conv / batchnorm / pooling /split / transpose / elementwise_ops / boxcoder / Fc / Mul / slice / squeeze / unsqueeze / matmul / matmulv2 / deforable_conv

本PR对第一类简单操作不做cache处理，保留第二类infershape复杂的cache操作；

本PR的影响：
正面影响：优化了库体积80K，简化了OpLite基类的接口，删除了和ParamBase之间关于infershapewithcache带来的耦合；
反面影响：没有把op的输出output的shape和特定的输入x进行绑定(对op的各个输入的shape均进行了缓存)，但这应该也不会浪费多少性能；

Q&A: 是否可以考虑把ParamBase去掉？