### PR TITLE
Update third-party-commitID.tar.gz

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -54,7 +54,9 @@ MIN_ANDROID_API_LEVEL_ARMV8=21
 ANDROID_API_LEVEL="Default"
 CMAKE_API_LEVEL_OPTIONS=""
 
-readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+# url that stores third-party tar.gz file to accelerate third-party lib installation
+readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
 readonly workspace=$PWD
 
 function readlinkf() {
@@ -98,13 +100,13 @@ function prepare_opencl_source_code {
 }
 
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_android.sh
+++ b/lite/tools/build_android.sh
@@ -67,8 +67,9 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 #####################################################################################################
 # 2. local variables, these variables should not be changed.
 #####################################################################################################
-# url that stores third-party zip file to accelerate third-paty lib installation
-readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+# url that stores third-party tar.gz file to accelerate third-party lib installation
+readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
 # absolute path of Paddle-Lite.
 readonly workspace=$PWD/$(dirname $0)/../../
 # basic options for android compiling.
@@ -141,13 +142,13 @@ function prepare_opencl_source_code {
 # 3.3 prepare third_party libraries for compiling
 # here we store third_party libraries into Paddle-Lite/third-party
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_bm.sh
+++ b/lite/tools/build_bm.sh
@@ -28,17 +28,19 @@ readonly CMAKE_COMMON_OPTIONS="-DWITH_LITE=ON \
 
 readonly NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-1}
 
-readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+# url that stores third-party tar.gz file to accelerate third-party lib installation
+readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
 readonly workspace=$(pwd)
 
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi
@@ -116,15 +118,15 @@ function main {
                 shift
                 ;;
             --dynamic=*)
-                BM_DYNAMIC_COMPILE=${i#*=} 
+                BM_DYNAMIC_COMPILE=${i#*=}
                 shift
                 ;;
             --save_bmodel=*)
-                BM_SAVE_BMODEL=${i#*=} 
+                BM_SAVE_BMODEL=${i#*=}
                 shift
                 ;;
             --save_umodel=*)
-                BM_SAVE_UMODEL=${i#*=} 
+                BM_SAVE_UMODEL=${i#*=}
                 shift
                 ;;
             *)

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -78,8 +78,10 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 #####################################################################################################
 # 2. local variables, these variables should not be changed.
 #####################################################################################################
-# url that stores third-party zip file to accelerate third-paty lib installation
-readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+# url that stores third-party tar.gz file to accelerate third-party lib installation
+readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
+
 # absolute path of Paddle-Lite.
 readonly workspace=$PWD/$(dirname $0)/../../
 # basic options for linux compiling.
@@ -243,12 +245,12 @@ function prepare_opencl_source_code {
 # 3.3 prepare third_party libraries for compiling
 # here we store third_party libraries into Paddle-Lite/third-party
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
-        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_macos.sh
+++ b/lite/tools/build_macos.sh
@@ -43,6 +43,10 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 #####################################################################################################
 # 2. local variables, these variables should not be changed.
 #####################################################################################################
+# url that stores third-party tar.gz file to accelerate third-party lib installation
+readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
+
 # on mac environment, we should expand the maximum file num to compile successfully
 os_name=`uname -s`
 if [ ${os_name} == "Darwin" ]; then
@@ -82,13 +86,13 @@ function prepare_opencl_source_code {
 }
 
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi
@@ -132,7 +136,7 @@ function make_armosx {
         build_dir=${build_dir}.opencl
         prepare_opencl_source_code $workspace
     fi
-    
+
     if [ ${WITH_TESTING} == "ON" ]; then
       BUILD_EXTRA=ON
       LITE_ON_TINY_PUBLISH=OFF
@@ -208,7 +212,7 @@ function make_x86 {
     BUILD_EXTRA=ON
     build_directory=${build_directory}.metal
   fi
-  
+
   if [ ${WITH_TESTING} == "ON" ]; then
     BUILD_EXTRA=ON
     LITE_ON_TINY_PUBLISH=OFF

--- a/lite/tools/build_mlu.sh
+++ b/lite/tools/build_mlu.sh
@@ -29,17 +29,22 @@ readonly CMAKE_COMMON_OPTIONS="-DWITH_LITE=ON \
 
 readonly NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}
 
-readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+# url that stores third-party tar.gz file to accelerate third-party lib installation
+readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
 readonly workspace=$(pwd)
 
 function prepare_thirdparty {
-    if [ ! -d $workspace/third-party ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
+
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
+        fi
+        tar xzf $THIRDPARTY_TAR
+    else
+        git submodule update --init --recursive
     fi
-    if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-        wget $THIRDPARTY_TAR
-    fi
-    tar xvf third-party-ea5576.tar.gz
 }
 
 # for code gen, a source file is generated after a test, but is dependended by some targets in cmake.

--- a/lite/tools/build_npu.sh
+++ b/lite/tools/build_npu.sh
@@ -28,7 +28,7 @@ function print_usage {
     echo
 }
 
-# for code gen, a source file is generated after a test, 
+# for code gen, a source file is generated after a test,
 # but is dependended by some targets in cmake.
 # here we fake an empty file to make cmake works.
 function prepare_workspace {
@@ -45,16 +45,18 @@ function prepare_workspace {
 }
 
 function prepare_thirdparty {
-    readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+    # url that stores third-party tar.gz file to accelerate third-party lib installation
+    readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+    readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
 
     readonly workspace=$PWD
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
 
-         if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_rknpu.sh
+++ b/lite/tools/build_rknpu.sh
@@ -5,7 +5,7 @@ set -ex
 ARM_OS="armlinux"                    # android only yet
 ARM_ABI="armv8"                     # armv8, armv7
 ARM_LANG="gcc"                      # gcc only yet
-DDK_ROOT="$(pwd)/rknpu"       
+DDK_ROOT="$(pwd)/rknpu"
 TARGET_NAME="test_subgraph_pass"    # default target
 BUILD_EXTRA=OFF                     # ON(with sequence ops)/OFF
 WITH_TESTING=ON     	            # ON/OFF
@@ -25,7 +25,7 @@ function print_usage {
     echo
 }
 
-# for code gen, a source file is generated after a test, 
+# for code gen, a source file is generated after a test,
 # but is dependended by some targets in cmake.
 # here we fake an empty file to make cmake works.
 function prepare_workspace {
@@ -42,16 +42,18 @@ function prepare_workspace {
 }
 
 function prepare_thirdparty {
-    readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+    # url that stores third-party tar.gz file to accelerate third-party lib installation
+    readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+    readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
 
     readonly workspace=$PWD
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
 
-         if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi

--- a/lite/tools/build_windows.bat
+++ b/lite/tools/build_windows.bat
@@ -23,7 +23,8 @@ set CMAKE_GENERATOR=Visual Studio 14 2015
 set ARCH=""
 set WITH_STRIP=OFF
 set OPTMODEL_DIR=""
-set THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+set THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+set THIRDPARTY_TAR=third-party-801f670.tar.gz
 set BAIDU_XPU_SDK_ROOT=""
 
 set workspace=%source_path%
@@ -213,7 +214,7 @@ goto:eof
         call "%vcvarsall_dir%" x86
         set ARCH="i386"
     )
- 
+
     cmake %root_dir%  -G Ninja -DARCH=%ARCH% ^
             -DMSVC_STATIC_CRT=%MSVC_STATIC_CRT% ^
             -DWITH_MKL=ON      ^
@@ -247,36 +248,36 @@ goto:eof
 
 :prepare_thirdparty
     if  EXIST "%workspace%\third-party" (
-        if NOT EXIST "%workspace%\third-party-ea5576.tar.gz" (
-            echo "The directory of third_party exists, the third-party-ea5576.tar.gz not exists."
+        if NOT EXIST "%workspace%\%THIRDPARTY_TAR%" (
+            echo "The directory of third_party exists, %THIRDPARTY_TAR% not exists."
             git submodule update --init --recursive
             call:rm_rebuild_dir "%workspace%\third-party\glog\src\extern_glog-build"
             call:rm_rebuild_dir "%workspace%\third-party\protobuf-host\src\extern_protobuf-build"
 
         ) else (
-               echo "The directory of third_party exists, the third-party-ea5576.tar.gz exists."
+               echo "The directory of third_party exists, the %THIRDPARTY_TAR% exists."
                call:rm_rebuild_dir "%workspace%\third-party"
-               !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-ea5576.tar.gz %workspace%
+               !python_path! %workspace%\lite\tools\untar.py %source_path%\%THIRDPARTY_TAR% %workspace%
         )
     ) else (
-        if NOT EXIST "%workspace%\third-party-ea5576.tar.gz" (
-            echo "The directory of third_party not exists, the third-party-ea5576.tar.gz not exists."
+        if NOT EXIST "%workspace%\%THIRDPARTY_TAR%" (
+            echo "The directory of third_party not exists, the %THIRDPARTY_TAR% not exists."
             call:download_third_party
-            if EXIST "%workspace%\third-party-ea5576.tar.gz" (
-                !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-ea5576.tar.gz %workspace%
+            if EXIST "%workspace%\%THIRDPARTY_TAR%" (
+                !python_path! %workspace%\lite\tools\untar.py %source_path%\%THIRDPARTY_TAR% %workspace%
             ) else (
-                echo "------------Can't download the third-party-ea5576.tar.gz!------"
+                echo "------------Can't download the %THIRDPARTY_TAR%!------"
             )
         ) else (
-            echo "The directory of third_party not exists, the third-party-ea5576.tar.gz exists."
-            !python_path! %workspace%\lite\tools\untar.py %source_path%\third-party-ea5576.tar.gz %workspace%
+            echo "The directory of third_party not exists, the %THIRDPARTY_TAR% exists."
+            !python_path! %workspace%\lite\tools\untar.py %source_path%\%THIRDPARTY_TAR% %workspace%
         )
     )
 goto:eof
 
 :download_third_party
 powershell.exe (new-object System.Net.WebClient).DownloadFile('%THIRDPARTY_TAR%', ^
-'%workspace%\third-party-ea5576.tar.gz')
+'%workspace%\%THIRDPARTY_TAR%')
 goto:eof
 
 :prepare_opencl_source_code

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -11,7 +11,10 @@ NUM_PROC=4
 readonly ADB_WORK_DIR="/data/local/tmp"
 readonly common_flags="-DWITH_LITE=ON -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=OFF -DWITH_PYTHON=OFF -DWITH_TESTING=ON -DLITE_WITH_ARM=OFF"
 
-readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+# url that stores third-party tar.gz file to accelerate third-party lib installation
+readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
+
 readonly workspace=$PWD
 
 NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}
@@ -35,13 +38,13 @@ fi
 
 function prepare_thirdparty {
     cd $workspace
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi
@@ -148,7 +151,7 @@ function run_gen_code_test {
     # 1. build test_cxx_api
     make test_cxx_api -j$NUM_CORES_FOR_COMPILE
 
-    # 2. run test_cxx_api_lite in emulator to get opt model 
+    # 2. run test_cxx_api_lite in emulator to get opt model
     local test_cxx_api_lite_path=$(find ./lite -name test_cxx_api)
     adb -s ${device} push "./third_party/install/lite_naive_model" ${adb_work_dir}
     adb -s ${device} push ${test_cxx_api_lite_path} ${adb_work_dir}
@@ -255,8 +258,8 @@ function build_single {
 function build {
     make lite_compile_deps -j$NUM_CORES_FOR_COMPILE
     if [ $LITE_WITH_COVERAGE = "ON" ];then
-        make coveralls_generate -j	
-    fi 
+        make coveralls_generate -j
+    fi
     # test publish inference lib
     # make publish_inference
 }
@@ -595,7 +598,7 @@ function run_test_case_on_remote_device {
         $remote_device_run $remote_device_name push "$config_dir" "$remote_device_work_dir"
         command_line="$command_line --config_dir ./$config_name"
     fi
-    
+
     # Run the model on the remote device
     $remote_device_run $remote_device_name shell "cd $remote_device_work_dir; export GLOG_v=5; LD_LIBRARY_PATH=$LD_LIBRARY_PATH:. $command_line"
 }

--- a/lite/tools/ci_test.sh
+++ b/lite/tools/ci_test.sh
@@ -6,7 +6,9 @@ TESTS_FILE="./lite_tests.txt"
 LIBS_FILE="./lite_libs.txt"
 LITE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)"
 
-readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+# url that stores third-party tar.gz file to accelerate third-party lib installation
+readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
 readonly workspace=$PWD
 
 NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}
@@ -46,15 +48,15 @@ if [ ${os_name} == "Darwin" ]; then
     ulimit -n 1024
 fi
 
-function prepare_thirdparty() {
+function prepare_thirdparty {
     cd $workspace
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi
@@ -400,7 +402,7 @@ function android_cpu_build_target() {
     mkdir -p $BUILD_DIRECTORY
     cd $BUILD_DIRECTORY
     prepare_workspace $ROOT_DIR $BUILD_DIRECTORY
-    
+
     cmake .. \
         -DWITH_GPU=OFF \
         -DWITH_MKL=OFF \

--- a/tools/ci_tools/ci_nn_accelerators_unit_test.sh
+++ b/tools/ci_tools/ci_nn_accelerators_unit_test.sh
@@ -6,7 +6,9 @@ TESTS_FILE="./lite_tests.txt"
 LIBS_FILE="./lite_libs.txt"
 LITE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)"
 
-readonly THIRDPARTY_TAR=https://paddlelite-data.bj.bcebos.com/third_party_libs/third-party-ea5576.tar.gz
+# url that stores third-party tar.gz file to accelerate third-party lib installation
+readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
+readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
 readonly workspace=$PWD
 
 NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}
@@ -46,15 +48,15 @@ if [ ${os_name} == "Darwin" ]; then
     ulimit -n 1024
 fi
 
-function prepare_thirdparty() {
+function prepare_thirdparty {
     cd $workspace
-    if [ ! -d $workspace/third-party -o -f $workspace/third-party-ea5576.tar.gz ]; then
+    if [ ! -d $workspace/third-party -o -f $workspace/$THIRDPARTY_TAR ]; then
         rm -rf $workspace/third-party
 
-        if [ ! -f $workspace/third-party-ea5576.tar.gz ]; then
-            wget $THIRDPARTY_TAR
+        if [ ! -f $workspace/$THIRDPARTY_TAR ]; then
+            wget $THIRDPARTY_URL/$THIRDPARTY_TAR
         fi
-        tar xzf third-party-ea5576.tar.gz
+        tar xzf $THIRDPARTY_TAR
     else
         git submodule update --init --recursive
     fi


### PR DESCRIPTION
#6516 在 third-party 下新增了 OpenCL 的头文件，但没有及时更新存储在 BOS 上的 tar 包。
本 PR 基于 commit id 801f670 重新打包 third-party ，上传到 BOS，并更新编译脚本。

原始 tar 包 12MB，新 tar 包 220KB

![image](https://user-images.githubusercontent.com/24290792/141883786-a811462a-61d8-4caf-9e8a-59fa5926d637.png)
