### PR TITLE
[size] replace openmp by thread-pool by default on android 

### DIFF
--- a/lite/kernels/CMakeLists.txt
+++ b/lite/kernels/CMakeLists.txt
@@ -2,7 +2,7 @@ message(STATUS "add lite kernels")
 
 set(lite_kernel_deps "" CACHE INTERNAL "" FORCE)
 if(LITE_THREAD_POOL)
-  set(lite_kernel_deps ${lite_kernel_deps} thread_pool)
+  set(lite_kernel_deps ${lite_kernel_deps})
 endif()
 
 if (LITE_BUILD_TAILOR)

--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -32,7 +32,7 @@ BUILD_ARM82_FP16=OFF
 # options of striping lib according to input model.
 OPTMODEL_DIR=""
 WITH_STRIP=OFF
-WITH_THREAD_POOL=OFF
+WITH_THREAD_POOL=ON
 # options of compiling NPU lib.
 WITH_HUAWEI_KIRIN_NPU=OFF
 HUAWEI_KIRIN_NPU_SDK_ROOT="$(pwd)/ai_ddk_lib/" # Download HiAI DDK from https://developer.huawei.com/consumer/cn/hiai/


### PR DESCRIPTION
```
./lite/tools/build_android.sh --toolchain=clang
```