### PR TITLE
[opencl][kernel]add matmul image op

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/matmul_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/matmul_kernel.cl
@@ -1,0 +1,133 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cl_common.h>
+
+__kernel void matmul_dimc(__read_only image2d_t input_x,
+                          __write_only image2d_t output,
+                          __global const CL_DTYPE4* input_y,
+                          int m,
+                          int k,
+                          int n) {
+  int out_r = get_global_id(1);
+  int out_c = get_global_id(0);
+  CL_DTYPE4 out0 = 0.f;
+  for (int i = 0; i < k; ++i) {
+    CL_DTYPE4 in_x =
+        READ_IMG_TYPE(CL_DTYPE_CHAR, input_x, SAMPLER, (int2)(i, out_r));
+    CL_DTYPE4 in_y = input_y[i * (n / 4) + out_c];
+    out0 = mad(in_x.x, in_y, out0);
+  }
+
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_c, out_r), out0);
+}
+
+__kernel void matmul_dim2_LM(__read_only image2d_t input_x,
+                             __write_only image2d_t output,
+                             __global const CL_DTYPE4* input_y,
+                             int M,
+                             int K,
+                             int N) {
+  int out_r = get_global_id(0);
+  int out_c = get_global_id(1);
+
+  int row = get_local_id(0);
+  int col = get_local_id(1);
+
+  int globalRow = 8 * get_group_id(0) + row;
+  int globalCol = 8 * get_group_id(1) + col;
+
+  __local CL_DTYPE4 Asub[8][8];
+  __local CL_DTYPE4 Bsub[8][8];
+
+  CL_DTYPE4 out0 = 0.f;
+  int numTiles = K / 8;
+
+  for (int t = 0; t < numTiles; t++) {
+    if (globalRow < M && globalCol < K) {
+      Asub[col][row] = READ_IMG_TYPE(
+          CL_DTYPE_CHAR, input_x, SAMPLER, (int2)(8 * t + col, globalRow));
+    }
+    if (globalRow < K && globalCol < N / 4) {
+      Bsub[col][row] = input_y[(8 * t + row) * (N / 4) + globalCol];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (globalRow < M && globalCol < N / 4) {
+      for (int k = 0; k < 8; k++) {
+        out0 = mad(Asub[k][row].x, Bsub[col][k], out0);
+      }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_c, out_r), out0);
+}
+
+__kernel void matmul_dim2_LM_transY(__read_only image2d_t input_x,
+                                    __write_only image2d_t output,
+                                    __global const CL_DTYPE* input_y,
+                                    int M,
+                                    int K,
+                                    int N) {
+  int out_r = get_global_id(0);
+  int out_c = get_global_id(1);
+
+  int row = get_local_id(0);
+  int col = get_local_id(1);
+
+  int globalRow = 8 * get_group_id(0) + row;
+  int globalCol = 8 * get_group_id(0) + col;
+
+  __local CL_DTYPE4 Asub[32][8];
+  __local CL_DTYPE Bsub[32][32];
+
+  CL_DTYPE4 out0 = 0.f;
+  int numTiles = K / 32;
+  for (int t = 0; t < numTiles; t++) {
+    if (globalRow < M && globalCol < K) {
+      for (int i = 0; i < 32 / 8; ++i) {
+        Asub[col * 4 + i][row] =
+            READ_IMG_TYPE(CL_DTYPE_CHAR,
+                          input_x,
+                          SAMPLER,
+                          (int2)(32 * t + (col * 4 + i), globalRow));
+      }
+    }
+    if (globalRow < N && globalCol < K) {
+      int global_h = 8 * get_group_id(1) + row;
+      for (int i = 0; i < 32 / 8; ++i) {
+        Bsub[row * 4 + 0][col * 4 + i] =
+            input_y[(global_h * 4 + 0) * K + (32 * t + (col * 4 + i))];
+        Bsub[row * 4 + 1][col * 4 + i] =
+            input_y[(global_h * 4 + 1) * K + (32 * t + (col * 4 + i))];
+        Bsub[row * 4 + 2][col * 4 + i] =
+            input_y[(global_h * 4 + 2) * K + (32 * t + (col * 4 + i))];
+        Bsub[row * 4 + 3][col * 4 + i] =
+            input_y[(global_h * 4 + 3) * K + (32 * t + (col * 4 + i))];
+      }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (globalRow < M && globalCol < N / 4) {
+      for (int k = 0; k < 32; k++) {
+        out0.x = mad(Asub[k][row].x, Bsub[col * 4 + 0][k], out0.x);
+        out0.y = mad(Asub[k][row].x, Bsub[col * 4 + 1][k], out0.y);
+        out0.z = mad(Asub[k][row].x, Bsub[col * 4 + 2][k], out0.z);
+        out0.w = mad(Asub[k][row].x, Bsub[col * 4 + 3][k], out0.w);
+      }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_c, out_r), out0);
+}

--- a/lite/core/optimizer/mir/memory_optimize_pass.cc
+++ b/lite/core/optimizer/mir/memory_optimize_pass.cc
@@ -132,9 +132,9 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
                             {"flatten", {{"X"}, {"Out"}}},
                             {"flatten2", {{"X"}, {"Out"}}},
                             {"squeeze", {{"X"}, {"Out"}}},
-                            {"squeeze2", {{"X"}, {"Out"}}},
+                            {"squeeze2", {{"X"}, {{"Out"}, {"XShape"}}}},
                             {"unsqueeze", {{"X"}, {"Out"}}},
-                            {"unsqueeze2", {{"X"}, {"Out"}}}};
+                            {"unsqueeze2", {{"X"}, {{"Out"}, {"XShape"}}}}};
     auto inplace_op_node = inplace_op_nodes.find(op_type);
     if (inplace_op_node != inplace_op_nodes.end()) {
       bool inplace = false;

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -50,6 +50,7 @@ add_kernel(greater_than_opencl_image OPENCL basic SRCS greater_than_image_comput
 add_kernel(fc_opencl_image OPENCL basic SRCS fc_image_compute.cc)
 add_kernel(argmax_opencl_image OPENCL basic SRCS argmax_image_compute.cc)
 add_kernel(max_opencl_image OPENCL basic SRCS max_image_compute.cc)
+add_kernel(matmul_opencl_image OPENCL basic SRCS matmul_image_compute.cc)
 # extra
 # wait to add ...
 

--- a/lite/kernels/opencl/matmul_image_compute.cc
+++ b/lite/kernels/opencl/matmul_image_compute.cc
@@ -117,7 +117,7 @@ class MatMulV2ImageCompute : public KernelLite<TARGET(kOpenCL),
   }
 
   void Run() override {
-    y_buf_ = GET_BUFFER_GPU(y_gpu_t_);
+    auto* y_buf_ = GET_BUFFER_GPU(y_gpu_t_);
     auto* x_img_ = GET_DATA_GPU(matmul_v2_param_->X);
     auto* out_img_ =
         MUTABLE_DATA_GPU(matmul_v2_param_->Out, UP_DIV(n_, 4), m_, nullptr);
@@ -212,7 +212,6 @@ class MatMulV2ImageCompute : public KernelLite<TARGET(kOpenCL),
   std::string time_stamp_{GetTimeStamp()};
   bool first_epoch_for_reinit_{true};
   DDim last_x_dims_;
-  const cl::Buffer* y_buf_{nullptr};
   std::unique_ptr<Tensor> y_gpu_t_{nullptr};
 
   cl::NDRange global_work_size_;

--- a/lite/kernels/opencl/matmul_image_compute.cc
+++ b/lite/kernels/opencl/matmul_image_compute.cc
@@ -181,7 +181,7 @@ class MatMulV2ImageCompute : public KernelLite<TARGET(kOpenCL),
                                   kernel,
                                   cl::NullRange,
                                   global_work_size_,
-                                  local_work_size_,  // cl::NullRange,//
+                                  local_work_size_,
                                   nullptr,
                                   event_);
     CL_CHECK_FATAL(status);

--- a/lite/kernels/opencl/matmul_image_compute.cc
+++ b/lite/kernels/opencl/matmul_image_compute.cc
@@ -1,0 +1,260 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "lite/backends/opencl/cl_include.h"
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+#include "lite/kernels/opencl/image_helper.h"
+#include "lite/operators/op_params.h"
+#include "lite/utils/replace_stl/stream.h"
+#include "lite/utils/string.h"
+#ifdef LITE_WITH_PROFILE
+#include "lite/core/profile/profiler.h"
+#endif
+#include "lite/backends/opencl/cl_utility.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace opencl {
+
+class MatMulV2ImageCompute : public KernelLite<TARGET(kOpenCL),
+                                               PRECISION(kFP16),
+                                               DATALAYOUT(kImageDefault)> {
+ public:
+  using param_t = operators::MatMulParam;
+
+  void transpose_cpu(const float* in_data,
+                     float* out_data,
+                     const int in_rows,
+                     const int in_cols) {
+    CHECK(in_data && out_data && in_rows > 0 && in_cols > 0);
+    for (int r = 0; r < in_rows; ++r) {
+      for (int c = 0; c < in_cols; ++c) {
+        out_data[c * in_rows + r] = in_data[r * in_cols + c];
+      }
+    }
+  }
+
+  void PrepareForRun() override {
+    matmul_v2_param_ = param_.get_mutable<param_t>();
+    transpose_x_ = matmul_v2_param_->transpose_X;
+    transpose_y_ = matmul_v2_param_->transpose_Y;
+    alpha_ = matmul_v2_param_->alpha;
+
+    Tensor y_trans_cpu_t;
+    auto y_t = matmul_v2_param_->Y;
+    if (y_t->persistable() && (transpose_y_ || usetranspose_y_)) {
+      y_trans_cpu_t.Resize(y_t->dims());
+      transpose_cpu(y_t->data<float>(),
+                    y_trans_cpu_t.mutable_data<float>(),
+                    y_t->dims()[0],
+                    y_t->dims()[1]);
+      y_t = &y_trans_cpu_t;
+    }
+    y_gpu_t_ = std::unique_ptr<Tensor>(new Tensor);
+    auto y_gpu_data =
+        y_gpu_t_->mutable_data(TARGET(kOpenCL), y_t->memory_size());
+    TargetWrapperCL::MemcpySync(
+        y_gpu_data, y_t->raw_data(), y_t->memory_size(), IoDirection::HtoD);
+  }
+
+  void ReInitWhenNeeded() override {
+    const auto x_dims = matmul_v2_param_->X->dims();
+    if ((!first_epoch_for_reinit_ && x_dims != last_x_dims_) ||
+        first_epoch_for_reinit_) {
+      last_x_dims_ = x_dims;
+      first_epoch_for_reinit_ = false;
+
+      // compute m,n,k
+      const auto y_dims = matmul_v2_param_->Y->dims();
+      CHECK_EQ(x_dims.size(), 2UL) << "Unsupported x_dims with " << x_dims;
+      CHECK_EQ(y_dims.size(), 2UL) << "Unsupported y_dims with " << y_dims;
+      CHECK_EQ(matmul_v2_param_->Out->dims().size(), 2UL);
+
+      if (transpose_x_) {
+        m_ = x_dims[1];
+        k_ = x_dims[0];
+      } else {
+        m_ = x_dims[0];
+        k_ = x_dims[1];
+      }
+
+      if (transpose_y_) {
+        n_ = y_dims[0];
+      } else {
+        n_ = y_dims[1];
+      }
+
+      const auto out_dims = matmul_v2_param_->Out->dims();
+      CHECK_EQ(m_, out_dims[0]);
+      CHECK_EQ(n_, out_dims[1]);
+
+      const int x_k = k_;
+      const int y_k = matmul_v2_param_->transpose_Y ? y_dims[1] : y_dims[0];
+      CHECK(x_k == y_k);
+
+#ifdef LITE_WITH_LOG
+      LOG(INFO) << "x_dims:" << x_dims;
+      LOG(INFO) << "y_dims:" << y_dims;
+      LOG(INFO) << "transpose_X:" << transpose_x_;
+      LOG(INFO) << "transpose_Y:" << transpose_y_;
+      LOG(INFO) << "m_:" << m_ << ", k_:" << k_ << ", n_=" << n_;
+#endif
+    }
+  }
+
+  void Run() override {
+    y_buf_ = GET_BUFFER_GPU(y_gpu_t_);
+    auto* x_img_ = GET_DATA_GPU(matmul_v2_param_->X);
+    auto* out_img_ =
+        MUTABLE_DATA_GPU(matmul_v2_param_->Out, UP_DIV(n_, 4), m_, nullptr);
+    auto x_dims = matmul_v2_param_->X->dims();
+    auto out_dims = matmul_v2_param_->Out->dims();
+    size_t x_img_w, x_img_h, out_img_w, out_img_h;
+    x_img_->getImageInfo(CL_IMAGE_WIDTH, &x_img_w);
+    x_img_->getImageInfo(CL_IMAGE_HEIGHT, &x_img_h);
+    out_img_->getImageInfo(CL_IMAGE_WIDTH, &out_img_w);
+    out_img_->getImageInfo(CL_IMAGE_HEIGHT, &out_img_h);
+    LOG(INFO) << "real input shape: " << x_img_w << " " << x_img_h;
+    LOG(INFO) << "real output shape: " << out_img_w << " " << out_img_h;
+
+    auto& context = ctx_->As<OpenCLContext>();
+    CHECK(context.cl_context() != nullptr);
+    cl_int status;
+    int arg_idx = 0;
+    if (x_dims.size() == 2 && x_img_w == x_dims[1] &&
+        out_dims[1] == out_img_w * 4) {
+      if (uselocalmem_ == false) {
+        kernel_func_name_ = "matmul_dimc";
+        global_work_size_ = cl::NDRange{
+            static_cast<cl::size_type>(out_img_w),
+            static_cast<cl::size_type>(out_img_h),
+        };
+      } else {
+        if (usetranspose_y_ == false) {
+          kernel_func_name_ = "matmul_dim2_LM";
+        } else {
+          kernel_func_name_ = "matmul_dim2_LM_transY";
+        }
+        local_work_size_ = cl::NDRange(8, 8);
+        global_work_size_ = cl::NDRange{
+            static_cast<cl::size_type>(
+                ROUND_UP(out_img_h, local_work_size_[0])),
+            static_cast<cl::size_type>(out_img_w),
+        };
+      }
+    }
+    context.cl_context()->AddKernel(kernel_func_name_,
+                                    "image/matmul_kernel.cl",
+                                    build_options_,
+                                    time_stamp_);
+    STL::stringstream kernel_key;
+    kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
+    kernel_ = context.cl_context()->GetKernel(kernel_key.str());
+    auto kernel = kernel_;
+    status = kernel.setArg(arg_idx++, *x_img_);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(arg_idx++, *out_img_);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(arg_idx++, *y_buf_);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(arg_idx++, m_);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(arg_idx++, k_);
+    CL_CHECK_FATAL(status);
+    status = kernel.setArg(arg_idx++, n_);
+    CL_CHECK_FATAL(status);
+    status = EnqueueNDRangeKernel(context,
+                                  kernel,
+                                  cl::NullRange,
+                                  global_work_size_,
+                                  local_work_size_,  // cl::NullRange,//
+                                  nullptr,
+                                  event_);
+    CL_CHECK_FATAL(status);
+  }
+
+#ifdef LITE_WITH_PROFILE
+  void SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) {
+    ch->kernel_func_name = kernel_func_name_;
+    ch->global_work_size = ch->NDRangeToStr(global_work_size_);
+    ch->local_work_size = ch->NDRangeToStr(local_work_size_);
+    ch->cl_event =
+        event_;  // `event_` defined in `kernel.h`, valid after kernel::Run
+  }
+#endif
+
+ private:
+  int m_{0};
+  int n_{0};
+  int k_{0};
+  bool transpose_x_{false};
+  bool transpose_y_{false};
+  bool uselocalmem_{false};
+  bool usetranspose_y_{false};
+  float alpha_{1.0f};
+  param_t* matmul_v2_param_{nullptr};
+  std::string kernel_func_name_{};
+  std::string build_options_{""};
+  std::string time_stamp_{GetTimeStamp()};
+  bool first_epoch_for_reinit_{true};
+  DDim last_x_dims_;
+  const cl::Buffer* y_buf_{nullptr};
+  std::unique_ptr<Tensor> y_gpu_t_{nullptr};
+
+  cl::NDRange global_work_size_;
+  cl::NDRange local_work_size_{cl::NullRange};
+  cl::Kernel kernel_;
+};
+
+}  // namespace opencl
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(matmul,
+                     kOpenCL,
+                     kFP16,
+                     kImageDefault,
+                     paddle::lite::kernels::opencl::MatMulV2ImageCompute,
+                     image2d)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kFP16),
+                                      DATALAYOUT(kImageDefault))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kFP16),
+                                       DATALAYOUT(kImageDefault))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(matmul_v2,
+                     kOpenCL,
+                     kFP16,
+                     kImageDefault,
+                     paddle::lite::kernels::opencl::MatMulV2ImageCompute,
+                     image2d)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kFP16),
+                                      DATALAYOUT(kImageDefault))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kHost))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kFP16),
+                                       DATALAYOUT(kImageDefault))})
+    .Finalize();


### PR DESCRIPTION
matmul写了用local mem和不用local mem的版本，主要是针对目前模型遇到的输入的2维是按照w来排布的，而输出的2维是按照c来排布的写的case。