### PR TITLE
Fix bug in directed loop problem

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -517,5 +517,23 @@ void Predictor::CheckInputValid() {
   }
 }
 
+void Predictor::ClearTensorArray(
+    const std::shared_ptr<const cpp::ProgramDesc> &program_desc) {
+  for (size_t blk_idx = 0; blk_idx < program_desc->BlocksSize(); blk_idx++) {
+    const cpp::BlockDesc *block =
+        program_desc->GetBlock<cpp::BlockDesc>(blk_idx);
+    for (size_t var_idx = 0; var_idx < block->VarsSize(); var_idx++) {
+      const cpp::VarDesc *var = block->GetVar<cpp::VarDesc>(var_idx);
+      CHECK(var);
+      if (var->GetType() == lite::VarDataType::LOD_TENSOR_ARRAY) {
+        std::vector<Tensor> *tensor_array_var =
+            program_->exec_scope()->FindMutableTensorList(var->Name());
+        CHECK(tensor_array_var);
+        tensor_array_var->clear();
+      }
+    }
+  }
+}
+
 }  // namespace lite
 }  // namespace paddle

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -176,6 +176,8 @@ class LITE_API Predictor {
 #ifdef LITE_WITH_XPU
     lite::TargetWrapperXPU::FreeL3Cache();
 #endif
+
+    ClearTensorArray(program_desc_);
   }
 
   /// \brief Release all tmp tensor to compress the size of the memory pool.
@@ -238,6 +240,9 @@ class LITE_API Predictor {
   // check if the input tensor precision type is correct.
   // would be called in Run().
   void CheckInputValid();
+
+  void ClearTensorArray(
+      const std::shared_ptr<const cpp::ProgramDesc>& program_desc);
 
  private:
   std::shared_ptr<cpp::ProgramDesc> program_desc_;

--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -40,7 +40,6 @@ void LightPredictor::Build(const std::string& lite_model_file,
 #endif
   BuildRuntimeProgram(program_desc_);
   PrepareFeedFetch();
-  program_desc_.reset();
 }
 
 void LightPredictor::Build(const std::string& model_dir,
@@ -393,6 +392,22 @@ bool LightPredictor::TryShrinkMemory() {
   }
   return true;
 }
-
+void LightPredictor::ClearTensorArray(
+    const std::shared_ptr<const cpp::ProgramDesc>& program_desc) {
+  for (size_t blk_idx = 0; blk_idx < program_desc->BlocksSize(); blk_idx++) {
+    const cpp::BlockDesc* block =
+        program_desc->GetBlock<cpp::BlockDesc>(blk_idx);
+    for (size_t var_idx = 0; var_idx < block->VarsSize(); var_idx++) {
+      const cpp::VarDesc* var = block->GetVar<cpp::VarDesc>(var_idx);
+      CHECK(var);
+      if (var->GetType() == lite::VarDataType::LOD_TENSOR_ARRAY) {
+        std::vector<Tensor>* tensor_array_var =
+            program_->exec_scope()->FindMutableTensorList(var->Name());
+        CHECK(tensor_array_var);
+        tensor_array_var->clear();
+      }
+    }
+  }
+}
 }  // namespace lite
 }  // namespace paddle

--- a/lite/api/light_api.h
+++ b/lite/api/light_api.h
@@ -65,6 +65,7 @@ class LITE_API LightPredictor {
   void Run() {
     CheckInputValid();
     program_->Run();
+    ClearTensorArray(program_desc_);
   }
 
   /// \brief Release all tmp tensor to compress the size of the memory pool.
@@ -129,6 +130,9 @@ class LITE_API LightPredictor {
 #ifdef ENABLE_ARM_FP16
   void WeightFP32ToFP16();
 #endif
+
+  void ClearTensorArray(
+      const std::shared_ptr<const cpp::ProgramDesc>& program_desc);
 
  private:
   std::shared_ptr<Scope> scope_;

--- a/lite/core/type_system.h
+++ b/lite/core/type_system.h
@@ -180,7 +180,8 @@ class Type : public DataType {
 // -------------------------------- compatible check ---------------------------
 static bool TargetCompatibleTo(const Type& a, const Type& b) {
   auto is_host = [](TargetType x) -> bool {
-    return x == TARGET(kHost) || x == TARGET(kX86) || x == TARGET(kARM);
+    return x == TARGET(kHost) || x == TARGET(kX86) || x == TARGET(kARM) ||
+           x == TARGET(kAny);
   };
   if (a.IsVoid() || b.IsVoid()) return true;
   if (a.IsTensor() || b.IsTensor() || a.IsTensorList() || b.IsTensorList()) {

--- a/lite/kernels/host/write_back_compute.h
+++ b/lite/kernels/host/write_back_compute.h
@@ -27,7 +27,9 @@ class WriteBackCompute
   void Run() override;
 
  private:
-  void RunImplement(const lite::Tensor* x, lite::Tensor* y);
+  void RunImplement(const lite::Tensor* x,
+                    lite::Tensor* y,
+                    bool is_tensor_array_copy = false);
 };
 
 }  // namespace host

--- a/lite/kernels/host/write_to_array_compute.cc
+++ b/lite/kernels/host/write_to_array_compute.cc
@@ -54,7 +54,7 @@ REGISTER_LITE_KERNEL(write_to_array,
                                            PRECISION(kAny),
                                            DATALAYOUT(kAny))})
     .BindOutput("FakeAssociatedOut",
-                {LiteType::GetTensorListTy(TARGET(kHost),
-                                           PRECISION(kAny),
-                                           DATALAYOUT(kAny))})
+                {LiteType::GetTensorTy(TARGET(kHost),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
     .Finalize();

--- a/lite/model_parser/ssa/program_desc.cc
+++ b/lite/model_parser/ssa/program_desc.cc
@@ -75,6 +75,7 @@ void PlainProgramDesc::InsertOpOfBlock(const general::BlockDesc& block_desc) {
       auto sub_id = raw_op->GetAttr<int>(op->proto().lock()->AttrKey());
       const auto& raw_sub = *(src_desc_->GetBlock<general::BlockDesc>(sub_id));
       InsertOpOfBlock(raw_sub);
+      op->UpdateInputOutput(*raw_op, *(dst_block->scope()));
       blocks_[sub_id]->SetBlockOpDesc(op.get());
       blocks_[sub_id]->AddBlockInputs(
           op->extra_inputs().cbegin(), op->extra_inputs().cend(), true);


### PR DESCRIPTION
修复有向环中tensorarray的相关bug：
bug1:
     重复调用predict->Run()接口时，需要清理tensorArray变量，否则tensorArray的size会不断膨胀。解决办法：predict->Run()函数中，program_->run()之后，调用ClearTensorArray();
![image](https://user-images.githubusercontent.com/63448337/135066210-f4ffe513-d5c1-4ede-a8e7-19fac3526560.png)

由于ClearTensorArray()函数需要program_desc_， 因此Build函数之后，不能调用program_desc_.reset()
![image](https://user-images.githubusercontent.com/63448337/135066497-4b2bef1b-aeb6-4bf2-9d58-92176c9fa5bf.png)

bug2:拓扑排序不稳定问题：
假设一个模型为：
![image](https://user-images.githubusercontent.com/63448337/135068710-770d59ae-51e9-461a-9d1e-ad988ea44a20.png)
while_op里面的细节为：
![image](https://user-images.githubusercontent.com/63448337/135068925-b4dbf3ea-94b3-4b84-b775-2683d87bbbdb.png)

剪枝 + 补偿 处理之后：
![image](https://user-images.githubusercontent.com/63448337/135070644-29e2da76-13ef-49ef-b835-ab58378441be.png)

即为：
![image](https://user-images.githubusercontent.com/63448337/135070683-5e6e0697-1cd9-4020-ad5e-040d200e9744.png)


note: 一个变量是while op的输入输出，会导致自环！但lite的拓扑排序貌似可以成功处理自环问题（根本原因未知）。

同时拓扑排序结果可能会导致op3在while op前面，导致错误。

正确结构：
改变while op变量的输出名字，同时var_1不再作为while op的输入， var1_1不能作为while op的输入。
![image](https://user-images.githubusercontent.com/63448337/135070127-888bf1c3-451d-4f31-937b-cda44ca9f2c7.png)

