### PR TITLE
Fix relu6sparse error

### DIFF
--- a/lite/backends/arm/math/sparse_conv_impl.cc
+++ b/lite/backends/arm/math/sparse_conv_impl.cc
@@ -996,7 +996,7 @@ void sparse_conv_fp32_pipelined(const float* A,
                                 ARMContext* ctx) {
   auto act_param = param.activation_param;
   auto act_type = act_param.active_type;
-  float alpha = 0.f;
+  volatile float alpha = 0.f;
   int flag_act = 0x00;  // relu: 1, relu6: 2, leakey: 3
   if (act_param.has_active) {
     if (act_type == lite_api::ActivationType::kRelu) {
@@ -1019,7 +1019,6 @@ void sparse_conv_fp32_pipelined(const float* A,
       const float* w = A;
       const int32_t* dmap = widx_dmap;
       const uint32_t* nnzmap = nidx_nnzmap;
-      float valpha = alpha;
 
       for (size_t i = 0; i < nc; i++) {
         uint32_t nnz = *nnzmap++;
@@ -1037,7 +1036,7 @@ void sparse_conv_fp32_pipelined(const float* A,
                 [widx_dmap] "+r"(dmap)
               : [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha)
+                [valpha] "r"(alpha)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
                 "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
                 "v16", "v17", "v18", "v21", "v22", "v23", "v24", "v25", 
@@ -1057,7 +1056,6 @@ void sparse_conv_fp32_pipelined(const float* A,
         const float* w = A;
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -1075,7 +1073,7 @@ void sparse_conv_fp32_pipelined(const float* A,
                 [widx_dmap] "+r"(dmap)
               : [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha)
+                [valpha] "r"(alpha)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
                 "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
                 "v16", "v17", "v18", "v21", "v22", "v23", "v24", "v25", 
@@ -1092,7 +1090,6 @@ void sparse_conv_fp32_pipelined(const float* A,
         const float* w = A;
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -1110,7 +1107,7 @@ void sparse_conv_fp32_pipelined(const float* A,
                 [widx_dmap] "+r"(dmap)
               : [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha)
+                [valpha] "r"(alpha)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
                 "v8", "v9", "v11", "v12", "v13", "v14", "v21", "v22", "v23",
                 "v24", "w1", "x1", "cc", "memory");
@@ -1126,7 +1123,6 @@ void sparse_conv_fp32_pipelined(const float* A,
         const float* w = A;
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -1144,7 +1140,7 @@ void sparse_conv_fp32_pipelined(const float* A,
                 [widx_dmap] "+r"(dmap)
               : [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha)
+                [valpha] "r"(alpha)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v9", "v11", "v12", "v21", 
               "v22", "w1", "x1", "cc", "memory");
           // clang-format on
@@ -1159,7 +1155,6 @@ void sparse_conv_fp32_pipelined(const float* A,
         const float* w = A;
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -1177,7 +1172,7 @@ void sparse_conv_fp32_pipelined(const float* A,
                 [widx_dmap] "+r"(dmap)
               : [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha)
+                [valpha] "r"(alpha)
               : "v0", "v1", "v2", "v3", "v4", "v9", "v11", "v21", 
               "w1", "w2", "w3", "w4", "w5", "x1", "cc", "memory");
           // clang-format on
@@ -1194,7 +1189,6 @@ void sparse_conv_fp32_pipelined(const float* A,
           const int32_t* dmap = widx_dmap;
           const uint32_t* nnzmap = nidx_nnzmap;
           const float* bs = bias;
-          float val = alpha;
           int mindex = mc / sizeof(float);
 
           for (size_t i = 0; i < nc; i++) {
@@ -1229,13 +1223,13 @@ void sparse_conv_fp32_pipelined(const float* A,
               case 2:
                 for (size_t k = 0; k < mindex; k++) {
                   *(output + k) = *(output + k) > 0 ? *(output + k) : 0;
-                  *(output + k) = *(output + k) < val ? *(output + k) : val;
+                  *(output + k) = *(output + k) < alpha ? *(output + k) : alpha;
                 }
                 break;
               default:
                 for (size_t k = 0; k < mindex; k++) {
-                  *(output + k) =
-                      *(output + k) >= 0 ? *(output + k) : *(output + k) * val;
+                  *(output + k) = *(output + k) >= 0 ? *(output + k)
+                                                     : *(output + k) * alpha;
                 }
                 break;
             }
@@ -1880,7 +1874,7 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
                                      ARMContext* ctx) {
   auto act_param = param.activation_param;
   auto act_type = act_param.active_type;
-  float alpha = 0.f;
+  volatile float alpha = 0.f;
   int flag_act = 0x00;  // relu: 1, relu6: 2, leakey: 3
   if (act_param.has_active) {
     if (act_type == lite_api::ActivationType::kRelu) {
@@ -1909,7 +1903,6 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
       for (size_t i = 0; i < nc; i++) {
         uint32_t nnz = *nnzmap++;
         float vsclae = *sc++;
-        float valpha = alpha;
         float vbias = (bias != nullptr) ? bias[i] : 0.0;
         // clang-format off
           asm volatile(SPARSE_INT8_F32_W48_V8_OUT
@@ -1921,7 +1914,7 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
             : [vscale] "r"(vsclae),
               [vbias] "r"(vbias),
               [vflag_act] "r"(flag_act),
-              [valpha] "r"(valpha)
+              [valpha] "r"(alpha)
             : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
                 "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
                 "v16", "v17", "v18", "v21", "v22", "v23", "v24", "v25", 
@@ -1941,7 +1934,6 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
         const float* sc = scale;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -1957,7 +1949,7 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
               : [vscale] "r"(vsclae),
                 [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha)
+                [valpha] "r"(alpha)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
                 "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
                 "v16", "v17", "v18", "v21", "v22", "v23", "v24", "v25", 
@@ -1975,7 +1967,6 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
         const float* sc = scale;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -1991,7 +1982,7 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
               : [vscale] "r"(vsclae),
                 [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha)
+                [valpha] "r"(alpha)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
                   "v8", "v9", "v11", "v12", "v13", "v14", "v21", "v22", "v23",
                   "v24", "w1", "x1", "cc", "memory");
@@ -2008,7 +1999,6 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
         const float* sc = scale;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -2024,7 +2014,7 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
               : [vscale] "r"(vsclae),
                 [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha)
+                [valpha] "r"(alpha)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v9", "v11", "v12", "v21", 
               "v22", "w1", "x1", "cc", "memory");
           // clang-format on
@@ -2040,7 +2030,6 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
         const float* sc = scale;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -2056,7 +2045,7 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
               : [vscale] "r"(vsclae),
                 [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha)
+                [valpha] "r"(alpha)
               : "v0", "v1", "v2", "v3", "v4", "v9", "v11", "v21", 
               "w1", "w2", "w3", "w4", "w5", "x1", "cc", "memory");
           // clang-format on
@@ -2074,8 +2063,6 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
           const uint32_t* nnzmap = nidx_nnzmap;
           const float* bs = bias;
           const float* sc = scale;
-          // const float* al = alpha;
-          float val = alpha;
           int mindex = mc / sizeof(int8_t);
 
           for (size_t i = 0; i < nc; i++) {
@@ -2109,14 +2096,14 @@ void sparse_conv_int8_fp32_pipelined(const int8_t* A,
                 for (size_t k = 0; k < mindex; k++) {
                   *(output + k) = *(output + k) * vscale + vbias;
                   *(output + k) = *(output + k) > 0 ? *(output + k) : 0;
-                  *(output + k) = *(output + k) < val ? *(output + k) : val;
+                  *(output + k) = *(output + k) < alpha ? *(output + k) : alpha;
                 }
                 break;
               default:
                 for (size_t k = 0; k < mindex; k++) {
                   *(output + k) = *(output + k) * vscale + vbias;
-                  *(output + k) =
-                      *(output + k) >= 0 ? *(output + k) : *(output + k) * val;
+                  *(output + k) = *(output + k) >= 0 ? *(output + k)
+                                                     : *(output + k) * alpha;
                 }
                 break;
             }
@@ -2877,7 +2864,7 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
                                      ARMContext* ctx) {
   auto act_param = param.activation_param;
   auto act_type = act_param.active_type;
-  float alpha = 0.f;
+  valitile float alpha = 0.f;
   int flag_act = 0x00;  // relu: 1, relu6: 2, leakey: 3
   if (act_param.has_active) {
     if (act_type == lite_api::ActivationType::kRelu) {
@@ -2906,7 +2893,6 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
       for (size_t i = 0; i < nc; i++) {
         uint32_t nnz = *nnzmap++;
         float vsclae = *sc++;
-        float valpha = alpha;
         float vbias = (bias != nullptr) ? bias[i] : 0.0;
         // clang-format off
           asm volatile(SPARSE_INT8_INT8_W48_V8_OUT
@@ -2918,7 +2904,7 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
             : [vscale] "r"(vsclae),
               [vbias] "r"(vbias),
               [vflag_act] "r"(flag_act),
-              [valpha] "r"(valpha),
+              [valpha] "r"(alpha),
               [vmax] "r"(vmax)
             : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
                 "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
@@ -2939,7 +2925,6 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
         const float* sc = scale;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -2955,7 +2940,7 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
               : [vscale] "r"(vsclae),
                 [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha),
+                [valpha] "r"(alpha),
                 [vmax] "r"(vmax)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
                 "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
@@ -2975,7 +2960,6 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
         const float* sc = scale;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -2991,7 +2975,7 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
               : [vscale] "r"(vsclae),
                 [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha),
+                [valpha] "r"(alpha),
                 [vmax] "r"(vmax)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
                   "v8", "v9", "v11", "v12", "v13", "v14", "v16", "v17", "v21", "v22", "v23",
@@ -3010,7 +2994,6 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
         const float* sc = scale;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -3026,7 +3009,7 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
               : [vscale] "r"(vsclae),
                 [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha),
+                [valpha] "r"(alpha),
                 [vmax] "r"(vmax)
               : "v0", "v1", "v2", "v3", "v4", "v5", "v8", "v9", "v10", "v11", "v12", "v16", "v21", 
               "v22", "w1", "x1", "cc", "memory");
@@ -3044,7 +3027,6 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
         const int32_t* dmap = widx_dmap;
         const uint32_t* nnzmap = nidx_nnzmap;
         const float* sc = scale;
-        float valpha = alpha;
 
         for (size_t i = 0; i < nc; i++) {
           uint32_t nnz = *nnzmap++;
@@ -3060,7 +3042,7 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
               : [vscale] "r"(vsclae),
                 [vbias] "r"(vbias),
                 [vflag_act] "r"(flag_act),
-                [valpha] "r"(valpha),
+                [valpha] "r"(alpha),
                 [vmax] "r"(vmax)
               : "v0", "v1", "v2", "v3", "v4", "v8", "v9", "v11", "v16", "v21", 
               "w1", "w2", "w3", "w4", "w5", "x1", "cc", "memory");
@@ -3080,8 +3062,6 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
           const uint32_t* nnzmap = nidx_nnzmap;
           const float* bs = bias;
           const float* sc = scale;
-          // const float* al = alpha;
-          float val = alpha;
 
           for (size_t i = 0; i < nc; i++) {
             float vbias = (bias != nullptr) ? *bs++ : 0;
@@ -3106,10 +3086,10 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
                   break;
                 case 2:  // relu6
                   out[k] = out[k] > 0 ? out[k] : 0;
-                  out[k] = out[k] < val ? out[k] : val;
+                  out[k] = out[k] < alpha ? out[k] : alpha;
                   break;
                 default:  // leaky_relu
-                  out[k] = out[k] >= 0 ? out[k] : out[k] * val;
+                  out[k] = out[k] >= 0 ? out[k] : out[k] * alpha;
                   break;
               }
               float vax = out[k] > -127.0 ? out[k] : -127.0;

--- a/lite/backends/arm/math/sparse_conv_impl.cc
+++ b/lite/backends/arm/math/sparse_conv_impl.cc
@@ -2864,7 +2864,7 @@ void sparse_conv_int8_int8_pipelined(const int8_t* A,
                                      ARMContext* ctx) {
   auto act_param = param.activation_param;
   auto act_type = act_param.active_type;
-  valitile float alpha = 0.f;
+  volatile float alpha = 0.f;
   int flag_act = 0x00;  // relu: 1, relu6: 2, leakey: 3
   if (act_param.has_active) {
     if (act_type == lite_api::ActivationType::kRelu) {


### PR DESCRIPTION
解决mbv2-int8模型精度对不齐问题，定位到clang编译器优化了alpha参数导致的，已解决；