### PR TITLE
[Frame] Add auto scan unit test frame

### DIFF
--- a/lite/tests/unittest_py/README.md
+++ b/lite/tests/unittest_py/README.md
@@ -1,0 +1,1 @@
+## How to use autoscan framwork to test kernel precision?

--- a/lite/tests/unittest_py/arm/test_mul_op.py
+++ b/lite/tests/unittest_py/arm/test_mul_op.py
@@ -16,7 +16,7 @@ import sys
 sys.path.append('..')
 
 from auto_scan_test_rpc import AutoScanTest, SkipReasons
-from program_config import TensorConfig, ProgramConfig
+from program_config import TensorConfig, ProgramConfig, OpConfig
 import numpy as np
 import paddle.inference as paddle_infer
 from functools import partial
@@ -36,25 +36,16 @@ class TestMulOp(AutoScanTest):
             return np.random.random(kwargs['in_shape']).astype(np.float32)
         def generate_input_y(*args, **kwargs):
             return np.random.random(kwargs['in_shape']).astype(np.float32)
-        ops_config = [{
-            "op_type": "mul",
-            "op_inputs": {
-                "X": ["input_data_x"],
-                "Y": ["input_data_y"],
-            },
-            "op_outputs": {
-                "Out": ["output_data"]
-            },
-            "op_attrs": {
-                "x_num_col_dims": 1,
-                "y_num_col_dims": 1
-            }
-        }]
-
-        ops = self.generate_op_config(ops_config)
+        mul_op = OpConfig(
+            type = "mul",
+            inputs = {"X": ["input_data_x"],
+                      "Y": ["input_data_y"]},
+            outputs = {"Out": ["output_data"]},
+            attrs = {"x_num_col_dims": 1,
+                     "y_num_col_dims": 1})
 
         program_config = ProgramConfig(
-            ops=ops,
+            ops=[mul_op],
             weights={
                 "input_data_y":
                 TensorConfig(data_gen=partial(generate_input_y, *args, **kwargs)),

--- a/lite/tests/unittest_py/arm/test_mul_op.py
+++ b/lite/tests/unittest_py/arm/test_mul_op.py
@@ -59,7 +59,8 @@ class TestMulOp(AutoScanTest):
         yield program_config
 
     def sample_predictor_configs(self, program_config):
-        config = {"valid_targets":"arm",}
+        config = {"valid_targets" : ["arm,float,NCHW"],
+                  "thread": 1}
         yield config, (1e-5, 1e-5)
 
     def add_skip_pass_case(self):

--- a/lite/tests/unittest_py/arm/test_mul_op.py
+++ b/lite/tests/unittest_py/arm/test_mul_op.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('..')
+
+from auto_scan_test_rpc import AutoScanTest, SkipReasons
+from program_config import TensorConfig, ProgramConfig
+import numpy as np
+import paddle.inference as paddle_infer
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+class TestMulOp(AutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        return True
+
+    def sample_program_configs(self, *args, **kwargs):
+        def generate_input(*args, **kwargs):
+            return np.random.random(kwargs['in_shape']).astype(np.float32)
+        def generate_input_y(*args, **kwargs):
+            return np.random.random(kwargs['in_shape']).astype(np.float32)
+        ops_config = [{
+            "op_type": "mul",
+            "op_inputs": {
+                "X": ["input_data_x"],
+                "Y": ["input_data_y"],
+            },
+            "op_outputs": {
+                "Out": ["output_data"]
+            },
+            "op_attrs": {
+                "x_num_col_dims": 1,
+                "y_num_col_dims": 1
+            }
+        }]
+
+        ops = self.generate_op_config(ops_config)
+
+        program_config = ProgramConfig(
+            ops=ops,
+            weights={
+                "input_data_y":
+                TensorConfig(data_gen=partial(generate_input_y, *args, **kwargs)),
+            },
+            inputs={
+                "input_data_x":
+                TensorConfig(data_gen=partial(generate_input, *args, **kwargs)),
+            },
+            outputs=["output_data"])
+
+        yield program_config
+
+    def sample_predictor_configs(self, program_config):
+        config = {"valid_targets":"arm",}
+        yield config, (1e-5, 1e-5)
+
+    def add_skip_pass_case(self):
+        pass
+
+    @given(
+        in_shape=st.lists(
+            st.integers(
+                min_value=2, max_value=2), min_size=2, max_size=2))
+    def test(self, *args, **kwargs):
+        self.add_skip_pass_case()
+        self.run_test(quant=False, *args, **kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lite/tests/unittest_py/auto_scan_base.py
+++ b/lite/tests/unittest_py/auto_scan_base.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import unittest
+import abc
+import os
+import enum
+import time
+import logging
+import shutil
+import paddle
+import paddle.fluid as fluid
+from paddle.fluid.initializer import NumpyArrayInitializer
+from paddle.fluid.core import PassVersionChecker
+import paddle.fluid.core as core
+from paddle import compat as cpt
+import paddle.inference as paddle_infer
+from typing import Optional, List, Callable, Dict, Any, Set
+from program_config import TensorConfig, OpConfig, ProgramConfig, create_fake_model, create_quant_model
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+settings.register_profile(
+    "ci",
+    max_examples=100,
+    suppress_health_check=hypothesis.HealthCheck.all(),
+    deadline=None,
+    print_blob=True,
+    derandomize=True,
+    report_multiple_bugs=False)
+settings.load_profile("ci")
+
+class SkipReasonsBase(enum.Enum):
+    # Paddle not support, but paddlelite support, we need to add the feature.
+    PADDLE_NOT_IMPLEMENTED = 0
+    # paddlelite not support.
+    PADDLELITE_NOT_SUPPORT = 1
+    # Accuracy is abnormal after enabling pass.
+    ACCURACY_ERROR = 2
+
+
+class AutoScanBaseTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        np.random.seed(1024)
+        paddle.enable_static()
+        super(AutoScanBaseTest, self).__init__(*args, **kwargs)
+        self.skip_cases = []
+        abs_dir = os.path.abspath(os.path.dirname(__file__))
+        self.cache_dir = os.path.join(abs_dir,
+                                      str(self.__module__) + '_cache_dir')
+
+    @abc.abstractmethod
+    def sample_program_configs(self):
+        '''
+        Generate all config with the combination of different Input tensor shape and
+        different Attr values.
+        '''
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def sample_predictor_configs(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def add_skip_case(
+            self,
+            teller: [Callable[[ProgramConfig, paddle_infer.Config], bool]],
+            reason: SkipReasonsBase,
+            note: str):
+        self.skip_cases.append((teller, reason, note))
+
+    @abc.abstractmethod
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        raise NotImplementedError
+
+    def run_test_config(self, model, params, prog_config, pred_config,
+                        feed_data) -> Dict[str, np.ndarray]:
+        '''
+        Test a single case.
+        '''
+        pred_config.set_model_buffer(model, len(model), params, len(params))
+        predictor = paddle_infer.create_predictor(pred_config)
+
+        for name, _ in prog_config.inputs.items():
+            input_tensor = predictor.get_input_handle(name)
+            input_tensor.copy_from_cpu(feed_data[name]['data'])
+            if feed_data[name]['lod'] is not None:
+                input_tensor.set_lod(feed_data[name]['lod'])
+        predictor.run()
+        result = {}
+        for out_name, o_name in zip(prog_config.outputs,
+                                    predictor.get_output_names()):
+            result[out_name] = predictor.get_output_handle(o_name).copy_to_cpu()
+        return result
+
+
+    @abc.abstractmethod
+    def assert_tensors_near(self,
+                            atol: float,
+                            rtol: float,
+                            tensor: Dict[str, np.array],
+                            baseline: Dict[str, np.array]):
+        for key, arr in tensor.items():
+            self.assertTrue(
+                baseline[key].shape == arr.shape,
+                "The output shapes are not equal, the baseline shape is " +
+                str(baseline[key].shape) + ', but got ' + str(arr.shape))
+            self.assertTrue(
+                np.allclose(
+                    baseline[key], arr, atol=atol, rtol=rtol),
+                "Output has diff. ")
+
+
+    def generate_op_config(self,
+                           ops_config: List[Dict[str, Any]]) -> List[OpConfig]:
+        ops = []
+        for i in range(len(ops_config)):
+            op_config = ops_config[i]
+            ops.append(
+                OpConfig(
+                    type=op_config['op_type'],
+                    inputs=op_config['op_inputs'],
+                    outputs=op_config['op_outputs'],
+                    attrs=op_config['op_attrs']))
+        return ops
+
+    @abc.abstractmethod
+    def skip_log(self, msg: str):
+        logging.warning("SKIP: " + msg)
+
+    @abc.abstractmethod
+    def fail_log(self, msg: str):
+        logging.error("FAILE: " + msg)
+
+    @abc.abstractmethod
+    def success_log(self, msg: str):
+        logging.info("SUCCESS: " + msg)
+
+    @abc.abstractmethod
+    def create_inference_config(self,
+                                passes: Optional[List[str]]=None,
+                                use_gpu: bool=False,
+                                use_mkldnn: bool=False,
+                                ir_optim: Optional[bool]=None):
+        config = paddle_infer.Config()
+        config.switch_ir_debug(True)
+        config.set_optim_cache_dir(self.cache_dir)
+        config.disable_glog_info()
+        if ir_optim is not None:
+            config.switch_ir_optim(ir_optim)
+        if use_gpu:
+            config.enable_use_gpu(100, 0)
+        if use_mkldnn:
+            config.enable_mkldnn()
+        if passes is not None:
+            config.pass_builder().set_passes(passes)
+            self.passes = passes
+        return config
+
+    def run_test(self, quant=False, *args, **kwargs):
+        status = True
+
+        for prog_config in self.sample_program_configs(*args, **kwargs):
+            # if program is invalid, we should skip that cases.
+            if not self.is_program_valid(prog_config):
+                continue
+
+            model, params = create_fake_model(prog_config)
+            if quant:
+                model, params = create_quant_model(model, params)
+
+            feed_data = {}
+            for name, tensor_config in prog_config.inputs.items():
+                feed_data[name] = {
+                    'data': tensor_config.data,
+                    'lod': tensor_config.lod
+                }
+            results: List[Dict[str, np.ndarray]] = []
+
+            # baseline: cpu no ir_optim run
+            base_config = self.create_inference_config(ir_optim=False)
+            logging.info('RUN program_config: ' + str(prog_config))
+            results.append(
+                self.run_test_config(model, params, prog_config, base_config,
+                                     feed_data))
+            self.success_log('RUN_CPU_BASELINE done')
+
+            for pred_config, (
+                    atol, rtol) in self.sample_predictor_configs(prog_config):
+                # skip info
+                skip_flag = False
+                for skip_info in self.skip_cases:
+                    if skip_info[0](prog_config, pred_config):
+                        skip_flag = True
+                        if skip_info[1] == SkipReasonsBase.ACCURACY_ERROR:
+                            self.skip_log("[ACCURACY_ERROR] " +
+                                          skip_info[2] + ' ' + ' vs ' + self.
+                                          paddlelite_config_str(pred_config))
+                        else:
+                            raise NotImplementedError
+                        break
+
+                if os.path.exists(self.cache_dir):
+                    shutil.rmtree(self.cache_dir)
+                if not os.path.exists(self.cache_dir):
+                    os.mkdir(self.cache_dir)
+
+                try:
+                    results.append(self.run_lite_config(model, params, feed_data, pred_config))
+
+                except Exception as e:
+                    self.fail_log(
+                        self.paddlelite_config_str(pred_config) +
+                        '\033[1;31m \nERROR INFO: {}\033[0m'.format(str(e)))
+                    if not skip_flag:
+                        status = False
+                    continue
+                self.success_log('RUN predictor_config ' + self.
+                                 paddlelite_config_str(pred_config) + ' done')
+
+        self.assertTrue(status)
+
+    def inference_config_str(self, config) -> bool:
+        dic = {}
+        enable_mkldnn = config.mkldnn_enabled()
+        dic['use_mkldnn'] = enable_mkldnn
+        enable_gpu = config.use_gpu()
+        return str(dic)
+
+    def paddlelite_config_str(self, config) -> bool:
+        return str(config)
+
+    @abc.abstractmethod
+    def run_lite_config(self, model, params, feed_data, pred_config) -> Dict[str, np.ndarray]:
+        raise NotImplementedError

--- a/lite/tests/unittest_py/auto_scan_base.py
+++ b/lite/tests/unittest_py/auto_scan_base.py
@@ -61,8 +61,6 @@ class AutoScanBaseTest(unittest.TestCase):
         super(AutoScanBaseTest, self).__init__(*args, **kwargs)
         self.skip_cases = []
         abs_dir = os.path.abspath(os.path.dirname(__file__))
-        self.cache_dir = os.path.join(abs_dir,
-                                      str(self.__module__) + '_cache_dir')
 
     @abc.abstractmethod
     def sample_program_configs(self):
@@ -159,7 +157,6 @@ class AutoScanBaseTest(unittest.TestCase):
                                 ir_optim: Optional[bool]=None):
         config = paddle_infer.Config()
         config.switch_ir_debug(True)
-        config.set_optim_cache_dir(self.cache_dir)
         config.disable_glog_info()
         if ir_optim is not None:
             config.switch_ir_optim(ir_optim)
@@ -214,12 +211,6 @@ class AutoScanBaseTest(unittest.TestCase):
                         else:
                             raise NotImplementedError
                         break
-
-                if os.path.exists(self.cache_dir):
-                    shutil.rmtree(self.cache_dir)
-                if not os.path.exists(self.cache_dir):
-                    os.mkdir(self.cache_dir)
-
                 try:
                     results.append(self.run_lite_config(model, params, feed_data, pred_config))
 

--- a/lite/tests/unittest_py/auto_scan_test.py
+++ b/lite/tests/unittest_py/auto_scan_test.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from auto_scan_base import AutoScanBaseTest, SkipReasonsBase
+import numpy as np
+import abc
+import enum
+import unittest
+from typing import Optional, List, Callable, Dict, Any, Set
+from paddlelite.lite import *
+
+SkipReasons = SkipReasonsBase
+
+class AutoScanTest(AutoScanBaseTest):
+    def run_lite_config(self, model, params, feed_data, pred_config) -> Dict[str, np.ndarray]:
+        valid_places=[Place(TargetType.Host, PrecisionType.FP32)]
+        config = CxxConfig()
+        config.set_valid_places(valid_places)
+        config.set_model_buffer(model, len(model), params, len(params))
+        predictor = create_paddle_predictor(config)
+        for name in inputs:
+            input_tensor = predictor.get_input_by_name(name)
+            input_tensor.from_numpy(inputs[name]['data'])
+            if inputs[name]['lod'] is not None:
+                input_tensor.set_lod(inputs[name]['lod'])
+        predictor.run()
+        result = {}
+        for out_name in predictor.get_output_names():
+            result[out_name] = predictor.get_output_by_name(out_name).numpy()
+        return result

--- a/lite/tests/unittest_py/auto_scan_test.py
+++ b/lite/tests/unittest_py/auto_scan_test.py
@@ -23,7 +23,7 @@ from paddlelite.lite import *
 SkipReasons = SkipReasonsBase
 
 class AutoScanTest(AutoScanBaseTest):
-    def run_lite_config(self, model, params, feed_data, pred_config) -> Dict[str, np.ndarray]:
+    def run_lite_config(self, model, params, inputs, pred_config) -> Dict[str, np.ndarray]:
         valid_places=[Place(TargetType.Host, PrecisionType.FP32)]
         config = CxxConfig()
         config.set_valid_places(valid_places)

--- a/lite/tests/unittest_py/auto_scan_test.py
+++ b/lite/tests/unittest_py/auto_scan_test.py
@@ -22,11 +22,68 @@ from paddlelite.lite import *
 
 SkipReasons = SkipReasonsBase
 
+
+# TargetType
+target_type_map = {
+      "Host": TargetType.Host,
+      "X86": TargetType.X86,
+      "CUDA": TargetType.CUDA,
+      "ARM": TargetType.ARM,
+      "OpenCL": TargetType.OpenCL,
+      "FPGA": TargetType.FPGA,
+      "NPU": TargetType.NPU,
+      "MLU": TargetType.MLU,
+      "RKNPU": TargetType.RKNPU,
+      "APU": TargetType.APU,
+      "HUAWEI_ASCEND_NPU": TargetType.HUAWEI_ASCEND_NPU,
+      "IMAGINATION_NNA": TargetType.IMAGINATION_NNA,
+      "INTEL_FPGA": TargetType.INTEL_FPGA,
+      "Any": TargetType.Any}
+
+# PrecisionType
+precision_type_map = {
+      "FP16": PrecisionType.FP16,
+      "FP32": PrecisionType.FP32,
+      "FP64": PrecisionType.FP64,
+      "UINT8": PrecisionType.UINT8,
+      "INT8": PrecisionType.INT8,
+      "INT16": PrecisionType.INT16,
+      "INT32": PrecisionType.INT32,
+      "INT64": PrecisionType.INT64,
+      "BOOL": PrecisionType.BOOL,
+       "Any": PrecisionType.Any}
+
+
+# DataLayoutType
+data_layout_map = {
+      "NCHW": DataLayoutType.NCHW,
+      "NHWC": DataLayoutType.NHWC,
+      "ImageDefault": DataLayoutType.ImageDefault,
+      "ImageFolder": DataLayoutType.ImageFolder,
+      "ImageNW": DataLayoutType.ImageNW,
+      "Any": DataLayoutType.Any}
+
+
+
+
+def ParsePlaceInfo(place_str):
+   # todo: this func should be completed later
+   return Place(TargetType.Host, PrecisionType.FP32)
+
+def ParsePaddleLiteConfig(self, config):
+    lite_config = CxxConfig()
+    if "valid_targets" in config:
+        valid_places = []
+        for place_str in config["valid_targets"]:
+            valid_places.append(ParsePlaceInfo(place_str))
+        lite_config.set_valid_places(valid_places)
+    if "thread" in config:
+        lite_config.set_thread(pred_config["thread"])
+    return lite_config
+
 class AutoScanTest(AutoScanBaseTest):
     def run_lite_config(self, model, params, inputs, pred_config) -> Dict[str, np.ndarray]:
-        valid_places=[Place(TargetType.Host, PrecisionType.FP32)]
-        config = CxxConfig()
-        config.set_valid_places(valid_places)
+        config = ParsePaddleLiteConfig(self, pred_config)
         config.set_model_buffer(model, len(model), params, len(params))
         predictor = create_paddle_predictor(config)
         for name in inputs:

--- a/lite/tests/unittest_py/auto_scan_test_rpc.py
+++ b/lite/tests/unittest_py/auto_scan_test_rpc.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from auto_scan_base import AutoScanBaseTest, SkipReasonsBase
+import numpy as np
+import abc
+import enum
+import unittest
+from typing import Optional, List, Callable, Dict, Any, Set
+import os
+
+import rpyc
+rpyc.core.protocol.DEFAULT_CONFIG['allow_pickle'] = True
+
+
+SkipReasons = SkipReasonsBase
+
+class AutoScanTest(AutoScanBaseTest):
+    def run_lite_config(self, model, params, feed_data, pred_config) -> Dict[str, np.ndarray]:
+        conn = rpyc.connect("localhost", 18812, config = rpyc.core.protocol.DEFAULT_CONFIG)
+        out = conn.root.run_lite_model(model,params,feed_data)
+        return out

--- a/lite/tests/unittest_py/host/test_assign_op.py
+++ b/lite/tests/unittest_py/host/test_assign_op.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('..')
+
+from auto_scan_test import AutoScanTest, SkipReasons
+from program_config import TensorConfig, ProgramConfig
+import numpy as np
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+class TestAssignOp(AutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        return True
+
+    def sample_program_configs(self, *args, **kwargs):
+        def generate_input(*args, **kwargs):
+            return np.random.random(kwargs['in_shape']).astype(np.float32)
+
+        ops_config = [{
+            "op_type": "assign",
+            "op_inputs": {
+                "X": ["input_data"],
+            },
+            "op_outputs": {
+                "Out": ["output_data"]
+            },
+            "op_attrs": {
+            }
+        }]
+
+        ops = self.generate_op_config(ops_config)
+
+        program_config = ProgramConfig(
+            ops=ops,
+            weights={
+            },
+            inputs={
+                "input_data":
+                TensorConfig(data_gen=partial(generate_input, *args, **kwargs)),
+            },
+            outputs=["output_data"])
+
+        yield program_config
+
+    def sample_predictor_configs(self, program_config):
+        config = {"valid_targets":"host",}
+        yield config, (1e-5, 1e-5)
+
+    def add_skip_pass_case(self):
+        pass
+
+    @given(
+        in_shape=st.lists(
+            st.integers(
+                min_value=1, max_value=8), max_size=2))
+    def test(self, *args, **kwargs):
+        self.add_skip_pass_case()
+        self.run_test(quant=False, *args, **kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lite/tests/unittest_py/host/test_assign_op.py
+++ b/lite/tests/unittest_py/host/test_assign_op.py
@@ -16,7 +16,7 @@ import sys
 sys.path.append('..')
 
 from auto_scan_test import AutoScanTest, SkipReasons
-from program_config import TensorConfig, ProgramConfig
+from program_config import TensorConfig, ProgramConfig, OpConfig
 import numpy as np
 from functools import partial
 from typing import Optional, List, Callable, Dict, Any, Set
@@ -34,24 +34,14 @@ class TestAssignOp(AutoScanTest):
         def generate_input(*args, **kwargs):
             return np.random.random(kwargs['in_shape']).astype(np.float32)
 
-        ops_config = [{
-            "op_type": "assign",
-            "op_inputs": {
-                "X": ["input_data"],
-            },
-            "op_outputs": {
-                "Out": ["output_data"]
-            },
-            "op_attrs": {
-            }
-        }]
-
-        ops = self.generate_op_config(ops_config)
-
+        assign_op = OpConfig(
+            type = "assign",
+            inputs = {"X" : ["input_data"]},
+            outputs = {"Out": ["output_data"]},
+            attrs = {})
         program_config = ProgramConfig(
-            ops=ops,
-            weights={
-            },
+            ops=[assign_op],
+            weights={},
             inputs={
                 "input_data":
                 TensorConfig(data_gen=partial(generate_input, *args, **kwargs)),

--- a/lite/tests/unittest_py/program_config.py
+++ b/lite/tests/unittest_py/program_config.py
@@ -1,0 +1,380 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, List, Callable, Dict, Any, Set
+import numpy as np
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle import compat as cpt
+from paddle.fluid.initializer import NumpyArrayInitializer
+from paddle.fluid.framework import convert_np_dtype_to_dtype_
+
+from paddle.fluid.contrib.slim.quantization import QuantizationTransformPass
+from paddle.fluid.contrib.slim.quantization import QuantizationFreezePass
+from paddle.fluid.framework import IrGraph, IrNode, Operator
+from paddle.fluid.executor import global_scope
+
+
+class TensorConfig:
+    '''
+    A config builder for a input or a weight.
+    '''
+
+    def __init__(self,
+                 lod: Optional[List[List[int]]]=None,
+                 data_gen: Optional[Callable[..., np.array]]=None):
+        '''
+        shape: The shape of the tensor.
+        dtype: The data type of the tensor.
+        data: The value of WeightVar. for input, it should be None 
+        '''
+        self.lod = lod
+        self.data_gen = data_gen
+        self.data = data_gen()
+        self.dtype = data_gen().dtype
+        self.shape = data_gen().shape
+
+    def __repr__(self):
+        return str({'shape': self.shape, 'lod': self.lod, 'dtype': self.dtype})
+
+
+class OpConfig:
+    '''  A config builder for generating a Op.  '''
+
+    def __init__(self,
+                 type: str,
+                 inputs: Dict[str, List[str]],
+                 outputs: Dict[str, List[str]],
+                 attrs: Dict[str, Any]):
+        self.type = type
+        self.inputs = inputs
+        self.outputs = outputs
+        self.attrs = attrs
+
+    def __repr__(self):
+        log_str = self.type
+        log_str += str(self.attrs)
+        return log_str
+
+
+class ProgramConfig:
+    '''  A config builder for generating a Program.  '''
+
+    def __init__(self,
+                 ops: List[OpConfig],
+                 weights: Dict[str, TensorConfig],
+                 inputs: Dict[str, TensorConfig],
+                 outputs: List[str]):
+        self.ops = ops
+        # if no weight need to save, we create a place_holder to help seriazlie params.
+        if not weights:
+
+            def generate_weight():
+                return np.array([1]).astype(np.float32)
+
+            self.weights = {
+                "place_holder_weight": TensorConfig(data_gen=generate_weight)
+            }
+        else:
+            self.weights = weights
+        self.inputs = inputs
+        self.outputs = outputs
+
+    def __repr__(self):
+        log_str = ''
+        for i in range(len(self.ops)):
+            if i != len(self.ops) - 1:
+                log_str += repr(self.ops[i]) + ' + '
+            else:
+                log_str += repr(self.ops[i])
+        log_str += ' -- '
+        for t, v in self.inputs.items():
+            log_str += '[' + t + ': ' + str(v) + ']'
+        for t, v in self.weights.items():
+            log_str += '[' + t + ': ' + str(v) + ']'
+
+        return log_str
+
+
+def create_fake_model(program_config):
+    '''  Create a Paddle model(in memory) according to the given config.  '''
+    paddle.enable_static()
+    main_program_desc = core.ProgramDesc()
+    util_program = fluid.Program()
+    main_block_desc = main_program_desc.block(0)
+
+    var_desc = main_block_desc.var(cpt.to_bytes("feed"))
+    var_desc.set_type(core.VarDesc.VarType.FEED_MINIBATCH)
+    var_desc.set_persistable(True)
+
+    index = 0
+    for name, tensor_config in program_config.inputs.items():
+        var_desc = main_block_desc.var(cpt.to_bytes(name))
+        var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
+        var_desc.set_dtype(convert_np_dtype_to_dtype_(tensor_config.dtype))
+        var_desc.set_shape(tensor_config.shape)
+        var_desc.set_need_check_feed(True)
+        op_desc = main_block_desc._prepend_op()
+        op_desc.set_type("feed")
+        op_desc.set_input('X', ["feed"])
+        op_desc.set_output('Out', [name])
+        op_desc._set_attr("col", index)
+        index = index + 1
+
+    save_var_map = {}
+    for name, tensor_config in program_config.weights.items():
+        var_desc = main_block_desc.var(cpt.to_bytes(name))
+        var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
+        var_desc.set_dtype(convert_np_dtype_to_dtype_(tensor_config.dtype))
+        var_desc.set_shape(tensor_config.shape)
+        var_desc.set_persistable(True)
+
+        save_var_map[name] = util_program.global_block().create_parameter(
+            dtype=tensor_config.dtype,
+            shape=tensor_config.shape,
+            type=core.VarDesc.VarType.LOD_TENSOR,
+            name=name,
+            initializer=NumpyArrayInitializer(tensor_config.data))
+    in_vars = []
+    for name in sorted(save_var_map.keys()):
+        in_vars.append(save_var_map[name])
+
+    out_var = util_program.global_block().create_var(
+        type=core.VarDesc.VarType.RAW, name="out_var_0")
+    out_var.desc.set_persistable(True)
+    util_program.global_block().append_op(
+        type='save_combine',
+        inputs={'X': in_vars},
+        outputs={'Y': out_var},
+        attrs={'file_path': '',
+               'save_to_memory': True})
+    for op_config in program_config.ops:
+        op_desc = main_block_desc.append_op()
+        op_desc.set_type(op_config.type)
+        for name, values in op_config.inputs.items():
+            op_desc.set_input(name, values)
+        for name, values in op_config.attrs.items():
+            op_desc._set_attr(name, values)
+        for name, values in op_config.outputs.items():
+            op_desc.set_output(name, values)
+            for v in values:
+                var_desc = main_block_desc.var(cpt.to_bytes(v))
+                var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
+                var_desc.set_dtype(
+                    convert_np_dtype_to_dtype_(tensor_config.dtype))
+        op_desc.infer_var_type(main_block_desc)
+        op_desc.infer_shape(main_block_desc)
+
+    for index, name in enumerate(program_config.outputs):
+        var_desc = main_block_desc.var(cpt.to_bytes("fetch"))
+        var_desc.set_type(core.VarDesc.VarType.FETCH_LIST)
+        var_desc.set_need_check_feed(True)
+        op_desc = main_block_desc.append_op()
+        op_desc.set_type("fetch")
+        op_desc.set_input('X', [name])
+        op_desc.set_output('Out', ["fetch"])
+        op_desc._set_attr("col", index)
+
+    main_program_desc._set_version()
+    paddle.fluid.core.save_op_version_info(main_program_desc)
+
+    model = main_program_desc.serialize_to_string()
+
+    util_program._sync_with_cpp()
+    place = fluid.CPUPlace()
+    executor = fluid.Executor(place)
+    scope = fluid.Scope()
+    with fluid.scope_guard(scope):
+        executor.run(util_program)
+        params = scope.find_var("out_var_0").get_bytes()
+    return model, params
+
+
+def create_quant_model(model,
+                       params,
+                       activation_quantize_type='moving_average_abs_max',
+                       weight_quantize_type='channel_wise_abs_max',
+                       save=False):
+    place = paddle.CUDAPlace(0)
+    scope = global_scope()
+    exe = paddle.static.Executor(place)
+    [inference_program, feed_target_names,
+     fetch_targets] = paddle.static.load_inference_model(
+         path_prefix=None,
+         executor=exe,
+         model_filename=model,
+         params_filename=params)
+    graph = IrGraph(core.Graph(inference_program.desc), for_test=True)
+
+    out_scale_op_list = [
+        "conv2d",
+        "depthwise_conv2d",
+        "mul",
+        "matmul",
+        "relu",
+        "leaky_relu",
+        "relu6",
+        "sigmoid",
+        "tanh",
+        "prelu",
+        "swish",
+        "softmax",
+        "batch_norm",
+        "layer_norm",
+        "elementwise_add",
+        "pool2d",
+        "reshape2",
+        "transpose2",
+        "concat",
+        "elementwise_mul",
+        "scale",
+        "slice",
+        "hard_swish",
+        "hard_sigmoid",
+        "conv2d_transpose",
+        "gru",
+        "bilinear_interp",
+        "nearest_interp",
+        "trilinear_interp",
+        "flatten",
+        "flatten2",
+        "transpose",
+        "pad2d",
+        "reshape",
+        "layer_norm",
+    ]
+    op_real_in_out_name = {
+        "conv2d": [["Input", "Filter"], ["Output"]],
+        "depthwise_conv2d": [["Input", "Filter"], ["Output"]],
+        "conv2d_transpose": [["Input", "Filter"], ["Output"]],
+        "mul": [["X", "Y"], ["Out"]],
+        "matmul": [["X", "Y"], ["Out"]],
+        "pool2d": [["X"], ["Out"]],
+        "elementwise_add": [["X", "Y"], ["Out"]],
+        "concat": [["X"], ["Out"]],
+        "softmax": [["X"], ["Out"]],
+        "argmax": [["X"], ["Out"]],
+        "transpose": [["X"], ["Out"]],
+        "equal": [["X", "Y"], ["Out"]],
+        "gather": [["X"], ["Out"]],
+        "greater_equal": [["X", "Y"], ["Out"]],
+        "greater_than": [["X", "Y"], ["Out"]],
+        "less_equal": [["X", "Y"], ["Out"]],
+        "less_than": [["X", "Y"], ["Out"]],
+        "mean": [["X"], ["Out"]],
+        "not_equal": [["X", "Y"], ["Out"]],
+        "reshape": [["X"], ["Out"]],
+        "reshape2": [["X"], ["Out"]],
+        "transpose2": [["X"], ["Out"]],
+        "bilinear_interp": [["X"], ["Out"]],
+        "nearest_interp": [["X"], ["Out"]],
+        "trilinear_interp": [["X"], ["Out"]],
+        "slice": [["Input"], ["Out"]],
+        "squeeze": [["X"], ["Out"]],
+        "elementwise_sub": [["X", "Y"], ["Out"]],
+        "relu": [["X"], ["Out"]],
+        "relu6": [["X"], ["Out"]],
+        "leaky_relu": [["X"], ["Out"]],
+        "prelu": [["X"], ["Out"]],
+        "tanh": [["X"], ["Out"]],
+        "swish": [["X"], ["Out"]],
+        "dropout": [["X"], ["Out"]],
+        "batch_norm": [["X"], ["Y"]],
+        "layer_norm": [["X"], ["Y"]],
+        "sigmoid": [["X"], ["Out"]],
+        "elementwise_mul": [["X", "Y"], ["Out"]],
+        "scale": [["X"], ["Out"]],
+        "hard_swish": [["X"], ["Out"]],
+        "hard_sigmoid": [["X"], ["Out"]],
+        "gru": [["Input", "Weight"], ["Hidden"]],
+        "lstm": [["Input", "Weight"], ["Hidden"]],
+        "pad2d": [["X"], ["Out"]],
+        "flatten": [["X"], ["Out"]],
+        "flatten2": [["X"], ["Out"]],
+    }
+
+    def _get_op_output_var_names(op):
+        """ """
+        assert isinstance(op, (IrNode, Operator)), \
+            "The input op should be IrNode or Operator."
+        var_names = []
+        op_name = op.name() if isinstance(op, IrNode) \
+            else op.type
+        if op_name not in op_real_in_out_name:
+            return []
+
+        name_list = op_real_in_out_name[op_name][1]
+        for name in name_list:
+            var_name = op.output(name)
+            if isinstance(var_name, list):
+                var_names.extend(var_name)
+            else:
+                var_names.append(var_name)
+        return var_names
+
+    transform_pass = QuantizationTransformPass(
+        scope=scope,
+        place=place,
+        activation_quantize_type=activation_quantize_type,
+        weight_quantize_type=weight_quantize_type)
+    transform_pass.apply(graph)
+
+    op_nodes = graph.all_op_nodes()
+    for op_node in op_nodes:
+        if op_node.name() in out_scale_op_list:
+            var_names = _get_op_output_var_names(op_node)
+            for var_name in var_names:
+                in_node = graph._find_node_by_name(op_node.outputs, var_name)
+                if in_node.dtype() not in \
+                    [core.VarDesc.VarType.FP64, core.VarDesc.VarType.FP32]:
+                    continue
+
+                op_node.op()._set_attr("out_threshold", 3.0)
+
+    # Freeze graph for inference, but the weight of fc/conv is still float type.
+    freeze_pass = QuantizationFreezePass(
+        scope=scope, place=place, weight_quantize_type=weight_quantize_type)
+    freeze_pass.apply(graph)
+
+    main_program = graph.to_program()
+
+    # modify fake_quantize_moving_average_abs_max(InScale) and fake_channel_wise_dequantize_max_abs(Scales)
+    op_nodes = graph.all_op_nodes()
+    for op_node in op_nodes:
+        if op_node.name() == 'fake_quantize_moving_average_abs_max':
+            var_name = op_node.input("InScale")[0]
+            tensor = scope.var(var_name).get_tensor()
+            tensor.set(np.array([1], dtype=np.float32), place)
+        elif op_node.name() == 'fake_channel_wise_dequantize_max_abs':
+            var_name = op_node.input("Scales")[0]
+            tensor = scope.var(var_name).get_tensor()
+            tensor.set(np.ones(tensor.shape(), dtype=np.float32), place)
+
+    if save:
+        fluid.io.save_inference_model(
+            'test_inference_model',
+            feed_target_names,
+            fetch_targets,
+            exe,
+            main_program=main_program)
+
+    feed_vars = [
+        main_program.global_block().var(name) for name in feed_target_names
+    ]
+    serialized_program = paddle.static.serialize_program(
+        feed_vars, fetch_targets, program=main_program)
+    serialized_params = paddle.static.serialize_persistables(
+        feed_vars, fetch_targets, executor=exe, program=main_program)
+    return serialized_program, serialized_params

--- a/lite/tests/unittest_py/requirements.txt
+++ b/lite/tests/unittest_py/requirements.txt
@@ -1,0 +1,2 @@
+numpy>=1.20
+hypothesis

--- a/lite/tests/unittest_py/rpc_service/README.md
+++ b/lite/tests/unittest_py/rpc_service/README.md
@@ -1,0 +1,12 @@
+### Start rpc server for auto scan unit test.
+
+`cd Paddle-Lite/lite/tests/unittest_py/rpc_service/`
+
+#### Step 1. Prepare environment
+- python3.9 is required
+- Paddle Lite is required : python3.9 -m pip install paddlelite
+- others : python3.9 -m pip install requirements.txt
+
+### Step 2. Start a rpc server
+- `cd sh start_rpc_server.sh`
+   - a rpc server bundled to port `18812` will be built

--- a/lite/tests/unittest_py/rpc_service/requirements.txt
+++ b/lite/tests/unittest_py/rpc_service/requirements.txt
@@ -1,0 +1,2 @@
+rpyc
+numpy

--- a/lite/tests/unittest_py/rpc_service/server.py
+++ b/lite/tests/unittest_py/rpc_service/server.py
@@ -1,0 +1,31 @@
+import rpyc
+from rpyc.utils.server import ThreadedServer
+from paddlelite.lite import *
+
+rpyc.core.protocol.DEFAULT_CONFIG['allow_pickle'] = True
+
+class RPCService(rpyc.Service):
+    def exposed_run_lite_model(self, model, params,inputs):
+        '''
+        Test a single case.
+        '''
+        valid_places=[Place(TargetType.ARM, PrecisionType.FP32)]
+        config = CxxConfig()
+        config.set_valid_places(valid_places)
+        config.set_model_buffer(model, len(model), params, len(params))
+        predictor = create_paddle_predictor(config)
+        for name in inputs:
+            input_tensor = predictor.get_input_by_name(name)
+            input_tensor.from_numpy(inputs[name]['data'])
+            if inputs[name]['lod'] is not None:
+                input_tensor.set_lod(inputs[name]['lod'])
+        predictor.run()
+        result = {}
+        for out_name in predictor.get_output_names():
+            result[out_name] = predictor.get_output_by_name(out_name).numpy()
+        return result
+
+
+if __name__ == "__main__":
+    server = ThreadedServer(RPCService, port =18812, protocol_config = rpyc.core.protocol.DEFAULT_CONFIG)
+    server.start()

--- a/lite/tests/unittest_py/rpc_service/start_rpc_server.sh
+++ b/lite/tests/unittest_py/rpc_service/start_rpc_server.sh
@@ -1,0 +1,7 @@
+# get process-id of current rpc server
+RPC_PID=$(lsof -i:18812 | grep Python | awk -F ' ' '{print $2}')
+# restart rpc server
+if [[ $RPC_PID != "" ]]; then
+  kill -9 ${RPC_PID}
+fi
+nohup python3.9 server.py >/dev/null 2>&1 &


### PR DESCRIPTION
## 增加 Paddle Lite 算子精度对齐方法
- 基本原理： 创建单个OP、在Paddle和Paddle Lite 上分别执行、比对最终输出精度

## 如何注册OP单测： DEMO `test_assign_op.py`
1、根据`OP`定义 实现 `sample_program_configs` 方法
``` Python
class TestAssignOp(AutoScanTest):
    ...
    def sample_program_configs(self, *args, **kwargs):
        def generate_input(*args, **kwargs):
            return np.random.random(kwargs['in_shape']).astype(np.float32)

        assign_op = OpConfig(
            type = "assign",
            inputs = {"X" : ["input_data"]},
            outputs = {"Out": ["output_data"]},
            attrs = {})
        program_config = ProgramConfig(
            ops=[assign_op],
            weights={},
            inputs={
                "input_data":
                TensorConfig(data_gen=partial(generate_input, *args, **kwargs)),
            },
            outputs=["output_data"])

        yield program_config
```

2、判断叉乘得到的OP属性和输入是否合法，需要实现`is_program_valid` 接口

``` Python
class TestAssignOp(AutoScanTest):
    def is_program_valid(self, program_config: ProgramConfig) -> bool:
         # is_sparse is only support False
         if program_config.ops[0].attrs['is_sparse'] == True:
             return False
         return True
```

3、针对不同的后端，分别进行测试，需要实现 `sample_predictor_configs` 接口
函数中需要设置 Paddle Lite Config，并且每一种后端设置的精度阈值都是(绝对误差1e-5, 相对误差1e-5)
``` python
    def sample_predictor_configs(self, program_config):
        config = {"valid_targets" : ["arm,float,NCHW"],
                  "thread": 1}
        yield config, (1e-5, 1e-5)
```

4、通过 `hypothesis` 设置属性 和 输入 的可能范围
``` python
    @given(
         is_sparse=st.booleans(),
         is_distributed=st.booleans(),
         padding_idx=st.integers(),
         axis=st.integers(
             min_value=-4, max_value=4),
         op_type=st.sampled_from(['lookup_table', 'lookup_table_v2']),
         epsilon=st.floats(
             min_value=0, max_value=0.001),
         begin_norm_axis=st.integers(
             min_value=-4, max_value=4),
         batch_size=st.integers(
             min_value=1, max_value=4),
         input_dim=st.sampled_from([32, 64]),
         weight_size=st.sampled_from([[64, 64], [64, 32]]))
     def test(self, *args, **kwargs):
         assume(kwargs['begin_norm_axis'] == 2)

         self.add_skip_pass_case()
         self.run_test(quant=False, *args, **kwargs)
```

5、如果存在需要SKIP的测试Case，请添加skip_case
``` Python
    def add_skip_pass_case(self):
         def teller1(program_config, predictor_config):
             if program_config.ops[3].attrs['axis'] in [
                     -1, 2
             ] and program_config.ops[5].attrs[
                     'begin_norm_axis'] == 2 and program_config.weights[
                         'embedding_weight1'].shape in [(64, 32), (64, 64)]:
                 return True
             return False

         self.add_skip_case(teller1, SkipReasons.ACCURACY_ERROR,
                            "The pass output has diff in a specific case.")
```

## 如何测试

- 环境要求： Python 、通过 Python 安装 Paddle 、Paddle Lite
- 执行测试 （用Python 执行单测）
   - x86算子： `cd Paddle-Lite/lite/test/unittest_py/host&& python test_assign_op.py`
   -  ARM 算子(M1 机器、需要在Python3.9 上安装 Paddle-Lite、使用Python3.8 安装 Paddle) 
       - `cd Paddle-Lite/lite/test/unittest_py/rpc_server/ && sh start_rpc_server.sh`
       - `cd Paddle-Lite/lite/test/unittest_py/arm && python3.8 test_mul_op.py`

## 如何新增一种测试方法

继承 `AutoScanBase` 类 并重新实现其中的 `AutoScanTest` (如何调用 Paddle Lite 执行模型并获取输出）
- 可以参考 `auto_scan_test_rpc.py`
``` python
from auto_scan_base import AutoScanBaseTest, SkipReasonsBase
from paddlelite.lite import *
...

SkipReasons = SkipReasonsBase

class AutoScanTest(AutoScanBaseTest):
    def run_lite_config(self, model, params, feed_data, pred_config) -> Dict[str, np.ndarray]:
        conn = rpyc.connect("localhost", 18812, config = rpyc.core.protocol.DEFAULT_CONFIG)
        out = conn.root.run_lite_model(model,params,feed_data)
        return out
```