### PR TITLE
[Benchmark Tool] Enable Arm linux function

### DIFF
--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -98,6 +98,9 @@ function set_benchmark_options {
     WITH_OPENCL=OFF
   else
     WITH_OPENCL=ON
+    if [ "${ARCH}" == "armv8" ] || [ "${ARCH}" == "armv7hf" ]; then
+      with_light_weight_framework=ON
+    fi
   fi
   if [ ${WITH_PROFILE} == "ON" ] || [ ${WITH_PRECISION_PROFILE} == "ON" ]; then
     WITH_LOG=ON


### PR DESCRIPTION
### For armv8
```shell
./lite/tools/build_linux.sh --arch=armv8 --with_profile=OFF --with_benchmark=ON full_publish
```

### For armv7hf
```
./lite/tools/build_linux.sh --arch=armv7hf --with_profile=OFF --with_benchmark=ON full_publish
```