### PR TITLE
Solve the directed loop about write_to_array op

### DIFF
--- a/lite/kernels/host/write_back_compute.h
+++ b/lite/kernels/host/write_back_compute.h
@@ -25,6 +25,9 @@ class WriteBackCompute
     : public KernelLite<TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny)> {
  public:
   void Run() override;
+
+ private:
+  void RunImplement(const lite::Tensor* x, lite::Tensor* y);
 };
 
 }  // namespace host

--- a/lite/model_parser/ssa/op_desc.cc
+++ b/lite/model_parser/ssa/op_desc.cc
@@ -107,14 +107,24 @@ constexpr char const WriteBackOp::input_lod_deps_[];
 constexpr char const WriteBackOp::input_lod_array_deps_[];
 constexpr char const WriteBackOp::input_src_[];
 constexpr char const WriteBackOp::input_dst_[];
+constexpr char const WriteBackOp::input_src_array_[];
+constexpr char const WriteBackOp::input_dst_array_[];
 
 WriteBackOp::WriteBackOp(const std::weak_ptr<VarDesc>& src,
                          const std::weak_ptr<VarDesc>& dst,
-                         int32_t block_idx) {
-  CHECK(src.lock()->GetType() == VarDataType::LOD_TENSOR);
-  CHECK(dst.lock()->GetType() == VarDataType::LOD_TENSOR);
-  AddInput(input_src_, src, block_idx);
-  AddInput(input_dst_, dst, block_idx);
+                         int32_t block_idx,
+                         bool tensor_array_copy) {
+  if (!tensor_array_copy) {
+    CHECK(src.lock()->GetType() == VarDataType::LOD_TENSOR);
+    CHECK(dst.lock()->GetType() == VarDataType::LOD_TENSOR);
+    AddInput(input_src_, src, block_idx);
+    AddInput(input_dst_, dst, block_idx);
+  } else {
+    CHECK(src.lock()->GetType() == VarDataType::LOD_TENSOR_ARRAY);
+    CHECK(dst.lock()->GetType() == VarDataType::LOD_TENSOR_ARRAY);
+    AddInput(input_src_array_, src, block_idx);
+    AddInput(input_dst_array_, dst, block_idx);
+  }
   for (auto& op : dst.lock()->target_ops()) {
     for (auto& dep_var : ConvertToSet(op->outputs())) {
       if (dep_var.lock()->GetType() == VarDataType::LOD_TENSOR) {

--- a/lite/model_parser/ssa/var_desc.cc
+++ b/lite/model_parser/ssa/var_desc.cc
@@ -31,7 +31,9 @@ std::weak_ptr<VarDesc> VarDesc::latest() {
 
 std::weak_ptr<VarDesc> VarDesc::Read(const OpDescBase& op_desc) {
   targets_.push_back(&op_desc);
-  std::shared_ptr<VarDesc> desc;
+  if (GetType() == VarDataType::LOD_TENSOR_ARRAY) {
+    if (mutable_) mutable_ = !mutable_;
+  }
   return latest();
 }
 
@@ -46,7 +48,8 @@ std::weak_ptr<VarDesc> VarDesc::NewDescendant() {
 
 std::weak_ptr<VarDesc> VarDesc::Written(const OpDescBase& op_desc) {
   std::weak_ptr<VarDesc> desc;
-  if (GetType() == VarDataType::LOD_TENSOR) {
+  if (GetType() == VarDataType::LOD_TENSOR ||
+      GetType() == VarDataType::LOD_TENSOR_ARRAY) {
     if (mutable_) {
       mutable_ = !mutable_;
       desc = shared_from_this();

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -2513,8 +2513,12 @@ struct CosSimParam : ParamBase {
 };
 
 struct WriteBackParam : ParamBase {
+  bool tensor_array_copy{false};
   const lite::Tensor* x{};
   lite::Tensor* y{};
+
+  std::vector<lite::Tensor>* array_x{};
+  std::vector<lite::Tensor>* array_y{};
 };
 
 struct UniqueWithCountsParam : ParamBase {

--- a/lite/operators/write_back_op.cc
+++ b/lite/operators/write_back_op.cc
@@ -20,23 +20,42 @@ namespace lite {
 namespace operators {
 
 bool WriteBackOp::CheckShape() const {
-  CHECK(param_.x);
-  CHECK(param_.y);
-  return true;
+  if (!param_.tensor_array_copy) {
+    CHECK(param_.x);
+    CHECK(param_.y);
+    return true;
+  } else {
+    CHECK(param_.array_x);
+    CHECK(param_.array_y);
+    return true;
+  }
 }
 
 bool WriteBackOp::InferShapeImpl() const {
-  param_.y->Resize(param_.x->dims());
-  param_.y->set_lod(param_.x->lod());
-  param_.y->set_precision(param_.x->precision());
-  param_.y->set_persistable(param_.x->persistable());
-  return true;
+  if (!param_.tensor_array_copy) {
+    param_.y->Resize(param_.x->dims());
+    param_.y->set_lod(param_.x->lod());
+    param_.y->set_precision(param_.x->precision());
+    param_.y->set_persistable(param_.x->persistable());
+    return true;
+  }
+  return false;
 }
 
 bool WriteBackOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
-  param_.x = scope->FindTensor(opdesc.Input("Src_LoDTensor").front());
-  param_.y = scope->FindMutableTensor(opdesc.Input("Dst_LoDTensor").front());
-  return true;
+  if (opdesc.HasAttr("tensor_array_copy")) param_.tensor_array_copy = true;
+  if (!param_.tensor_array_copy) {
+    param_.x = scope->FindTensor(opdesc.Input("Src_LoDTensor").front());
+    param_.y = scope->FindMutableTensor(opdesc.Input("Dst_LoDTensor").front());
+    return true;
+  } else {
+    auto src = opdesc.Input("Src_LoDTensorArray").front();
+    auto dst = opdesc.Input("Dst_LoDTensorArray").front();
+    param_.array_x = scope->FindVar(src)->GetMutable<std::vector<Tensor>>();
+    param_.array_y = scope->FindVar(dst)->GetMutable<std::vector<Tensor>>();
+    return true;
+  }
+  return false;
 }
 
 }  // namespace operators


### PR DESCRIPTION
解决关于write_to_array算子的有向环问题，解决思路：增加write_array_back算子以去掉环，本pr只是实现了去掉该场景的有向环，并未实现write_array_back算子，write_array_back算子由后续pr实现。
本pr解决的典型有向环场景为：
场景1: 对TensorArray变量“先读后写形成环”
array_0.out为TensorArray变量，block_1算子的执行顺序为lod_array_length，arg_max，write_to_array；
1. block_0
![image](https://user-images.githubusercontent.com/63448337/133250988-c8ddd770-2cce-4240-92d4-52eefdd901ff.png)

2. block_1
![image](https://user-images.githubusercontent.com/63448337/133251029-84c88883-52ad-4201-85b8-f433635f6772.png)

处理后：
![image](https://user-images.githubusercontent.com/63448337/133250188-2446c5d3-270e-43b2-a8c7-e92310af6ee9.png)

![image](https://user-images.githubusercontent.com/63448337/133250295-3434be05-33cf-442e-a992-1f9317c5eb6b.png)

场景2: 对TensorArray变量“先写后读再写形成环”
array_0.out为TensorArray变量，block_0算子执行顺序为：op，conditional_block;   block_1算子的执行顺序为：lod_array_length，arg_max，write_to_array；
1. block_0
![image](https://user-images.githubusercontent.com/63448337/133250484-168800d9-d912-448d-aa2d-18450377715c.png)

2. block_1
![image](https://user-images.githubusercontent.com/63448337/133250679-fb0ad593-5908-4bf3-9311-28be4567bd83.png)

处理后：
![image](https://user-images.githubusercontent.com/63448337/133250755-1ad3d84f-ae34-4889-837f-8b566d569cdd.png)

![image](https://user-images.githubusercontent.com/63448337/133250791-16e3b53f-37f1-48a6-a574-8b288b1203a8.png)

可见，该PR对上述两种场景的处理后的结果相同。

更新：修改了write_back_op的行为，支持vector<tensor>回写，后续会优化write_back_op的实现。