### PR TITLE
[metal]fix memory is not released in time in some kernels

### DIFF
--- a/lite/kernels/metal/image_op/dropout_image_compute.h
+++ b/lite/kernels/metal/image_op/dropout_image_compute.h
@@ -45,6 +45,8 @@ class DropoutImageCompute
     virtual ~DropoutImageCompute();
 
    private:
+    void run_without_mps();
+        
     const MetalImage* input_buffer_;
     MetalImage* output_buffer_{nullptr};
     std::shared_ptr<MetalBuffer> param_buffer_;

--- a/lite/kernels/metal/image_op/dropout_image_compute.h
+++ b/lite/kernels/metal/image_op/dropout_image_compute.h
@@ -46,7 +46,7 @@ class DropoutImageCompute
 
    private:
     void run_without_mps();
-        
+
     const MetalImage* input_buffer_;
     MetalImage* output_buffer_{nullptr};
     std::shared_ptr<MetalBuffer> param_buffer_;

--- a/lite/kernels/metal/image_op/dropout_image_compute.mm
+++ b/lite/kernels/metal/image_op/dropout_image_compute.mm
@@ -53,6 +53,12 @@ void DropoutImageCompute::PrepareForRun() {
 }
 
 void DropoutImageCompute::Run() {
+    @autoreleasepool {
+        run_without_mps();
+    }
+}
+
+void DropoutImageCompute::run_without_mps() {
     auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();

--- a/lite/kernels/metal/image_op/elementwise_div_image_compute.h
+++ b/lite/kernels/metal/image_op/elementwise_div_image_compute.h
@@ -45,6 +45,7 @@ class ElementwiseDivImageCompute
     virtual ~ElementwiseDivImageCompute();
 
    private:
+    void run_without_mps();
     void setup_without_mps();
 
     MetalImage* output_buffer_{nullptr};

--- a/lite/kernels/metal/image_op/elementwise_div_image_compute.mm
+++ b/lite/kernels/metal/image_op/elementwise_div_image_compute.mm
@@ -44,6 +44,12 @@ void ElementwiseDivImageCompute::PrepareForRun() {
 }
 
 void ElementwiseDivImageCompute::Run() {
+    @autoreleasepool {
+        run_without_mps();
+    }
+}
+
+void ElementwiseDivImageCompute::run_without_mps() {
     auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();

--- a/lite/kernels/metal/image_op/elementwise_sub_image_compute.h
+++ b/lite/kernels/metal/image_op/elementwise_sub_image_compute.h
@@ -45,6 +45,7 @@ class ElementwiseSubImageCompute
     virtual ~ElementwiseSubImageCompute();
 
    private:
+    void run_without_mps();
     void setup_without_mps();
 
     MetalImage* output_buffer_{nullptr};

--- a/lite/kernels/metal/image_op/elementwise_sub_image_compute.mm
+++ b/lite/kernels/metal/image_op/elementwise_sub_image_compute.mm
@@ -43,6 +43,12 @@ void ElementwiseSubImageCompute::PrepareForRun() {
 }
 
 void ElementwiseSubImageCompute::Run() {
+    @autoreleasepool {
+        run_without_mps();
+    }
+}
+
+void ElementwiseSubImageCompute::run_without_mps() {
     auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();

--- a/lite/kernels/metal/image_op/interp_image_compute.h
+++ b/lite/kernels/metal/image_op/interp_image_compute.h
@@ -70,6 +70,7 @@ class NearestInterpImageCompute
     virtual ~NearestInterpImageCompute();
 
    private:
+    void run_without_mps();
     void setup_without_mps();
 
     const MetalImage* input_buffer_;

--- a/lite/kernels/metal/image_op/interp_image_compute.mm
+++ b/lite/kernels/metal/image_op/interp_image_compute.mm
@@ -39,6 +39,12 @@ void BilinearInterpImageCompute::PrepareForRun() {
 }
 
 void BilinearInterpImageCompute::Run() {
+    @autoreleasepool {
+        run_without_mps();
+    }
+}
+
+void BilinearInterpImageCompute::run_without_mps() {
     auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();
@@ -109,6 +115,12 @@ void NearestInterpImageCompute::PrepareForRun() {
 }
 
 void NearestInterpImageCompute::Run() {
+    @autoreleasepool {
+        run_without_mps();
+    }
+}
+
+void NearestInterpImageCompute::run_without_mps() {
     auto pipline = pipline_;
     auto outTexture = output_buffer_->image();
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();


### PR DESCRIPTION
适配地图模型时发现：一些kernel 的Run未用autoreleasepool包裹 导致OC对象释放不及时；