### PR TITLE
[kernel][opencl]optimize both transpose conv and depthwise transpose conv

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/conv2d_transpose_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_transpose_kernel.cl
@@ -60,23 +60,22 @@ __kernel void conv2d_transpose(
       kernel_shape.y - mad24(kernel_start_y, stride_shape.y, padding_shape.y) +
       out_h_idx - 1;
 
-  int kernel_x_0, kernel_x_1, kernel_x_2, kernel_x_3, kernel_y;
 #ifndef IS_DEPTHWISE
-  int kernel_y_base = mul24(out_c_blk_idx, kernel_size);
+  int kernel_x_0, kernel_x_1, kernel_x_2, kernel_x_3, kernel_y;
 #endif
   CL_DTYPE4 in0;
   CL_DTYPE4 weights0, weights1, weights2, weights3;
 #ifndef IS_DEPTHWISE
   for (int ic = 0; ic < input_c_blks; ic++) {
+    int kernel_y_base = mul24(ic, kernel_size);
     int in_idx = mul24(ic, input_shape.x);
-    kernel_x_0 = ic << 2;
-#else
-  int in_idx = mul24(out_c_blk_idx, input_shape.x);
-  kernel_x_0 = out_c_blk_idx << 2;
-#endif
+    kernel_x_0 = out_c_blk_idx << 2;
     kernel_x_1 = kernel_x_0 + 1;
     kernel_x_2 = kernel_x_0 + 2;
     kernel_x_3 = kernel_x_0 + 3;
+#else
+  int in_idx = mul24(out_c_blk_idx, input_shape.x);
+#endif
     for (int k_y = valid_kernel_height, idx_h = kernel_start_y; k_y >= 0;
          k_y -= stride_shape.y, idx_h++) {
       int in_y_idx = mad24(
@@ -89,9 +88,8 @@ __kernel void conv2d_transpose(
         kernel_y = mad24(k_y,
                          kernel_shape.x,
                          k_x + kernel_y_base);  // (k_y * k_w + k_x) + k_y_base
-#else
-      kernel_y = mad24(k_y, kernel_shape.x, k_x);
 #endif
+#ifndef IS_DEPTHWISE
         weights0 = READ_IMG_TYPE(
             CL_DTYPE_CHAR, filter, SAMPLER, (int2)(kernel_x_0, kernel_y));
         weights1 = READ_IMG_TYPE(
@@ -100,7 +98,11 @@ __kernel void conv2d_transpose(
             CL_DTYPE_CHAR, filter, SAMPLER, (int2)(kernel_x_2, kernel_y));
         weights3 = READ_IMG_TYPE(
             CL_DTYPE_CHAR, filter, SAMPLER, (int2)(kernel_x_3, kernel_y));
-
+#else
+      int kernel_x = mad24(out_c_blk_idx, kernel_shape.x, k_x);
+      weights0 =
+          READ_IMG_TYPE(CL_DTYPE_CHAR, filter, SAMPLER, (int2)(kernel_x, k_y));
+#endif
         int in_width_value0 = in_width0;
         in_width_value0 =
             select(in_idx + in_width_value0,
@@ -111,15 +113,27 @@ __kernel void conv2d_transpose(
                             SAMPLER,
                             (int2)(in_width_value0, in_nh_value));
 #ifndef IS_DEPTHWISE
-        out0 = mad(in0.x, weights0, out0);
-        out0 = mad(in0.y, weights1, out0);
-        out0 = mad(in0.z, weights2, out0);
-        out0 = mad(in0.w, weights3, out0);
+        out0.x = mad(in0.x, weights0.x, out0.x);
+        out0.x = mad(in0.y, weights0.y, out0.x);
+        out0.x = mad(in0.z, weights0.z, out0.x);
+        out0.x = mad(in0.w, weights0.w, out0.x);
+
+        out0.y = mad(in0.x, weights1.x, out0.y);
+        out0.y = mad(in0.y, weights1.y, out0.y);
+        out0.y = mad(in0.z, weights1.z, out0.y);
+        out0.y = mad(in0.w, weights1.w, out0.y);
+
+        out0.z = mad(in0.x, weights2.x, out0.z);
+        out0.z = mad(in0.y, weights2.y, out0.z);
+        out0.z = mad(in0.z, weights2.z, out0.z);
+        out0.z = mad(in0.w, weights2.w, out0.z);
+
+        out0.w = mad(in0.x, weights3.x, out0.w);
+        out0.w = mad(in0.y, weights3.y, out0.w);
+        out0.w = mad(in0.z, weights3.z, out0.w);
+        out0.w = mad(in0.w, weights3.w, out0.w);
 #else
-      out0.x += in0.x * weights0.x;
-      out0.y += in0.y * weights1.x;
-      out0.z += in0.z * weights2.x;
-      out0.w += in0.w * weights3.x;
+      out0 = mad(in0, weights0, out0);
 #endif
         in_width0++;
       }

--- a/lite/kernels/opencl/conv_transpose_image_compute.cc
+++ b/lite/kernels/opencl/conv_transpose_image_compute.cc
@@ -406,3 +406,4 @@ REGISTER_LITE_KERNEL(depthwise_conv2d_transpose,
                                        DATALAYOUT(kImageDefault))})
     .BindPaddleOpVersion("depthwise_conv2d_transpose", 1)
     .Finalize();
+

--- a/lite/kernels/opencl/conv_transpose_image_compute.cc
+++ b/lite/kernels/opencl/conv_transpose_image_compute.cc
@@ -406,4 +406,3 @@ REGISTER_LITE_KERNEL(depthwise_conv2d_transpose,
                                        DATALAYOUT(kImageDefault))})
     .BindPaddleOpVersion("depthwise_conv2d_transpose", 1)
     .Finalize();
-

--- a/lite/kernels/opencl/conv_transpose_image_compute.cc
+++ b/lite/kernels/opencl/conv_transpose_image_compute.cc
@@ -65,19 +65,7 @@ void ConvTransposeImageCompute::PrepareForRun() {
    * Upload filter, bias to opencl device
    *********************************************/
   auto* filter_cpu = conv_param_->filter->mutable_data<float>();
-  std::vector<float> filter_cpu_trans(conv_param_->filter->numel());
-  DDimLite filter_trans_dims{
-      {filter_dims[1], filter_dims[0], filter_dims[2], filter_dims[3]}};
 
-  // Convert filter layout from IOHW to OIHW
-  if (filter_dims.size() == 4 && filter_dims[1] > 1) {
-    IOHW2OIHW<float, int64_t>(filter_cpu,
-                              filter_cpu_trans.data(),
-                              filter_trans_dims[0],
-                              filter_trans_dims[1],
-                              filter_trans_dims[2],
-                              filter_trans_dims[3]);
-  }
   filter_gpu_image_ = std::unique_ptr<Tensor>(new Tensor);
   tensor_hold_filter_image_ = std::unique_ptr<Tensor>(new Tensor);
   tensor_hold_bias_image_ = std::unique_ptr<Tensor>(new Tensor);
@@ -88,24 +76,24 @@ void ConvTransposeImageCompute::PrepareForRun() {
     kernel_func_names_.push_back(kernel_name);
 
     CLImageConverterNBlock converter;
-    const DDim& filter_image_dims =
-        converter.InitImageDimInfoWith(filter_trans_dims);
+    const DDim& filter_image_dims = converter.InitImageDimInfoWith(filter_dims);
     filter_image_w_ = filter_image_dims[0];  // ((C + 3) / 4) * 4;
     filter_image_h_ = filter_image_dims[1];  // ((N + 3) / 4) * H * W;
     tensor_hold_filter_image_->Resize({1, filter_image_w_, filter_image_h_, 4});
     auto* filter_image_data = MUTABLE_DATA_CPU(tensor_hold_filter_image_);
 
-    converter.NCHWToImage(
-        filter_cpu_trans.data(), filter_image_data, filter_trans_dims);
+    converter.NCHWToImage((float*)filter_cpu, filter_image_data, filter_dims);
     MUTABLE_DATA_GPU(
         filter_gpu_image_, filter_image_w_, filter_image_h_, filter_image_data);
   } else if ((groups_ == input_tensor_c_) && (groups_ == output_tensor_c_)) {
-    // for depthwsie conv transpose
+    // for depthwise conv transpose
     std::string kernel_name = "conv2d_transpose";
     build_options_single += " -DIS_DEPTHWISE ";
     kernel_func_names_.push_back(kernel_name);
 
-    CLImageConverterNBlock converter;
+    DDimLite filter_trans_dims{
+        {filter_dims[1], filter_dims[0], filter_dims[2], filter_dims[3]}};
+    CLImageConverterDefault converter;
     const DDim& filter_image_dims =
         converter.InitImageDimInfoWith(filter_trans_dims);
     filter_image_w_ = filter_image_dims[0];


### PR DESCRIPTION
主要是对transpose conv对weights也省略了IOHW2OIHW()的调用。另外对depthwise transpose conv对weights换用了default converter来转image格式，较为紧凑，没有多余对补0，节省一点内存。