### PR TITLE
[lightweight 2]replace rtti

### DIFF
--- a/cmake/postproject.cmake
+++ b/cmake/postproject.cmake
@@ -115,8 +115,17 @@ endif()
 if (LITE_ON_TINY_PUBLISH)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -Ofast -Os -fomit-frame-pointer")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -ffunction-sections")
+    # 1. strip useless symbols from third-party libs
+    # exclude-libs is not supported on macOs system
     if(NOT ARMMACOS)
-    check_linker_flag(-Wl,--gc-sections)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--exclude-libs,ALL")
+      check_linker_flag(-Wl,--gc-sections)
+    endif()
+    # 2. strip rtti lib to reduce lib size
+    #     2.1 replace typeid by fastTypeId
+    #     2.2 replace dynamic_cast by static_cast
+    if(NOT LITE_WITH_NNADAPTER)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
     endif()
 endif()
 

--- a/lite/core/optimizer/mir/pass_manager.h
+++ b/lite/core/optimizer/mir/pass_manager.h
@@ -73,7 +73,7 @@ class PassManager {
   template <typename PassTy>
   PassTy* LookUp(const std::string& key) {
     auto it = pass_map_.find(key);
-    if (it != pass_map_.end()) return dynamic_cast<PassTy*>(it->second);
+    if (it != pass_map_.end()) return static_cast<PassTy*>(it->second);
     return nullptr;
   }
 

--- a/lite/kernels/npu/bridges/graph.h
+++ b/lite/kernels/npu/bridges/graph.h
@@ -79,9 +79,9 @@ class Graph {
                             PrecisionType precision = PRECISION(kFloat),
                             DataLayoutType layout = DATALAYOUT(kNCHW)) {
     Node::Role role = Node::Role::kVar;
-    if (typeid(T) == typeid(ge::op::Const)) {
+    if (FastTypeId<T>() == FastTypeId<ge::op::Const>()) {
       role = Node::Role::kConst;
-    } else if (typeid(T) == typeid(ge::op::Data)) {
+    } else if (FastTypeId<T>() == FastTypeId<ge::op::Data>()) {
       role = Node::Role::kData;
     }
     auto node = std::make_shared<Node>(precision, layout, role);

--- a/lite/operators/conv_op.h
+++ b/lite/operators/conv_op.h
@@ -175,7 +175,7 @@ class ConvOpLite : public OpLite {
       padding_algorithm_ = op_desc.GetAttr<std::string>("padding_algorithm");
     }
     // For Int8
-    const OpInfo* op_info = dynamic_cast<const OpInfo*>(&op_desc);
+    const OpInfo* op_info = static_cast<const OpInfo*>(&op_desc);
     if (op_info != nullptr && op_info->HasAttr("enable_int8")) {
       param_.enable_int8 = op_info->GetAttr<bool>("enable_int8");
       auto input_scale_name = "Input0_scale";

--- a/lite/operators/conv_transpose_op.cc
+++ b/lite/operators/conv_transpose_op.cc
@@ -151,7 +151,7 @@ bool ConvTransposeOpLite::AttachImpl(const cpp::OpDesc& op_desc,
   param_.dilations = std::make_shared<std::vector<int>>(dilations);
 
   // For Int8
-  const OpInfo* op_info = dynamic_cast<const OpInfo*>(&op_desc);
+  const OpInfo* op_info = static_cast<const OpInfo*>(&op_desc);
   if (op_info != nullptr && op_info->HasAttr("enable_int8")) {
     param_.enable_int8 = op_info->GetAttr<bool>("enable_int8");
     auto input_scale_name = "Input0_scale";

--- a/lite/operators/fc_op.cc
+++ b/lite/operators/fc_op.cc
@@ -115,7 +115,7 @@ bool FcOpLite::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   }
 
   // For Int8
-  const OpInfo* op_info = dynamic_cast<const OpInfo*>(&op_desc);
+  const OpInfo* op_info = static_cast<const OpInfo*>(&op_desc);
   if (op_info != nullptr && op_info->HasAttr("enable_int8")) {
     param_.enable_int8 = op_info->GetAttr<bool>("enable_int8");
     auto input_scale_name = "Input0_scale";

--- a/lite/operators/gru_op.cc
+++ b/lite/operators/gru_op.cc
@@ -102,7 +102,7 @@ bool GRUOpLite::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   }
 
   // For int8
-  const OpInfo* op_info = dynamic_cast<const OpInfo*>(&op_desc);
+  const OpInfo* op_info = static_cast<const OpInfo*>(&op_desc);
   if (op_info != nullptr && op_info->HasAttr("enable_int8") &&
       op_info->GetAttr<bool>("enable_int8")) {
     param_.enable_int8 = true;

--- a/lite/operators/lstm_op.cc
+++ b/lite/operators/lstm_op.cc
@@ -117,7 +117,7 @@ bool LstmOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
       GetActivationType(opdesc.GetAttr<std::string>("candidate_activation"));
 
   // For int8
-  const OpInfo *op_info = dynamic_cast<const OpInfo *>(&opdesc);
+  const OpInfo *op_info = static_cast<const OpInfo *>(&opdesc);
   if (op_info != nullptr && op_info->HasAttr("enable_int8") &&
       op_info->GetAttr<bool>("enable_int8")) {
     param_.enable_int8 = true;

--- a/lite/operators/matmul_op.cc
+++ b/lite/operators/matmul_op.cc
@@ -148,7 +148,7 @@ bool MatMulOpLite::AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) {
   param_.transpose_Y = op_desc.GetAttr<bool>("transpose_Y");
   param_.alpha = op_desc.GetAttr<float>("alpha");
 
-  const OpInfo *op_info = dynamic_cast<const OpInfo *>(&op_desc);
+  const OpInfo *op_info = static_cast<const OpInfo *>(&op_desc);
   if (op_info != nullptr && op_info->HasAttr("enable_int8")) {
     param_.enable_int8 = op_info->GetAttr<bool>("enable_int8");
     auto input_scale_name = "X0_scale";

--- a/lite/operators/sparse_conv_op.h
+++ b/lite/operators/sparse_conv_op.h
@@ -122,7 +122,7 @@ class SparseConvOp : public OpLite {
     }
 
     // For Int8
-    const OpInfo* op_info = dynamic_cast<const OpInfo*>(&op_desc);
+    const OpInfo* op_info = static_cast<const OpInfo*>(&op_desc);
     if (op_info != nullptr && op_info->HasAttr("enable_int8")) {
       param_.enable_int8 = op_info->GetAttr<bool>("enable_int8");
       auto input_scale_name = "Input0_scale";

--- a/lite/operators/subgraph_op.cc
+++ b/lite/operators/subgraph_op.cc
@@ -40,7 +40,7 @@ bool SubgraphOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   param_.output_data_names =
       op_desc.GetAttr<std::vector<std::string>>("output_data_names");
   // Get the quantization parameters of input and output data variables
-  auto op_info = dynamic_cast<const OpInfo*>(&op_desc);
+  auto op_info = static_cast<const OpInfo*>(&op_desc);
   param_.input_data_scales.clear();
   param_.output_data_scales.clear();
   for (auto& input_data_name : param_.input_data_names) {

--- a/lite/utils/CMakeLists.txt
+++ b/lite/utils/CMakeLists.txt
@@ -55,6 +55,7 @@ lite_cc_library(utils SRCS ${UTILS_SRC} DEPS ${UTILS_DEPS})
 ###########################################################
 lite_cc_test(test_varient SRCS varient_test.cc)
 lite_cc_test(test_utils_string SRCS string_test.cc)
+lite_cc_test(test_fast_type_id SRCS fast_type_id_test.cc)
 # fp16 unit test
 if (WITH_TESTING)
     if (LITE_WITH_CUDA)

--- a/lite/utils/any.h
+++ b/lite/utils/any.h
@@ -19,6 +19,7 @@
 #include <typeinfo>
 #include <utility>
 
+#include "lite/utils/fast_type_id.h"
 #include "lite/utils/log/cp_logging.h"
 
 namespace paddle {
@@ -58,7 +59,7 @@ class Any {
   inline bool valid() const;
   inline void clear();
   inline void swap(Any& other);
-  inline const std::type_info& type() const;
+  inline FastTypeIdType type();
 
   template <typename T, typename... Args>
   inline void construct(Args&&... args);
@@ -87,7 +88,7 @@ class Any {
   struct Type {
     void (*destroy)(Data* data);
     void (*create_from_data)(Data* dst, const Data& src);
-    const std::type_info* ptype_info;
+    FastTypeIdType ptype_info;
   };
 
   template <typename T>
@@ -100,9 +101,6 @@ class Any {
 
   template <typename T>
   inline void check_type() const;
-
-  template <typename T>
-  inline void check_type_by_name() const;
 
   const Type* type_{nullptr};
   Data data_;
@@ -210,17 +208,17 @@ inline bool Any::empty() const { return type_ == nullptr; }
 
 inline bool Any::valid() const { return empty() == false; }
 
-inline const std::type_info& Any::type() const {
+inline FastTypeIdType Any::type() {
   if (type_ != nullptr) {
-    return *(type_->ptype_info);
+    return type_->ptype_info;
   } else {
-    return typeid(void);
+    return FastTypeId<void>();
   }
 }
 
 template <typename T>
 inline bool Any::is_type() const {
-  if ((type_ == nullptr) || (*(type_->ptype_info) != typeid(T))) {
+  if ((type_ == nullptr) || (type_->ptype_info != FastTypeId<T>())) {
     return false;
   }
   return true;
@@ -229,15 +227,9 @@ inline bool Any::is_type() const {
 template <typename T>
 inline void Any::check_type() const {
   CHECK_EQ((type_ == nullptr), false);
-  CHECK_EQ((*(type_->ptype_info) == typeid(T)), true)
-      << "Any struct is stored in the type " << type_->ptype_info->name()
-      << ", but trying to obtain the type " << typeid(T).name() << ".";
-}
-
-template <typename T>
-inline void Any::check_type_by_name() const {
-  CHECK_EQ((type_ == nullptr), false);
-  CHECK_EQ(strcmp(type_->ptype_info->name(), typeid(T).name()), 0);
+  CHECK_EQ((type_->ptype_info == FastTypeId<T>()), true)
+      << "Error: the data type stored in 'Any' struct is different from the "
+         "data type you  want to obtain!";
 }
 
 template <typename T>
@@ -306,7 +298,7 @@ class Any::TypeInfo : public std::conditional<Any::data_on_stack<T>::value,
       type_.destroy = TypeInfo<T>::destroy;
     }
     type_.create_from_data = TypeInfo<T>::create_from_data;
-    type_.ptype_info = &typeid(T);
+    type_.ptype_info = FastTypeId<T>();
   }
 };
 

--- a/lite/utils/fast_type_id.h
+++ b/lite/utils/fast_type_id.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace paddle {
+namespace lite {
+
+template <typename Type>
+struct FastTypeTag {
+  constexpr static char dummy_var = 0;
+};
+
+template <typename Type>
+constexpr char FastTypeTag<Type>::dummy_var;
+
+// FastTypeId<Type>() evaluates at compile/link-time to a unique pointer for the
+// passed-in type. These are meant to be good match for keys into maps or
+// straight up comparisons.
+using FastTypeIdType = const void*;
+
+template <typename Type>
+constexpr inline FastTypeIdType FastTypeId() {
+  return &FastTypeTag<Type>::dummy_var;
+}
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/utils/fast_type_id_test.cc
+++ b/lite/utils/fast_type_id_test.cc
@@ -1,0 +1,117 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "lite/utils/fast_type_id.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <map>
+#include <vector>
+
+namespace paddle {
+namespace lite {
+
+// NOLINTNEXTLINE
+#define PRIM_TYPES(_) \
+  _(bool)             \
+  _(int16_t)          \
+  _(uint16_t)         \
+  _(int)              \
+  _(unsigned int)     \
+  _(int64_t)          \
+  _(uint64_t)         \
+  _(float)            \
+  _(double)           \
+  _(long double)
+
+TEST(FastTypeIdTest, PrimitiveTypes) {
+  FastTypeIdType type_ids[] = {
+#define _(T) FastTypeId<T>(),
+      PRIM_TYPES(_)
+#undef _
+#define _(T) FastTypeId<const T>(),
+          PRIM_TYPES(_)
+#undef _
+#define _(T) FastTypeId<volatile T>(),
+              PRIM_TYPES(_)
+#undef _
+#define _(T) FastTypeId<const volatile T>(),
+                  PRIM_TYPES(_)
+#undef _
+  };
+  size_t total_type_ids = sizeof(type_ids) / sizeof(FastTypeIdType);
+
+  for (int i = 0; i < total_type_ids; ++i) {
+    EXPECT_EQ(type_ids[i], type_ids[i]);
+    for (int j = 0; j < i; ++j) {
+      EXPECT_NE(type_ids[i], type_ids[j]);
+    }
+  }
+}
+
+#define FIXED_WIDTH_TYPES(_) \
+  _(int8_t)                  \
+  _(uint8_t)                 \
+  _(int16_t)                 \
+  _(uint16_t)                \
+  _(int32_t)                 \
+  _(uint32_t)                \
+  _(int64_t)                 \
+  _(uint64_t)
+
+TEST(FastTypeIdTest, FixedWidthTypes) {
+  FastTypeIdType type_ids[] = {
+#define _(T) FastTypeId<T>(),
+      FIXED_WIDTH_TYPES(_)
+#undef _
+#define _(T) FastTypeId<const T>(),
+          FIXED_WIDTH_TYPES(_)
+#undef _
+#define _(T) FastTypeId<volatile T>(),
+              FIXED_WIDTH_TYPES(_)
+#undef _
+#define _(T) FastTypeId<const volatile T>(),
+                  FIXED_WIDTH_TYPES(_)
+#undef _
+  };
+  size_t total_type_ids = sizeof(type_ids) / sizeof(FastTypeIdType);
+
+  for (int i = 0; i < total_type_ids; ++i) {
+    EXPECT_EQ(type_ids[i], type_ids[i]);
+    for (int j = 0; j < i; ++j) {
+      EXPECT_NE(type_ids[i], type_ids[j]);
+    }
+  }
+}
+
+TEST(FastTypeIdTest, AliasTypes) {
+  using int_alias = int;
+  EXPECT_EQ(FastTypeId<int_alias>(), FastTypeId<int>());
+}
+
+TEST(FastTypeIdTest, TemplateSpecializations) {
+  EXPECT_NE(FastTypeId<std::vector<int>>(), FastTypeId<std::vector<int64_t>>());
+
+  EXPECT_NE((FastTypeId<std::map<int, float>>()),
+            (FastTypeId<std::map<int, double>>()));
+}
+
+struct Base {};
+struct Derived : Base {};
+struct PDerived : private Base {};
+
+TEST(FastTypeIdTest, Inheritance) {
+  EXPECT_NE(FastTypeId<Base>(), FastTypeId<Derived>());
+  EXPECT_NE(FastTypeId<Base>(), FastTypeId<PDerived>());
+}
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/utils/varient.h
+++ b/lite/utils/varient.h
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <exception>
 #include <memory>
+#include <type_traits>
 #include <typeinfo>
 #include <utility>
 #include "lite/utils/fast_type_id.h"

--- a/lite/utils/varient.h
+++ b/lite/utils/varient.h
@@ -16,9 +16,9 @@
 #include <algorithm>
 #include <exception>
 #include <memory>
-#include <type_traits>
 #include <typeinfo>
 #include <utility>
+#include "lite/utils/fast_type_id.h"
 #include "lite/utils/log/cp_logging.h"
 #include "lite/utils/string.h"
 
@@ -44,20 +44,22 @@ template <typename... Ts>
 struct variant_helper;
 template <typename F, typename... Ts>
 struct variant_helper<F, Ts...> {
-  inline static void destroy(size_t id, void* data) {
-    if (id == typeid(F).hash_code())
+  inline static void destroy(FastTypeIdType id, void* data) {
+    if (id == FastTypeId<F>())
       reinterpret_cast<F*>(data)->~F();
     else
       variant_helper<Ts...>::destroy(id, data);
   }
-  inline static void move(size_t old_t, void* old_v, void* new_v) {
-    if (old_t == typeid(F).hash_code())
+  inline static void move(FastTypeIdType old_t, void* old_v, void* new_v) {
+    if (old_t == FastTypeId<F>())
       new (new_v) F(std::move(*reinterpret_cast<F*>(old_v)));
     else
       variant_helper<Ts...>::move(old_t, old_v, new_v);
   }
-  inline static void copy(size_t old_t, const void* old_v, void* new_v) {
-    if (old_t == typeid(F).hash_code())
+  inline static void copy(FastTypeIdType old_t,
+                          const void* old_v,
+                          void* new_v) {
+    if (old_t == FastTypeId<F>())
       new (new_v) F(*reinterpret_cast<const F*>(old_v));
     else
       variant_helper<Ts...>::copy(old_t, old_v, new_v);
@@ -65,9 +67,11 @@ struct variant_helper<F, Ts...> {
 };
 template <>
 struct variant_helper<> {
-  inline static void destroy(size_t id, void* data) {}
-  inline static void move(size_t old_t, void* old_v, void* new_v) {}
-  inline static void copy(size_t old_t, const void* old_v, void* new_v) {}
+  inline static void destroy(FastTypeIdType id, void* data) {}
+  inline static void move(FastTypeIdType old_t, void* old_v, void* new_v) {}
+  inline static void copy(FastTypeIdType old_t,
+                          const void* old_v,
+                          void* new_v) {}
 };
 
 template <typename... Ts>
@@ -77,8 +81,8 @@ struct variant {
   static const size_t data_align = static_max<alignof(Ts)...>::value;
   using data_t = typename std::aligned_storage<data_size, data_align>::type;
   using helper_t = variant_helper<Ts...>;
-  static inline size_t invalid_type() { return typeid(void).hash_code(); }
-  size_t type_id;
+  static inline FastTypeIdType invalid_type() { return FastTypeId<void>(); }
+  FastTypeIdType type_id;
   data_t data;
 
  public:
@@ -97,10 +101,10 @@ struct variant {
   }
   template <typename T>
   bool is() {
-    return (type_id == typeid(T).hash_code());
+    return (type_id == FastTypeId<T>());
   }
 
-  size_t type() { return type_id; }
+  FastTypeIdType type() { return type_id; }
 
   bool valid() { return (type_id != invalid_type()); }
 
@@ -109,22 +113,22 @@ struct variant {
     // First we destroy the current contents
     helper_t::destroy(type_id, &data);
     new (&data) T(std::forward<Args>(args)...);
-    type_id = typeid(T).hash_code();
+    type_id = FastTypeId<T>();
   }
   template <typename T>
   const T& get() const {
     // It is a dynamic_cast-like behaviour
-    if (type_id == typeid(T).hash_code()) {
+    if (type_id == FastTypeId<T>()) {
       return *reinterpret_cast<const T*>(&data);
     } else {
 #ifdef LITE_ON_TINY_PUBLISH
-      LOG(FATAL) << "unmatched type, store as " << type_id
-                 << " , but want to get " << typeid(T).name();
+      LOG(FATAL) << "Error: unmatched data type, the data type stored in this "
+                    "varient is different from the data type you  want to "
+                    "obtain!";
 #else
       throw std::invalid_argument(
-          string_format("unmatched type, store as %d, but want to get %s",
-                        type_id,
-                        typeid(T).name()));
+          "Error: unmatched data type, the data type stored in this varient is "
+          "different from the data type you  want to obtain!");
 #endif
     }
     return *reinterpret_cast<const T*>(&data);
@@ -134,7 +138,7 @@ struct variant {
   const T get_if() const {
     static_assert(std::is_pointer<T>::value,
                   "Use get_if, make sure T is pointer");
-    if (type_id == typeid(T).hash_code()) {
+    if (type_id == FastTypeId<T>()) {
       return *reinterpret_cast<const T*>(&data);
     } else {
       return nullptr;
@@ -144,14 +148,17 @@ struct variant {
   template <typename T>
   T* get_mutable() {
     // It is a dynamic_cast-like behaviour
-    if (type_id == typeid(T).hash_code()) {
+    if (type_id == FastTypeId<T>()) {
       return reinterpret_cast<T*>(&data);
     } else {
 #ifdef LITE_ON_TINY_PUBLISH
-      LOG(ERROR) << "unmatched type get, should be " << type_id << " but get "
-                 << typeid(T).name();
+      LOG(FATAL) << "Error: unmatched data type, the data type stored in this "
+                    "varient is different from the data type you  want to "
+                    "obtain!";
 #else
-      throw std::invalid_argument("unmatched type");
+      throw std::invalid_argument(
+          "Error: unmatched data type, the data type stored in this varient is "
+          "different from the data type you  want to obtain!");
 #endif
     }
   }


### PR DESCRIPTION
- 本PR内容：裁剪掉Paddle-Lite 动态库中、第三方库相关的符号
  - 效果：预测库体积压缩
  - 存在的问题：`-Wl,--exclude-libs` 命令在arm macOS上不支持、当前arm macos上编译产出 存在不同（后续解决）


- 本PR内容：裁剪掉Paddle-Lite 中的rtti内容
  - 效果：预测库体积压缩
```
编译命令：
./lite/tools/build_android.sh --with_log=OFF --toolchain=clang

commit: af9d5e93e620346d2b5ee8bd8ee08d0f64a0feec
产出的体积：2118Kb

合入本PR
产出的体积：1822Kb

最终收益：
296Kb
