### PR TITLE
[ci] fix ci_*.sh

### DIFF
--- a/tools/ci_tools/ci_benchmark.sh
+++ b/tools/ci_tools/ci_benchmark.sh
@@ -127,6 +127,7 @@ function check_benchmark_result() {
   else
     echo -e "$GREEN_COLOR avg_time[${avg_time}] <= avg_time_thres[${avg_time_thres}] on device[$device_alias] Passed. $OFF_COLOR"
     # TODO: update .json automatically(after this pr is merged)
+    # sed -i "s/\${avg_time_baseline}\b/${avg_time}/" $config_path
   fi
   return 0
 }
@@ -282,9 +283,9 @@ function build_and_test_on_remote_device() {
   local oss=(${os_list//,/ })
   local archs=(${arch_list//,/ })
   local toolchains=(${toolchain_list//,/ })
-  for os in $oss; do
-    for arch in $archs; do
-      for toolchain in $toolchains; do
+  for os in ${oss[@]}; do
+    for arch in ${archs[@]}; do
+      for toolchain in ${toolchains[@]}; do
         # Build
         echo "Build with $os+$arch+$toolchain ..."
         $build_target_func $os $arch $toolchain

--- a/tools/ci_tools/ci_nn_accelerators_unit_test.sh
+++ b/tools/ci_tools/ci_nn_accelerators_unit_test.sh
@@ -319,9 +319,9 @@ function build_and_test_on_remote_device() {
     local archs=(${arch_list//,/ })
     local toolchains=(${toolchain_list//,/ })
     local unit_test_check_items=(${unit_test_check_list//,/ })
-    for os in $oss; do
-        for arch in $archs; do
-            for toolchain in $toolchains; do
+    for os in ${oss[@]}; do
+        for arch in ${archs[@]}; do
+            for toolchain in ${toolchains[@]}; do
                 # Build all tests and prepare device environment for running tests
                 echo "Build tests with $arch+$toolchain"
                 $build_target_func $os $arch $toolchain $extra_arguments
@@ -401,7 +401,7 @@ function android_cpu_build_target() {
     mkdir -p $BUILD_DIR
     cd $BUILD_DIR
     prepare_workspace $ROOT_DIR $BUILD_DIR
-    
+
     cmake .. \
         -DWITH_GPU=OFF \
         -DWITH_MKL=OFF \
@@ -583,7 +583,7 @@ function huawei_ascend_npu_build_and_test() {
     cd $BUILD_DIR
     prepare_workspace $ROOT_DIR $BUILD_DIR
     local archs=(${ARCH_LIST//,/ })
-    for arch in $archs; do 
+    for arch in ${archs[@]}; do
         sdk_root_dir="/usr/local/Ascend/ascend-toolkit/latest"
         if [ "${arch}" == "x86" ]; then
             with_x86=ON

--- a/tools/ci_tools/utils.sh
+++ b/tools/ci_tools/utils.sh
@@ -44,7 +44,7 @@ function prepare_models {
 function adb_device_check() {
   local adb_device_name=$1
   if [[ -n "$adb_device_name" ]]; then
-    for line in $(adb devices | grep -v "List" | awk '{print $1}'); do
+    for line in $(adb devices | grep -v "List" | grep device | awk '{print $1}'); do
       online_device_name=$(echo $line | awk '{print $1}')
       if [[ "$adb_device_name" == "$online_device_name" ]]; then
         return 0


### PR DESCRIPTION
shell 中在遍历数组时，脚本中的实现只能获取到第一个元素，应改为：${var_name[@]}