### PR TITLE
Update md5 func

### DIFF
--- a/lite/utils/md5.h
+++ b/lite/utils/md5.h
@@ -18,7 +18,7 @@
 namespace paddle {
 namespace lite {
 
-std::string MD5(std::string message) {
+static std::string MD5(std::string message) {
   const uint32_t shiftAmounts[] = {
       7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
       5, 9,  14, 20, 5, 9,  14, 20, 5, 9,  14, 20, 5, 9,  14, 20,


### PR DESCRIPTION
the implementation of md5() func is defined in md5.h 
if `md5.h` is  included in different source files, redefinition errors may occur

cherry-pick from #7166 