### PR TITLE
[Pass] Support transpose_Y in matmul_elt_add_fuse_pass

### DIFF
--- a/lite/core/optimizer/mir/fusion/matmul_elementwise_add_fuse_pass.cc
+++ b/lite/core/optimizer/mir/fusion/matmul_elementwise_add_fuse_pass.cc
@@ -31,17 +31,17 @@ void MatmulElementwiseAddFusePass::Apply(
   }
 #if defined(LITE_WITH_X86) || defined(LITE_WITH_CUDA) || defined(LITE_WITH_ARM)
 #ifdef LITE_WITH_MLU
-  fusion::MatmulElementwiseAddFuser fuser(false);
+  fusion::MatmulElementwiseAddFuser fuser(false, graph);
   fuser(graph.get());
 #else
-  fusion::MatmulElementwiseAddFuser fuser(true);
+  fusion::MatmulElementwiseAddFuser fuser(true, graph);
   fuser(graph.get());
 #endif
 #endif
-  fusion::MatmulElementwiseAddFuser fuser2(false);
+  fusion::MatmulElementwiseAddFuser fuser2(false, graph);
   fuser2(graph.get());
 #ifdef LITE_WITH_FPGA
-  fusion::MatmulElementwiseAddFuser fpga_fuser(true);
+  fusion::MatmulElementwiseAddFuser fpga_fuser(true, graph);
   fpga_fuser(graph.get());
 #endif
 }

--- a/lite/core/optimizer/mir/fusion/matmul_elementwise_add_fuser.h
+++ b/lite/core/optimizer/mir/fusion/matmul_elementwise_add_fuser.h
@@ -25,13 +25,17 @@ namespace fusion {
 
 class MatmulElementwiseAddFuser : public FuseBase {
  public:
-  explicit MatmulElementwiseAddFuser(bool with_relu) : with_relu_(with_relu) {}
+  explicit MatmulElementwiseAddFuser(bool with_relu,
+                                     const std::unique_ptr<SSAGraph>& graph)
+      : with_relu_(with_relu), graph_(graph) {}
   void BuildPattern() override;
   void InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) override;
 
  private:
   cpp::OpDesc GenOpDesc(const key2nodes_t& matched) override;
+  void CreatePattern();
   bool with_relu_;
+  const std::unique_ptr<SSAGraph>& graph_;
 };
 
 }  // namespace fusion


### PR DESCRIPTION
【问题】
当`matmul`中的`transpose_Y`参数为`true`时，无法通过 matmul_elt_add_fuse_pass 融合为`FC`，也无法通过 matmul_fuse_pass 将`matmul`转换为`mul`。
比如如下模型结构中，`matmul`中的`transpose_Y`参数为`true`，经 opt 图优化前后结构一样，无法转为`FC`进行计算。
![image](https://user-images.githubusercontent.com/24290792/136688647-4a2142d9-7093-438e-89b0-bdc11accdb37.png)

【本PR工作】
在 matmul_elt_add_fuse_pass 中实现支持这一 case：`transpose_Y`为`true`且`Y`为`persistable()`
如上提到的子结构经该 pass 后，可以转为`FC`：


【效果】
使用 cls_blur_model_fp32 模型验证，arm cpu/opencl 精度保持不变。