### PR TITLE
[x86] add int8 pass

### DIFF
--- a/lite/api/paddle_use_passes.h
+++ b/lite/api/paddle_use_passes.h
@@ -117,3 +117,4 @@ USE_MIR_PASS(__xpu__concat_conv2d_fuse_pass);
 USE_MIR_PASS(__xpu__bigru_fuse_pass);
 USE_MIR_PASS(__xpu__conv_pixel_shuffle_fuse_pass);
 USE_MIR_PASS(__xpu__dynamic_lstm_fuse_pass);
+USE_MIR_PASS(x86_int8_attribute_pass);

--- a/lite/api/tools/opt_base.cc
+++ b/lite/api/tools/opt_base.cc
@@ -106,6 +106,8 @@ void OptBase::SetValidPlaces(const std::string& valid_places) {
     } else if (target_repr == "x86") {
       valid_places_.emplace_back(Place{TARGET(kX86), PRECISION(kFloat)});
       valid_places_.emplace_back(Place{TARGET(kX86), PRECISION(kInt64)});
+      valid_places_.emplace_back(Place{TARGET(kX86), PRECISION(kInt8)});
+      valid_places_.emplace_back(Place{TARGET(kX86), PRECISION(kAny)});
     } else if (target_repr == "x86_opencl") {
       valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault)});

--- a/lite/core/optimizer/mir/x86_int8_attribute_pass.cc
+++ b/lite/core/optimizer/mir/x86_int8_attribute_pass.cc
@@ -1,0 +1,107 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/optimizer/mir/x86_int8_attribute_pass.h"
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+#include "lite/api/paddle_place.h"
+#include "lite/core/optimizer/mir/pass_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+void X86Int8AttributePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
+  std::vector<mir::Node*> nodes;
+  for (auto* node : graph->StmtTopologicalOrder()) {
+    if (node->IsStmt()) {
+      const std::string op_type = node->stmt()->op_type();
+      auto iter = std::find(int8_ops_.begin(), int8_ops_.end(), op_type);
+      if (iter != int8_ops_.end()) {
+        nodes.push_back(node);
+      }
+    }
+  }
+
+  for (auto* node : nodes) {
+    const std::string op_type = node->stmt()->op_type();
+    VLOG(4) << "op_type: " << op_type;
+    OpInfo* op_info = node->stmt()->mutable_op_info();
+    auto* scope = node->stmt()->op()->scope();
+    for (auto* in_node : node->inlinks) {
+      CHECK(in_node->IsArg()) << "The input node should be variable.";
+      bool enable_int8 = op_info->HasAttr("enable_int8") ? true : false;
+      if (enable_int8) {
+        auto weight_name = op_info->Input("Filter").front();
+        auto input_name = op_info->Input("Input").front();
+        auto weight_scale = op_info->GetInputScale(weight_name);
+        auto input_scale = op_info->GetInputScale(input_name);
+        if (op_type == "fc") {
+          weight_scale = op_info->GetInputScale("W0_scale");
+          input_scale = op_info->GetInputScale("Input0_scale");
+          weight_name = op_info->Input("W").front();
+        }
+        auto conv_weight_t =
+            scope->FindVar(weight_name)->GetMutable<lite::Tensor>();
+        auto conv_weight_d = conv_weight_t->data<int8_t>();
+        int out_channel = conv_weight_t->dims()[0];
+        int size = conv_weight_t->data_size() / out_channel;
+        CHECK_EQ(weight_scale.size(), out_channel)
+            << "Int8 size of weight_scale must be equal out_channel, "
+            << " actual size of weight_scale is: " << weight_scale.size()
+            << ", out_channel is: " << out_channel;
+
+        if (op_info->HasInput("Bias") && op_info->Input("Bias").size() > 0) {
+          auto bias_name = op_info->Input("Bias").front();
+          auto conv_bias_t =
+              scope->FindVar(bias_name)->GetMutable<lite::Tensor>();
+          auto conv_bias_d = conv_bias_t->mutable_data<float>();
+          compute_new_bias(conv_bias_d,
+                           conv_weight_d,
+                           conv_bias_d,
+                           weight_scale,
+                           input_scale,
+                           out_channel,
+                           size);
+
+        } else {
+          auto* bias_tensor = scope->NewTensor("new_bias");
+          bias_tensor->Resize({out_channel});
+          // data
+          auto bias_d = bias_tensor->mutable_data<float>();
+          bias_tensor->set_persistable(true);
+          compute_new_bias(bias_d,
+                           conv_weight_d,
+                           nullptr,
+                           weight_scale,
+                           input_scale,
+                           out_channel,
+                           size);
+          op_info->SetInput("Bias", {"new_bias"});
+          node->stmt()->ResetOp(*op_info, graph->valid_places());
+        }
+      }
+    }
+  }
+}
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_MIR_PASS(x86_int8_attribute_pass,
+                  paddle::lite::mir::X86Int8AttributePass)
+    .BindTargets({TARGET(kX86)});

--- a/lite/core/optimizer/mir/x86_int8_attribute_pass.h
+++ b/lite/core/optimizer/mir/x86_int8_attribute_pass.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <memory>
+#include <string>
+#include <vector>
+#include "lite/api/paddle_place.h"
+#include "lite/core/op_registry.h"
+#include "lite/core/optimizer/mir/pass.h"
+#include "lite/core/target_wrapper.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+/*
+ * Use x86_int8_attribute_pass method to update bias val in model.
+ * if int8 op has bias, then bias - 128 * weight_scale * in_scale;
+ * else int8 op add bias input, and val is (- 128 * weight * weight_scale *
+ * in_scale).
+ * x86 int8 compute need int8 val and uint8 val to compute
+ * out = (in + 128) * weight * in_ scale * wei_scale + (bias - 128 * weight *
+ * in_ scale * wei_scale)
+ */
+class X86Int8AttributePass : public ProgramPass {
+ public:
+  void Apply(const std::unique_ptr<SSAGraph>& graph) override;
+  // bias_d = conv_bias_d - 128 * weight_scale * input_scale * conv_weight_d
+  inline void compute_new_bias(float* bias_d,
+                               const int8_t* conv_weight_d,
+                               float* conv_bias_d,
+                               std::vector<float> weight_scale,
+                               std::vector<float> input_scale,
+                               int h,
+                               int w) {
+    for (int i = 0; i < h; i++) {
+      auto bias_val = conv_bias_d ? conv_bias_d[i] : 0.f;
+      float sum = 0.f;
+      float scale = weight_scale[i] * input_scale[0] * 128;
+      const int8_t* wei_ptr = conv_weight_d + i * w;
+      for (int j = 0; j < w; j++) {
+        sum += static_cast<float>(wei_ptr[j]) * scale;
+      }
+      bias_d[i] = bias_val - sum;
+    }
+  }
+
+ private:
+  std::vector<std::string> int8_ops_{
+      "conv2d", "depthwise_conv2d", "conv2d_transpose", "fc"};
+};
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/optimizer/optimizer.cc
+++ b/lite/core/optimizer/optimizer.cc
@@ -293,6 +293,7 @@ std::unique_ptr<RuntimeProgram> RunDefaultOptimizer(
   const std::string pqd_pass{"post_quant_dynamic_pass"};
   const std::string pqd_depend_pass{"lite_quant_dequant_fuse_pass"};
   const std::string fp16_pass{"fp16_attribute_pass"};
+  const std::string x86_int8_pass{"x86_int8_attribute_pass"};
 
   for (const std::string& pass : passes) {
     if (pass == msa_pass) {
@@ -314,6 +315,15 @@ std::unique_ptr<RuntimeProgram> RunDefaultOptimizer(
     if (place.target == TARGET(kARM)) {
       if (place.precision == PRECISION(kFP16)) {
         passes_local.push_back(fp16_pass);
+        break;
+      }
+    }
+  }
+
+  for (auto place : valid_places) {
+    if (place.target == TARGET(kX86)) {
+      if (place.precision == PRECISION(kInt8)) {
+        passes_local.push_back(x86_int8_pass);
         break;
       }
     }

--- a/lite/core/optimizer/optimizer.h
+++ b/lite/core/optimizer/optimizer.h
@@ -29,6 +29,7 @@
 #include "lite/core/optimizer/mir/ssa_graph.h"
 #include "lite/core/optimizer/mir/static_kernel_pick_pass.h"
 #include "lite/core/optimizer/mir/type_target_cast_pass.h"
+#include "lite/core/optimizer/mir/x86_int8_attribute_pass.h"
 #include "lite/core/program.h"
 #include "lite/core/types.h"
 #include "lite/model_parser/model_parser.h"


### PR DESCRIPTION
X86  量化的指令集只支持uint8和 int8 相乘的DOT处理，但input和filter 均是int8_t，故需要将input 设置为unit8_t. 计算
即卷积计算修改为如下：
[int8, fp32] : (din+128) * weight * wei_scale * in_scale + (bias - 128 * wei_scale * in_scale) = (din+128) * weight * wei_scale * in_scale + new_bias
[int8, int8] : (din+128) * weight * wei_scale * in_scale / out_scale + (bias - 128 * wei_scale * in_scale) / out_scale = (din+128) * weight * wei_scale * in_scale / out_scale + new_bias / out_scale
在OPT转换模型的时候，需更新bias 数值

