### PR TITLE
[OpenCL] Support layout type: kImageFolder

### DIFF
--- a/lite/api/tools/opt_base.cc
+++ b/lite/api/tools/opt_base.cc
@@ -109,9 +109,13 @@ void OptBase::SetValidPlaces(const std::string& valid_places) {
       valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault)});
       valid_places_.emplace_back(
+          Place{TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageFolder)});
+      valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNCHW)});
       valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kImageDefault)});
+      valid_places_.emplace_back(
+          Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kImageFolder)});
       valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW)});
       valid_places_.emplace_back(
@@ -146,9 +150,13 @@ void OptBase::SetValidPlaces(const std::string& valid_places) {
       valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault)});
       valid_places_.emplace_back(
+          Place{TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageFolder)});
+      valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNCHW)});
       valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kImageDefault)});
+      valid_places_.emplace_back(
+          Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kImageFolder)});
       valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW)});
       valid_places_.emplace_back(Place{TARGET(kX86), PRECISION(kFloat)});
@@ -508,7 +516,7 @@ void OptBase::PrintAllSupportedOpsInMdformat() {
                                                            "英特尔FPGA",
                                                            "华为昇腾NPU",
                                                            "联发科APU",
-                                                           "瑞芯微NPU	",
+                                                           "瑞芯微NPU",
                                                            "华为麒麟NPU",
                                                            "颖脉NNA",
                                                            "晶晨NPU"};

--- a/lite/backends/opencl/cl_kernel/image/layout_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/layout_kernel.cl
@@ -353,8 +353,8 @@ __kernel void image2d_folder_to_buffer(__read_only image2d_t input,
                                        __global float* output,
                                        __private const int out_h,
                                        __private const int out_w) {
-  const int pos_x = get_global_id(0);  // 0-17
-  const int pos_y = get_global_id(1);  // 0
+  const int pos_x = get_global_id(0);
+  const int pos_y = get_global_id(1);
 
   CL_DTYPE4 in =
       READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(pos_x, pos_y));

--- a/lite/backends/opencl/cl_kernel/image/layout_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/layout_kernel.cl
@@ -313,6 +313,42 @@ __kernel void image2d_to_buffer_with_post255(__read_only image2d_t input,
 }
 
 ////////////////////////////////////////////////////////
+// image2d_default -> image2d_folder
+////////////////////////////////////////////////////////
+__kernel void image2d_default_to_image2d_folder(__read_only image2d_t input,
+                                                __write_only image2d_t output,
+                                                __private const int in_img_w,
+                                                __private const int in_img_h) {
+  const int pos_x = get_global_id(0);
+  const int pos_y = get_global_id(1);
+
+  CL_DTYPE4 in =
+      READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(pos_x, pos_y));
+
+  CL_DTYPE4 in0 = 0.f;
+  CL_DTYPE4 in1 = 0.f;
+  CL_DTYPE4 in2 = 0.f;
+  CL_DTYPE4 in3 = 0.f;
+
+  in0 = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(pos_x * 4, pos_y));
+  if (pos_x * 4 + 1 < in_img_w) {
+    in1 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR, input, SAMPLER, (int2)(pos_x * 4 + 1, pos_y));
+  }
+  if (pos_x * 4 + 2 < in_img_w) {
+    in2 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR, input, SAMPLER, (int2)(pos_x * 4 + 2, pos_y));
+  }
+  if (pos_x * 4 + 3 < in_img_w) {
+    in3 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR, input, SAMPLER, (int2)(pos_x * 4 + 3, pos_y));
+  }
+
+  CL_DTYPE4 out = (CL_DTYPE4)(in0.x, in1.x, in2.x, in3.x);
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(pos_x, pos_y), out);
+}
+
+////////////////////////////////////////////////////////
 // image2d_folder -> image2d_default
 ////////////////////////////////////////////////////////
 __kernel void image2d_folder_to_image2d_default(__read_only image2d_t input,

--- a/lite/core/optimizer/mir/type_layout_cast_pass.cc
+++ b/lite/core/optimizer/mir/type_layout_cast_pass.cc
@@ -89,7 +89,8 @@ void TypeLayoutTransformPass::ComplementInputs(
   };
   auto* in_arg_type = const_cast<Type*>(in->AsArg().type);
   if (is_host(in_arg_type->target()) &&
-      in_arg_type->layout() == DATALAYOUT(kImageDefault)) {
+      (in_arg_type->layout() == DATALAYOUT(kImageDefault) ||
+       in_arg_type->layout() == DATALAYOUT(kImageFolder))) {
     return;
   }
 

--- a/lite/core/optimizer/mir/type_layout_cast_pass.cc
+++ b/lite/core/optimizer/mir/type_layout_cast_pass.cc
@@ -75,8 +75,8 @@ void TypeLayoutTransformPass::ComplementInputs(
   CHECK(in->AsArg().type);
   VLOG(3) << "\n inst_in_tensor_name:" << inst_in_tensor_name
           << "\n in->AsArg().name:" << in->AsArg().name
-          << "\n *in->AsArg().type:" << *in->AsArg().type
-          << "\n *decl_arg_type:" << *decl_arg_type
+          << "\n *in->AsArg().type(from):" << *in->AsArg().type
+          << "\n *decl_arg_type(to):" << *decl_arg_type
           << "\n inst.op()->DebugString():" << inst.op()->DebugString();
 
   // TODO(ysh329): conflict if tensor with kARM target but kImageDefault(OpenCL
@@ -185,7 +185,8 @@ void TypeLayoutTransformPass::AddLayoutInst(
           (TargetCompatibleTo(*in_arg_ty, from) &&
            /* skip precision check: PrecisionCompatibleTo(*in_arg_ty, from) &&*/
            DeviceCompatibleTo(*in_arg_ty, from) &&
-           out_arg_ty->layout() == to.layout())) {
+           DataLayoutCompatible(*in_arg_ty, from) &&
+           (out_arg_ty->layout() == to.layout()))) {
         is_found = true;
       } else if (TypeCompatible(*in_arg_ty, from) &&
                  out_arg_ty->layout() == to.layout()) {

--- a/lite/core/profile/precision_profiler.h
+++ b/lite/core/profile/precision_profiler.h
@@ -334,12 +334,6 @@ class PrecisionProfiler {
       switch (layout_type) {
         case DATALAYOUT(kImageDefault): {
           auto in_dims = in->dims();
-          // special case
-          if ((in_dims.size() == 2) &&
-              (op_name == "fc" || op_name == "softmax")) {
-            in_dims = DDim(std::vector<DDim::value_type>(
-                {in->dims()[0], in->dims()[1], 1, 1}));
-          }
           paddle::lite::CLImageConverterDefault default_convertor;
           auto image_shape = default_convertor.InitImageDimInfoWith(in_dims);
           size_t im_w = image_shape[0];
@@ -364,10 +358,52 @@ class PrecisionProfiler {
                                       cl_image2d_row_pitch,
                                       cl_image2d_slice_pitch,
                                       IoDirection::DtoH);
-          // TODO(zhaoyang-star): Tensor shape padding mode will change from
-          // high-dim padding to low-dim padding to fit image2d.
-          // ImageConverter will be changed.
           default_convertor.ImageToNCHW(
+              in_data_v, real_out_v.data(), image_shape, in_dims);
+          CHECK(real_out_v.size() == in->numel());
+          *mean = compute_mean<float>(real_out_v.data(), real_out_v.size());
+          *std_dev = compute_standard_deviation<float>(
+              real_out_v.data(), in->numel(), true, *mean);
+          *ave_grow_rate = compute_average_grow_rate<float>(real_out_v.data(),
+                                                            real_out_v.size());
+          std::shared_ptr<lite::Tensor> real_out_t(new lite::Tensor);
+          real_out_t->Resize(in_dims);
+          float* real_out_data = real_out_t->mutable_data<float>();
+          memcpy(real_out_data,
+                 real_out_v.data(),
+                 real_out_v.size() * sizeof(float));
+          if (write_result_to_file) {
+            write_tensorfile<float>(real_out_t.get(), name, log_dir_);
+          }
+          return;
+        }
+        case DATALAYOUT(kImageFolder): {
+          auto in_dims = in->dims();
+          paddle::lite::CLImageConverterFolder folder_convertor;
+          auto image_shape = folder_convertor.InitImageDimInfoWith(in_dims);
+          size_t im_w = image_shape[0];
+          size_t im_h = image_shape[1];
+          VLOG(1) << "image shape(W,H) of " << name << ": " << im_w << " "
+                  << im_h;
+          auto* in_data_v =
+              use_fp16
+                  ? static_cast<void*>(
+                        calloc(im_w * im_h * 4, sizeof(uint16_t)))
+                  : static_cast<void*>(calloc(im_w * im_h * 4, sizeof(float)));
+
+          std::vector<float> real_out_v(in->numel());
+          const size_t cl_image2d_row_pitch{0};
+          const size_t cl_image2d_slice_pitch{0};
+          TargetWrapperCL::ImgcpySync(in_data_v,
+                                      use_fp16
+                                          ? in->data<uint16_t, cl::Image2D>()
+                                          : in->data<float, cl::Image2D>(),
+                                      im_w,
+                                      im_h,
+                                      cl_image2d_row_pitch,
+                                      cl_image2d_slice_pitch,
+                                      IoDirection::DtoH);
+          folder_convertor.ImageToNCHW(
               in_data_v, real_out_v.data(), image_shape, in_dims);
           CHECK(real_out_v.size() == in->numel());
           *mean = compute_mean<float>(real_out_v.data(), real_out_v.size());

--- a/lite/core/type_system.h
+++ b/lite/core/type_system.h
@@ -194,17 +194,17 @@ static bool DataLayoutCompatibleTo(const Type& a, const Type& b) {
   return a.IsVoid() ||                 //
          (a.layout() == b.layout() ||  //
           ((b.layout() == DATALAYOUT(kAny)) &&
-           (a.layout() != DATALAYOUT(kImageDefault) ||
+           (a.layout() != DATALAYOUT(kImageDefault) &&
             a.layout() != DATALAYOUT(kImageFolder))));
 }
 static bool DataLayoutCompatible(const Type& a, const Type& b) {
   return a.IsVoid() || b.IsVoid() ||   //
          (a.layout() == b.layout() ||  //
           ((b.layout() == DATALAYOUT(kAny)) &&
-           (a.layout() != DATALAYOUT(kImageDefault) ||
+           (a.layout() != DATALAYOUT(kImageDefault) &&
             a.layout() != DATALAYOUT(kImageFolder))) ||
           ((a.layout() == DATALAYOUT(kAny)) &&
-           (b.layout() != DATALAYOUT(kImageDefault) ||
+           (b.layout() != DATALAYOUT(kImageDefault) &&
             b.layout() != DATALAYOUT(kImageFolder))));
 }
 

--- a/lite/core/type_system.h
+++ b/lite/core/type_system.h
@@ -194,15 +194,18 @@ static bool DataLayoutCompatibleTo(const Type& a, const Type& b) {
   return a.IsVoid() ||                 //
          (a.layout() == b.layout() ||  //
           ((b.layout() == DATALAYOUT(kAny)) &&
-           (a.layout() != DATALAYOUT(kImageDefault))));
+           (a.layout() != DATALAYOUT(kImageDefault) ||
+            a.layout() != DATALAYOUT(kImageFolder))));
 }
 static bool DataLayoutCompatible(const Type& a, const Type& b) {
   return a.IsVoid() || b.IsVoid() ||   //
          (a.layout() == b.layout() ||  //
           ((b.layout() == DATALAYOUT(kAny)) &&
-           (a.layout() != DATALAYOUT(kImageDefault))) ||
+           (a.layout() != DATALAYOUT(kImageDefault) ||
+            a.layout() != DATALAYOUT(kImageFolder))) ||
           ((a.layout() == DATALAYOUT(kAny)) &&
-           (b.layout() != DATALAYOUT(kImageDefault))));
+           (b.layout() != DATALAYOUT(kImageDefault) ||
+            b.layout() != DATALAYOUT(kImageFolder))));
 }
 
 static bool PrecisionCompatibleTo(const Type& a, const Type& b) {

--- a/lite/kernels/opencl/fc_image_compute.cc
+++ b/lite/kernels/opencl/fc_image_compute.cc
@@ -323,7 +323,7 @@ REGISTER_LITE_KERNEL(fc,
     .BindInput("Input",
                {LiteType::GetTensorTy(TARGET(kOpenCL),
                                       PRECISION(kFP16),
-                                      DATALAYOUT(kImageDefault))})
+                                      DATALAYOUT(kImageFolder))})
     .BindInput("Bias", {LiteType::GetTensorTy(TARGET(kHost))})
     .BindInput("W", {LiteType::GetTensorTy(TARGET(kHost))})
     .BindInput("Alpha", {LiteType::GetTensorTy(TARGET(kHost))})

--- a/lite/kernels/opencl/fc_image_compute.cc
+++ b/lite/kernels/opencl/fc_image_compute.cc
@@ -22,7 +22,7 @@ namespace opencl {
 
 class FcImageCompute : public KernelLite<TARGET(kOpenCL),
                                          PRECISION(kFP16),
-                                         DATALAYOUT(kImageDefault)> {
+                                         DATALAYOUT(kImageFolder)> {
  public:
   void PrepareForRun() override {
     auto& param = this->Param<operators::FcParam>();
@@ -317,7 +317,7 @@ class FcImageCompute : public KernelLite<TARGET(kOpenCL),
 REGISTER_LITE_KERNEL(fc,
                      kOpenCL,
                      kFP16,
-                     kImageDefault,
+                     kImageFolder,
                      paddle::lite::kernels::opencl::FcImageCompute,
                      image2d)
     .BindInput("Input",
@@ -330,5 +330,5 @@ REGISTER_LITE_KERNEL(fc,
     .BindOutput("Out",
                 {LiteType::GetTensorTy(TARGET(kOpenCL),
                                        PRECISION(kFP16),
-                                       DATALAYOUT(kImageDefault))})
+                                       DATALAYOUT(kImageFolder))})
     .Finalize();

--- a/lite/kernels/opencl/fc_image_compute_test.cc
+++ b/lite/kernels/opencl/fc_image_compute_test.cc
@@ -89,7 +89,7 @@ void test(const lite_api::CLPrecisionType p,
             << " m=" << m << " n=" << n << " k=" << k;
 
   auto kernels = KernelRegistry::Global().Create(
-      "fc", TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault));
+      "fc", TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageFolder));
   ASSERT_FALSE(kernels.empty());
   auto kernel = std::move(kernels.front());
 
@@ -238,4 +238,4 @@ TEST(fc, compute_basic) {
 }  // namespace lite
 }  // namespace paddle
 
-USE_LITE_KERNEL(fc, kOpenCL, kFP16, kImageDefault, image2d);
+USE_LITE_KERNEL(fc, kOpenCL, kFP16, kImageFolder, image2d);

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -427,9 +427,6 @@ class LayoutComputeImageFolderToImageDefault
 
   void PrepareForRun() override {
     auto& param = Param<param_t>();
-    if (!fp16_support_) {
-      build_options_ += " -DCL_DTYPE_FLOAT_FORCE";
-    }
     VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     auto& context = ctx_->As<OpenCLContext>();
     context.cl_context()->AddKernel(kernel_func_name_,
@@ -451,8 +448,8 @@ class LayoutComputeImageFolderToImageDefault
     auto x_dims = param.x->dims();
     auto y_dims = param.y->dims();
 
-    CLImageConverterDefault default_converter;
     CLImageConverterFolder folder_converter;
+    CLImageConverterDefault default_converter;
     auto x_image_shape = folder_converter.InitImageDimInfoWith(x_dims);
     auto y_image_shape = default_converter.InitImageDimInfoWith(y_dims);
 
@@ -461,11 +458,8 @@ class LayoutComputeImageFolderToImageDefault
     auto* x_data = GET_DATA_GPU(param.x);
 
 #ifdef LITE_WITH_LOG
-    VLOG(2) << "param.process_type:" << param.process_type;
     VLOG(2) << "x_dims:" << x_dims;
     VLOG(2) << "y_dims:" << y_dims;
-    VLOG(2) << "param.x->memory_size():" << param.x->memory_size();
-    VLOG(2) << "param.y->memory_size():" << param.y->memory_size();
     VLOG(2) << "x_image_shape(w,h):" << x_image_shape[0] << " "
             << x_image_shape[1];
     VLOG(2) << "y_image_shape(w,h):" << y_image_shape[0] << " "
@@ -559,11 +553,8 @@ class LayoutComputeImageFolderToBufferChw
     auto* x_data = GET_DATA_GPU(param.x);
 
 #ifdef LITE_WITH_LOG
-    VLOG(2) << "param.process_type:" << param.process_type;
     VLOG(2) << "x_dims:" << x_dims;
     VLOG(2) << "y_dims:" << y_dims;
-    VLOG(2) << "param.x->memory_size():" << param.x->memory_size();
-    VLOG(2) << "param.y->memory_size():" << param.y->memory_size();
     VLOG(2) << "x_image_shape(w,h):" << x_image_shape[0] << " "
             << x_image_shape[1];
 #endif
@@ -612,7 +603,7 @@ class LayoutComputeImageFolderToBufferChw
  private:
   std::string time_stamp_{GetTimeStamp()};
   std::string kernel_func_name_{"image2d_folder_to_buffer"};
-  std::string build_options_{""};
+  std::string build_options_{"-DCL_DTYPE_float "};
 };
 
 }  // namespace opencl

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -223,18 +223,8 @@ class LayoutComputeImageDefaultToBufferChw
         new_dims[4 - x_dims.size() + j] = x_dims[j];
       }
     } else if (x_dims.size() < 5) {
-      // mainly for fc and softmax_1x1
-      // TODO(zhaoyang-star): Tensor shape padding mode will change from
-      // high-dim padding to low-dim padding to fit image2d.
-      // ImageConverter will be changed.
-      if (x_dims.size() == 2) {
-        for (int j = 0; j < x_dims.size(); ++j) {
-          new_dims[j] = x_dims[j];
-        }
-      } else {
-        for (int j = 0; j < x_dims.size(); ++j) {
-          new_dims[4 - x_dims.size() + j] = x_dims[j];
-        }
+      for (int j = 0; j < x_dims.size(); ++j) {
+        new_dims[4 - x_dims.size() + j] = x_dims[j];
       }
     } else {
       LOG(FATAL) << "unsupported layout tensor dims size, the dims size is: "
@@ -494,9 +484,9 @@ class LayoutComputeImageFolderToImageDefault
     CL_CHECK_FATAL(status);
     status = kernel.setArg(++arg_idx, *y_data);
     CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(y_dims[0]));
+    status = kernel.setArg(++arg_idx, static_cast<const int>(y_image_shape[0]));
     CL_CHECK_FATAL(status);
-    status = kernel.setArg(++arg_idx, static_cast<const int>(y_dims[1]));
+    status = kernel.setArg(++arg_idx, static_cast<const int>(y_image_shape[1]));
     CL_CHECK_FATAL(status);
 
     auto global_work_size =

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -427,6 +427,204 @@ class LayoutComputeBufferChwToImage2DNw
   std::string build_options_{"-DCL_DTYPE_float "};
 };
 
+// [ImageFolder] -> [ImageDefault]
+class LayoutComputeImageFolderToImageDefault
+    : public KernelLite<TARGET(kOpenCL),
+                        PRECISION(kAny),
+                        DATALAYOUT(kImageDefault)> {
+ public:
+  using param_t = operators::LayoutParam;
+
+  void PrepareForRun() override {
+    auto& param = Param<param_t>();
+    if (!fp16_support_) {
+      build_options_ += " -DCL_DTYPE_FLOAT_FORCE";
+    }
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
+    auto& context = ctx_->As<OpenCLContext>();
+    context.cl_context()->AddKernel(kernel_func_name_,
+                                    "image/layout_kernel.cl",
+                                    build_options_,
+                                    time_stamp_);
+  }
+
+#ifdef LITE_WITH_PROFILE
+  void SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
+    ch->kernel_func_name = kernel_func_name_;
+    ch->cl_event =
+        event_;  // `event_` defined in `kernel.h`, valid after kernel::Run
+  }
+#endif
+
+  void Run() override {
+    auto& param = Param<param_t>();
+    auto x_dims = param.x->dims();
+    auto y_dims = param.y->dims();
+
+    CLImageConverterDefault default_converter;
+    CLImageConverterFolder folder_converter;
+    auto x_image_shape = folder_converter.InitImageDimInfoWith(x_dims);
+    auto y_image_shape = default_converter.InitImageDimInfoWith(y_dims);
+
+    const cl::Image2D* y_data =
+        MUTABLE_DATA_GPU(param.y, y_image_shape[0], y_image_shape[1], nullptr);
+    auto* x_data = GET_DATA_GPU(param.x);
+
+#ifdef LITE_WITH_LOG
+    VLOG(2) << "param.process_type:" << param.process_type;
+    VLOG(2) << "x_dims:" << x_dims;
+    VLOG(2) << "y_dims:" << y_dims;
+    VLOG(2) << "param.x->memory_size():" << param.x->memory_size();
+    VLOG(2) << "param.y->memory_size():" << param.y->memory_size();
+    VLOG(2) << "x_image_shape(w,h):" << x_image_shape[0] << " "
+            << x_image_shape[1];
+    VLOG(2) << "y_image_shape(w,h):" << y_image_shape[0] << " "
+            << y_image_shape[1];
+#endif
+
+    auto& context = ctx_->As<OpenCLContext>();
+    CHECK(context.cl_context() != nullptr);
+    STL::stringstream kernel_key;
+    kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
+    auto kernel = context.cl_context()->GetKernel(kernel_key.str());
+
+    int arg_idx = 0;
+    cl_int status;
+    status = kernel.setArg(arg_idx, *x_data);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, *y_data);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, static_cast<const int>(y_dims[0]));
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, static_cast<const int>(y_dims[1]));
+    CL_CHECK_FATAL(status);
+
+    auto global_work_size =
+        cl::NDRange{static_cast<cl::size_type>(x_image_shape[0]),
+                    static_cast<cl::size_type>(x_image_shape[1])};
+#ifdef LITE_WITH_LOG
+    for (auto i = 0; i < global_work_size.dimensions(); i++) {
+      VLOG(2) << "global_work_size[" << i << "]: " << global_work_size[i];
+    }
+#endif
+
+    status = EnqueueNDRangeKernel(context,
+                                  kernel,
+                                  cl::NullRange,
+                                  global_work_size,
+                                  cl::NullRange,
+                                  nullptr,
+                                  event_);
+    CL_CHECK_FATAL(status);
+  }
+
+  std::string doc() const override {
+    return "Trans Layout from cl::Image2D(ImageFolder) to "
+           "cl::Image2D(ImageDefault/RGBA)";
+  }
+
+ private:
+  std::string time_stamp_{GetTimeStamp()};
+  std::string kernel_func_name_{"image2d_folder_to_image2d_default"};
+  std::string build_options_{""};
+};
+
+// [ImageFolder] -> [NCHW]
+class LayoutComputeImageFolderToBufferChw
+    : public KernelLite<TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kNCHW)> {
+ public:
+  using param_t = operators::LayoutParam;
+
+  void PrepareForRun() override {
+    auto& param = Param<param_t>();
+    if (!fp16_support_) {
+      build_options_ += " -DCL_DTYPE_FLOAT_FORCE";
+    }
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
+    auto& context = ctx_->As<OpenCLContext>();
+    context.cl_context()->AddKernel(kernel_func_name_,
+                                    "image/layout_kernel.cl",
+                                    build_options_,
+                                    time_stamp_);
+  }
+
+#ifdef LITE_WITH_PROFILE
+  void SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
+    ch->kernel_func_name = kernel_func_name_;
+    ch->cl_event =
+        event_;  // `event_` defined in `kernel.h`, valid after kernel::Run
+  }
+#endif
+
+  void Run() override {
+    auto& param = Param<param_t>();
+    auto x_dims = param.x->dims();
+    auto y_dims = param.y->dims();
+
+    CLImageConverterFolder folder_converter;
+    auto x_image_shape = folder_converter.InitImageDimInfoWith(x_dims);
+
+    const cl::Buffer* y_data =
+        param.y->mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+    auto* x_data = GET_DATA_GPU(param.x);
+
+#ifdef LITE_WITH_LOG
+    VLOG(2) << "param.process_type:" << param.process_type;
+    VLOG(2) << "x_dims:" << x_dims;
+    VLOG(2) << "y_dims:" << y_dims;
+    VLOG(2) << "param.x->memory_size():" << param.x->memory_size();
+    VLOG(2) << "param.y->memory_size():" << param.y->memory_size();
+    VLOG(2) << "x_image_shape(w,h):" << x_image_shape[0] << " "
+            << x_image_shape[1];
+#endif
+
+    auto& context = ctx_->As<OpenCLContext>();
+    CHECK(context.cl_context() != nullptr);
+    STL::stringstream kernel_key;
+    kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
+    auto kernel = context.cl_context()->GetKernel(kernel_key.str());
+
+    int arg_idx = 0;
+    cl_int status;
+    status = kernel.setArg(arg_idx, *x_data);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, *y_data);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, static_cast<const int>(y_dims[0]));
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(++arg_idx, static_cast<const int>(y_dims[1]));
+    CL_CHECK_FATAL(status);
+
+    auto global_work_size =
+        cl::NDRange{static_cast<cl::size_type>(x_image_shape[0]),
+                    static_cast<cl::size_type>(x_image_shape[1])};
+#ifdef LITE_WITH_LOG
+    for (auto i = 0; i < global_work_size.dimensions(); i++) {
+      VLOG(2) << "global_work_size[" << i << "]: " << global_work_size[i];
+    }
+#endif
+
+    status = EnqueueNDRangeKernel(context,
+                                  kernel,
+                                  cl::NullRange,
+                                  global_work_size,
+                                  cl::NullRange,
+                                  nullptr,
+                                  event_);
+    CL_CHECK_FATAL(status);
+  }
+
+  std::string doc() const override {
+    return "Trans Layout from cl::Image2D(ImageFolder) to "
+           "cl::Buffer(NCHW)";
+  }
+
+ private:
+  std::string time_stamp_{GetTimeStamp()};
+  std::string kernel_func_name_{"image2d_folder_to_buffer"};
+  std::string build_options_{""};
+};
+
 }  // namespace opencl
 }  // namespace kernels
 }  // namespace lite
@@ -513,6 +711,42 @@ REGISTER_LITE_KERNEL(
                {LiteType::GetTensorTy(TARGET(kOpenCL),
                                       PRECISION(kAny),
                                       DATALAYOUT(kImageDefault))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kNCHW))})
+    .Finalize();
+
+// [ImageFolder] -> [ImageDefault]
+REGISTER_LITE_KERNEL(
+    layout,
+    kOpenCL,
+    kAny,
+    kImageDefault,
+    paddle::lite::kernels::opencl::LayoutComputeImageFolderToImageDefault,
+    ImageFolder_to_ImageDefault)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kImageFolder))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kImageDefault))})
+    .Finalize();
+
+// [ImageFolder] -> [NCHW]
+REGISTER_LITE_KERNEL(
+    layout,
+    kOpenCL,
+    kAny,
+    kNCHW,
+    paddle::lite::kernels::opencl::LayoutComputeImageFolderToBufferChw,
+    ImageFolder_to_NCHW)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kImageFolder))})
     .BindOutput("Out",
                 {LiteType::GetTensorTy(TARGET(kOpenCL),
                                        PRECISION(kAny),

--- a/lite/kernels/opencl/softmax_image_compute.cc
+++ b/lite/kernels/opencl/softmax_image_compute.cc
@@ -22,7 +22,7 @@ namespace opencl {
 
 class SoftmaxComputeImage2D : public KernelLite<TARGET(kOpenCL),
                                                 PRECISION(kFP16),
-                                                DATALAYOUT(kImageDefault)> {
+                                                DATALAYOUT(kImageFolder)> {
  public:
   using param_t = operators::SoftmaxParam;
 
@@ -141,9 +141,8 @@ class SoftmaxComputeImage2D : public KernelLite<TARGET(kOpenCL),
 #endif
 
   void SetGlobalLocal() {
-    lite::CLImageConverterDefault default_convertor;
-    const auto extend_dims = ExtendInputDims(last_x_dims_);
-    out_img_shape_ = default_convertor.InitImageDimInfoWith(extend_dims);
+    CLImageConverterFolder folder_convertor;
+    out_img_shape_ = folder_convertor.InitImageDimInfoWith(last_x_dims_);
 
     if (onexone_flag_) {
       local_work_size_ = cl::NDRange(32, 1, 1);
@@ -225,15 +224,15 @@ class SoftmaxComputeImage2D : public KernelLite<TARGET(kOpenCL),
 REGISTER_LITE_KERNEL(softmax,
                      kOpenCL,
                      kFP16,
-                     kImageDefault,
+                     kImageFolder,
                      paddle::lite::kernels::opencl::SoftmaxComputeImage2D,
                      def)
     .BindInput("X",
                {LiteType::GetTensorTy(TARGET(kOpenCL),
                                       PRECISION(kFP16),
-                                      DATALAYOUT(kImageDefault))})
+                                      DATALAYOUT(kImageFolder))})
     .BindOutput("Out",
                 {LiteType::GetTensorTy(TARGET(kOpenCL),
                                        PRECISION(kFP16),
-                                       DATALAYOUT(kImageDefault))})
+                                       DATALAYOUT(kImageFolder))})
     .Finalize();

--- a/lite/kernels/opencl/softmax_image_compute_test.cc
+++ b/lite/kernels/opencl/softmax_image_compute_test.cc
@@ -81,7 +81,7 @@ void test(const lite_api::CLPrecisionType p,
             << " axis=" << axis;
 
   auto kernels = KernelRegistry::Global().Create(
-      "softmax", TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault));
+      "softmax", TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageFolder));
   ASSERT_FALSE(kernels.empty());
   auto kernel = std::move(kernels.front());
 

--- a/lite/kernels/opencl/softmax_image_compute_test.cc
+++ b/lite/kernels/opencl/softmax_image_compute_test.cc
@@ -94,18 +94,7 @@ void test(const lite_api::CLPrecisionType p,
   kernel->SetParam(param);
   kernel->SetContext(std::move(context));
 
-  DDim x_ext_dim = DDim(std::vector<DDim::value_type>{1, 1, 1, 1});
-  if (x_dim.size() == 2 && axis != 0) {
-    x_ext_dim[0] = x_dim[0];
-    x_ext_dim[1] = x_dim[1];
-  } else {
-    for (int i = 0; i < x_dim.size(); i++) {
-      x_ext_dim[4 - x_dim.size() + i] = x_dim[i];
-    }
-  }
   DDim out_dim = x_dim;
-  DDim out_ext_dim = x_ext_dim;
-
   x.Resize(x_dim);
   out.Resize(out_dim);
 
@@ -114,16 +103,16 @@ void test(const lite_api::CLPrecisionType p,
   std::vector<float> out_from_gpu(out_dim.production());
   fill_data_rand(x_cpu.data(), -1.f, 1.f, x_dim.production());
 
-  CLImageConverterDefault* default_converter = new CLImageConverterDefault();
-  DDim x_image_shape = default_converter->InitImageDimInfoWith(x_ext_dim);
-  DDim out_image_shape = default_converter->InitImageDimInfoWith(out_ext_dim);
+  CLImageConverterFolder* folder_converter = new CLImageConverterFolder();
+  DDim x_image_shape = folder_converter->InitImageDimInfoWith(x_dim);
+  DDim out_image_shape = folder_converter->InitImageDimInfoWith(out_dim);
   VLOG(4) << "x_image_shape = " << x_image_shape[0] << " " << x_image_shape[1];
   VLOG(4) << "out_image_shape = " << out_image_shape[0] << " "
           << out_image_shape[1];
 
   const size_t dtype_size = fp16_flag ? sizeof(half_t) : sizeof(float);
   std::vector<char> x_image_data(x_image_shape.production() * 4 * dtype_size);
-  default_converter->NCHWToImage(x_cpu.data(), x_image_data.data(), x_ext_dim);
+  folder_converter->NCHWToImage(x_cpu.data(), x_image_data.data(), x_dim);
   MUTABLE_DATA_GPU(&x, x_image_shape[0], x_image_shape[1], x_image_data.data());
   auto* out_image =
       MUTABLE_DATA_GPU(&out, out_image_shape[0], out_image_shape[1], nullptr);
@@ -143,8 +132,8 @@ void test(const lite_api::CLPrecisionType p,
                               cl_image2d_row_pitch,
                               cl_image2d_slice_pitch,
                               IoDirection::DtoH);
-  default_converter->ImageToNCHW(
-      out_image_data.data(), out_from_gpu.data(), out_image_shape, out_ext_dim);
+  folder_converter->ImageToNCHW(
+      out_image_data.data(), out_from_gpu.data(), out_image_shape, out_dim);
 
   // run cpu ref
   softmax_baseline(x_cpu.data(), out_from_cpu.data(), x_dim, axis);
@@ -200,4 +189,4 @@ TEST(softmax, compute_basic) {
 }  // namespace lite
 }  // namespace paddle
 
-USE_LITE_KERNEL(softmax, kOpenCL, kFP16, kImageDefault, def);
+USE_LITE_KERNEL(softmax, kOpenCL, kFP16, kImageFolder, def);


### PR DESCRIPTION
- OpenCL backend 中新增对 Data Layout:`kImageFolder`的支持
- 新增[ImageDefault] -> [ImageFolder]、[ImageFolder] -> [ImageDefault]、[ImageFolder] -> [NCHW] 的 layout 转换

`kImageFolder`与`kImageDefault`的区别：
- 当 tensor 维度小于等于 2 时，二者在计算 image shape 时不同
- 当 tensor 维度大于 2 时，二者无差异

当前，FC, Softmax_1x1 的实现中，其 Input/Out tensor 均是`kImageFolder`的 Layout。

- [x] 安卓端 mali/adreno 验证 lens_mnasnet 和其他模型 fp16/fp32 精度 passed
- [x] 验证AI-RANK所有模型精度 passed
- [x] 验证FC、softmax单测 passed

应用本PR后，lens_mnasnet 的模型结构截图：
![image](https://user-images.githubusercontent.com/24290792/136559860-684d770a-7699-4896-9269-aabe9487e6c7.png)
