### PR TITLE
[Cherry-Pick][FrameWork]Fix intel_fpga compilation

### DIFF
--- a/cmake/lite.cmake
+++ b/cmake/lite.cmake
@@ -291,6 +291,9 @@ function(lite_cc_binary TARGET)
         get_property(cuda_deps GLOBAL PROPERTY CUDA_MODULES)
         target_link_libraries(${TARGET} ${cuda_deps})
     endif()
+    if(LITE_WITH_INTEL_FPGA)
+        target_link_libraries(${TARGET} ${intel_fpga_deps})
+    endif()
 
     if (NOT APPLE AND NOT WIN32)
         # strip binary target to reduce size

--- a/lite/kernels/intel_fpga/CMakeLists.txt
+++ b/lite/kernels/intel_fpga/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(LITE_WITH_INTEL_FPGA)
   set(IS_FAKED_KERNEL false CACHE INTERNAL "")
-  set(intel_fpga_deps ${lite_kernel_deps} ${intel_fpga_runtime_libs})
+  set(intel_fpga_deps ${lite_kernel_deps} ${intel_fpga_runtime_libs} CACHE INTERNAL "")
   set(lite_kernel_deps ${lite_kernel_deps} ${intel_fpga_runtime_libs} CACHE INTERNAL "")
 elseif(LITE_ON_MODEL_OPTIMIZE_TOOL OR LITE_WITH_PYTHON)
   set(IS_FAKED_KERNEL true CACHE INTERNAL "")


### PR DESCRIPTION
benchmark_bin test_model_bin两个目标均包含intel_fpga的kernel，在kernel中调用了外部符号。链接时符号未找到定义的原因有：

变量 intel_fpga_deps 未设置为全局变量，致使父文件中变量值为空。
cc_library()或lite_cc_binary()方法中，未链接libvnna.so，使得链接器无法对符号"intelfpga_conv2d"进行重定位（动态链接打桩或直接静态链接），链接报错。