### PR TITLE
[doc] fix doc build error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,2 @@
+sphinx:
+  version: "4.2"


### PR DESCRIPTION
- 问题：readthedoc 文档在线编译失败
- 问题定位：文档编译时 ， `sphinx<2` + `docutils-0.18` 不互相兼容
- 解决方法：升级sphinx版本到 `4.2.0`