### PR TITLE
[Benchmark Tool] Disable opencl by default when compile benchmark_bin for armlinux

### DIFF
--- a/docs/benchmark/benchmark_tools.md
+++ b/docs/benchmark/benchmark_tools.md
@@ -124,6 +124,7 @@ avg   = 32.723
 | :-- | :-- | :-- | :-- |
 | arch                  | 目标 ARM 架构    |  armv7 / armv8   |  armv8   |
 | toolchain             | 工具链           |  gcc / clang     |  gcc     |
+| with_opencl           | 编译 OpenCL     |  OFF / ON        |  OFF     |
 | with_profile          | 逐层时间 profile |  ON / OFF        |  OFF     |
 | with_precision_profile| 逐层精度 profile |  ON / OFF        |  OFF     |
 
@@ -140,11 +141,11 @@ avg   = 32.723
 wget https://paddle-inference-dist.bj.bcebos.com/AI-Rank/mobile/MobileNetV1.tar.gz
 tar zxvf MobileNetV1.tar.gz
 
-# 上传文件到 armlinux 设备
+# 上传文件到 arm linux 设备
 
 ```
 
-然后通过`ssh`登录到 armlinux 设备，执行：
+然后通过`ssh`登录到 arm linux 设备，执行：
 ```shell
 # 性能测试
 cd /path/to/benchmark_bin; \
@@ -367,6 +368,7 @@ Benchnark 工具提供了丰富的运行时选项，来满足不同的运行时�
 - 设备 OS 为 macOS(x86 芯片) 时，通过使用`--backend=opencl,x86`来实现
 
 说明：
+- 当考虑在 ARM Linux 系统的设备上，使用 GPU 运行模型时，需要在编译时手动添加编译选项`--with_opencl=ON`
 - 由于 Linux 上运行 OpenCL 必须提前预装 OpenCL 相关驱动库，因此暂不支持使用 Linux 系统上的 GPU 执行模型推理预测
 - 当指定在 GPU 上运行模型时，有如下 4 个重要运行时参数，不同设置会对性能有较大影响：
   - `--opencl_cache_dir`：设置 opencl cache 文件的存放路径，当显式设置该选项后，会开启 opencl kernel 预编译 和 auto-tune 功能
@@ -405,7 +407,7 @@ NNAdapter 已支持的新硬件列表如下：
 ##### NNAdapter 运行时库及新硬件 Hal 库编译
 ###### nnadapter.so
 - Huawei Kirin NPU / Mediatek NPU 请参考 『在 Android 上运行性能测试』编译预测库。
-— Huawei Ascend NPU（arm host） / Rockchip NPU / Imagination NNA / Amlogic NPU 请参考 『在 ARMLinux 上运行性能测试』编译预测库。
+— Huawei Ascend NPU（arm host） / Rockchip NPU / Imagination NNA / Amlogic NPU 请参考 『在 ARM Linux 上运行性能测试』编译预测库。
 - Huawei Ascend NPU（x86 host）请参考『在 Linux 上运行性能测试』编译预测库。
 - 新硬件所需的 DDK 可在 [Paddle Lite 通用示例程序](https://paddlelite-demo.bj.bcebos.com/devices/generic/PaddleLite-generic-demo.tar.gz)中获取。
 

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -77,11 +77,11 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 
 
 
-#####################################################################################################
-# 2. local variables, these variables should not be changed.
-#####################################################################################################
-# url that stores third-party zip file to accelerate third-paty lib installation
-readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+    #####################################################################################################
+    # 2. local variables, these variables should not be changed.
+    #####################################################################################################
+    # url that stores third-party zip file to accelerate third-paty lib installation
+    readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 # absolute path of Paddle-Lite.
 readonly workspace=$PWD/$(dirname $0)/../../
 # basic options for linux compiling.
@@ -95,15 +95,16 @@ function set_benchmark_options {
   WITH_EXTRA=ON
   WITH_EXCEPTION=ON
   WITH_NNADAPTER=ON
+  # Turn off opencl. Additional third party library need to be installed on
+  # Linux. Otherwise opencl is not supported on Linux. See link for more info:
+  # https://software.intel.com/content/www/us/en/develop/articles/opencl-drivers.html
+  # For arm linux os, opencl is also disabled by default because some devices have not
+  # fully support opencl.
+  WITH_OPENCL=OFF
   if [ "${ARCH}" == "x86" ]; then
-    # Turn off opencl. Additional third party library need to be installed on
-    # Linux. Otherwise opencl is not supported on Linux. See link for more info:
-    # https://software.intel.com/content/www/us/en/develop/articles/opencl-drivers.html
-    WITH_OPENCL=OFF
     WITH_LIGHT_WEIGHT_FRAMEWORK=OFF
   else
     WITH_LIGHT_WEIGHT_FRAMEWORK=ON
-    WITH_OPENCL=ON
   fi
   if [ ${WITH_PROFILE} == "ON" ] || [ ${WITH_PRECISION_PROFILE} == "ON" ]; then
     WITH_LOG=ON

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -27,7 +27,12 @@ OPTMODEL_DIR=""
 # options of compiling x86 lib
 WITH_STATIC_MKL=OFF
 WITH_AVX=ON
-# options of compiling OPENCL lib.
+# options of compiling OpenCL lib, default is OFF.
+# 1. Additional third party library need to be installed on Linux.
+#    Otherwise OpenCL is not supported on Linux. See link for more info:
+#    https://software.intel.com/content/www/us/en/develop/articles/opencl-drivers.html
+# 2. For ARM Linux OS, OpenCL is also disabled by default because some devices
+#    do not fully support OpenCL.
 WITH_OPENCL=OFF
 # options of compiling rockchip NPU lib.
 WITH_ROCKCHIP_NPU=OFF
@@ -95,12 +100,7 @@ function set_benchmark_options {
   WITH_EXTRA=ON
   WITH_EXCEPTION=ON
   WITH_NNADAPTER=ON
-  # Turn off opencl. Additional third party library need to be installed on
-  # Linux. Otherwise opencl is not supported on Linux. See link for more info:
-  # https://software.intel.com/content/www/us/en/develop/articles/opencl-drivers.html
-  # For arm linux os, opencl is also disabled by default because some devices have not
-  # fully support opencl.
-  WITH_OPENCL=OFF
+
   if [ "${ARCH}" == "x86" ]; then
     WITH_LIGHT_WEIGHT_FRAMEWORK=OFF
   else

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -77,11 +77,11 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 
 
 
-    #####################################################################################################
-    # 2. local variables, these variables should not be changed.
-    #####################################################################################################
-    # url that stores third-party zip file to accelerate third-paty lib installation
-    readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+#####################################################################################################
+# 2. local variables, these variables should not be changed.
+#####################################################################################################
+# url that stores third-party zip file to accelerate third-paty lib installation
+readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
 # absolute path of Paddle-Lite.
 readonly workspace=$PWD/$(dirname $0)/../../
 # basic options for linux compiling.

--- a/tools/ci_tools/ci_benchmark.sh
+++ b/tools/ci_tools/ci_benchmark.sh
@@ -204,8 +204,10 @@ function run_on_remote_device() {
   local model_name=$(basename $model_dir)
   local input_shape=`jq -r --arg v $model_name '.model[] | select(.name == $v).input_shape' $config_path`
   local backends=""
-  if [[ "$os" == "android" || "$os" == "armlinux" ]]; then
+  if [[ "$os" == "android" ]]; then
     backends=("arm" "opencl,arm")
+  elif [ "$os" == "armlinux" ]; then
+    backends=("arm")
   elif [ "$os" == "linux" ]; then
     backends=("x86")
   elif [ "$os" == "macos" ]; then


### PR DESCRIPTION
**【问题】**
由于新硬件部分如 rk1808s0 的设备 OS 是 arm linux，但是其上面没有 libOpenCL.so；当前的 build_linux.sh 在编译 benchmark_bin 时默认会使能 opencl，当在设备上运行时，会因为执行 runtime_context_assign_pass 时找不到 libOpenCL.so 而报错退出。
问题根源在于： armlinux 设备对 opencl 的支持情况参差不齐，有些设备如 rk3399 / rv1109 上是完全支持 opencl 的，有些设备如 rk1808s0 上没有 libOpenCL.so，因此不支持 opencl。

**【解决方法】**
build_linux.sh 中在编译 benchmark_bin 时不修改 opencl 的编译设置选项，由于 WITH_OPENCL 默认是关闭的，因此当明确需要在 arm linux 设备的 GPU 上运行模型时，需要在编译时额外加入`--with_opencl=ON`选项。