### PR TITLE
fix compile for glog and protobuf

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -108,6 +108,8 @@ function prepare_thirdparty {
         tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
+	rm -rf $workspace/third-party/glog/src/extern_glog-build 
+	rm -rf $workspace/third-party/protobuf-host/src/extern_protobuf-build 
     fi
 }
 

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -223,6 +223,8 @@ function prepare_thirdparty {
         tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
+        rm -rf $workspace/third-party/glog/src/extern_glog-build
+        rm -rf $workspace/third-party/protobuf-host/src/extern_protobuf-build
     fi
 }
 ####################################################################################################

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -44,6 +44,8 @@ function prepare_thirdparty {
         tar xzf third-party-ea5576.tar.gz
     else
         git submodule update --init --recursive
+        rm -rf $workspace/third-party/glog/src/extern_glog-build
+        rm -rf $workspace/third-party/protobuf-host/src/extern_protobuf-build
     fi
     cd -
 }


### PR DESCRIPTION
之前如果编译过一次Paddle-Lite，并且编译失败，再编译就需要手动删除glog和protobuf的东西
非常，不合理。