### PR TITLE
fix_inceptionV4

### DIFF
--- a/lite/backends/metal/metal_kernel/texture/ConcatKernel.metal
+++ b/lite/backends/metal/metal_kernel/texture/ConcatKernel.metal
@@ -152,6 +152,16 @@ struct ConcatParam {
 
 #define V VZ
 #define R 4
+#define N 6
+#define P ftype
+#include "ConcatKernel.inc.metal"
+#undef P
+#undef N
+#undef R
+#undef V
+
+#define V VZ
+#define R 4
 #define N 4
 #define P ftype
 #include "ConcatKernel.inc.metal"
@@ -173,6 +183,16 @@ struct ConcatParam {
 #define V VZ
 #define R 4
 #define N 2
+#define P ftype
+#include "ConcatKernel.inc.metal"
+#undef P
+#undef N
+#undef R
+#undef V
+
+#define V VZ
+#define R 3
+#define N 6
 #define P ftype
 #include "ConcatKernel.inc.metal"
 #undef P

--- a/lite/kernels/metal/image_op/conv2d_image_compute.mm
+++ b/lite/kernels/metal/image_op/conv2d_image_compute.mm
@@ -252,12 +252,20 @@ std::string Conv2dImageCompute::KernelFunctionName(const param_t& param,
             } else {
                 return "group_conv_3x3";
             }
+        } else if (filter_w == 1 && filter_h == 3) {
+            return "conv_3x1";
+        } else if (filter_w == 3 && filter_h == 1) {
+            return "conv_1x3";
         } else if (filter_w == 1 && filter_h == 5) {
             return "conv_5x1";
         } else if (filter_w == 5 && filter_h == 1) {
             return "conv_1x5";
         } else if (filter_w == 7 && filter_h == 7) {
             return "conv_7x7";
+        } else if (filter_w == 1 && filter_h == 7) {
+            return "conv_7x1";
+        } else if (filter_w == 7 && filter_h == 1) {
+            return "conv_1x7";
         } else {
             return "";
         }


### PR DESCRIPTION
修复InceptionV metal模型bug，主要问题有以下：
1. 缺少conv2d_1x7 conv2d_7x1 conv2d_1x3 conv2d_3x1 以及函数声明
2. 缺少concat 6个输入函数声明