### PR TITLE
[Pass] Support density_prior_box in SSDBoxesCalcOfflinePass

### DIFF
--- a/lite/core/optimizer/mir/elimination/ssd_boxes_calc_offline_pass.cc
+++ b/lite/core/optimizer/mir/elimination/ssd_boxes_calc_offline_pass.cc
@@ -507,5 +507,4 @@ void SSDBoxesCalcOfflinePass::ComputeConcat(
 REGISTER_MIR_PASS(ssd_boxes_calc_offline_pass,
                   paddle::lite::mir::SSDBoxesCalcOfflinePass)
     .BindTargets(
-        {TARGET(kRKNPU), TARGET(kNPU), TARGET(kOpenCL), TARGET(kNNAdapter)})
-    .BindKernel("box_coder");
+        {TARGET(kRKNPU), TARGET(kNPU), TARGET(kOpenCL), TARGET(kNNAdapter)});

--- a/lite/core/optimizer/mir/elimination/ssd_boxes_calc_offline_pass.cc
+++ b/lite/core/optimizer/mir/elimination/ssd_boxes_calc_offline_pass.cc
@@ -507,4 +507,5 @@ void SSDBoxesCalcOfflinePass::ComputeConcat(
 REGISTER_MIR_PASS(ssd_boxes_calc_offline_pass,
                   paddle::lite::mir::SSDBoxesCalcOfflinePass)
     .BindTargets(
-        {TARGET(kRKNPU), TARGET(kNPU), TARGET(kOpenCL), TARGET(kNNAdapter)});
+        {TARGET(kRKNPU), TARGET(kNPU), TARGET(kOpenCL), TARGET(kNNAdapter)})
+    .BindKernel("box_coder");

--- a/lite/core/optimizer/mir/elimination/ssd_boxes_calc_offline_pass.h
+++ b/lite/core/optimizer/mir/elimination/ssd_boxes_calc_offline_pass.h
@@ -27,8 +27,8 @@ namespace paddle {
 namespace lite {
 namespace mir {
 
-// Prior-box don't depend on feature-map data, only depend on image &
-// feature-map size,
+// Prior_box/Density_prior_box don't depend on feature-map data, only depend on
+// image & feature-map size,
 // so if the shape is determined, we can calculate it offline in opt stage,
 // and the reshape(2) & flatten(2) & concat which linked with prior-box can
 // be calculate offline too.
@@ -39,7 +39,8 @@ namespace mir {
 //       |                       |                 |                       |
 //       |                       |                 |                       |
 //       |                       |                 |                       |
-//       ----- OP: prior box -----                 ------OP: prior box-----
+//       ----- OP: prior_box ----                  ------OP: prior_box-----
+//          or depsity_prior_box                      or depsity_prior_box
 //                  |                                           |
 //                  |                                           |
 //                  |                                           |
@@ -86,6 +87,7 @@ namespace mir {
 //                   |                                    |
 //                   |                                    |
 //                   ----------- OP: box coder -----------
+//                            or depsity_prior_box
 //                                     |
 //                                     |
 //                                     v
@@ -102,24 +104,27 @@ class SSDBoxesCalcOfflinePass : public mir::StmtPass {
   void ExpandAspectRatios(const std::vector<float>& input_aspect_ratior,
                           bool flip,
                           std::vector<float>* output_aspect_ratior);
-  void ComputePriorbox(const lite::Tensor* input,
-                       const lite::Tensor* image,
-                       lite::Tensor** boxes,
-                       lite::Tensor** variances,
-                       const std::vector<float>& min_size_,
-                       const std::vector<float>& max_size_,
-                       const std::vector<float>& aspect_ratio_,
-                       const std::vector<float>& variance_,
-                       int img_w_,
-                       int img_h_,
-                       float step_w_,
-                       float step_h_,
-                       float offset_,
-                       int prior_num_,
-                       bool is_flip_,
-                       bool is_clip_,
-                       const std::vector<std::string>& order_,
-                       bool min_max_aspect_ratios_order);
+  void ComputeDensityPriorBox(const lite::Tensor* input,
+                              const lite::Tensor* image,
+                              lite::Tensor** boxes,
+                              lite::Tensor** variances,
+                              const std::vector<float>& min_size_,
+                              const std::vector<float>& fixed_size_,
+                              const std::vector<float>& fixed_ratio_,
+                              const std::vector<int>& density_size_,
+                              const std::vector<float>& max_size_,
+                              const std::vector<float>& aspect_ratio_,
+                              const std::vector<float>& variance_,
+                              int img_w_,
+                              int img_h_,
+                              float step_w_,
+                              float step_h_,
+                              float offset_,
+                              int prior_num_,
+                              bool is_flip_,
+                              bool is_clip_,
+                              const std::vector<std::string>& order_,
+                              bool min_max_aspect_ratios_order);
   void ComputeReshape(const lite::Tensor* in, lite::Tensor* out);
   void ComputeFlatten(const lite::Tensor* in, lite::Tensor* out);
   void ComputeConcat(const std::vector<lite::Tensor*> inputs,

--- a/lite/core/optimizer/mir/elimination/ssd_boxes_calc_offline_pass.h
+++ b/lite/core/optimizer/mir/elimination/ssd_boxes_calc_offline_pass.h
@@ -87,7 +87,6 @@ namespace mir {
 //                   |                                    |
 //                   |                                    |
 //                   ----------- OP: box coder -----------
-//                            or depsity_prior_box
 //                                     |
 //                                     |
 //                                     v

--- a/lite/kernels/opencl/box_coder_image_compute.cc
+++ b/lite/kernels/opencl/box_coder_image_compute.cc
@@ -219,7 +219,7 @@ REGISTER_LITE_KERNEL(
                                        DATALAYOUT(kImageDefault))})
     .Finalize();
 
-REGISTER_LITE_KERNEL(box_coder,
+REGISTER_LITE_KERNEL(box_coder_no_pass,
                      kOpenCL,
                      kFP16,
                      kImageDefault,

--- a/lite/kernels/opencl/box_coder_image_compute.cc
+++ b/lite/kernels/opencl/box_coder_image_compute.cc
@@ -206,26 +206,6 @@ typedef paddle::lite::kernels::opencl::BoxCoderComputeImage BoxCoder_image;
 REGISTER_LITE_KERNEL(
     box_coder, kOpenCL, kFP16, kImageDefault, BoxCoder_image, ImageDefault)
     .BindInput("PriorBox",
-               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFloat))})
-    .BindInput("PriorBoxVar",
-               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFloat))})
-    .BindInput("TargetBox",
-               {LiteType::GetTensorTy(TARGET(kOpenCL),
-                                      PRECISION(kFP16),
-                                      DATALAYOUT(kImageDefault))})
-    .BindOutput("OutputBox",
-                {LiteType::GetTensorTy(TARGET(kOpenCL),
-                                       PRECISION(kFP16),
-                                       DATALAYOUT(kImageDefault))})
-    .Finalize();
-
-REGISTER_LITE_KERNEL(box_coder_no_pass,
-                     kOpenCL,
-                     kFP16,
-                     kImageDefault,
-                     BoxCoder_image,
-                     ImageDefaultNoUseSSDBoxesCalcOfflinePass)
-    .BindInput("PriorBox",
                {LiteType::GetTensorTy(TARGET(kOpenCL),
                                       PRECISION(kFP16),
                                       DATALAYOUT(kImageDefault))})

--- a/lite/kernels/opencl/box_coder_image_compute_test.cc
+++ b/lite/kernels/opencl/box_coder_image_compute_test.cc
@@ -285,8 +285,3 @@ TEST(box_coder_image2d, compute) {
 }  // namespace paddle
 
 USE_LITE_KERNEL(box_coder, kOpenCL, kFP16, kImageDefault, ImageDefault);
-USE_LITE_KERNEL(box_coder_no_pass,
-                kOpenCL,
-                kFP16,
-                kImageDefault,
-                ImageDefaultNoUseSSDBoxesCalcOfflinePass);

--- a/lite/kernels/opencl/box_coder_image_compute_test.cc
+++ b/lite/kernels/opencl/box_coder_image_compute_test.cc
@@ -285,7 +285,7 @@ TEST(box_coder_image2d, compute) {
 }  // namespace paddle
 
 USE_LITE_KERNEL(box_coder, kOpenCL, kFP16, kImageDefault, ImageDefault);
-USE_LITE_KERNEL(box_coder,
+USE_LITE_KERNEL(box_coder_no_pass,
                 kOpenCL,
                 kFP16,
                 kImageDefault,


### PR DESCRIPTION
- 在`SSDBoxesCalcOfflinePass`中支持`density_prior_box`：之前该 pass 只支持`prior_box`；使用 facebox 模型验证的效果如下；使用固化尺寸模型后，在麒麟970手机上，opencl fp16 tune off 速度150ms；加入pass优化后速度119ms
![image](https://user-images.githubusercontent.com/24290792/132273517-b4073b37-a18e-43f7-8909-a36c9dd8704a.png)

![image](https://user-images.githubusercontent.com/24290792/132273372-3f0797ea-734c-4ae8-8921-6690c22da8b2.png)

- 在`SSDBoxesCalcOfflinePass`中增加约束：当 img shape 或 input shape 在 opt 阶段无法读到时，跳过本 pass；如果不跳过 pass，则因读到的 img shape 或 input shape 的 HW 维度是`-1`导致在计算 prior_box 时出现段错误
- 删除将PriorBox和PriorBoxVar注册为 Host 上的 kernel