### PR TITLE
[Paddle-Lite] fix_concat_metal

### DIFF
--- a/lite/backends/metal/metal_kernel/texture/ConcatKernel.metal
+++ b/lite/backends/metal/metal_kernel/texture/ConcatKernel.metal
@@ -131,18 +131,8 @@ struct ConcatParam {
 #pragma mark z
 
 #define V VZ
-#define R 6
-#define N 4
-#define P ftype
-#include "ConcatKernel.inc.metal"
-#undef P
-#undef N
-#undef R
-#undef V
-
-#define V VZ
-#define R 5
-#define N 4
+#define R 4
+#define N 6
 #define P ftype
 #include "ConcatKernel.inc.metal"
 #undef P

--- a/lite/backends/metal/metal_kernel/texture/ConcatKernel.metal
+++ b/lite/backends/metal/metal_kernel/texture/ConcatKernel.metal
@@ -152,6 +152,16 @@ struct ConcatParam {
 
 #define V VZ
 #define R 4
+#define N 5
+#define P ftype
+#include "ConcatKernel.inc.metal"
+#undef P
+#undef N
+#undef R
+#undef V
+
+#define V VZ
+#define R 4
 #define N 4
 #define P ftype
 #include "ConcatKernel.inc.metal"
@@ -173,6 +183,16 @@ struct ConcatParam {
 #define V VZ
 #define R 4
 #define N 2
+#define P ftype
+#include "ConcatKernel.inc.metal"
+#undef P
+#undef N
+#undef R
+#undef V
+
+#define V VZ
+#define R 3
+#define N 5
 #define P ftype
 #include "ConcatKernel.inc.metal"
 #undef P


### PR DESCRIPTION
fastscnn 中 concat op 有五个输入，在运行无法调用backend中算子函数，进行修复