### PR TITLE
fix arm reduce_prod

### DIFF
--- a/lite/kernels/arm/reduce_prod_compute.cc
+++ b/lite/kernels/arm/reduce_prod_compute.cc
@@ -111,3 +111,13 @@ REGISTER_LITE_KERNEL(
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
+
+#ifdef LITE_BUILD_EXTRA
+using reduce_prob_arm_int32_f =
+    paddle::lite::kernels::arm::ReduceProdCompute<int, PRECISION(kFloat)>;
+REGISTER_LITE_KERNEL(
+    reduce_prod, kARM, kFloat, kNCHW, reduce_prob_arm_int32_f, int32)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .Finalize();
+#endif  // LITE_BUILD_EXTRA


### PR DESCRIPTION
1. kernel pick无法正确选择int32 kernel
2. 兼容旧版本产出的opt模型