### PR TITLE
[OpenCL][kernels]fix op bugs

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/elementwise_add_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/elementwise_add_kernel.cl
@@ -41,6 +41,28 @@ __kernel void elementwise_add(__read_only image2d_t input,
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
 }
 
+__kernel void elementwise_add_n1c1h1(__read_only image2d_t input,
+                                     __read_only image2d_t bias,
+                                     __write_only image2d_t output,
+                                     int h,
+                                     int w) {
+  int x = get_global_id(0);
+  int y = get_global_id(1);
+
+  int2 coords;
+  coords.x = x;
+  coords.y = y;
+
+  CL_DTYPE4 cur_in =
+      READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(x % w, 0));
+  CL_DTYPE4 in = (CL_DTYPE4)(cur_in.x);
+  CL_DTYPE4 cur_bias = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, SAMPLER, coords);
+
+  CL_DTYPE4 alpha;
+  CL_DTYPE4 out = activation_type4(in + cur_bias, alpha);
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, coords, out);
+}
+
 __kernel void elementwise_add_n1h1w1(__read_only image2d_t input,
                                      __read_only image2d_t bias,
                                      __write_only image2d_t outputImage,
@@ -81,7 +103,9 @@ __kernel void channel_add(__read_only image2d_t input,
 
   CL_DTYPE4 in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, coords);
   CL_DTYPE4 biase = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, SAMPLER, coords_bias);
-  CL_DTYPE4 output = in + (CL_DTYPE4)(biase.x);
+
+  CL_DTYPE4 alpha;
+  CL_DTYPE4 output = activation_type4(in + (CL_DTYPE4)(biase.x), alpha);
 
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
 }

--- a/lite/backends/opencl/cl_kernel/image/elementwise_mul_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/elementwise_mul_kernel.cl
@@ -37,6 +37,31 @@ __kernel void elementwise_mul(__read_only image2d_t input,
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, outputImage, coords, output);
 }
 
+__kernel void elementwise_mul_n1c1h1(__read_only image2d_t input,
+                                     __read_only image2d_t bias,
+                                     __write_only image2d_t output,
+                                     int input_w) {
+  int x = get_global_id(0);
+  int y = get_global_id(1);
+
+  int2 coords;
+  coords.x = x;
+  coords.y = y;
+
+  CL_DTYPE4 cur_in =
+      READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(x % input_w, 0));
+  CL_DTYPE4 in = (CL_DTYPE4)(cur_in.x);
+  CL_DTYPE4 cur_bias = READ_IMG_TYPE(CL_DTYPE_CHAR, bias, SAMPLER, coords);
+
+#ifdef FUSE_SCALE
+  CL_DTYPE4 out =
+      fuse_scale(in * cur_bias, SCALE_SLOPE, SCALE_BIAS, SCALE_ALPHA);
+#else
+  CL_DTYPE4 out = in * cur_bias;
+#endif
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, coords, out);
+}
+
 __kernel void channel_mul(__read_only image2d_t input,
                           __read_only image2d_t bias,
                           __write_only image2d_t outputImage,

--- a/lite/backends/opencl/cl_kernel/image/layout_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/layout_kernel.cl
@@ -141,6 +141,19 @@ __kernel void image2d_to_buffer(__read_only image2d_t input,
   }
 }
 
+__kernel void image2d_to_buffer_nc(__read_only image2d_t input,
+                                   __global CL_DTYPE* out,
+                                   __private const int image_w,
+                                   __private const int image_h) {
+  const in_c = get_global_id(0);
+  const in_n = get_global_id(1);
+
+  CL_COMPUTE_DTYPE4 in =
+      READ_IMG_TYPE(CL_COMPUTE_DTYPE_CHAR, input, SAMPLER, (int2)(in_c, in_n));
+
+  out[in_n * image_w + in_c] = in.x;
+}
+
 #if 0  // NOTE(ysh329): keep, un-used from paddle-mobile
 ////////////////////////////////////////////////////////
 // buffer -> image2d_nw

--- a/lite/kernels/opencl/elementwise_add_image_compute.cc
+++ b/lite/kernels/opencl/elementwise_add_image_compute.cc
@@ -49,6 +49,9 @@ void ElementwiseAddImageCompute::PrepareForRun() {
 
   if (y->dims().size() == 4) {
     kernel_func_name_ = "elementwise_add";  // y: ImageDefault
+    if (x->dims()[0] == 1 && x->dims()[1] == 1 && x->dims()[2] == 1) {
+      kernel_func_name_ = "elementwise_add_n1c1h1";
+    }
     if (y->dims()[0] == 1 && y->dims()[2] == 1 && y->dims()[3] == 1) {
       kernel_func_name_ = "elementwise_add_n1h1w1";
     }
@@ -206,6 +209,19 @@ void ElementwiseAddImageCompute::Run() {
     status = kernel.setArg(4, output_w);
     CL_CHECK_FATAL(status);
   } else if (kernel_func_name_ == "elementwise_add_n1h1w1") {
+    int output_w = out->dims()[3];
+    int output_h = out->dims()[2];
+    status = kernel.setArg(0, *x_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(1, *y_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(2, *out_img);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(3, output_h);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(4, output_w);
+    CL_CHECK_FATAL(status);
+  } else if (kernel_func_name_ == "elementwise_add_n1c1h1") {
     int output_w = out->dims()[3];
     int output_h = out->dims()[2];
     status = kernel.setArg(0, *x_img);

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -269,37 +269,62 @@ class LayoutComputeImageDefaultToBufferChw
     int arg_idx = 0;
     cl_int status = kernel.setArg(arg_idx, *x_data);
     CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(in_width));
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(in_height));
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, *y_data);
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(size_ch));
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(size_block));
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(size_batch));
-    CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(C));
-    CL_CHECK_FATAL(status);
-#ifdef LITE_WITH_LOG
-    VLOG(2) << "gws:[3D]" << ((new_dims[1] + 3) / 4) << " " << new_dims[3]
-            << " " << (new_dims[0] * new_dims[2]);
-#endif
-    auto global_work_size =
-        cl::NDRange{static_cast<cl::size_type>((new_dims[1] + 3) / 4),
-                    static_cast<cl::size_type>(new_dims[3]),
-                    static_cast<cl::size_type>(new_dims[0] * new_dims[2])};
+    if (x_dims.size() == 2 &&
+        x_dims[0] == 1) {  // layout kernel specific for nc
+      auto global_work_size =
+          cl::NDRange{static_cast<cl::size_type>(x_image_shape["width"]),
+                      static_cast<cl::size_type>(x_image_shape["height"])};
 
-    status = EnqueueNDRangeKernel(context,
-                                  kernel,
-                                  cl::NullRange,
-                                  global_work_size,
-                                  cl::NullRange,
-                                  nullptr,
-                                  event_);
-    CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, *y_data);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx,
+                             static_cast<const int>(x_image_shape["width"]));
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx,
+                             static_cast<const int>(x_image_shape["height"]));
+      CL_CHECK_FATAL(status);
+
+      status = EnqueueNDRangeKernel(context,
+                                    kernel,
+                                    cl::NullRange,
+                                    global_work_size,
+                                    cl::NullRange,
+                                    nullptr,
+                                    event_);
+      CL_CHECK_FATAL(status);
+    } else {
+      status = kernel.setArg(++arg_idx, static_cast<const int>(in_width));
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<const int>(in_height));
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, *y_data);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<const int>(size_ch));
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<const int>(size_block));
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<const int>(size_batch));
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<const int>(C));
+      CL_CHECK_FATAL(status);
+#ifdef LITE_WITH_LOG
+      VLOG(2) << "gws:[3D]" << ((new_dims[1] + 3) / 4) << " " << new_dims[3]
+              << " " << (new_dims[0] * new_dims[2]);
+#endif
+      auto global_work_size =
+          cl::NDRange{static_cast<cl::size_type>((new_dims[1] + 3) / 4),
+                      static_cast<cl::size_type>(new_dims[3]),
+                      static_cast<cl::size_type>(new_dims[0] * new_dims[2])};
+
+      status = EnqueueNDRangeKernel(context,
+                                    kernel,
+                                    cl::NullRange,
+                                    global_work_size,
+                                    cl::NullRange,
+                                    nullptr,
+                                    event_);
+      CL_CHECK_FATAL(status);
+    }
   }
 
   std::string doc() const override {

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -44,6 +44,8 @@ class LayoutComputeBufferChwToImageDefault
     auto& param = Param<param_t>();
     if (param.process_type == 1) {
       kernel_func_name_ = "buffer_to_image2d_with_pre255";
+    } else if (x_dims.size() == 2 && x_dims[0] == 1) {
+      kernel_func_name_ = "image2d_to_buffer_nc";
     }
     if (!fp16_support_) {
       build_options_ += " -DCL_DTYPE_FLOAT_FORCE";

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -44,8 +44,6 @@ class LayoutComputeBufferChwToImageDefault
     auto& param = Param<param_t>();
     if (param.process_type == 1) {
       kernel_func_name_ = "buffer_to_image2d_with_pre255";
-    } else if (x_dims.size() == 2 && x_dims[0] == 1) {
-      kernel_func_name_ = "image2d_to_buffer_nc";
     }
     if (!fp16_support_) {
       build_options_ += " -DCL_DTYPE_FLOAT_FORCE";
@@ -183,8 +181,11 @@ class LayoutComputeImageDefaultToBufferChw
 
   void PrepareForRun() override {
     auto& param = Param<param_t>();
+    auto x_dims = param.x->dims();
     if (param.process_type == 1) {
       kernel_func_name_ = "image2d_to_buffer_with_post255";
+    } else if (x_dims.size() == 2 && x_dims[0] == 1) {
+      kernel_func_name_ = "image2d_to_buffer_nc";
     }
     if (!fp16_support_) {
       build_options_ += " -DCL_DTYPE_FLOAT_FORCE";

--- a/lite/operators/unsqueeze_op.cc
+++ b/lite/operators/unsqueeze_op.cc
@@ -132,7 +132,7 @@ bool Unsqueeze2Op::CheckShape() const {
 bool Unsqueeze2Op::InferShapeImpl() const {
   UnsqueezeOp::InferShapeImpl();
   auto x_dims = param_.X->dims();
-  std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1, 0);
+  std::vector<DDim::value_type> xshape_dims(x_dims.size() + 1, 1);
   for (size_t i = 0; i < x_dims.size(); i++) {
     xshape_dims[i + 1] = x_dims[i];
   }


### PR DESCRIPTION
在layout_kernel.cl中新增image2d_to_buffer_nc() 函数支持n和c的二维case；
在elementwise_add_kernel.cl中的channel_add()核函数中增加activation的处理；
在elementwise_add_kernel.cl中新增elementwise_add_n1c1h1()函数支持输入x是n,c,h=1的4维case；
在elementwise_mul_kernel.cl中新增elementwise_mul_n1c1h1()函数支持输入x是n,c,h=1的4维case；
