### PR TITLE
[Pass][OpenCL] Add restrict for OpenCL Context Init

### DIFF
--- a/lite/core/optimizer/mir/runtime_context_assign_pass.cc
+++ b/lite/core/optimizer/mir/runtime_context_assign_pass.cc
@@ -25,11 +25,11 @@ class RuntimeContextAssignPass : public StmtPass {
 
   void Apply(const std::unique_ptr<SSAGraph>& graph) override {
 #ifdef LITE_WITH_OPENCL
+    using OpenCLContext = Context<TargetType::kOpenCL>;
+    std::unique_ptr<KernelContext> local_ctx(new KernelContext());
     const auto& valid_places = graph->valid_places();
     for (const auto& place : valid_places) {
       if (place.target == TARGET(kOpenCL)) {
-        using OpenCLContext = Context<TargetType::kOpenCL>;
-        std::unique_ptr<KernelContext> local_ctx(new KernelContext());
         local_ctx->As<OpenCLContext>().InitOnce();
         break;
       }

--- a/lite/core/optimizer/mir/runtime_context_assign_pass.cc
+++ b/lite/core/optimizer/mir/runtime_context_assign_pass.cc
@@ -25,9 +25,15 @@ class RuntimeContextAssignPass : public StmtPass {
 
   void Apply(const std::unique_ptr<SSAGraph>& graph) override {
 #ifdef LITE_WITH_OPENCL
-    using OpenCLContext = Context<TargetType::kOpenCL>;
-    std::unique_ptr<KernelContext> local_ctx(new KernelContext());
-    local_ctx->As<OpenCLContext>().InitOnce();
+    const auto& valid_places = graph->valid_places();
+    for (const auto& place : valid_places) {
+      if (place.target == TARGET(kOpenCL)) {
+        using OpenCLContext = Context<TargetType::kOpenCL>;
+        std::unique_ptr<KernelContext> local_ctx(new KernelContext());
+        local_ctx->As<OpenCLContext>().InitOnce();
+        break;
+      }
+    }
 #endif
     for (auto& node : graph->mutable_nodes()) {
       if (!node.IsStmt()) continue;

--- a/lite/core/optimizer/mir/runtime_context_assign_pass.cc
+++ b/lite/core/optimizer/mir/runtime_context_assign_pass.cc
@@ -25,7 +25,6 @@ class RuntimeContextAssignPass : public StmtPass {
 
   void Apply(const std::unique_ptr<SSAGraph>& graph) override {
 #ifdef LITE_WITH_OPENCL
-    using OpenCLContext = Context<TargetType::kOpenCL>;
     std::unique_ptr<KernelContext> local_ctx(new KernelContext());
     const auto& valid_places = graph->valid_places();
     for (const auto& place : valid_places) {


### PR DESCRIPTION
**【问题】**
由于新硬件部分如 rk1808s0 的设备 OS 是 arm linux，但是其上面没有 libOpenCL.so；当前的 build_linux.sh 在编译 benchmark_bin 时默认会使能 opencl，当在设备上运行时，会因为执行 runtime_context_assign_pass 时找不到 libOpenCL.so 而报错退出。

问题根源在于： 
runtime_context_assign_pass 在判断创建 OpenCL Context 时约束条件不够，应该同时满足：enable 宏`LITE_WITH_OPENCL` 和 graph 的 valid_places 的 TARGET 含有`kOpenCL`时，才会创建 OpenCL Context.

另外，armlinux 设备对 opencl 的支持情况参差不齐，有些设备如 rk3399 / rv1109 上是完全支持 opencl 的，有些设备如 rk1808s0 上没有 libOpenCL.so，因此不支持 opencl。

**【解决方法】**
在 runtime_context_assign_pass 中加入完备的约束条件。