### PR TITLE
[Metal] Fix_conv_activation_pass and add MPS of Relu6 HardSigmoid HardSwish

### DIFF
--- a/lite/backends/metal/metal_kernel/texture/Common.metal
+++ b/lite/backends/metal/metal_kernel/texture/Common.metal
@@ -56,6 +56,7 @@ enum ActivationType : ushort {
     PRELU = 3,
     LEAKY_RELU = 4,
     HARD_SIGMOID = 5,
+    HARD_SWISH = 10,
 };
 
 struct DropoutParam {
@@ -67,7 +68,8 @@ struct MetalActivationParam {
     float threshold;  // RELU6
     float alpha;      // LEAKY_RELU
     float offset;     // HARD_SIGMOID
-    float slope;
+    float slope;      // HARD_SIGMOID
+    float scale;      // HARD_SWISH
 };
 
 struct ElementwiseAddParam {
@@ -321,6 +323,9 @@ inline ftype4 activation(const ftype4 input, constant MetalActivationParam& para
             return fmax(input, ftype(param.alpha) * input);
         case HARD_SIGMOID:
             return fmax(0.0, fmin(1.0, ftype(param.slope) * input + ftype(param.offset)));
+        case HARD_SWISH:
+            return (fmin(ftype(param.threshold), fmax(0.0, input + ftype(param.offset)))) * input /
+                   param.scale;
     }
 }
 

--- a/lite/core/optimizer/mir/fusion/conv_activation_fuse_pass.cc
+++ b/lite/core/optimizer/mir/fusion/conv_activation_fuse_pass.cc
@@ -81,6 +81,10 @@ void ConvActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   if (has_metal) {
     act_types.push_back("relu");
     act_types.push_back("relu6");
+    act_types.push_back("hard_sigmoid");
+    act_types.push_back("hard_swish");
+    act_types.push_back("prelu");
+    act_types.push_back("leaky_relu");
   }
 
   if (has_nnadapter) {
@@ -98,8 +102,9 @@ void ConvActivationFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
         has_alpha = false;
       }
       if (act_type == "hard_swish") {
-        if (has_arm && conv_type == "depthwise_conv2d") {
-          // it doesn't support conv_dw_conv+hardswish
+        if (has_arm && !has_metal && !has_opencl &&
+            conv_type == "depthwise_conv2d") {
+          // TARGET(kARM) doesn't support conv_dw_conv+hardswish
           continue;
         }
       }

--- a/lite/kernels/metal/image_op/conv2d_image_compute.mm
+++ b/lite/kernels/metal/image_op/conv2d_image_compute.mm
@@ -129,7 +129,7 @@ void Conv2dImageCompute::init_for_run() {
         }
     }
 
-    // MPS don't support LeakyRelu and kHardSwish
+    // MPS don't support LeakyRelu and HardSwish
     switch (param.activation_param.active_type) {
         case lite_api::ActivationType::kIndentity:
         case lite_api::ActivationType::kRelu:

--- a/lite/kernels/metal/image_op/metal_params.h
+++ b/lite/kernels/metal/image_op/metal_params.h
@@ -37,7 +37,8 @@ struct ActivationMetalParam {
     float threshold;  // RELU6
     float alpha;      // LEAKY_RELU
     float offset;     // HARD_SIGMOID
-    float slope;
+    float slope;      // HARD_SIGMOID
+    float scale;      // HARD_SWISH
 };
 
 struct MetalConvParam {


### PR DESCRIPTION
增加了RELU6 Hardsigmoid等MPS实现，增加了HardSwish非MPS实现
MobileNetV2 模型 MPS 测试
## MobileNetV2 模型 MPS 测试
|模型|cost(ms)|设备|MPS
|--|--|--|--|
|MobileNetV2|10.3771|iPhone11 metal|YES Relu6|
|MobileNetV2|11.4458|iPhone11 metal|NO Relu6|

有显著加速效果

