### PR TITLE
[NNAdapter] Fix the unit test of comparison operations

### DIFF
--- a/lite/tests/kernels/compare_compute_test.cc
+++ b/lite/tests/kernels/compare_compute_test.cc
@@ -149,8 +149,12 @@ class CompareComputeTester : public arena::TestCase {
   void PrepareData() override {
     std::vector<T> dx(x_dims_.production());
     std::vector<T> dy(y_dims_.production());
-    fill_data_rand<T>(dx.data(), -5, 5, x_dims_.production());
-    fill_data_rand<T>(dy.data(), -5, 5, y_dims_.production());
+    for (int i = 0; i < static_cast<int>(dx.size()); i++) {
+      dx[i] = static_cast<T>(1 - i % 3);
+    }
+    for (int i = 0; i < static_cast<int>(dy.size()); i++) {
+      dy[i] = static_cast<T>(2 - i % 4);
+    }
     SetCommonTensor(x_, x_dims_, dx.data());
     SetCommonTensor(y_, y_dims_, dy.data());
   }


### PR DESCRIPTION
==、!= 并不适用于fp32类型数据，为了减少随机挂的问题，在构造单测输入时，刻意使用int类型