### PR TITLE
[Compile] Support python3.9

### DIFF
--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -26,7 +26,7 @@ ExternalProject_Add(
         extern_pybind
         ${EXTERNAL_PROJECT_LOG_ARGS}
         GIT_REPOSITORY  "https://github.com/pybind/pybind11.git"
-        GIT_TAG         "v2.2.4"
+        GIT_TAG         "v2.6.0"
         PREFIX          ${PYBIND_SOURCE_DIR}
         UPDATE_COMMAND  ""
         CONFIGURE_COMMAND ""


### PR DESCRIPTION
- pybind11 低版本不兼容 python3.9
- 本PR提升了工程中的pybind版本