### PR TITLE
[NNAdapter] Support padding_algorithm in Conv2d op converter and device HALs

### DIFF
--- a/lite/backends/nnadapter/nnadapter/core/operation/conv2d.cc
+++ b/lite/backends/nnadapter/nnadapter/core/operation/conv2d.cc
@@ -16,11 +16,60 @@
 #include "core/hal/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
+
+NNADAPTER_EXPORT void UpdateConv2DPadAndDilation(
+    int32_t input_size,
+    int32_t filter_height_or_width,
+    NNAdapterAutoPadCode auto_pad,
+    int32_t* pad_top_or_left,
+    int32_t* pad_bottom_or_right,
+    int32_t stride_height_or_width,
+    int32_t* dilation_height_or_width) {
+  NNADAPTER_CHECK_NE(input_size, NNADAPTER_UNKNOWN);
+  if (auto_pad == NNADAPTER_AUTO_PAD_SAME) {
+    auto output_size =
+        (input_size + stride_height_or_width - 1) / stride_height_or_width;
+    auto pad_size = (output_size - 1) * stride_height_or_width +
+                    filter_height_or_width - input_size;
+    pad_size = pad_size < 0 ? 0 : pad_size;
+    *pad_top_or_left = pad_size / 2;
+    *pad_bottom_or_right = pad_size - *pad_top_or_left;
+    *dilation_height_or_width = 1;
+  } else if (auto_pad == NNADAPTER_AUTO_PAD_VALID) {
+    *pad_top_or_left = 0;
+    *pad_bottom_or_right = 0;
+  }
+}
+
+NNADAPTER_EXPORT int32_t
+CalcConv2DOutputSize(int32_t input_size,
+                     int32_t filter_height_or_width,
+                     NNAdapterAutoPadCode auto_pad,
+                     int32_t pad_top_or_left,
+                     int32_t pad_bottom_or_right,
+                     int32_t stride_height_or_width,
+                     int32_t dilation_height_or_width) {
+  if (input_size == NNADAPTER_UNKNOWN) {
+    return NNADAPTER_UNKNOWN;
+  }
+  UpdateConv2DPadAndDilation(input_size,
+                             filter_height_or_width,
+                             auto_pad,
+                             &pad_top_or_left,
+                             &pad_bottom_or_right,
+                             stride_height_or_width,
+                             &dilation_height_or_width);
+  auto dkernel = dilation_height_or_width * (filter_height_or_width - 1) + 1;
+  return (input_size + (pad_top_or_left + pad_bottom_or_right) - dkernel) /
+             stride_height_or_width +
+         1;
+}
 
 int PrepareConv2D(hal::Operation* operation) {
   CONV2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
@@ -30,22 +79,20 @@ int PrepareConv2D(hal::Operation* operation) {
                                 int32_t* output_dimensions) {
     output_dimensions[0] = input_dimensions[0];
     output_dimensions[1] = output_channel_size;
-    int dkernel = dilation_height * (filter_height - 1) + 1;
-    output_dimensions[2] =
-        input_dimensions[2] == NNADAPTER_UNKNOWN
-            ? NNADAPTER_UNKNOWN
-            : ((input_dimensions[2] + (pad_height_top + pad_height_bottom) -
-                dkernel) /
-                   stride_height +
-               1);
-    dkernel = dilation_width * (filter_width - 1) + 1;
-    output_dimensions[3] =
-        input_dimensions[3] == NNADAPTER_UNKNOWN
-            ? NNADAPTER_UNKNOWN
-            : ((input_dimensions[3] + (pad_width_left + pad_width_right) -
-                dkernel) /
-                   stride_width +
-               1);
+    output_dimensions[2] = CalcConv2DOutputSize(input_dimensions[2],
+                                                filter_height,
+                                                auto_pad,
+                                                pad_height_top,
+                                                pad_height_bottom,
+                                                stride_height,
+                                                dilation_height);
+    output_dimensions[3] = CalcConv2DOutputSize(input_dimensions[3],
+                                                filter_width,
+                                                auto_pad,
+                                                pad_width_left,
+                                                pad_width_right,
+                                                stride_width,
+                                                dilation_width);
   };
   infer_output_shape(input_operand->type.dimensions,
                      output_operand->type.dimensions);

--- a/lite/backends/nnadapter/nnadapter/core/operation/conv2d.h
+++ b/lite/backends/nnadapter/nnadapter/core/operation/conv2d.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include "nnadapter.h"  // NOLINT
+
 namespace nnadapter {
 namespace operation {
 
@@ -42,6 +44,9 @@ namespace operation {
   auto bias_operand = input_operands[2];                                       \
   NNADAPTER_VLOG(5) << "bias: " << OperandToString(bias_operand);              \
   /* Auto pad: not support auto_pad. */                                        \
+  auto auto_pad = static_cast<NNAdapterAutoPadCode>(                           \
+      *reinterpret_cast<int32_t*>(input_operands[3]->buffer));                 \
+  NNADAPTER_VLOG(5) << "auto_pad: " << AutoPadCodeToString(auto_pad);          \
   /* Pads: Pads are transed according to auto_pad, so pads are used. */        \
   uint32_t pads_size =                                                         \
       input_operands[4]->length / static_cast<uint32_t>(sizeof(int32_t));      \
@@ -83,8 +88,27 @@ namespace operation {
   auto output_operand = output_operands[0];                                    \
   NNADAPTER_VLOG(5) << "output: " << OperandToString(output_operand);          \
   /* Check depthwise mode */                                                   \
-  bool is_depthwise_mode = (group != 1 && input_channel_size == group);        \
+  bool is_depthwise_mode = group != 1 && input_channel_size == group &&        \
+                           output_channel_size % input_channel_size == 0;      \
   NNADAPTER_VLOG(5) << "depthwise mode(" << is_depthwise_mode << ").";
+
+// Update the values of pad and dilation according to auto_pad and input_size
+void UpdateConv2DPadAndDilation(int32_t input_size,
+                                int32_t filter_height_or_width,
+                                NNAdapterAutoPadCode auto_pad,
+                                int32_t* pad_top_or_left,
+                                int32_t* pad_bottom_or_right,
+                                int32_t stride_height_or_width,
+                                int32_t* dilation_height_or_width);
+// Calculate the height or width of the output operand of Conv2D according to
+// the pads, dilation, stride and etc.
+int32_t CalcConv2DOutputSize(int32_t input_size,
+                             int32_t filter_height_or_width,
+                             NNAdapterAutoPadCode auto_pad,
+                             int32_t pad_top_or_left,
+                             int32_t pad_bottom_or_right,
+                             int32_t stride_height_or_width,
+                             int32_t dilation_height_or_width);
 
 }  // namespace operation
 }  // namespace nnadapter

--- a/lite/backends/nnadapter/nnadapter/core/operation/pad.h
+++ b/lite/backends/nnadapter/nnadapter/core/operation/pad.h
@@ -17,27 +17,27 @@
 namespace nnadapter {
 namespace operation {
 
-#define PAD_OPERATION_EXTRACT_INPUTS_OUTPUTS                        \
-  auto& input_operands = operation->input_operands;                 \
-  auto& output_operands = operation->output_operands;               \
-  auto input_count = input_operands.size();                         \
-  auto output_count = output_operands.size();                       \
-  NNADAPTER_CHECK_EQ(input_count, 4);                               \
-  NNADAPTER_CHECK_EQ(output_count, 1);                              \
-  /* Input */                                                       \
-  auto input_operand = input_operands[0];                           \
-  NNADAPTER_VLOG(5) << "input: " << OperandToString(input_operand); \
-  /* Pads */                                                        \
-  auto pads_operand = input_operands[1];                            \
-  NNADAPTER_VLOG(5) << "pads: " << OperandToString(pads_operand);   \
-  /* Mode */                                                        \
-  auto mode_operand = input_operands[2];                            \
-  NNADAPTER_VLOG(5) << "mode: " << OperandToString(mode_operand);   \
-  /* Value */                                                       \
-  auto value_operand = input_operands[3];                           \
-  NNADAPTER_VLOG(5) << "value: " << OperandToString(value_operand); \
-  /* Output */                                                      \
-  auto output_operand = output_operands[0];                         \
+#define PAD_OPERATION_EXTRACT_INPUTS_OUTPUTS                          \
+  auto& input_operands = operation->input_operands;                   \
+  auto& output_operands = operation->output_operands;                 \
+  auto input_count = input_operands.size();                           \
+  auto output_count = output_operands.size();                         \
+  NNADAPTER_CHECK_EQ(input_count, 4);                                 \
+  NNADAPTER_CHECK_EQ(output_count, 1);                                \
+  /* Input */                                                         \
+  auto input_operand = input_operands[0];                             \
+  NNADAPTER_VLOG(5) << "input: " << OperandToString(input_operand);   \
+  /* Pads */                                                          \
+  auto pads_operand = input_operands[1];                              \
+  NNADAPTER_VLOG(5) << "pads: " << OperandToString(pads_operand);     \
+  /* Mode */                                                          \
+  auto mode = *reinterpret_cast<int32_t*>(input_operands[2]->buffer); \
+  NNADAPTER_VLOG(5) << "mode: " << mode;                              \
+  /* Value */                                                         \
+  auto value_operand = input_operands[3];                             \
+  NNADAPTER_VLOG(5) << "value: " << OperandToString(value_operand);   \
+  /* Output */                                                        \
+  auto output_operand = output_operands[0];                           \
   NNADAPTER_VLOG(5) << "output: " << OperandToString(output_operand);
 
 }  // namespace operation

--- a/lite/backends/nnadapter/nnadapter/driver/amlogic_npu/CMakeLists.txt
+++ b/lite/backends/nnadapter/nnadapter/driver/amlogic_npu/CMakeLists.txt
@@ -23,7 +23,7 @@ include(dependencies.cmake)
 aux_source_directory(./converter CONVERTERS)
 aux_source_directory(optimizer OPTIMIZERS)
 set(DRIVER_SRCS utility.cc ${OPTIMIZERS} ${CONVERTERS} engine.cc driver.cc)
-set(DRIVER_DEPS ${NNADAPTER_UTILITIES} nnadapter_optimizer_symm2asymm ${${DEVICE_NAME}_deps})
+set(DRIVER_DEPS ${NNADAPTER_CORE} ${NNADAPTER_UTILITIES} nnadapter_optimizer_symm2asymm ${${DEVICE_NAME}_deps})
 
 add_library(${DRIVER_NAME} SHARED ${DRIVER_SRCS})
 target_link_libraries(${DRIVER_NAME} "-Wl,--start-group" ${DRIVER_DEPS} "-Wl,--end-group")

--- a/lite/backends/nnadapter/nnadapter/driver/amlogic_npu/converter/conv2d.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/amlogic_npu/converter/conv2d.cc
@@ -21,6 +21,23 @@ namespace nnadapter {
 namespace amlogic_npu {
 int ConvertConv2D(Converter* converter, hal::Operation* operation) {
   CONV2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
+  // Dynamic shapes are still not supported
+  NNADAPTER_CHECK_EQ(input_operand->type.dynamic_dimension_count, 0);
+  operation::UpdateConv2DPadAndDilation(input_operand->type.dimensions[2],
+                                        filter_height,
+                                        auto_pad,
+                                        &pad_height_top,
+                                        &pad_height_bottom,
+                                        stride_height,
+                                        &dilation_height);
+  operation::UpdateConv2DPadAndDilation(input_operand->type.dimensions[3],
+                                        filter_width,
+                                        auto_pad,
+                                        &pad_width_left,
+                                        &pad_width_right,
+                                        stride_width,
+                                        &dilation_width);
+
   // Convert to amlnpu tensors and operators
   auto input_tensor = converter->GetMappedTensor(input_operand);
   if (!input_tensor) {

--- a/lite/backends/nnadapter/nnadapter/driver/amlogic_npu/converter/softmax.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/amlogic_npu/converter/softmax.cc
@@ -22,6 +22,7 @@ namespace amlogic_npu {
 
 int ConvertSoftmax(Converter* converter, hal::Operation* operation) {
   SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
+
   // Convert to amlnpu tensors and operators
   auto input_tensor = converter->GetMappedTensor(input_operand);
   if (!input_tensor) {

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/CMakeLists.txt
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/CMakeLists.txt
@@ -22,7 +22,7 @@ include(dependencies.cmake)
 aux_source_directory(converter CONVERTERS)
 aux_source_directory(optimizer OPTIMIZERS)
 set(DRIVER_SRCS utility.cc ${OPTIMIZERS} model_client.cc converter.cc ${CONVERTERS} driver.cc)
-set(DRIVER_DEPS ${NNADAPTER_UTILITIES} ${${DEVICE_NAME}_deps})
+set(DRIVER_DEPS ${NNADAPTER_CORE} ${NNADAPTER_UTILITIES} ${${DEVICE_NAME}_deps})
 
 add_library(${DRIVER_NAME} SHARED ${DRIVER_SRCS})
 target_link_libraries(${DRIVER_NAME} "-Wl,--start-group" ${DRIVER_DEPS} "-Wl,--end-group")

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter.cc
@@ -365,10 +365,11 @@ std::shared_ptr<Operator> Program::AddConstantOperator(
   NNADAPTER_CHECK(values)
       << "The values of constant operator should not be nullptr.";
   auto num_values = ProductionOfDimensions(dimensions);
-  auto shape = dimensions.size() > 0 ? ge::Shape(ConvertDimensions(dimensions))
-                                     : ge::Shape();
+  auto shape = dimensions.size() > 0
+                   ? ge::Shape(ConvertToGEDimensions(dimensions))
+                   : ge::Shape();
   auto tensor_desc = std::make_shared<ge::TensorDesc>(
-      shape, ge::FORMAT_NCHW, ConvertPrecision(precision));
+      shape, ge::FORMAT_NCHW, ConvertToGEPrecision(precision));
   // Add anonymous constant operator
   auto name = GetOperatorName(nullptr);
   auto op = std::make_shared<ge::op::Const>();
@@ -422,10 +423,11 @@ std::shared_ptr<Operator> Program::ConvertOperand(
       dimensions.push_back(operand->type.dimensions[i]);
     }
   }
-  auto shape = dimensions.size() > 0 ? ge::Shape(ConvertDimensions(dimensions))
-                                     : ge::Shape();
+  auto shape = dimensions.size() > 0
+                   ? ge::Shape(ConvertToGEDimensions(dimensions))
+                   : ge::Shape();
   auto tensor_desc = std::make_shared<ge::TensorDesc>(
-      shape, ge::FORMAT_NCHW, ConvertPrecision(operand->type.precision));
+      shape, ge::FORMAT_NCHW, ConvertToGEPrecision(operand->type.precision));
   auto name = GetOperatorName(operand);
   if (IsConstantOperand(operand)) {
     auto op = std::make_shared<ge::op::Const>(name);

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter.h
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter.h
@@ -189,7 +189,7 @@ class Program {
   ({                                                                           \
     auto shape = ge::Shape();                                                  \
     auto format = ge::FORMAT_NCHW;                                             \
-    auto dtype = ConvertPrecision(dst->type.precision);                        \
+    auto dtype = ConvertToGEPrecision(dst->type.precision);                    \
     auto tensor_desc = std::make_shared<ge::TensorDesc>(shape, format, dtype); \
     src->update_output_desc_##name(*tensor_desc);                              \
     UpdateOperatorMap(                                                         \
@@ -200,7 +200,7 @@ class Program {
   ({                                                                           \
     auto shape = ge::Shape();                                                  \
     auto format = ge::FORMAT_NCHW;                                             \
-    auto dtype = ConvertPrecision(dst->type.precision);                        \
+    auto dtype = ConvertToGEPrecision(dst->type.precision);                    \
     auto tensor_desc = std::make_shared<ge::TensorDesc>(shape, format, dtype); \
     src->update_dynamic_output_desc_##name(index, *tensor_desc);               \
     UpdateOperatorMap(                                                         \

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter/cast.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter/cast.cc
@@ -34,7 +34,7 @@ int Program::ConvertCast(hal::Operation* operation) {
       *reinterpret_cast<NNAdapterOperandPrecisionCode*>(
           input_operands[1]->buffer);
   NNADAPTER_VLOG(5) << "dtype: " << dtype;
-  ge::DataType otype = ConvertPrecision(dtype);
+  ge::DataType otype = ConvertToGEPrecision(dtype);
   // Output
   auto output_operand = output_operands[0];
   NNADAPTER_VLOG(5) << "output: " << OperandToString(output_operand);

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter/conv2d.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter/conv2d.cc
@@ -22,6 +22,22 @@ namespace huawei_ascend_npu {
 
 int Program::ConvertConv2D(hal::Operation* operation) {
   CONV2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
+  // Dynamic shapes are still not supported
+  NNADAPTER_CHECK_EQ(input_operand->type.dynamic_dimension_count, 0);
+  operation::UpdateConv2DPadAndDilation(input_operand->type.dimensions[2],
+                                        filter_height,
+                                        auto_pad,
+                                        &pad_height_top,
+                                        &pad_height_bottom,
+                                        stride_height,
+                                        &dilation_height);
+  operation::UpdateConv2DPadAndDilation(input_operand->type.dimensions[3],
+                                        filter_width,
+                                        auto_pad,
+                                        &pad_width_left,
+                                        &pad_width_right,
+                                        stride_width,
+                                        &dilation_width);
 
   // Convert to GE operators
   auto input_operator = GetMappedOperator(input_operand);

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter/pad.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter/pad.cc
@@ -22,16 +22,16 @@ namespace huawei_ascend_npu {
 
 int Program::ConvertPad(hal::Operation* operation) {
   PAD_OPERATION_EXTRACT_INPUTS_OUTPUTS
+
   // Convert to GE operators
-  auto mode_code = *reinterpret_cast<int32_t*>(mode_operand->buffer);
-  std::string mode = ConvertPadMode(mode_code);
+  std::string pad_mode = ConvertPadModeCodeToGEPadMode(mode);
   auto value = *reinterpret_cast<float*>(value_operand->buffer);
-  NNADAPTER_CHECK_EQ(mode, "constant")
-      << "Ascend npu only support mode=constant right now, "
+  NNADAPTER_CHECK_EQ(pad_mode, "constant")
+      << "HuaewiAscendNPU only support mode=constant right now, "
          "but received mode is "
-      << mode;
+      << pad_mode;
   NNADAPTER_CHECK_LT(std::abs(value), 1e-6)
-      << "Ascend npu only support constant_values=0 right now, "
+      << "HuaewiAscendNPU only support constant_values=0 right now, "
          "but received constant_value is "
       << value;
   auto input_operator = GetMappedOperator(input_operand);
@@ -45,7 +45,7 @@ int Program::ConvertPad(hal::Operation* operation) {
   auto value_operator = ConvertOperand(value_operand);
   auto pad_name = GetOperatorName(output_operand);
   auto pad_op = std::make_shared<ge::op::PadV3>(pad_name);
-  pad_op->set_attr_mode(mode);
+  pad_op->set_attr_mode(pad_mode);
   SET_INPUT(pad_op, x, input_operator);
   SET_INPUT(pad_op, paddings, pads_operator);
   SET_INPUT(pad_op, constant_values, value_operator);

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter/softmax.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/converter/softmax.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "core/operation/softmax.h"
 #include "driver/huawei_ascend_npu/converter.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
@@ -20,24 +21,7 @@ namespace nnadapter {
 namespace huawei_ascend_npu {
 
 int Program::ConvertSoftmax(hal::Operation* operation) {
-  auto& input_operands = operation->input_operands;
-  auto& output_operands = operation->output_operands;
-  auto input_count = input_operands.size();
-  auto output_count = output_operands.size();
-  NNADAPTER_CHECK_EQ(input_count, 2);
-  NNADAPTER_CHECK_EQ(output_count, 1);
-  // Input
-  auto input_operand = input_operands[0];
-  NNADAPTER_VLOG(5) << "input: " << OperandToString(input_operand);
-  // Axis
-  auto axis = *reinterpret_cast<int32_t*>(input_operands[1]->buffer);
-  if (axis < 0) {
-    axis += input_operand->type.dimension_count;
-  }
-  NNADAPTER_VLOG(5) << "axis=" << axis;
-  // Output
-  auto output_operand = output_operands[0];
-  NNADAPTER_VLOG(5) << "output: " << OperandToString(output_operand);
+  SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Convert to GE operators
   auto input_operator = GetMappedOperator(input_operand);

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/model_client.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/model_client.cc
@@ -117,9 +117,9 @@ bool AclModelClient::GetModelIOTensorDim(
     auto data_type = aclmdlGetInputDataType(model_desc_, i);
     auto format = aclmdlGetInputFormat(model_desc_, i);
     std::string name(aclmdlGetInputNameByIndex(model_desc_, i));
-    ge::TensorDesc ge_tensor_desc(ge::Shape(ConvertACLDimensions(dims)),
-                                  ConvertACLFormat(format),
-                                  ConvertACLDataType(data_type));
+    ge::TensorDesc ge_tensor_desc(ge::Shape(ConvertACLDimsToGEDims(dims)),
+                                  ConvertACLFormatToGEFormat(format),
+                                  ConvertACLDataTypeToGEDataType(data_type));
     ge_tensor_desc.SetName(name.c_str());
     input_tensor_descs->push_back(ge_tensor_desc);
   }
@@ -131,9 +131,9 @@ bool AclModelClient::GetModelIOTensorDim(
     auto data_type = aclmdlGetOutputDataType(model_desc_, i);
     auto format = aclmdlGetOutputFormat(model_desc_, i);
     std::string name(aclmdlGetOutputNameByIndex(model_desc_, i));
-    ge::TensorDesc ge_tensor_desc(ge::Shape(ConvertACLDimensions(dims)),
-                                  ConvertACLFormat(format),
-                                  ConvertACLDataType(data_type));
+    ge::TensorDesc ge_tensor_desc(ge::Shape(ConvertACLDimsToGEDims(dims)),
+                                  ConvertACLFormatToGEFormat(format),
+                                  ConvertACLDataTypeToGEDataType(data_type));
     ge_tensor_desc.SetName(name.c_str());
     output_tensor_descs->push_back(ge_tensor_desc);
   }
@@ -293,7 +293,8 @@ bool AclModelClient::Process(uint32_t input_count,
     aclmdlIODims dimensions;
     ACL_CALL(aclmdlGetCurOutputDims(model_desc_, i, &dimensions));
     NNADAPTER_CHECK_EQ(dimensions.dimCount, type->dimension_count);
-    ConvertACLDimensions(dimensions, type->dimensions, &type->dimension_count);
+    ConvertACLDimsToGEDims(
+        dimensions, type->dimensions, &type->dimension_count);
     auto host_ptr = arg->access(arg->memory, type);
     NNADAPTER_CHECK(host_ptr);
     auto length = GetOperandTypeBufferLength(*type);

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/utility.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/utility.cc
@@ -275,7 +275,7 @@ ge::DataType GetGEDataType<bool>() {
   return ge::DT_BOOL;
 }
 
-ge::DataType ConvertACLDataType(aclDataType input_data_type) {
+ge::DataType ConvertACLDataTypeToGEDataType(aclDataType input_data_type) {
   ge::DataType output_data_type = ge::DT_FLOAT;
   switch (input_data_type) {
     case ACL_FLOAT:
@@ -308,7 +308,7 @@ ge::DataType ConvertACLDataType(aclDataType input_data_type) {
   return output_data_type;
 }
 
-ge::Format ConvertACLFormat(aclFormat input_format) {
+ge::Format ConvertACLFormatToGEFormat(aclFormat input_format) {
   ge::Format output_format = ge::FORMAT_NCHW;
   switch (input_format) {
     case ACL_FORMAT_NCHW:
@@ -329,7 +329,7 @@ ge::Format ConvertACLFormat(aclFormat input_format) {
   return output_format;
 }
 
-std::vector<int64_t> ConvertACLDimensions(
+std::vector<int64_t> ConvertACLDimsToGEDims(
     const aclmdlIODims& input_dimensions) {
   std::vector<int64_t> output_dimensions(input_dimensions.dimCount);
   for (size_t i = 0; i < input_dimensions.dimCount; i++) {
@@ -338,98 +338,82 @@ std::vector<int64_t> ConvertACLDimensions(
   return output_dimensions;
 }
 
-void ConvertACLDimensions(const aclmdlIODims& input_dimensions,
-                          int32_t* output_dimensions,
-                          uint32_t* output_dimensions_count) {
+void ConvertACLDimsToGEDims(const aclmdlIODims& input_dimensions,
+                            int32_t* output_dimensions,
+                            uint32_t* output_dimensions_count) {
   for (size_t i = 0; i < input_dimensions.dimCount; i++) {
     output_dimensions[i] = static_cast<int32_t>(input_dimensions.dims[i]);
   }
 }
 
-ge::DataType ConvertPrecision(NNAdapterOperandPrecisionCode input_precision) {
-  ge::DataType output_precision = ge::DT_FLOAT;
-  switch (input_precision) {
+ge::DataType ConvertToGEPrecision(
+    NNAdapterOperandPrecisionCode precision_code) {
+  switch (precision_code) {
     case NNADAPTER_TENSOR_BOOL8:
     case NNADAPTER_BOOL8:
-      output_precision = ge::DT_BOOL;
-      break;
+      return ge::DT_BOOL;
     case NNADAPTER_TENSOR_INT8:
     case NNADAPTER_INT8:
-      output_precision = ge::DT_INT8;
-      break;
+      return ge::DT_INT8;
     case NNADAPTER_TENSOR_INT16:
     case NNADAPTER_INT16:
-      output_precision = ge::DT_INT16;
-      break;
+      return ge::DT_INT16;
     case NNADAPTER_TENSOR_INT32:
     case NNADAPTER_INT32:
-      output_precision = ge::DT_INT32;
-      break;
+      return ge::DT_INT32;
     case NNADAPTER_TENSOR_INT64:
     case NNADAPTER_INT64:
-      output_precision = ge::DT_INT64;
-      break;
+      return ge::DT_INT64;
     case NNADAPTER_TENSOR_UINT8:
     case NNADAPTER_UINT8:
-      output_precision = ge::DT_UINT8;
-      break;
+      return ge::DT_UINT8;
     case NNADAPTER_TENSOR_QUANT_UINT8_ASYMM_PER_LAYER:
-      output_precision = ge::DT_QUINT8;
-      break;
+      return ge::DT_QUINT8;
     case NNADAPTER_TENSOR_UINT16:
     case NNADAPTER_UINT16:
-      output_precision = ge::DT_UINT16;
-      break;
+      return ge::DT_UINT16;
     case NNADAPTER_TENSOR_UINT32:
     case NNADAPTER_UINT32:
-      output_precision = ge::DT_UINT32;
-      break;
+      return ge::DT_UINT32;
     case NNADAPTER_TENSOR_UINT64:
     case NNADAPTER_UINT64:
-      output_precision = ge::DT_UINT64;
-      break;
+      return ge::DT_UINT64;
     case NNADAPTER_TENSOR_FLOAT16:
     case NNADAPTER_FLOAT16:
-      output_precision = ge::DT_FLOAT16;
-      break;
+      return ge::DT_FLOAT16;
     case NNADAPTER_TENSOR_FLOAT32:
     case NNADAPTER_FLOAT32:
-      output_precision = ge::DT_FLOAT;
-      break;
+      return ge::DT_FLOAT;
     case NNADAPTER_TENSOR_FLOAT64:
     case NNADAPTER_FLOAT64:
-      output_precision = ge::DT_DOUBLE;
-      break;
+      return ge::DT_DOUBLE;
     default:
       NNADAPTER_LOG(FATAL)
           << "Failed to convert the NNAdapter operand precision code("
-          << OperandPrecisionCodeToString(input_precision)
+          << OperandPrecisionCodeToString(precision_code)
           << ") to ge::DataType !";
       break;
   }
-  return output_precision;
+  return ge::DT_FLOAT;
 }
 
-ge::Format ConvertDataLayout(NNAdapterOperandLayoutCode input_layout) {
-  ge::Format output_layout = ge::FORMAT_NCHW;
-  switch (input_layout) {
+ge::Format ConvertToGEDataLayout(NNAdapterOperandLayoutCode layout_code) {
+  switch (layout_code) {
     case NNADAPTER_NCHW:
-      output_layout = ge::FORMAT_NCHW;
-      break;
+      return ge::FORMAT_NCHW;
     case NNADAPTER_NHWC:
-      output_layout = ge::FORMAT_NHWC;
-      break;
+      return ge::FORMAT_NHWC;
     default:
       NNADAPTER_LOG(FATAL)
           << "Failed to convert the NNAdapter operand layout code("
-          << OperandLayoutCodeToString(input_layout) << ") to ge::Format !";
+          << OperandLayoutCodeToString(layout_code) << ") to ge::Format !";
       break;
   }
-  return output_layout;
+  return ge::FORMAT_NCHW;
 }
 
-std::vector<int64_t> ConvertDimensions(const int32_t* input_dimensions,
-                                       uint32_t input_dimensions_count) {
+std::vector<int64_t> ConvertToGEDimensions(const int32_t* input_dimensions,
+                                           uint32_t input_dimensions_count) {
   std::vector<int64_t> output_dimensions;
   for (uint32_t i = 0; i < input_dimensions_count; i++) {
     output_dimensions.push_back(input_dimensions[i]);
@@ -437,33 +421,28 @@ std::vector<int64_t> ConvertDimensions(const int32_t* input_dimensions,
   return output_dimensions;
 }
 
-std::vector<int64_t> ConvertDimensions(
+std::vector<int64_t> ConvertToGEDimensions(
     const std::vector<int32_t>& input_dimensions) {
-  return ConvertDimensions(&input_dimensions[0], input_dimensions.size());
+  return ConvertToGEDimensions(&input_dimensions[0], input_dimensions.size());
 }
 
-std::string ConvertPadMode(int pad_mode_code) {
-  std::string pad_mode;
+std::string ConvertPadModeCodeToGEPadMode(int pad_mode_code) {
   switch (pad_mode_code) {
     case NNADAPTER_PAD_MODE_CONSTANT:
-      pad_mode = "constant";
-      break;
+      return "constant";
     case NNADAPTER_PAD_MODE_REFLECT:
-      pad_mode = "reflect";
-      break;
+      return "reflect";
     case NNADAPTER_PAD_MODE_REPLICATE:
-      pad_mode = "replicate";
-      break;
+      return "replicate";
     case NNADAPTER_PAD_MODE_EDGE:
-      pad_mode = "edge";
-      break;
+      return "edge";
     default:
       NNADAPTER_LOG(FATAL)
           << "Failed to convert the NNAdapter operand pad mode code("
           << pad_mode_code << ") to pad mode !";
       break;
   }
-  return pad_mode;
+  return "constant";
 }
 
 }  // namespace huawei_ascend_npu

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/utility.h
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_ascend_npu/utility.h
@@ -80,22 +80,22 @@ template <>
 ge::DataType GetGEDataType<bool>();
 
 // Convert ACL types to GE types
-ge::DataType ConvertACLDataType(aclDataType input_data_type);
-ge::Format ConvertACLFormat(aclFormat input_format);
-std::vector<int64_t> ConvertACLDimensions(const aclmdlIODims& input_dimensions);
-void ConvertACLDimensions(const aclmdlIODims& input_dimensions,
-                          int32_t* output_dimensions,
-                          uint32_t* output_dimensions_count);
+ge::DataType ConvertACLDataTypeToGEDataType(aclDataType input_data_type);
+ge::Format ConvertACLFormatToGEFormat(aclFormat input_format);
+std::vector<int64_t> ConvertACLDimsToGEDims(
+    const aclmdlIODims& input_dimensions);
+void ConvertACLDimsToGEDims(const aclmdlIODims& input_dimensions,
+                            int32_t* output_dimensions,
+                            uint32_t* output_dimensions_count);
 
 // Convert NNAdapter types to GE types
-ge::DataType ConvertPrecision(NNAdapterOperandPrecisionCode input_precision);
-ge::Format ConvertDataLayout(NNAdapterOperandLayoutCode input_layout);
-std::vector<int64_t> ConvertDimensions(const int32_t* input_dimensions,
-                                       uint32_t input_dimensions_count);
-std::vector<int64_t> ConvertDimensions(
+ge::DataType ConvertToGEPrecision(NNAdapterOperandPrecisionCode precision_code);
+ge::Format ConvertToGEDataLayout(NNAdapterOperandLayoutCode layout_code);
+std::vector<int64_t> ConvertToGEDimensions(const int32_t* input_dimensions,
+                                           uint32_t input_dimensions_count);
+std::vector<int64_t> ConvertToGEDimensions(
     const std::vector<int32_t>& input_dimensions);
-int32_t ConvertFuseCode(int32_t input_fuse_code);
-std::string ConvertPadMode(int pad_mode_code);
+std::string ConvertPadModeCodeToGEPadMode(int pad_mode_code);
 
 }  // namespace huawei_ascend_npu
 }  // namespace nnadapter

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/CMakeLists.txt
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/CMakeLists.txt
@@ -23,7 +23,7 @@ include(dependencies.cmake)
 aux_source_directory(converter CONVERTERS)
 aux_source_directory(optimizer OPTIMIZERS)
 set(DRIVER_SRCS utility.cc ${OPTIMIZERS} converter.cc ${CONVERTERS} driver.cc)
-set(DRIVER_DEPS ${NNADAPTER_UTILITIES} ${${DEVICE_NAME}_deps})
+set(DRIVER_DEPS ${NNADAPTER_CORE} ${NNADAPTER_UTILITIES} ${${DEVICE_NAME}_deps})
 
 add_library(${DRIVER_NAME} SHARED ${DRIVER_SRCS})
 target_link_libraries(${DRIVER_NAME} "-Wl,--start-group" ${DRIVER_DEPS} "-Wl,--end-group")

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/converter.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/converter.cc
@@ -304,10 +304,11 @@ std::shared_ptr<Operator> Program::AddConstantOperator(
   NNADAPTER_CHECK(values)
       << "The values of constant operator should not be nullptr.";
   auto num_values = ProductionOfDimensions(dimensions);
-  auto shape = dimensions.size() > 0 ? ge::Shape(ConvertDimensions(dimensions))
-                                     : ge::Shape();
+  auto shape = dimensions.size() > 0
+                   ? ge::Shape(ConvertToGEDimensions(dimensions))
+                   : ge::Shape();
   auto tensor_desc = std::make_shared<ge::TensorDesc>(
-      shape, ge::FORMAT_NCHW, ConvertPrecision(precision));
+      shape, ge::FORMAT_NCHW, ConvertToGEPrecision(precision));
   // Add anonymous constant operator
   auto name = GetOperatorName(nullptr);
   auto op = std::make_shared<hiai::op::Const>(name);
@@ -355,10 +356,11 @@ std::shared_ptr<Operator> Program::ConvertOperand(
       dimensions.push_back(operand->type.dimensions[i]);
     }
   }
-  auto shape = dimensions.size() > 0 ? ge::Shape(ConvertDimensions(dimensions))
-                                     : ge::Shape();
+  auto shape = dimensions.size() > 0
+                   ? ge::Shape(ConvertToGEDimensions(dimensions))
+                   : ge::Shape();
   auto tensor_desc = std::make_shared<ge::TensorDesc>(
-      shape, ge::FORMAT_NCHW, ConvertPrecision(operand->type.precision));
+      shape, ge::FORMAT_NCHW, ConvertToGEPrecision(operand->type.precision));
   auto name = GetOperatorName(operand);
   if (IsConstantOperand(operand)) {
     auto op = std::make_shared<hiai::op::Const>(name);

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/converter.h
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/converter.h
@@ -171,7 +171,7 @@ class Program {
   ({                                                                           \
     auto shape = ge::Shape();                                                  \
     auto format = ge::FORMAT_NCHW;                                             \
-    auto dtype = ConvertPrecision(dst->type.precision);                        \
+    auto dtype = ConvertToGEPrecision(dst->type.precision);                    \
     auto tensor_desc = std::make_shared<ge::TensorDesc>(shape, format, dtype); \
     UpdateOperatorMap(                                                         \
         dst, std::make_shared<Operator>(src, tensor_desc, #name, -1));         \
@@ -181,7 +181,7 @@ class Program {
   ({                                                                           \
     auto shape = ge::Shape();                                                  \
     auto format = ge::FORMAT_NCHW;                                             \
-    auto dtype = ConvertPrecision(dst->type.precision);                        \
+    auto dtype = ConvertToGEPrecision(dst->type.precision);                    \
     auto tensor_desc = std::make_shared<ge::TensorDesc>(shape, format, dtype); \
     UpdateOperatorMap(                                                         \
         dst, std::make_shared<Operator>(src, tensor_desc, #name, index));      \

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/converter/elementwise.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/converter/elementwise.cc
@@ -72,7 +72,7 @@ int Program::ConvertElementwise(hal::Operation* operation) {
   if (fuse_code != NNADAPTER_FUSED_NONE) {
     auto act_name = GetOperatorName(output_operand);
     auto act_op = std::make_shared<hiai::op::Activation>(act_name);
-    act_op->set_attr_mode(ConvertFuseCode(fuse_code));
+    act_op->set_attr_mode(ConvertFuseCodeToGEActMode(fuse_code));
     SET_INPUT(act_op, x, eltwise_operator);
     MAP_OUTPUT(act_op, y, output_operand);
   }

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/converter/softmax.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/converter/softmax.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "core/operation/softmax.h"
 #include "driver/huawei_kirin_npu/converter.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
@@ -20,24 +21,7 @@ namespace nnadapter {
 namespace huawei_kirin_npu {
 
 int Program::ConvertSoftmax(hal::Operation* operation) {
-  auto& input_operands = operation->input_operands;
-  auto& output_operands = operation->output_operands;
-  auto input_count = input_operands.size();
-  auto output_count = output_operands.size();
-  NNADAPTER_CHECK_EQ(input_count, 2);
-  NNADAPTER_CHECK_EQ(output_count, 1);
-  // Input
-  auto input_operand = input_operands[0];
-  NNADAPTER_VLOG(5) << "input: " << OperandToString(input_operand);
-  // Axis
-  auto axis = *reinterpret_cast<int32_t*>(input_operands[1]->buffer);
-  if (axis < 0) {
-    axis += input_operand->type.dimension_count;
-  }
-  NNADAPTER_VLOG(5) << "axis=" << axis;
-  // Output
-  auto output_operand = output_operands[0];
-  NNADAPTER_VLOG(5) << "output: " << OperandToString(output_operand);
+  SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Convert to GE operators
   auto input_operator = GetMappedOperator(input_operand);

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/utility.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/utility.cc
@@ -261,78 +261,62 @@ ge::DataType GetGEDataType<bool>() {
   return ge::DT_BOOL;
 }
 
-ge::DataType ConvertPrecision(NNAdapterOperandPrecisionCode input_precision) {
-  ge::DataType output_precision = ge::DT_FLOAT;
-  switch (input_precision) {
+ge::DataType ConvertToGEPrecision(
+    NNAdapterOperandPrecisionCode precision_code) {
+  switch (precision_code) {
     case NNADAPTER_TENSOR_BOOL8:
-      output_precision = ge::DT_BOOL;
-      break;
+      return ge::DT_BOOL;
     case NNADAPTER_TENSOR_INT8:
-      output_precision = ge::DT_INT8;
-      break;
+      return ge::DT_INT8;
     case NNADAPTER_TENSOR_INT16:
-      output_precision = ge::DT_INT16;
-      break;
+      return ge::DT_INT16;
     case NNADAPTER_TENSOR_INT32:
-      output_precision = ge::DT_INT32;
-      break;
+      return ge::DT_INT32;
     case NNADAPTER_TENSOR_INT64:
-      output_precision = ge::DT_INT64;
-      break;
+      return ge::DT_INT64;
     case NNADAPTER_TENSOR_UINT8:
-      output_precision = ge::DT_UINT8;
-      break;
+      return ge::DT_UINT8;
     case NNADAPTER_TENSOR_QUANT_UINT8_ASYMM_PER_LAYER:
-      output_precision = ge::DT_QUINT8;
-      break;
+      return ge::DT_QUINT8;
     case NNADAPTER_TENSOR_UINT16:
-      output_precision = ge::DT_UINT16;
-      break;
+      return ge::DT_UINT16;
     case NNADAPTER_TENSOR_UINT32:
-      output_precision = ge::DT_UINT32;
-      break;
+      return ge::DT_UINT32;
     case NNADAPTER_TENSOR_UINT64:
-      output_precision = ge::DT_UINT64;
-      break;
+      return ge::DT_UINT64;
     case NNADAPTER_TENSOR_FLOAT16:
-      output_precision = ge::DT_FLOAT16;
-      break;
+      return ge::DT_FLOAT16;
     case NNADAPTER_TENSOR_FLOAT32:
-      output_precision = ge::DT_FLOAT;
-      break;
+      return ge::DT_FLOAT;
     case NNADAPTER_TENSOR_FLOAT64:
-      output_precision = ge::DT_DOUBLE;
-      break;
+      return ge::DT_DOUBLE;
     default:
       NNADAPTER_LOG(FATAL)
           << "Failed to convert the NNAdapter operand precision code("
-          << OperandPrecisionCodeToString(input_precision)
-          << ") to ge::DataType !";
+          << OperandPrecisionCodeToString(precision_code)
+          << ") to ge::DataType!";
       break;
   }
-  return output_precision;
+  return ge::DT_FLOAT;
 }
 
-ge::Format ConvertDataLayout(NNAdapterOperandLayoutCode input_layout) {
-  ge::Format output_layout = ge::FORMAT_NCHW;
-  switch (input_layout) {
+ge::Format ConvertToGEDataLayout(NNAdapterOperandLayoutCode layout_code) {
+  switch (layout_code) {
     case NNADAPTER_NCHW:
-      output_layout = ge::FORMAT_NCHW;
-      break;
+      return ge::FORMAT_NCHW;
     case NNADAPTER_NHWC:
-      output_layout = ge::FORMAT_NHWC;
-      break;
+      return ge::FORMAT_NHWC;
     default:
       NNADAPTER_LOG(FATAL)
           << "Failed to convert the NNAdapter operand layout code("
-          << OperandLayoutCodeToString(input_layout) << ") to ge::Format !";
+          << OperandLayoutCodeToString(layout_code) << ") to ge::Format!";
       break;
   }
-  return output_layout;
+  return ge::FORMAT_NCHW;
 }
 
-std::vector<int64_t> ConvertDimensions(const int32_t* input_dimensions,
-                                       uint32_t input_dimensions_count) {
+std::vector<int64_t> ConvertToGEDimensions(const int32_t* input_dimensions,
+                                           uint32_t input_dimensions_count) {
   std::vector<int64_t> output_dimensions;
   for (uint32_t i = 0; i < input_dimensions_count; i++) {
     output_dimensions.push_back(input_dimensions[i]);
@@ -340,30 +324,43 @@ std::vector<int64_t> ConvertDimensions(const int32_t* input_dimensions,
   return output_dimensions;
 }
 
-std::vector<int64_t> ConvertDimensions(
+std::vector<int64_t> ConvertToGEDimensions(
     const std::vector<int32_t>& input_dimensions) {
-  return ConvertDimensions(&input_dimensions[0], input_dimensions.size());
+  return ConvertToGEDimensions(&input_dimensions[0], input_dimensions.size());
 }
 
-int32_t ConvertFuseCode(int32_t input_fuse_code) {
-  int output_act_mode;
-  switch (input_fuse_code) {
+int32_t ConvertFuseCodeToGEActMode(int32_t fuse_code) {
+  switch (fuse_code) {
     case NNADAPTER_FUSED_RELU:
-      output_act_mode = 1;
-      break;
+      return 1;
     case NNADAPTER_FUSED_RELU1:
-      output_act_mode = 7;
-      break;
+      return 7;
     case NNADAPTER_FUSED_RELU6:
-      output_act_mode = 14;
-      break;
+      return 14;
     default:
       NNADAPTER_LOG(FATAL) << "Failed to convert the NNAdapter fuse code("
-                           << input_fuse_code
+                           << FuseCodeToString(fuse_code)
                            << ") to a GE activation operator!";
       break;
   }
-  return output_act_mode;
+  return 0;
+}
+
+std::string ConvertAutoPadCodeToGEPadMode(NNAdapterAutoPadCode auto_pad_code) {
+  switch (auto_pad_code) {
+    case NNADAPTER_PAD_NONE:
+      return "SPECIFIC";
+    case NNADAPTER_PAD_SAME:
+      return "SAME";
+    case NNADAPTER_PAD_VALID:
+      return "VALID";
+    default:
+      NNADAPTER_LOG(FATAL) << "Failed to convert the NNAdapter pad code("
+                           << PadCodeToString(auto_pad_code)
+                           << ") to GE pad mode!";
+      break;
+  }
+  return "SPECIFIC";
 }
 
 }  // namespace huawei_kirin_npu

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/utility.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/utility.cc
@@ -339,8 +339,7 @@ int32_t ConvertFuseCodeToGEActMode(int32_t fuse_code) {
       return 14;
     default:
       NNADAPTER_LOG(FATAL) << "Failed to convert the NNAdapter fuse code("
-                           << FuseCodeToString(fuse_code)
-                           << ") to a GE activation operator!";
+                           << fuse_code << ") to a GE activation operator!";
       break;
   }
   return 0;
@@ -348,15 +347,15 @@ int32_t ConvertFuseCodeToGEActMode(int32_t fuse_code) {
 
 std::string ConvertAutoPadCodeToGEPadMode(NNAdapterAutoPadCode auto_pad_code) {
   switch (auto_pad_code) {
-    case NNADAPTER_PAD_NONE:
+    case NNADAPTER_AUTO_PAD_NONE:
       return "SPECIFIC";
-    case NNADAPTER_PAD_SAME:
+    case NNADAPTER_AUTO_PAD_SAME:
       return "SAME";
-    case NNADAPTER_PAD_VALID:
+    case NNADAPTER_AUTO_PAD_VALID:
       return "VALID";
     default:
-      NNADAPTER_LOG(FATAL) << "Failed to convert the NNAdapter pad code("
-                           << PadCodeToString(auto_pad_code)
+      NNADAPTER_LOG(FATAL) << "Failed to convert the NNAdapter auto_pad code("
+                           << AutoPadCodeToString(auto_pad_code)
                            << ") to GE pad mode!";
       break;
   }

--- a/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/utility.h
+++ b/lite/backends/nnadapter/nnadapter/driver/huawei_kirin_npu/utility.h
@@ -65,13 +65,14 @@ template <>
 ge::DataType GetGEDataType<bool>();
 
 // Convert NNAdapter types to GE types
-ge::DataType ConvertPrecision(NNAdapterOperandPrecisionCode input_precision);
-ge::Format ConvertDataLayout(NNAdapterOperandLayoutCode input_layout);
-std::vector<int64_t> ConvertDimensions(const int32_t* input_dimensions,
-                                       uint32_t input_dimensions_count);
-std::vector<int64_t> ConvertDimensions(
+ge::DataType ConvertToGEPrecision(NNAdapterOperandPrecisionCode precision_code);
+ge::Format ConvertToGEDataLayout(NNAdapterOperandLayoutCode layout_code);
+std::vector<int64_t> ConvertToGEDimensions(const int32_t* input_dimensions,
+                                           uint32_t input_dimensions_count);
+std::vector<int64_t> ConvertToGEDimensions(
     const std::vector<int32_t>& input_dimensions);
-int32_t ConvertFuseCode(int32_t input_fuse_code);
+int32_t ConvertFuseCodeToGEActMode(int32_t fuse_code);
+std::string ConvertAutoPadCodeToGEPadMode(NNAdapterAutoPadCode auto_pad_code);
 
 }  // namespace huawei_kirin_npu
 }  // namespace nnadapter

--- a/lite/backends/nnadapter/nnadapter/driver/imagination_nna/CMakeLists.txt
+++ b/lite/backends/nnadapter/nnadapter/driver/imagination_nna/CMakeLists.txt
@@ -22,7 +22,7 @@ include(dependencies.cmake)
 
 aux_source_directory(converter CONVERTERS)
 set(DRIVER_SRCS imgdnn_manager.cc utility.cc ${CONVERTERS} converter.cc driver.cc)
-set(DRIVER_DEPS ${NNADAPTER_UTILITIES} nnadapter_optimizer_symm2asymm ${${DEVICE_NAME}_deps})
+set(DRIVER_DEPS ${NNADAPTER_CORE} ${NNADAPTER_UTILITIES} nnadapter_optimizer_symm2asymm ${${DEVICE_NAME}_deps})
 
 add_library(${DRIVER_NAME} SHARED ${DRIVER_SRCS})
 target_link_libraries(${DRIVER_NAME} "-Wl,--start-group" ${DRIVER_DEPS} "-Wl,--end-group")

--- a/lite/backends/nnadapter/nnadapter/driver/imagination_nna/converter.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/imagination_nna/converter.cc
@@ -275,7 +275,8 @@ imgdnn_tensor Program::AddTensor(int32_t* dimensions,
   desc.type = type;
   NNADAPTER_CHECK(dimensions);
   NNADAPTER_CHECK_GT(dimension_count, 0);
-  ConvertDimensions(dimensions, dimension_count, desc.size, &desc.dimensions);
+  ConvertToImgdnnDimensions(
+      dimensions, dimension_count, desc.size, &desc.dimensions);
   if (quant_scales && quant_scale_count > 0) {
     // Quantization types
     if (quant_scale_count > 1) {
@@ -354,7 +355,7 @@ imgdnn_tensor Program::AddTensor(const NNAdapterOperandType* type,
   }
   return AddTensor(dimensions.data(),
                    dimensions.size(),
-                   ConvertPrecision(type->precision),
+                   ConvertToImgdnnPrecision(type->precision),
                    quant_scales,
                    zero_point,
                    quant_scale_count,

--- a/lite/backends/nnadapter/nnadapter/driver/imagination_nna/converter/conv2d.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/imagination_nna/converter/conv2d.cc
@@ -23,6 +23,22 @@ namespace imagination_nna {
 
 int Program::ConvertConv2D(hal::Operation* operation) {
   CONV2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
+  // Dynamic shapes are still not supported
+  NNADAPTER_CHECK_EQ(input_operand->type.dynamic_dimension_count, 0);
+  operation::UpdateConv2DPadAndDilation(input_operand->type.dimensions[2],
+                                        filter_height,
+                                        auto_pad,
+                                        &pad_height_top,
+                                        &pad_height_bottom,
+                                        stride_height,
+                                        &dilation_height);
+  operation::UpdateConv2DPadAndDilation(input_operand->type.dimensions[3],
+                                        filter_width,
+                                        auto_pad,
+                                        &pad_width_left,
+                                        &pad_width_right,
+                                        stride_width,
+                                        &dilation_width);
 
   // Convert to imgdnn tensors and operators
   auto input_tensor = GetMappedTensor(input_operand);

--- a/lite/backends/nnadapter/nnadapter/driver/imagination_nna/converter/softmax.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/imagination_nna/converter/softmax.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "core/operation/softmax.h"
 #include "driver/imagination_nna/converter.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
@@ -21,24 +22,7 @@ namespace nnadapter {
 namespace imagination_nna {
 
 int Program::ConvertSoftmax(hal::Operation* operation) {
-  auto& input_operands = operation->input_operands;
-  auto& output_operands = operation->output_operands;
-  auto input_count = input_operands.size();
-  auto output_count = output_operands.size();
-  NNADAPTER_CHECK_EQ(input_count, 2);
-  NNADAPTER_CHECK_EQ(output_count, 1);
-  // Input
-  auto input_operand = input_operands[0];
-  NNADAPTER_VLOG(5) << "input: " << OperandToString(input_operand);
-  // Axis
-  auto axis = *reinterpret_cast<int32_t*>(input_operands[1]->buffer);
-  if (axis < 0) {
-    axis += input_operand->type.dimension_count;
-  }
-  NNADAPTER_VLOG(5) << "axis=" << axis;
-  // Output
-  auto output_operand = output_operands[0];
-  NNADAPTER_VLOG(5) << "output: " << OperandToString(output_operand);
+  SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Convert to imgdnn tensors and operators
   auto input_tensor = GetMappedTensor(input_operand);

--- a/lite/backends/nnadapter/nnadapter/driver/imagination_nna/utility.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/imagination_nna/utility.cc
@@ -19,79 +19,65 @@
 namespace nnadapter {
 namespace imagination_nna {
 
-imgdnn_type ConvertPrecision(NNAdapterOperandPrecisionCode input_precision) {
-  imgdnn_type output_precision;
-  switch (input_precision) {
+imgdnn_type ConvertToImgdnnPrecision(
+    NNAdapterOperandPrecisionCode precision_code) {
+  switch (precision_code) {
     case NNADAPTER_TENSOR_INT8:
-      output_precision = IMGDNN_TYPE_I8;
-      break;
+      return IMGDNN_TYPE_I8;
     case NNADAPTER_TENSOR_QUANT_INT8_SYMM_PER_LAYER:
-      output_precision = IMGDNN_TYPE_Q_I8;
-      break;
+      return IMGDNN_TYPE_Q_I8;
     case NNADAPTER_TENSOR_QUANT_INT8_SYMM_PER_CHANNEL:
-      output_precision = IMGDNN_TYPE_QPA_I8;
-      break;
+      return IMGDNN_TYPE_QPA_I8;
     case NNADAPTER_TENSOR_INT16:
-      output_precision = IMGDNN_TYPE_I16;
-      break;
+      return IMGDNN_TYPE_I16;
     case NNADAPTER_TENSOR_INT32:
     case NNADAPTER_TENSOR_QUANT_INT32_SYMM_PER_LAYER:
     case NNADAPTER_TENSOR_QUANT_INT32_SYMM_PER_CHANNEL:
-      output_precision = IMGDNN_TYPE_I32;
-      break;
+      return IMGDNN_TYPE_I32;
     case NNADAPTER_TENSOR_UINT8:
-      output_precision = IMGDNN_TYPE_U8;
-      break;
+      return IMGDNN_TYPE_U8;
     case NNADAPTER_TENSOR_QUANT_UINT8_ASYMM_PER_LAYER:
-      output_precision = IMGDNN_TYPE_Q_U8;
-      break;
+      return IMGDNN_TYPE_Q_U8;
     case NNADAPTER_TENSOR_UINT16:
-      output_precision = IMGDNN_TYPE_U16;
-      break;
+      return IMGDNN_TYPE_U16;
     case NNADAPTER_TENSOR_UINT32:
     case NNADAPTER_TENSOR_QUANT_UINT32_ASYMM_PER_LAYER:
-      output_precision = IMGDNN_TYPE_U32;
-      break;
+      return IMGDNN_TYPE_U32;
     case NNADAPTER_TENSOR_FLOAT16:
-      output_precision = IMGDNN_TYPE_F16;
-      break;
+      return IMGDNN_TYPE_F16;
     case NNADAPTER_TENSOR_FLOAT32:
-      output_precision = IMGDNN_TYPE_F32;
-      break;
+      return IMGDNN_TYPE_F32;
     default:
       NNADAPTER_LOG(FATAL)
           << "Failed to convert the NNAdapter operand precision code("
-          << OperandPrecisionCodeToString(input_precision)
+          << OperandPrecisionCodeToString(precision_code)
           << ") to imgdnn_type !";
       break;
   }
-  return output_precision;
+  return IMGDNN_TYPE_F32;
 }
 
-imgdnn_dimensions_order ConvertDataLayout(
-    NNAdapterOperandLayoutCode input_layout) {
-  imgdnn_dimensions_order output_layout = IMGDNN_UNKNOWN;
-  switch (input_layout) {
+imgdnn_dimensions_order ConvertToImgdnnDataLayout(
+    NNAdapterOperandLayoutCode layout_code) {
+  switch (layout_code) {
     case NNADAPTER_NCHW:
-      output_layout = IMGDNN_NCHW;
-      break;
+      return IMGDNN_NCHW;
     case NNADAPTER_NHWC:
-      output_layout = IMGDNN_NHWC;
-      break;
+      return IMGDNN_NHWC;
     default:
       NNADAPTER_LOG(FATAL)
           << "Failed to convert the NNAdapter operand layout code("
-          << OperandLayoutCodeToString(input_layout)
+          << OperandLayoutCodeToString(layout_code)
           << ") to imgdnn_dimensions_order !";
       break;
   }
-  return output_layout;
+  return IMGDNN_UNKNOWN;
 }
 
-void ConvertDimensions(int32_t* input_dimensions,
-                       uint32_t input_dimensions_count,
-                       size_t* output_dimensions,
-                       unsigned int* output_dimensions_count) {
+void ConvertToImgdnnDimensions(int32_t* input_dimensions,
+                               uint32_t input_dimensions_count,
+                               size_t* output_dimensions,
+                               unsigned int* output_dimensions_count) {
   NNADAPTER_CHECK_LE(input_dimensions_count, IMGDNN_DESCRIPTOR_MAX_DIM);
   *output_dimensions_count = input_dimensions_count;
   for (uint32_t i = 0; i < input_dimensions_count; i++) {

--- a/lite/backends/nnadapter/nnadapter/driver/imagination_nna/utility.h
+++ b/lite/backends/nnadapter/nnadapter/driver/imagination_nna/utility.h
@@ -22,13 +22,14 @@ namespace nnadapter {
 namespace imagination_nna {
 
 // Convert NNAdapter types to imgdnn types
-imgdnn_type ConvertPrecision(NNAdapterOperandPrecisionCode input_precision);
-imgdnn_dimensions_order ConvertDataLayout(
-    NNAdapterOperandLayoutCode input_layout);
-void ConvertDimensions(int32_t* input_dimensions,
-                       uint32_t input_dimensions_count,
-                       size_t* output_dimensions,
-                       unsigned int* output_dimensions_count);
+imgdnn_type ConvertToImgdnnPrecision(
+    NNAdapterOperandPrecisionCode precision_code);
+imgdnn_dimensions_order ConvertToImgdnnDataLayout(
+    NNAdapterOperandLayoutCode layout_code);
+void ConvertToImgdnnDimensions(int32_t* input_dimensions,
+                               uint32_t input_dimensions_count,
+                               size_t* output_dimensions,
+                               unsigned int* output_dimensions_count);
 
 }  // namespace imagination_nna
 }  // namespace nnadapter

--- a/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/CMakeLists.txt
+++ b/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/CMakeLists.txt
@@ -23,7 +23,7 @@ include(dependencies.cmake)
 aux_source_directory(converter CONVERTERS)
 aux_source_directory(optimizer OPTIMIZERS)
 set(DRIVER_SRCS neuron_adapter_wrapper.cc utility.cc ${OPTIMIZERS} ${CONVERTERS} converter.cc driver.cc)
-set(DRIVER_DEPS ${NNADAPTER_UTILITIES} nnadapter_optimizer_symm2asymm nnadapter_optimizer_nchw2nhwc ${${DEVICE_NAME}_deps})
+set(DRIVER_DEPS ${NNADAPTER_CORE} ${NNADAPTER_UTILITIES} nnadapter_optimizer_symm2asymm nnadapter_optimizer_nchw2nhwc ${${DEVICE_NAME}_deps})
 
 add_library(${DRIVER_NAME} SHARED ${DRIVER_SRCS})
 target_link_libraries(${DRIVER_NAME} "-Wl,--start-group" ${DRIVER_DEPS} "-Wl,--end-group")

--- a/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter.cc
@@ -371,7 +371,8 @@ uint32_t Program::AddOperand(int32_t* dimensions,
   type.type = precision;
   std::vector<uint32_t> converted_dimensions;
   if (dimensions && dimension_count > 0) {
-    converted_dimensions = ConvertDimensions(dimensions, dimension_count);
+    converted_dimensions =
+        ConvertToNeuronDimensions(dimensions, dimension_count);
     type.dimensions = &converted_dimensions[0];
   }
   type.dimensionCount = converted_dimensions.size();

--- a/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter/elementwise.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter/elementwise.cc
@@ -48,7 +48,8 @@ int Program::ConvertElementwise(hal::Operation* operation) {
   if (input1_index == INVALID_INDEX) {
     input1_index = ConvertOperand(input1_operand);
   }
-  auto fuse_code_index = AddInt32ConstantOperand(ConvertFuseCode(fuse_code));
+  auto fuse_code_index =
+      AddInt32ConstantOperand(ConvertFuseCodeToNeuronFuseCode(fuse_code));
   auto output_index = ConvertOperand(output_operand);
   NeuronOperationType op_type;
   if (operation->type == NNADAPTER_ADD) {

--- a/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter/fully_connected.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter/fully_connected.cc
@@ -58,7 +58,8 @@ int Program::ConvertFullyConnected(hal::Operation* operation) {
   }
   auto weight_index = ConvertOperand(weight_operand);
   auto bias_index = ConvertOperand(bias_operand);
-  auto fuse_code_index = AddInt32ConstantOperand(ConvertFuseCode(fuse_code));
+  auto fuse_code_index =
+      AddInt32ConstantOperand(ConvertFuseCodeToNeuronFuseCode(fuse_code));
   auto output_index = ConvertOperand(output_operand);
   std::vector<uint32_t> input_indexes = {
       input_index, weight_index, bias_index, fuse_code_index};

--- a/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter/pool2d.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter/pool2d.cc
@@ -36,7 +36,8 @@ int Program::ConvertPool2D(hal::Operation* operation) {
   auto stride_height_index = AddInt32ConstantOperand(stride_height);
   auto filter_width_index = AddInt32ConstantOperand(kernel_width);
   auto filter_height_index = AddInt32ConstantOperand(kernel_height);
-  auto fuse_code_index = AddInt32ConstantOperand(ConvertFuseCode(fuse_code));
+  auto fuse_code_index =
+      AddInt32ConstantOperand(ConvertFuseCodeToNeuronFuseCode(fuse_code));
   auto output_index = ConvertOperand(output_operand);
   std::vector<uint32_t> input_indexes = {input_index,
                                          padding_width_left_index,

--- a/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter/softmax.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/converter/softmax.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "core/operation/softmax.h"
 #include "driver/mediatek_apu/converter.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
@@ -20,24 +21,7 @@ namespace nnadapter {
 namespace mediatek_apu {
 
 int Program::ConvertSoftmax(hal::Operation* operation) {
-  auto& input_operands = operation->input_operands;
-  auto& output_operands = operation->output_operands;
-  auto input_count = input_operands.size();
-  auto output_count = output_operands.size();
-  NNADAPTER_CHECK_EQ(input_count, 2);
-  NNADAPTER_CHECK_EQ(output_count, 1);
-  // Input
-  auto input_operand = input_operands[0];
-  NNADAPTER_VLOG(5) << "input: " << OperandToString(input_operand);
-  // Axis
-  auto axis = *reinterpret_cast<int32_t*>(input_operands[1]->buffer);
-  if (axis < 0) {
-    axis += input_operand->type.dimension_count;
-  }
-  NNADAPTER_VLOG(5) << "axis=" << axis;
-  // Output
-  auto output_operand = output_operands[0];
-  NNADAPTER_VLOG(5) << "output: " << OperandToString(output_operand);
+  SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Convert to Neuron operands and operations
   auto input_index = GetMappedIndex(input_operand);

--- a/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/utility.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/utility.cc
@@ -46,63 +46,50 @@ int NeuronOperandDataTypeLength(int data_type) {
   return 0;
 }
 
-int ConvertPrecision(NNAdapterOperandPrecisionCode input_precision) {
-  int output_precision = 0;
-  switch (input_precision) {
+int ConvertToNeuronPrecision(NNAdapterOperandPrecisionCode precision_code) {
+  switch (precision_code) {
     case NNADAPTER_BOOL8:
-      output_precision = NEURON_BOOL;
-      break;
+      return NEURON_BOOL;
     case NNADAPTER_FLOAT16:
-      output_precision = NEURON_FLOAT16;
-      break;
+      return NEURON_FLOAT16;
     case NNADAPTER_FLOAT32:
-      output_precision = NEURON_FLOAT32;
-      break;
+      return NEURON_FLOAT32;
     case NNADAPTER_INT32:
-      output_precision = NEURON_INT32;
-      break;
+      return NEURON_INT32;
     case NNADAPTER_UINT32:
-      output_precision = NEURON_UINT32;
-      break;
+      return NEURON_UINT32;
     case NNADAPTER_TENSOR_BOOL8:
-      output_precision = NEURON_TENSOR_BOOL8;
-      break;
+      return NEURON_TENSOR_BOOL8;
     case NNADAPTER_TENSOR_FLOAT16:
-      output_precision = NEURON_TENSOR_FLOAT16;
-      break;
+      return NEURON_TENSOR_FLOAT16;
     case NNADAPTER_TENSOR_FLOAT32:
-      output_precision = NEURON_TENSOR_FLOAT32;
-      break;
+      return NEURON_TENSOR_FLOAT32;
     case NNADAPTER_TENSOR_INT32:
-      output_precision = NEURON_TENSOR_INT32;
-      break;
+      return NEURON_TENSOR_INT32;
     case NNADAPTER_TENSOR_QUANT_INT8_SYMM_PER_LAYER:
-      output_precision = NEURON_TENSOR_QUANT8_SYMM;
-      break;
+      return NEURON_TENSOR_QUANT8_SYMM;
     case NNADAPTER_TENSOR_QUANT_INT8_SYMM_PER_CHANNEL:
-      output_precision = NEURON_TENSOR_QUANT8_SYMM_PER_CHANNEL;
-      break;
+      return NEURON_TENSOR_QUANT8_SYMM_PER_CHANNEL;
     case NNADAPTER_TENSOR_QUANT_UINT8_ASYMM_PER_LAYER:
-      output_precision = NEURON_TENSOR_QUANT8_ASYMM;
-      break;
+      return NEURON_TENSOR_QUANT8_ASYMM;
     default:
       NNADAPTER_LOG(FATAL)
           << "Failed to convert the NNAdapter operand precision code("
-          << OperandPrecisionCodeToString(input_precision)
+          << OperandPrecisionCodeToString(precision_code)
           << ") to the Neuron operand precision code!";
       break;
   }
-  return output_precision;
+  return 0;
 }
 
-int ConvertDataLayout(NNAdapterOperandLayoutCode input_layout) {
-  NNADAPTER_CHECK_EQ(input_layout, NNADAPTER_NHWC)
+int ConvertToNeuronDataLayout(NNAdapterOperandLayoutCode layout_code) {
+  NNADAPTER_CHECK_EQ(layout_code, NNADAPTER_NHWC)
       << "Neuron only supports NHWC data layout!";
   return 0;
 }
 
-std::vector<uint32_t> ConvertDimensions(int32_t* input_dimensions,
-                                        uint32_t input_dimensions_count) {
+std::vector<uint32_t> ConvertToNeuronDimensions(
+    int32_t* input_dimensions, uint32_t input_dimensions_count) {
   std::vector<uint32_t> output_dimensions(input_dimensions_count);
   for (size_t i = 0; i < input_dimensions_count; i++) {
     auto dimension = input_dimensions[i];
@@ -112,27 +99,22 @@ std::vector<uint32_t> ConvertDimensions(int32_t* input_dimensions,
   return output_dimensions;
 }
 
-int32_t ConvertFuseCode(int32_t input_fuse_code) {
-  int output_fuse_code = NEURON_FUSED_NONE;
-  switch (input_fuse_code) {
+int32_t ConvertFuseCodeToNeuronFuseCode(int32_t fuse_code) {
+  switch (fuse_code) {
     case NNADAPTER_FUSED_NONE:
-      output_fuse_code = NEURON_FUSED_NONE;
-      break;
+      return NEURON_FUSED_NONE;
     case NNADAPTER_FUSED_RELU:
-      output_fuse_code = NEURON_FUSED_RELU;
-      break;
+      return NEURON_FUSED_RELU;
     case NNADAPTER_FUSED_RELU1:
-      output_fuse_code = NEURON_FUSED_RELU1;
-      break;
+      return NEURON_FUSED_RELU1;
     case NNADAPTER_FUSED_RELU6:
-      output_fuse_code = NEURON_FUSED_RELU6;
-      break;
+      return NEURON_FUSED_RELU6;
     default:
       NNADAPTER_LOG(FATAL) << "Failed to convert the NNAdapter fuse code("
-                           << input_fuse_code << ") to the Neuron fuse code!";
+                           << fuse_code << ") to the Neuron fuse code!";
       break;
   }
-  return output_fuse_code;
+  return NEURON_FUSED_NONE;
 }
 
 }  // namespace mediatek_apu

--- a/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/utility.h
+++ b/lite/backends/nnadapter/nnadapter/driver/mediatek_apu/utility.h
@@ -24,11 +24,11 @@ namespace mediatek_apu {
 int NeuronOperandDataTypeLength(int data_type);
 
 // Convert NNAdapter types to Neuron types
-int ConvertPrecision(NNAdapterOperandPrecisionCode input_precision);
-int ConvertDataLayout(NNAdapterOperandLayoutCode input_layout);
-std::vector<uint32_t> ConvertDimensions(int32_t* input_dimensions,
-                                        uint32_t input_dimensions_count);
-int32_t ConvertFuseCode(int32_t input_code);
+int ConvertToNeuronPrecision(NNAdapterOperandPrecisionCode precision_code);
+int ConvertToNeuronDataLayout(NNAdapterOperandLayoutCode layout_code);
+std::vector<uint32_t> ConvertToNeuronDimensions(
+    int32_t* input_dimensions, uint32_t input_dimensions_count);
+int32_t ConvertFuseCodeToNeuronFuseCode(int32_t fuse_code);
 
 }  // namespace mediatek_apu
 }  // namespace nnadapter

--- a/lite/backends/nnadapter/nnadapter/driver/rockchip_npu/CMakeLists.txt
+++ b/lite/backends/nnadapter/nnadapter/driver/rockchip_npu/CMakeLists.txt
@@ -23,7 +23,7 @@ include(dependencies.cmake)
 aux_source_directory(./converter CONVERTERS)
 aux_source_directory(optimizer OPTIMIZERS)
 set(DRIVER_SRCS utility.cc ${OPTIMIZERS} ${CONVERTERS} engine.cc driver.cc)
-set(DRIVER_DEPS ${NNADAPTER_UTILITIES} nnadapter_optimizer_symm2asymm ${${DEVICE_NAME}_deps})
+set(DRIVER_DEPS ${NNADAPTER_CORE} ${NNADAPTER_UTILITIES} nnadapter_optimizer_symm2asymm ${${DEVICE_NAME}_deps})
 
 add_library(${DRIVER_NAME} SHARED ${DRIVER_SRCS})
 target_link_libraries(${DRIVER_NAME} "-Wl,--start-group" ${DRIVER_DEPS} "-Wl,--end-group")

--- a/lite/backends/nnadapter/nnadapter/driver/rockchip_npu/converter/conv2d.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/rockchip_npu/converter/conv2d.cc
@@ -22,6 +22,23 @@ namespace rockchip_npu {
 
 int ConvertConv2D(Converter* converter, hal::Operation* operation) {
   CONV2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
+  // Dynamic shapes are still not supported
+  NNADAPTER_CHECK_EQ(input_operand->type.dynamic_dimension_count, 0);
+  operation::UpdateConv2DPadAndDilation(input_operand->type.dimensions[2],
+                                        filter_height,
+                                        auto_pad,
+                                        &pad_height_top,
+                                        &pad_height_bottom,
+                                        stride_height,
+                                        &dilation_height);
+  operation::UpdateConv2DPadAndDilation(input_operand->type.dimensions[3],
+                                        filter_width,
+                                        auto_pad,
+                                        &pad_width_left,
+                                        &pad_width_right,
+                                        stride_width,
+                                        &dilation_width);
+
   // Convert to rknpu tensors and operators
   auto input_tensor = converter->GetMappedTensor(input_operand);
   if (!input_tensor) {

--- a/lite/backends/nnadapter/nnadapter/driver/rockchip_npu/converter/softmax.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/rockchip_npu/converter/softmax.cc
@@ -22,6 +22,7 @@ namespace rockchip_npu {
 
 int ConvertSoftmax(Converter* converter, hal::Operation* operation) {
   SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
+
   // Convert to rknpu tensors and operators
   auto input_tensor = converter->GetMappedTensor(input_operand);
   if (!input_tensor) {

--- a/lite/backends/nnadapter/nnadapter/driver/rockchip_npu/optimizer/fix_ops.cc
+++ b/lite/backends/nnadapter/nnadapter/driver/rockchip_npu/optimizer/fix_ops.cc
@@ -41,8 +41,11 @@ static void FixRELUDepthwiseConv2D(hal::Model* model,
     NNADAPTER_CHECK_GT(output_operand->type.dimension_count, 1);
     auto group = *reinterpret_cast<int32_t*>(
         operation_consumer->input_operands[6]->buffer);
-    bool is_depthwise_mode =
-        (group != 1 && output_operand->type.dimensions[1] == group);
+    auto input_channel_size = output_operand->type.dimensions[1];
+    auto output_channel_size =
+        operation_consumer->input_operands[1]->type.dimensions[0];
+    bool is_depthwise_mode = group != 1 && input_channel_size == group &&
+                             output_channel_size % input_channel_size == 0;
     if (is_depthwise_mode) {
       AddDummyOperation(model, output_operand);
       break;

--- a/lite/backends/nnadapter/nnadapter/nnadapter.h
+++ b/lite/backends/nnadapter/nnadapter/nnadapter.h
@@ -192,7 +192,7 @@ typedef enum {
    * H_in, W_in].
    * * 1: auto_pad, a NNADAPTER_INT32 scalar. 0 means "EXPLICIT" so that
    * paddings is used. 1 means "SAME". 2 means "VALID". It must be one of
-   * NNAdapterPadCode values.
+   * NNAdapterAutoPadCode values.
    * * 2: pads, a NNADAPTER_INT32 tensor, with shape [4] and data {height_top,
    * height_bottom, width_left, width_right}, or with shape[0] and no data.
    * * 3: kernel_shape, a NNADAPTER_INT32 tensor, with shape [2] and data
@@ -347,7 +347,7 @@ typedef enum {
    * bias_scale[i] = input_scale * filter_scale[i] for each output channel.
    * * 3: auto_pad, a NNADAPTER_INT32 scalar. 0 means "EXPLICIT" so that
    * paddings is used. 1 means "SAME". 2 means "VALID". It must be one of
-   * NNAdapterPadCode.
+   * NNAdapterAutoPadCode.
    * * 4: pads, a NNADAPTER_INT32 tensor, with shape [4] and data {height_top,
    * height_bottom, width_left, width_right}, or with shape[0] and no data.
    * * 5: strides, a NNADAPTER_INT32 tensor, with shape [2] and data
@@ -403,7 +403,7 @@ typedef enum {
    * bias_scale[i] = input_scale * filter_scale[i] for each output channel.
    * * 3: auto_pad, a NNADAPTER_INT32 scalar. 0 means "EXPLICIT" so that
    * paddings is used. 1 means "SAME". 2 means "VALID". It must be one of
-   * NNAdapterPadCode.
+   * NNAdapterAutoPadCode.
    * * 4: pads, a NNADAPTER_INT32 tensor, with shape [4] and data {height_top,
    * height_bottom, width_left, width_right}, or shape[0] and no data.
    * * 5: strides, a NNADAPTER_INT32 tensor, with shape [2] and data
@@ -751,7 +751,7 @@ typedef enum {
    * H_in, W_in].
    * * 1: auto_pad, a NNADAPTER_INT32 scalar. 0 means "EXPLICIT" so that
    * paddings is used. 1 means "SAME". 2 means "VALID". It must be one of
-   * NNAdapterPadCode values.
+   * NNAdapterAutoPadCode values.
    * * 2: pads, a NNADAPTER_INT32 tensor, with shape [4] and data {height_top,
    * height_bottom, width_left, width_right}, or with shape[0] and no data.
    * * 3: kernel_shape, a NNADAPTER_INT32 tensor, with shape [2] and data
@@ -836,7 +836,7 @@ typedef enum {
    * with value [x0_begin, x0_end, x1_begin, x1_end,...].
    * * 2: mode, a NNADAPTER_INT32 scalar.
    * Supported modes: `constant`(default), `reflect`, `edge`.
-   * It should be a value of NNAdapterPadMode.
+   * It should be a value of NNAdapterPadModeCode.
    * * 3: value, a scalar with the same type as input,
    * only be used if the mode is "constant".
    *
@@ -1234,13 +1234,13 @@ typedef enum {
  */
 typedef enum {
   /** Use explicit pads. */
-  NNADAPTER_PAD_NONE = 0,
+  NNADAPTER_AUTO_PAD_NONE = 0,
   /** Results in padding evenly to the left/right or up/down of the input such
      that output has the same height/width dimension as the input.*/
-  NNADAPTER_PAD_SAME = 1,
+  NNADAPTER_AUTO_PAD_SAME = 1,
   /** No padding. */
-  NNADAPTER_PAD_VALID = 2,
-} NNAdapterPadCode;
+  NNADAPTER_AUTO_PAD_VALID = 2,
+} NNAdapterAutoPadCode;
 
 /**
  * Device codes.

--- a/lite/backends/nnadapter/nnadapter/utility/debug.cc
+++ b/lite/backends/nnadapter/nnadapter/utility/debug.cc
@@ -587,6 +587,19 @@ NNADAPTER_EXPORT std::string DeviceCodeToString(NNAdapterDeviceCode type) {
   return name;
 }
 
+NNADAPTER_EXPORT std::string AutoPadCodeToString(NNAdapterAutoPadCode type) {
+  std::string name;
+  switch (type) {
+    NNADAPTER_TYPE_TO_STRING(AUTO_PAD_NONE);
+    NNADAPTER_TYPE_TO_STRING(AUTO_PAD_SAME);
+    NNADAPTER_TYPE_TO_STRING(AUTO_PAD_VALID);
+    default:
+      name = "UNKNOWN";
+      break;
+  }
+  return name;
+}
+
 #undef NNADAPTER_TYPE_TO_STRING
 
 NNADAPTER_EXPORT std::string OperandPrecisionCodeToSymbol(

--- a/lite/backends/nnadapter/nnadapter/utility/debug.h
+++ b/lite/backends/nnadapter/nnadapter/utility/debug.h
@@ -31,6 +31,7 @@ std::string OperandLifetimeCodeToString(NNAdapterOperandLifetimeCode type);
 std::string OperationTypeToString(NNAdapterOperationType type);
 std::string FuseCodeToString(NNAdapterFuseCode type);
 std::string DeviceCodeToString(NNAdapterDeviceCode type);
+std::string AutoPadCodeToString(NNAdapterAutoPadCode type);
 std::string DimensionsToString(const int32_t* dimensions,
                                uint32_t dimension_count);
 std::string OperandToString(hal::Operand* operand);

--- a/lite/kernels/nnadapter/bridges/conv_op.cc
+++ b/lite/kernels/nnadapter/bridges/conv_op.cc
@@ -191,7 +191,7 @@ int ConvConverter(void* ctx, OpLite* op, KernelBase* kernel) {
 
   // Auto_pad operand
   auto auto_pad_operand = converter->AddInt32ConstantOperand(
-      static_cast<int32_t>(PaddingAlgorithm2PadCode(padding_algorithm)));
+      static_cast<int32_t>(PaddingAlgorithm2AutoPadCode(padding_algorithm)));
 
   // Pads operand(optional)
   auto pads_operand = converter->AddInt32ConstantOperand(

--- a/lite/kernels/nnadapter/bridges/conv_transpose_op.cc
+++ b/lite/kernels/nnadapter/bridges/conv_transpose_op.cc
@@ -206,7 +206,7 @@ int ConvTransposeConverter(void* ctx, OpLite* op, KernelBase* kernel) {
 
   // Auto_pad operand
   auto auto_pad_operand = converter->AddInt32ConstantOperand(
-      static_cast<int32_t>(PaddingAlgorithm2PadCode(padding_algorithm)));
+      static_cast<int32_t>(PaddingAlgorithm2AutoPadCode(padding_algorithm)));
 
   // Pads operand(optional)
   auto pads_operand = converter->AddInt32ConstantOperand(

--- a/lite/kernels/nnadapter/bridges/pool_op.cc
+++ b/lite/kernels/nnadapter/bridges/pool_op.cc
@@ -103,7 +103,7 @@ int PoolConverter(void* ctx, OpLite* op, KernelBase* kernel) {
 
   // Auto_pad operand
   auto auto_pad_operand = converter->AddInt32ConstantOperand(
-      static_cast<int32_t>(PaddingAlgorithm2PadCode(padding_algorithm)));
+      static_cast<int32_t>(PaddingAlgorithm2AutoPadCode(padding_algorithm)));
 
   // Pads operand(optional)
   auto pads_operand = converter->AddInt32ConstantOperand(

--- a/lite/kernels/nnadapter/bridges/utility.cc
+++ b/lite/kernels/nnadapter/bridges/utility.cc
@@ -430,19 +430,19 @@ NNAdapterPadModeCode PadMode2NNAdapterPadModeCode(std::string mode) {
   return NNADAPTER_PAD_MODE_NONE;
 }
 
-NNAdapterPadCode PaddingAlgorithm2PadCode(
+NNAdapterAutoPadCode PaddingAlgorithm2AutoPadCode(
     const std::string& padding_algorithm) {
-  NNAdapterPadCode pad_code;
+  NNAdapterAutoPadCode auto_pad_code;
   if (padding_algorithm == "EXPLICIT" || padding_algorithm.empty()) {
-    pad_code = NNADAPTER_PAD_NONE;
+    auto_pad_code = NNADAPTER_AUTO_PAD_NONE;
   } else if (padding_algorithm == "SAME") {
-    pad_code = NNADAPTER_PAD_SAME;
+    auto_pad_code = NNADAPTER_AUTO_PAD_SAME;
   } else if (padding_algorithm == "VALID") {
-    pad_code = NNADAPTER_PAD_VALID;
+    auto_pad_code = NNADAPTER_AUTO_PAD_VALID;
   } else {
     LOG(FATAL) << "Unsupported padding algorithm: " << padding_algorithm;
   }
-  return pad_code;
+  return auto_pad_code;
 }
 
 }  // namespace nnadapter

--- a/lite/kernels/nnadapter/bridges/utility.h
+++ b/lite/kernels/nnadapter/bridges/utility.h
@@ -169,7 +169,8 @@ NNAdapterOperandPrecisionCode Precision2NNAdapterScalarPrecisionCode(
 
 NNAdapterPadModeCode PadMode2NNAdapterPadModeCode(std::string mode);
 
-NNAdapterPadCode PaddingAlgorithm2PadCode(const std::string& padding_algorithm);
+NNAdapterAutoPadCode PaddingAlgorithm2AutoPadCode(
+    const std::string& padding_algorithm);
 
 }  // namespace nnadapter
 }  // namespace subgraph

--- a/lite/kernels/nnadapter/converter/all.h
+++ b/lite/kernels/nnadapter/converter/all.h
@@ -14,6 +14,7 @@
 
 #ifndef __NNADAPTER_CONVERTER_ALL_H__  // NOLINT
 #define __NNADAPTER_CONVERTER_ALL_H__
+
 REGISTER_CONVERTER(conv2d,
                    ConvertConv2D,
                    "rockchip_npu,mediatek_apu,huawei_kirin_npu,huawei_ascend_"

--- a/lite/kernels/nnadapter/converter/conv2d.cc
+++ b/lite/kernels/nnadapter/converter/conv2d.cc
@@ -77,7 +77,7 @@ int ConvertConv2D(Converter* converter, OpInfo* op, Scope* scope) {
   }
   VLOG(5) << "padding_algorithm:" << padding_algorithm;
   // Check depthwise mode
-  bool is_depthwise_mode = op_type == "depthwise_conv2d" || (groups != 1);
+  bool is_depthwise_mode = op_type == "depthwise_conv2d";
   VLOG(5) << "depthwise mode(" << is_depthwise_mode << ").";
   // Check quantization mode
   bool is_quant_mode = false;
@@ -99,6 +99,13 @@ int ConvertConv2D(Converter* converter, OpInfo* op, Scope* scope) {
   auto input_operand = converter->GetMappedOperand(input_name);
   CHECK(input_operand);
   auto input_type = converter->GetOperandType(input_operand);
+  // Check depthwise mode according to the dimensions
+  auto input_channel_size = input_type->dimensions[1];
+  // Should not support dynamic shape for input channel size
+  CHECK(input_channel_size != NNADAPTER_UNKNOWN);
+  is_depthwise_mode |= (groups != 1 && input_channel_size == groups &&
+                        output_channel_size % input_channel_size == 0);
+  VLOG(5) << "Update depthwise mode(" << is_depthwise_mode << ").";
   // Filter operand
   NNAdapterOperand* filter_operand = nullptr;
   std::vector<float> bias_scales;
@@ -193,21 +200,21 @@ int ConvertConv2D(Converter* converter, OpInfo* op, Scope* scope) {
   } else {
     // Add dummy zero bias operand
     // Use int32 as the data type of bias if it is a quantized type
-    auto bias_size =
+    std::vector<int8_t> zeros(
         output_channel_size *
-        (is_quant_mode ? sizeof(int32_t)
-                       : GetNNOperandPrecisionDataLength(*input_type));
-    std::vector<int8_t> zeros(bias_size, 0);
-    bias_operand =
-        converter->AddConstantOperand(reinterpret_cast<void*>(zeros.data()),
-                                      DDim({output_channel_size}),
-                                      input_type->precision,
-                                      true,
-                                      bias_scales);
+            (is_quant_mode ? sizeof(int32_t)
+                           : GetNNOperandPrecisionDataLength(*input_type)),
+        0);
+    bias_operand = converter->AddConstantOperand(
+        reinterpret_cast<void*>(zeros.data()),
+        DDim({output_channel_size}),
+        is_quant_mode ? NNADAPTER_TENSOR_INT32 : input_type->precision,
+        true,
+        bias_scales);
   }
   // Auto_pad operand
   auto auto_pad_operand = converter->AddConstantOperand(
-      static_cast<int32_t>(PaddingAlgorithm2PadCode(padding_algorithm)));
+      static_cast<int32_t>(PaddingAlgorithm2AutoPadCode(padding_algorithm)));
   // Pads operand(optional)
   auto pads_operand = converter->AddConstantOperand(paddings);
   // Strides operand
@@ -217,58 +224,46 @@ int ConvertConv2D(Converter* converter, OpInfo* op, Scope* scope) {
   // Dilations operand
   auto dilations_operand = converter->AddConstantOperand(dilations);
   // Fuse code operand
-  std::vector<std::string> activation_support_split_ops{"leaky_relu"};
-  bool conv_with_act_fusion = true;
   int32_t fuse_code_value = NNADAPTER_FUSED_NONE;
   if (act_type == "relu") {
     fuse_code_value = NNADAPTER_FUSED_RELU;
+    act_type = "";
   } else if (act_type == "relu1") {
     fuse_code_value = NNADAPTER_FUSED_RELU1;
+    act_type = "";
   } else if (act_type == "relu6") {
     fuse_code_value = NNADAPTER_FUSED_RELU6;
-  } else if (!act_type.empty()) {
-    if (std::find(activation_support_split_ops.begin(),
-                  activation_support_split_ops.end(),
-                  act_type) == activation_support_split_ops.end()) {
-      LOG(WARNING) << "Unsupported activation type: " << act_type;
-      return UNSUPPORTED_FEATURE;
-    }
-    VLOG(5) << "Split conv + " << act_type
-            << " fusion operator into two operators!";
-    conv_with_act_fusion = false;
+    act_type = "";
   }
   auto fuse_code_operand = converter->AddConstantOperand(fuse_code_value);
   // Output operand
   auto output_operand = converter->AddOutputOperand(output_name, output_scales);
   // Conv2D operation
-  std::vector<NNAdapterOperand*> input_operands = {input_operand,
-                                                   filter_operand,
-                                                   bias_operand,
-                                                   auto_pad_operand,
-                                                   pads_operand,
-                                                   strides_operand,
-                                                   group_operand,
-                                                   dilations_operand,
-                                                   fuse_code_operand};
-  std::vector<NNAdapterOperand*> output_operands = {output_operand};
-  converter->AddOperation(NNADAPTER_CONV_2D, &input_operands, &output_operands);
-
-  // Activation operation without fusion
-  if (!conv_with_act_fusion) {
-    std::vector<NNAdapterOperand*> activation_input_operands{output_operand};
-    auto activation_output_operand = converter->AddOutputOperand(output_name);
-    std::vector<NNAdapterOperand*> activation_output_operands{
-        activation_output_operand};
+  converter->AddOperation(NNADAPTER_CONV_2D,
+                          {input_operand,
+                           filter_operand,
+                           bias_operand,
+                           auto_pad_operand,
+                           pads_operand,
+                           strides_operand,
+                           group_operand,
+                           dilations_operand,
+                           fuse_code_operand},
+                          {output_operand});
+  // Unpack the fused activations
+  if (!act_type.empty()) {
+    auto fused_act_output_operand =
+        converter->AddOutputOperand(output_name, output_scales);
     if (act_type == "leaky_relu") {
       auto alpha = op->GetAttr<float>("leaky_relu_alpha");
       auto alpha_operand = converter->AddConstantOperand(alpha);
-      activation_input_operands.push_back(alpha_operand);
       converter->AddOperation(NNADAPTER_LEAKY_RELU,
-                              &activation_input_operands,
-                              &activation_output_operands);
+                              {output_operand, alpha_operand},
+                              {fused_act_output_operand});
+    } else {
+      LOG(FATAL) << "Failed to unpack the fused activation type: " << act_type;
     }
   }
-
   return NO_ERROR;
 }
 

--- a/lite/kernels/nnadapter/converter/cumsum.cc
+++ b/lite/kernels/nnadapter/converter/cumsum.cc
@@ -41,10 +41,10 @@ int ConvertCumsum(Converter* converter, OpInfo* op, Scope* scope) {
   auto output_operand = converter->AddOutputOperand(out_name);
 
   // Cumsum operation
-  std::vector<NNAdapterOperand*> input_operands = {
-      input_operand, axis_operand, exclusive_operand, reverse_operand};
-  std::vector<NNAdapterOperand*> output_operands = {output_operand};
-  converter->AddOperation(NNADAPTER_CUM_SUM, &input_operands, &output_operands);
+  converter->AddOperation(
+      NNADAPTER_CUM_SUM,
+      {input_operand, axis_operand, exclusive_operand, reverse_operand},
+      {output_operand});
   return NO_ERROR;
 }
 

--- a/lite/kernels/nnadapter/converter/softmax.cc
+++ b/lite/kernels/nnadapter/converter/softmax.cc
@@ -74,9 +74,8 @@ int ConvertSoftmax(Converter* converter, OpInfo* op, Scope* scope) {
   }
   auto output_operand = converter->AddOutputOperand(out_name, out_scales);
   // Softmax operation
-  std::vector<NNAdapterOperand*> input_operands = {input_operand, axis_operand};
-  std::vector<NNAdapterOperand*> output_operands = {output_operand};
-  converter->AddOperation(NNADAPTER_SOFTMAX, &input_operands, &output_operands);
+  converter->AddOperation(
+      NNADAPTER_SOFTMAX, {input_operand, axis_operand}, {output_operand});
   return NO_ERROR;
 }
 

--- a/lite/kernels/nnadapter/converter/unary_activations.cc
+++ b/lite/kernels/nnadapter/converter/unary_activations.cc
@@ -72,8 +72,6 @@ int ConvertUnaryActivations(Converter* converter, OpInfo* op, Scope* scope) {
   }
   auto output_operand = converter->AddOutputOperand(out_name, out_scales);
   // Unary activation operation
-  std::vector<NNAdapterOperand*> input_operands{input_operand};
-  std::vector<NNAdapterOperand*> output_operands{output_operand};
   NNAdapterOperationType unary_act_operation_type;
   if (op_type == "sigmoid") {
     unary_act_operation_type = NNADAPTER_SIGMOID;
@@ -94,7 +92,7 @@ int ConvertUnaryActivations(Converter* converter, OpInfo* op, Scope* scope) {
     return UNSUPPORTED_FEATURE;
   }
   converter->AddOperation(
-      unary_act_operation_type, &input_operands, &output_operands);
+      unary_act_operation_type, {input_operand}, {output_operand});
   return NO_ERROR;
 }
 

--- a/lite/kernels/nnadapter/utility.cc
+++ b/lite/kernels/nnadapter/utility.cc
@@ -659,19 +659,19 @@ DDim ConvertNNDimensionsToDDim(int32_t* input_dimensions,
   return DDim(output_dimensions);
 }
 
-NNAdapterPadCode PaddingAlgorithm2PadCode(
+NNAdapterAutoPadCode PaddingAlgorithm2AutoPadCode(
     const std::string& padding_algorithm) {
-  NNAdapterPadCode pad_code;
+  NNAdapterAutoPadCode auto_pad_code;
   if (padding_algorithm == "EXPLICIT" || padding_algorithm.empty()) {
-    pad_code = NNADAPTER_PAD_NONE;
+    auto_pad_code = NNADAPTER_AUTO_PAD_NONE;
   } else if (padding_algorithm == "SAME") {
-    pad_code = NNADAPTER_PAD_SAME;
+    auto_pad_code = NNADAPTER_AUTO_PAD_SAME;
   } else if (padding_algorithm == "VALID") {
-    pad_code = NNADAPTER_PAD_VALID;
+    auto_pad_code = NNADAPTER_AUTO_PAD_VALID;
   } else {
     LOG(FATAL) << "Unsupported padding_algorithm: " << padding_algorithm;
   }
-  return pad_code;
+  return auto_pad_code;
 }
 
 }  // namespace nnadapter

--- a/lite/kernels/nnadapter/utility.h
+++ b/lite/kernels/nnadapter/utility.h
@@ -268,8 +268,10 @@ void ConvertVectorToNNDimensions(const std::vector<int64_t>& input_dimensions,
                                  uint32_t* output_dimension_count = nullptr);
 DDim ConvertNNDimensionsToDDim(int32_t* input_dimensions,
                                uint32_t input_dimension_count);
-
-NNAdapterPadCode PaddingAlgorithm2PadCode(const std::string& padding_algorithm);
+// Convert the attribute 'padding_algorithm' in Conv2d/DepthwiseConv2d to
+// NNAdapterAutoPadCode
+NNAdapterAutoPadCode PaddingAlgorithm2AutoPadCode(
+    const std::string& padding_algorithm);
 
 }  // namespace nnadapter
 }  // namespace kernels

--- a/lite/tests/kernels/conv_compute_test.cc
+++ b/lite/tests/kernels/conv_compute_test.cc
@@ -447,9 +447,7 @@ TEST(Conv2d, precision) {
   TestConvDilations(place, abs_error);
   TestConvStrides(place, abs_error);
   TestConvPaddings(place, abs_error);
-#if !defined(LITE_WITH_NNADAPTER)
   TestConvPaddingAlgorithm(place, abs_error);
-#endif
   TestConvBias(place, abs_error);
   TestConvAct(place, abs_error);
 }


### PR DESCRIPTION
1. NNADAPTER_CONV2D的infer shape支持auto_pad，适配所有已支持硬件的HAL中的CONV2D converter
2. 修复新conv2d op converter在量化模型且不存在bias，添加的dummy bias数据类型错误的问题，跑通3D pose detect模型
3. NNAdapterPadCode -> NNAdapterAutoPadCode
4. Refine code