### PR TITLE
[Benchmark Tool] Supporting NNAdapter backend

### DIFF
--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -213,7 +213,6 @@ if(NOT IOS AND NOT LITE_ON_TINY_PUBLISH)
     lite_cc_binary(benchmark_bin SRCS tools/benchmark.cc tools/flags.cc tools/opt_base.cc
         DEPS gflags
         CV_DEPS paddle_cv_arm)
-    target_link_libraries(benchmark_bin nnadapter)
 endif()
 
 # opt tool

--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -213,6 +213,7 @@ if(NOT IOS AND NOT LITE_ON_TINY_PUBLISH)
     lite_cc_binary(benchmark_bin SRCS tools/benchmark.cc tools/flags.cc tools/opt_base.cc
         DEPS gflags
         CV_DEPS paddle_cv_arm)
+    target_link_libraries(benchmark_bin nnadapter)
 endif()
 
 # opt tool

--- a/lite/api/tools/benchmark.h
+++ b/lite/api/tools/benchmark.h
@@ -208,6 +208,20 @@ void SetBackendConfig(lite_api::MobileConfig& config) {  // NOLINT
     }
     config.set_opencl_precision(gpu_precision);
   }
+
+  std::vector<std::string> nnadapter_backends = {"imagination_nna",
+                                                 "rockchip_npu",
+                                                 "mediatek_apu",
+                                                 "huawei_kirin_npu",
+                                                 "huawei_ascend_npu",
+                                                 "amlogic_npu"};
+  if (std::find(nnadapter_backends.begin(),
+                nnadapter_backends.end(),
+                FLAGS_backend) != nnadapter_backends.end()) {
+    std::cout << "NNAdapter Backends: " << FLAGS_backend << std::endl;
+    config.set_nnadapter_device_names({FLAGS_backend});
+    config.set_nnadapter_context_properties(FLAGS_nnadapter_context_properties);
+  }
 }
 
 void OutputOptModel(const std::string& save_optimized_model_path) {

--- a/lite/api/tools/benchmark.h
+++ b/lite/api/tools/benchmark.h
@@ -219,6 +219,7 @@ void SetBackendConfig(lite_api::MobileConfig& config) {  // NOLINT
     }
     config.set_opencl_precision(gpu_precision);
   }
+
   // nnadapter option
   if (with_nnadapter) {
     std::vector<std::string> nnadapter_devices;

--- a/lite/api/tools/benchmark.h
+++ b/lite/api/tools/benchmark.h
@@ -219,7 +219,7 @@ void SetBackendConfig(lite_api::MobileConfig& config) {  // NOLINT
     }
     config.set_opencl_precision(gpu_precision);
   }
-
+  // nnadapter option
   if (with_nnadapter) {
     std::vector<std::string> nnadapter_devices;
     auto device_list = lite::Split(FLAGS_nnadapter_device_names, ",");

--- a/lite/api/tools/benchmark.h
+++ b/lite/api/tools/benchmark.h
@@ -164,90 +164,82 @@ const std::string PrintUsage() {
 }
 
 void SetBackendConfig(lite_api::MobileConfig& config) {  // NOLINT
-  auto target_list = lite::Split(FLAGS_backend, ",");
   std::vector<std::string> nnadapter_backends = {"imagination_nna",
                                                  "rockchip_npu",
                                                  "mediatek_apu",
                                                  "huawei_kirin_npu",
                                                  "huawei_ascend_npu",
                                                  "amlogic_npu"};
-  std::vector<std::string> nnadapter_devices;
 
-  if (target_list.size() < 1) {
-    std::cout << "No backends input!" << std::endl;
-    return;
+  if (FLAGS_backend == "opencl" || FLAGS_backend == "x86_opencl") {
+    // Set opencl kernel binary.
+    // Large addtitional prepare time is cost due to algorithm selecting and
+    // building kernel from source code.
+    // Prepare time can be reduced dramitically after building algorithm file
+    // and OpenCL kernel binary on the first running.
+    // The 1st running time will be a bit longer due to the compiling time if
+    // you don't call `set_opencl_binary_path_name` explicitly.
+    // So call `set_opencl_binary_path_name` explicitly is strongly
+    // recommended.
+
+    // Make sure you have write permission of the binary path.
+    // We strongly recommend each model has a unique binary name.
+    config.set_opencl_binary_path_name(FLAGS_opencl_cache_dir,
+                                       FLAGS_opencl_kernel_cache_file);
+
+    // opencl tune option
+    auto tune_mode = CL_TUNE_NONE;
+    if (FLAGS_opencl_tune_mode == "none") {
+      tune_mode = CL_TUNE_NONE;
+    } else if (FLAGS_opencl_tune_mode == "normal") {
+      tune_mode = CL_TUNE_NORMAL;
+    } else if (FLAGS_opencl_tune_mode == "rapid") {
+      tune_mode = CL_TUNE_RAPID;
+    } else if (FLAGS_opencl_tune_mode == "exhaustive") {
+      tune_mode = CL_TUNE_EXHAUSTIVE;
+    } else {
+      std::cerr << "Illegal opencl tune mode: " << FLAGS_opencl_tune_mode
+                << std::endl;
+    }
+    config.set_opencl_tune(
+        tune_mode, FLAGS_opencl_cache_dir, FLAGS_opencl_tuned_file);
+
+    // opencl precision option
+    auto gpu_precision = CL_PRECISION_FP16;
+    if (FLAGS_gpu_precision == "auto") {
+      gpu_precision = CL_PRECISION_AUTO;
+    } else if (FLAGS_gpu_precision == "fp16") {
+      gpu_precision = CL_PRECISION_FP16;
+    } else if (FLAGS_gpu_precision == "fp32") {
+      gpu_precision = CL_PRECISION_FP32;
+    }
+    config.set_opencl_precision(gpu_precision);
   }
 
-  if (target_list.size() == 1) {
-    if (FLAGS_backend == "opencl" || FLAGS_backend == "x86_opencl") {
-      // Set opencl kernel binary.
-      // Large addtitional prepare time is cost due to algorithm selecting and
-      // building kernel from source code.
-      // Prepare time can be reduced dramitically after building algorithm file
-      // and OpenCL kernel binary on the first running.
-      // The 1st running time will be a bit longer due to the compiling time if
-      // you don't call `set_opencl_binary_path_name` explicitly.
-      // So call `set_opencl_binary_path_name` explicitly is strongly
-      // recommended.
+  if (FLAGS_backend == "nnadapter") {
+    std::vector<std::string> nnadapter_devices;
+    auto device_list = lite::Split(FLAGS_nnadapter_device_names, ",");
 
-      // Make sure you have write permission of the binary path.
-      // We strongly recommend each model has a unique binary name.
-      config.set_opencl_binary_path_name(FLAGS_opencl_cache_dir,
-                                         FLAGS_opencl_kernel_cache_file);
-
-      // opencl tune option
-      auto tune_mode = CL_TUNE_NONE;
-      if (FLAGS_opencl_tune_mode == "none") {
-        tune_mode = CL_TUNE_NONE;
-      } else if (FLAGS_opencl_tune_mode == "normal") {
-        tune_mode = CL_TUNE_NORMAL;
-      } else if (FLAGS_opencl_tune_mode == "rapid") {
-        tune_mode = CL_TUNE_RAPID;
-      } else if (FLAGS_opencl_tune_mode == "exhaustive") {
-        tune_mode = CL_TUNE_EXHAUSTIVE;
-      } else {
-        std::cerr << "Illegal opencl tune mode: " << FLAGS_opencl_tune_mode
-                  << std::endl;
-      }
-      config.set_opencl_tune(
-          tune_mode, FLAGS_opencl_cache_dir, FLAGS_opencl_tuned_file);
-
-      // opencl precision option
-      auto gpu_precision = CL_PRECISION_FP16;
-      if (FLAGS_gpu_precision == "auto") {
-        gpu_precision = CL_PRECISION_AUTO;
-      } else if (FLAGS_gpu_precision == "fp16") {
-        gpu_precision = CL_PRECISION_FP16;
-      } else if (FLAGS_gpu_precision == "fp32") {
-        gpu_precision = CL_PRECISION_FP32;
-      }
-      config.set_opencl_precision(gpu_precision);
+    if (device_list.size() < 1) {
+      std::cerr << "The device list for nnadapter is null!" << std::endl;
+      return;
     }
 
-    if (std::find(nnadapter_backends.begin(),
-                  nnadapter_backends.end(),
-                  FLAGS_backend) != nnadapter_backends.end()) {
-      nnadapter_devices.push_back(FLAGS_backend);
-    }
-  }
-
-  if (target_list.size() > 1) {
-    for (auto& target : target_list) {
+    for (auto& device : device_list) {
       if (std::find(nnadapter_backends.begin(),
                     nnadapter_backends.end(),
-                    target) != nnadapter_backends.end()) {
-        nnadapter_devices.push_back(target);
+                    device) != nnadapter_backends.end()) {
+        nnadapter_devices.push_back(device);
       }
     }
-  }
 
-  if (nnadapter_devices.size() >= 1) {
-    std::cout << "nnadapter_devices_check" << std::endl;
-    for (auto d : nnadapter_devices) {
-      std::cout << "[lsy-device]" << d << std::endl;
+    if (nnadapter_devices.size() == 0) {
+      std::cout << "No avaliable device found for nnadapter" << std::endl;
+    } else {
+      config.set_nnadapter_device_names(nnadapter_devices);
+      config.set_nnadapter_context_properties(
+          FLAGS_nnadapter_context_properties);
     }
-    config.set_nnadapter_device_names(nnadapter_devices);
-    config.set_nnadapter_context_properties(FLAGS_nnadapter_context_properties);
   }
 }
 
@@ -264,8 +256,11 @@ void OutputOptModel(const std::string& save_optimized_model_path) {
 
   if (FLAGS_backend != "") {
     if (FLAGS_cpu_precision == "fp16") opt.EnableFloat16();
-    opt.SetValidPlaces(FLAGS_backend);
-    std::cout << "[lsy]SetValidPlaces: " << FLAGS_backend << std::endl;
+    if (FLAGS_backend == "nnadapter") {
+      opt.SetValidPlaces(FLAGS_nnadapter_device_names);
+    } else {
+      opt.SetValidPlaces(FLAGS_backend);
+    }
   }
 
   auto previous_opt_model = save_optimized_model_path + ".nb";

--- a/lite/api/tools/benchmark.h
+++ b/lite/api/tools/benchmark.h
@@ -171,6 +171,10 @@ void SetBackendConfig(lite_api::MobileConfig& config) {  // NOLINT
                                                  "huawei_ascend_npu",
                                                  "amlogic_npu"};
 
+  auto backends_list = lite::Split(FLAGS_backend, ",");
+  bool with_nnadapter =
+      std::find(backends_list.begin(), backends_list.end(), "nnadapter") !=
+      backends_list.end();
   if (FLAGS_backend == "opencl" || FLAGS_backend == "x86_opencl") {
     // Set opencl kernel binary.
     // Large addtitional prepare time is cost due to algorithm selecting and
@@ -216,7 +220,7 @@ void SetBackendConfig(lite_api::MobileConfig& config) {  // NOLINT
     config.set_opencl_precision(gpu_precision);
   }
 
-  if (FLAGS_backend == "nnadapter") {
+  if (with_nnadapter) {
     std::vector<std::string> nnadapter_devices;
     auto device_list = lite::Split(FLAGS_nnadapter_device_names, ",");
 
@@ -230,11 +234,15 @@ void SetBackendConfig(lite_api::MobileConfig& config) {  // NOLINT
                     nnadapter_backends.end(),
                     device) != nnadapter_backends.end()) {
         nnadapter_devices.push_back(device);
+      } else {
+        std::cerr << "Find and ignore unsupport nnadapter device: " << device
+                  << std::endl;
       }
     }
 
     if (nnadapter_devices.size() == 0) {
-      std::cout << "No avaliable device found for nnadapter" << std::endl;
+      std::cerr << "No avaliable device found for nnadapter" << std::endl;
+      return;
     } else {
       config.set_nnadapter_device_names(nnadapter_devices);
       config.set_nnadapter_context_properties(
@@ -245,7 +253,6 @@ void SetBackendConfig(lite_api::MobileConfig& config) {  // NOLINT
 
 void OutputOptModel(const std::string& save_optimized_model_path) {
   auto opt = paddle::lite_api::OptBase();
-
   if (!FLAGS_uncombined_model_dir.empty()) {
     opt.SetModelDir(FLAGS_uncombined_model_dir);
   } else {
@@ -255,9 +262,25 @@ void OutputOptModel(const std::string& save_optimized_model_path) {
   opt.SetOptimizeOut(save_optimized_model_path);
 
   if (FLAGS_backend != "") {
+    auto backends_list = lite::Split(FLAGS_backend, ",");
+    bool with_nnadapter =
+        std::find(backends_list.begin(), backends_list.end(), "nnadapter") !=
+        backends_list.end();
     if (FLAGS_cpu_precision == "fp16") opt.EnableFloat16();
-    if (FLAGS_backend == "nnadapter") {
-      opt.SetValidPlaces(FLAGS_nnadapter_device_names);
+    if (with_nnadapter) {
+      std::string valid_places;
+      for (auto& backend : backends_list) {
+        if (backend != "nnadapter") {
+          valid_places += backend;
+          valid_places += ',';
+        }
+      }
+      if (FLAGS_nnadapter_device_names != "") {
+        valid_places += FLAGS_nnadapter_device_names;
+      } else {
+        valid_places.pop_back();
+      }
+      opt.SetValidPlaces(valid_places);
     } else {
       opt.SetValidPlaces(FLAGS_backend);
     }

--- a/lite/api/tools/flags.cc
+++ b/lite/api/tools/flags.cc
@@ -46,6 +46,7 @@ DEFINE_string(opencl_tuned_file,
               "paddle_lite_opencl_tuned.params",
               opencl_tuned_file_msg);
 DEFINE_string(opencl_tune_mode, "normal", opencl_tune_mode_msg);
+DEFINE_string(nnadapter_device_names, "", nnadapter_device_names_msg);
 DEFINE_string(nnadapter_context_properties,
               "null",
               nnadapter_context_properties_msg);

--- a/lite/api/tools/flags.cc
+++ b/lite/api/tools/flags.cc
@@ -48,7 +48,7 @@ DEFINE_string(opencl_tuned_file,
 DEFINE_string(opencl_tune_mode, "normal", opencl_tune_mode_msg);
 DEFINE_string(nnadapter_device_names, "", nnadapter_device_names_msg);
 DEFINE_string(nnadapter_context_properties,
-              "null",
+              "",
               nnadapter_context_properties_msg);
 
 // Profiling options

--- a/lite/api/tools/flags.cc
+++ b/lite/api/tools/flags.cc
@@ -46,6 +46,9 @@ DEFINE_string(opencl_tuned_file,
               "paddle_lite_opencl_tuned.params",
               opencl_tuned_file_msg);
 DEFINE_string(opencl_tune_mode, "normal", opencl_tune_mode_msg);
+DEFINE_string(nnadapter_context_properties,
+              "null",
+              nnadapter_context_properties_msg);
 
 // Profiling options
 DEFINE_bool(enable_op_time_profile, false, enable_op_time_profile_msg);

--- a/lite/api/tools/flags.h
+++ b/lite/api/tools/flags.h
@@ -83,6 +83,8 @@ static const char opencl_tuned_file_msg[] =
     "We strongly recommend each model has a unique param name.";
 static const char opencl_tune_mode_msg[] =
     "Set opencl tune option: none, rapid, normal, exhaustive.";
+static const char nnadapter_context_properties_msg[] =
+    "Set nnadapter device hardware resources, default to null";
 
 // Profiling options
 static const char enable_op_time_profile_msg[] =
@@ -124,6 +126,8 @@ DECLARE_string(opencl_cache_dir);
 DECLARE_string(opencl_kernel_cache_file);
 DECLARE_string(opencl_tuned_file);
 DECLARE_string(opencl_tune_mode);
+DECLARE_string(nnadapter_device_name);
+DECLARE_string(nnadapter_context_properties);
 
 // Profiling options
 DECLARE_bool(enable_op_time_profile);

--- a/lite/api/tools/flags.h
+++ b/lite/api/tools/flags.h
@@ -65,7 +65,7 @@ static const char result_path_msg[] = "Save benchmark info to the file.";
 static const char backend_msg[] =
     "To use a particular backend for execution. "
     "Should be one of: arm|opencl|x86|x86_opencl|"
-    "npu|xpu|";
+    "npu|xpu|nnadapter|";
 static const char cpu_precision_msg[] =
     "Register fp32 or fp16 arm-cpu kernel when optimized model. "
     "Should be one of: fp32, fp16.";
@@ -83,6 +83,10 @@ static const char opencl_tuned_file_msg[] =
     "We strongly recommend each model has a unique param name.";
 static const char opencl_tune_mode_msg[] =
     "Set opencl tune option: none, rapid, normal, exhaustive.";
+static const char nnadapter_device_names_msg[] =
+    "Set nnadapter device names. "
+    "Should be one of: huawei_kirin_npu|huawei_ascend_npu|rockchip_npu|"
+    "imagination_nna|mediatek_apu|";
 static const char nnadapter_context_properties_msg[] =
     "Set nnadapter device hardware resources, default to null";
 
@@ -126,7 +130,7 @@ DECLARE_string(opencl_cache_dir);
 DECLARE_string(opencl_kernel_cache_file);
 DECLARE_string(opencl_tuned_file);
 DECLARE_string(opencl_tune_mode);
-DECLARE_string(nnadapter_device_name);
+DECLARE_string(nnadapter_device_names);
 DECLARE_string(nnadapter_context_properties);
 
 // Profiling options


### PR DESCRIPTION
#### Android交叉编译
```shell
bash~$ time ./lite/tools/build_android.sh --arch=armv7 --toolchain=clang --with_profile=OFF --with_benchmark=ON --with_nnadapter=ON full_publish

bash~$ time ./lite/tools/build_android.sh --arch=armv8 --toolchain=clang --with_profile=OFF --with_benchmark=ON --with_nnadapter=ON full_publish
```
#### Linux/macOS x86 编译：
```shell
bash~$ time ./lite/tools/build_linux.sh --arch=x86 --with_profile=OFF --with_benchmark=ON --with_nnadapter=ON full_publish
```

#### benchmark测速（以ascend为例）：
* benchmark_bin只动态链接libnnadapter.so，具体加载哪种硬件的driver hal是由libnnadapter.so根据backends判定的。
* 用户需将运行所需要的driver hal以及各类动态库路径添加至LD_LIBRARY_PATH变量中。
* nnadapter_context_properties，用于标识硬件资源（比如运行在哪张卡上），除ascend外无需设置此参数。
* SUBGRAPH_CUSTOM_PARTITION_CONFIG_FILE可选，如不为空，opt工具将从此环境变量中读取文件。
* 各新硬件libnnadapter.so不可混用，需要重新生成。
```shell
###
benchmark_bin --- dyn_link ---> libnnadapter.so --- dyn_link ---> driver_hal.so
###
bash~$ export LD_LIBRARY_PATH=add_your_shared_library_path_here:$LD_LIBRARY_PATH
bash~$ export SUBGRAPH_CUSTOM_PARTITION_CONFIG_FILE=add_your_subgraph_partition_config_file_here

bash~$ ./benchmark_bin \
    --model_file=./MobileNetV1/model \
    --param_file=./MobileNetV1/params \
    --input_shape=1,3,224,224 \
    --warmup=10 \
    --repeats=20 \
    --backend=x86,nnadapter \
    --nnadapter_device_names=huawei_ascend_npu \
    --nnadapter_context_properties="HUAWEI_ASCEND_NPU_SELECTED_DEVICE_IDS=0"

    ...
    ...
    ======= Model Info =======
    optimized_model_file: ./MobileNetV1/opt.nb
    input_data_path: All 1.f
    input_shape: 1,3,224,224
    output tensor num: 1
    --- output tensor 0 ---
    output shape(NCHW): 1 1000
    output tensor 0 elem num: 1000
    output tensor 0 mean value: 0.00100001
    output tensor 0 standard deviation: 0.00220936
    
    ======= Runtime Info =======
    benchmark_bin version: a1a13f7d1
    threads: 1
    power_mode: 0
    warmup: 10
    repeats: 20
    result_path:
    
    ======= Backend Info =======
    backend: x86,nnadapter
    cpu precision: fp32
    
    ======= Perf Info =======
    Time(unit: ms):
    init  = 18.336
    first = 10443.581
    min   = 2.733
    max   = 2.811
    avg   = 2.779
    
   [I  9/26  9: 6:58.560 ...apter/driver/huawei_ascend_npu/driver.cc:85 DestroyProgram] Destroy program for huawei_ascend_npu.
```

---
#### 新硬件异构计算测试
|Item|Result|
|-|-|
|huawei_kirin_npu + arm| passed |
|huawei_ascend_npu + x86| passed|
|rockchip_npu + arm| passed |
|mediatek_apu + arm| passed |
|imagination_nna + arm| passed |

