### PR TITLE
[opt]enable fp16 in opt tool

### DIFF
--- a/lite/tools/cmake_tools/parse_kernel_registry.py
+++ b/lite/tools/cmake_tools/parse_kernel_registry.py
@@ -71,7 +71,7 @@ with open(faked_kernels_list_path) as f:
         with open(path.strip()) as g:
             c = g.read()
             kernel_parser = RegisterLiteKernelParser(c)
-            kernel_parser.parse(with_extra, enable_arm_fp16)
+            kernel_parser.parse(with_extra, "ON")
 
             for k in kernel_parser.kernels:
                   kernel = "%s,%s,%s,%s,%s" % (


### PR DESCRIPTION
- issue : opt 无法转化模型为fp16格式
- 定位与修复： fake kernel 无需进行fp16 是否支持的判断、应该直接链接到最终产出中