### PR TITLE
[Frame]Update AutoScan frame, detailed information are added

### DIFF
--- a/lite/api/python/pybind/pybind.cc
+++ b/lite/api/python/pybind/pybind.cc
@@ -314,6 +314,11 @@ void BindLiteCxxPredictor(py::module *m) {
       .def("get_output_by_name", &CxxPaddleApiImpl::GetOutputByName)
       .def("run", &CxxPaddleApiImpl::Run)
       .def("get_version", &CxxPaddleApiImpl::GetVersion)
+      .def("save_optimized_pb_model",
+           [](CxxPaddleApiImpl &self, const std::string &output_dir) {
+             self.SaveOptimizedModel(output_dir,
+                                     lite_api::LiteModelType::kProtobuf);
+           })
       .def("save_optimized_model",
            [](CxxPaddleApiImpl &self, const std::string &output_dir) {
              self.SaveOptimizedModel(output_dir,

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -233,7 +233,9 @@ void LoadModelPb(const std::string &model_dir,
       model_buffer.is_empty()
           ? FindModelFileName(model_dir, model_file, combined)
           : "";
-  OPT_LOG << "Loading topology data from " << prog_path;
+  if (model_buffer.is_empty()) {
+    OPT_LOG << "Loading topology data from " << prog_path;
+  }
   framework::proto::ProgramDesc pb_proto_prog =
       *LoadProgram(prog_path, model_buffer);
   pb::ProgramDesc pb_prog(&pb_proto_prog);
@@ -260,7 +262,9 @@ void LoadModelPb(const std::string &model_dir,
 
     LoadCombinedParamsPb(param_file, scope, *cpp_prog, model_buffer);
   }
-  OPT_LOG << "1. Model is successfully loaded!";
+  if (model_buffer.is_empty()) {
+    OPT_LOG << "1. Model is successfully loaded!";
+  }
 }
 
 void SaveModelPb(const std::string &model_dir,

--- a/lite/tests/unittest_py/auto_scan_base.py
+++ b/lite/tests/unittest_py/auto_scan_base.py
@@ -267,13 +267,6 @@ class AutoScanBaseTest(unittest.TestCase):
         if not self.passes:
             raise ValueError(
                 "In PassAutoScan you should give a valid pass name.")
-        last_passed_program = os.path.join(self.cache_dir,
-                                           self.passes[-1],
-                                           "model")
-        if not os.path.exists(last_passed_program):
-            raise ValueError(
-                "Cannot find file {}, please make sure that your pass name is correct".
-                format(last_passed_program))
         pg = paddle.static.deserialize_program(model_bytes)
         main_block = pg.desc.block(0)
         after_op_list = list()

--- a/lite/tests/unittest_py/auto_scan_test.py
+++ b/lite/tests/unittest_py/auto_scan_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from auto_scan_base import AutoScanBaseTest, SkipReasonsBase
+from auto_scan_base import AutoScanBaseTest, IgnoreReasonsBase
 import numpy as np
 import logging
 import abc
@@ -23,7 +23,7 @@ import copy
 from typing import Optional, List, Callable, Dict, Any, Set
 from paddlelite.lite import *
 
-SkipReasons = SkipReasonsBase
+IgnoreReasons = IgnoreReasonsBase
 
 def ParsePlaceInfo(place_str):
    # todo: this func should be completed later
@@ -64,6 +64,7 @@ class AutoScanTest(AutoScanBaseTest):
             f.write(model)
         with open(self.cache_dir + "/params", "wb") as f:
             f.write(params)
+
         # 2. run inference
         config = ParsePaddleLiteConfig(self, pred_config)
         config.set_model_buffer(model, len(model), params, len(params))
@@ -75,14 +76,16 @@ class AutoScanTest(AutoScanBaseTest):
             if inputs[name]['lod'] is not None:
                 input_tensor.set_lod(inputs[name]['lod'])
         predictor.run()
+
         # 3. inference results
         result = {}
         for out_name in predictor.get_output_names():
             result[out_name] = predictor.get_output_by_name(out_name).numpy()
         result_res = copy.deepcopy(result)
+
         # 4. optimized model
-        predictor.save_optimized_pb_model(self.cache_dir+ "/"+ self.passes[-1])
-        with open(self.cache_dir + "/" + self.passes[-1] + "/model", "rb") as f:
+        predictor.save_optimized_pb_model(self.cache_dir+ "/opt_model/")
+        with open(self.cache_dir + "/opt_model/model", "rb") as f:
             model = f.read()
 
         return result_res, model

--- a/lite/tests/unittest_py/auto_scan_test.py
+++ b/lite/tests/unittest_py/auto_scan_test.py
@@ -59,88 +59,43 @@ def ParsePaddleLiteConfig(self, config):
 
 class AutoScanTest(AutoScanBaseTest):
     def run_lite_config(self, model, params, inputs, pred_config) -> Dict[str, np.ndarray]:
+        # 1. store original model
+        with open(self.cache_dir + "/model", "wb") as f:
+            f.write(model)
+        with open(self.cache_dir + "/params", "wb") as f:
+            f.write(params)
+        # 2. run inference
         config = ParsePaddleLiteConfig(self, pred_config)
         config.set_model_buffer(model, len(model), params, len(params))
         predictor = create_paddle_predictor(config)
+
         for name in inputs:
             input_tensor = predictor.get_input_by_name(name)
             input_tensor.from_numpy(inputs[name]['data'])
             if inputs[name]['lod'] is not None:
                 input_tensor.set_lod(inputs[name]['lod'])
         predictor.run()
+        # 3. inference results
         result = {}
         for out_name in predictor.get_output_names():
             result[out_name] = predictor.get_output_by_name(out_name).numpy()
-
-        with open(self.cache_dir + "/model", "wb") as f:
-            f.write(model)
-        with open(self.cache_dir + "/params", "wb") as f:
-            f.write(params)
-        opt=Opt()
-        opt.set_model_dir(self.cache_dir)
-        valid_targets = ""
-        for place_str in pred_config["valid_targets"]:
-            infos = ''.join(place_str.split()).split(",")
-            valid_targets += infos[0].lower()
-            valid_targets += ","
-        opt.set_valid_places(valid_targets)
-        opt.set_model_type("protobuf")
-        opt.set_optimize_out(self.cache_dir)
-        opt.run()
-        with open(self.cache_dir + "/model", "rb") as f:
+        result_res = copy.deepcopy(result)
+        # 4. optimized model
+        predictor.save_optimized_pb_model(self.cache_dir+ "/"+ self.passes[-1])
+        with open(self.cache_dir + "/" + self.passes[-1] + "/model", "rb") as f:
             model = f.read()
 
-        result_res = copy.deepcopy(result)
         return result_res, model
 
 
-class FusePassAutoScanTest(AutoScanBaseTest):
-    def assert_op_size(self, fusion_before_num, fusion_after_num, origin_model, optimized_model):
-        pg = paddle.static.deserialize_program(optimized_model)
-        main_block = pg.desc.block(0)
-        after_op_size = main_block.op_size()
-        pg = paddle.static.deserialize_program(origin_model)
-        main_block = pg.desc.block(0)
-        before_op_size = main_block.op_size()
-        self.assertTrue(before_op_size == fusion_before_num,
-                        'before fusion op size is {}, but got {}!'.format(
-                            before_op_size, fusion_before_num))
-        self.assertTrue(after_op_size == fusion_after_num,
-                        'after fusion op size is {}, but got {}!'.format(
-                            after_op_size, fusion_after_num))
-
-    def run_lite_config(self, model, params, inputs, pred_config) -> Dict[str, np.ndarray]:
-        config = ParsePaddleLiteConfig(self, pred_config)
-        config.set_model_buffer(model, len(model), params, len(params))
-        self.origin_model = model
-        predictor = create_paddle_predictor(config)
-        for name in inputs:
-            input_tensor = predictor.get_input_by_name(name)
-            input_tensor.from_numpy(inputs[name]['data'])
-            if inputs[name]['lod'] is not None:
-                input_tensor.set_lod(inputs[name]['lod'])
-        predictor.run()
-        result = {}
-        for out_name in predictor.get_output_names():
-            result[out_name] = predictor.get_output_by_name(out_name).numpy()
-
-        with open(self.cache_dir + "/model", "wb") as f:
-            f.write(model)
-        with open(self.cache_dir + "/params", "wb") as f:
-            f.write(params)
-        opt=Opt()
-        opt.set_model_dir(self.cache_dir)
-        valid_targets = ""
-        for place_str in pred_config["valid_targets"]:
-            infos = ''.join(place_str.split()).split(",")
-            valid_targets += infos[0].lower()
-            valid_targets += ","
-        opt.set_valid_places(valid_targets)
-        opt.set_model_type("protobuf")
-        opt.set_optimize_out(self.cache_dir)
-        opt.run()
-        with open(self.cache_dir + "/model", "rb") as f:
-            model = f.read()
-
-        result_res = copy.deepcopy(result)
-        return result_res, model
+class FusePassAutoScanTest(AutoScanTest):
+    def run_and_statis(
+            self,
+            quant=False,
+            max_examples=100,
+            reproduce=None,
+            min_success_num=25,
+            max_duration=180,
+            passes=None ):
+        assert passes is not None, "Parameter of passes must be defined in function run_and_statis."
+        super().run_and_statis(quant, max_examples, reproduce, min_success_num, max_duration, passes)

--- a/lite/tests/unittest_py/auto_scan_test_rpc.py
+++ b/lite/tests/unittest_py/auto_scan_test_rpc.py
@@ -34,24 +34,14 @@ class AutoScanTest(AutoScanBaseTest):
         result_res = copy.deepcopy(out)
         return result_res, model
 
-class FusePassAutoScanTest(AutoScanBaseTest):
-    def assert_op_size(self, fusion_before_num, fusion_after_num, origin_model, optimized_model):
-        pg = paddle.static.deserialize_program(optimized_model)
-        main_block = pg.desc.block(0)
-        after_op_size = main_block.op_size()
-        pg = paddle.static.deserialize_program(origin_model)
-        main_block = pg.desc.block(0)
-        before_op_size = main_block.op_size()
-        self.assertTrue(before_op_size == fusion_before_num,
-                        'before fusion op size is {}, but got {}!'.format(
-                            before_op_size, fusion_before_num))
-        self.assertTrue(after_op_size == fusion_after_num,
-                        'after fusion op size is {}, but got {}!'.format(
-                            after_op_size, fusion_after_num))
-
-    def run_lite_config(self, model, params, inputs, pred_config) -> Dict[str, np.ndarray]:
-        self.origin_model = model
-        conn = rpyc.connect("localhost", 18812, config = rpyc.core.protocol.DEFAULT_CONFIG)
-        out, model = conn.root.run_lite_model(model,params,inputs, pred_config)
-        result_res = copy.deepcopy(out)
-        return result_res, model
+class FusePassAutoScanTest(AutoScanTest):
+    def run_and_statis(
+            self,
+            quant=False,
+            max_examples=100,
+            reproduce=None,
+            min_success_num=25,
+            max_duration=180,
+            passes=None ):
+        assert passes is not None, "Parameter of passes must be defined in function run_and_statis."
+        super().run_and_statis(quant, max_examples, reproduce, min_success_num, max_duration, passes)

--- a/lite/tests/unittest_py/auto_scan_test_rpc.py
+++ b/lite/tests/unittest_py/auto_scan_test_rpc.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from auto_scan_base import AutoScanBaseTest, SkipReasonsBase
+from auto_scan_base import AutoScanBaseTest, IgnoreReasonsBase
 import numpy as np
 import abc
 import enum
@@ -25,7 +25,7 @@ import copy
 rpyc.core.protocol.DEFAULT_CONFIG['allow_pickle'] = True
 
 
-SkipReasons = SkipReasonsBase
+IgnoreReasons = IgnoreReasonsBase
 
 class AutoScanTest(AutoScanBaseTest):
     def run_lite_config(self, model, params, feed_data, pred_config) -> Dict[str, np.ndarray]:

--- a/lite/tests/unittest_py/op/backends/arm/test_mul_op.py
+++ b/lite/tests/unittest_py/op/backends/arm/test_mul_op.py
@@ -17,7 +17,7 @@ sys.path.append('../../common')
 sys.path.append('../../../')
 
 import test_mul_op_base
-from auto_scan_test_rpc import AutoScanTest, SkipReasons
+from auto_scan_test_rpc import AutoScanTest, IgnoreReasons
 from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
 import unittest
 
@@ -37,7 +37,7 @@ class TestMulOp(AutoScanTest):
         config.set_threads(1)
         yield config, ["mul"], (1e-5, 1e-5)
 
-    def add_skip_pass_case(self):
+    def add_ignore_pass_case(self):
         pass
 
     def test(self, *args, **kwargs):

--- a/lite/tests/unittest_py/op/backends/arm/test_mul_op.py
+++ b/lite/tests/unittest_py/op/backends/arm/test_mul_op.py
@@ -23,31 +23,25 @@ import unittest
 
 import hypothesis
 from hypothesis import given, settings, seed, example, assume
-import hypothesis.strategies as st
 
 class TestMulOp(AutoScanTest):
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
-    def sample_program_configs(self, *args, **kwargs):
-        return test_mul_op_base.sample_program_configs(*args, **kwargs)
+    def sample_program_configs(self, draw):
+        return test_mul_op_base.sample_program_configs(draw)
 
     def sample_predictor_configs(self):
         config = CxxConfig()
         config.set_valid_places({Place(TargetType.ARM, PrecisionType.FP32, DataLayoutType.NCHW)})
         config.set_threads(1)
-        yield config, (1e-5, 1e-5)
+        yield config, ["mul"], (1e-5, 1e-5)
 
     def add_skip_pass_case(self):
         pass
 
-    @given(
-        in_shape=st.lists(
-            st.integers(
-                min_value=2, max_value=2), min_size=2, max_size=2))
     def test(self, *args, **kwargs):
-        self.add_skip_pass_case()
-        self.run_test(quant=False, *args, **kwargs)
+        self.run_and_statis(quant=False, max_examples=25)
 
 if __name__ == "__main__":
     unittest.main()

--- a/lite/tests/unittest_py/op/backends/host/test_assign_op.py
+++ b/lite/tests/unittest_py/op/backends/host/test_assign_op.py
@@ -23,30 +23,25 @@ import unittest
 
 import hypothesis
 from hypothesis import given, settings, seed, example, assume
-import hypothesis.strategies as st
+
 
 class TestAssignOp(AutoScanTest):
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
-    def sample_program_configs(self, *args, **kwargs):
-        return test_assign_op_base.sample_program_configs(*args, **kwargs)
+    def sample_program_configs(self, draw):
+        return test_assign_op_base.sample_program_configs(draw)
 
     def sample_predictor_configs(self):
         config = CxxConfig()
         config.set_valid_places({Place(TargetType.Host, PrecisionType.FP32, DataLayoutType.NCHW)})
-        yield config, (1e-5, 1e-5)
+        yield config, ["assign"], (1e-5, 1e-5)
 
     def add_skip_pass_case(self):
         pass
 
-    @given(
-        in_shape=st.lists(
-            st.integers(
-                min_value=1, max_value=8), max_size=2))
     def test(self, *args, **kwargs):
-        self.add_skip_pass_case()
-        self.run_test(quant=False, *args, **kwargs)
+        self.run_and_statis(quant=False, max_examples=25)
 
 if __name__ == "__main__":
     unittest.main()

--- a/lite/tests/unittest_py/op/backends/host/test_assign_op.py
+++ b/lite/tests/unittest_py/op/backends/host/test_assign_op.py
@@ -17,7 +17,7 @@ sys.path.append('../../common')
 sys.path.append('../../../')
 
 import test_assign_op_base
-from auto_scan_test import AutoScanTest, SkipReasons
+from auto_scan_test import AutoScanTest, IgnoreReasons
 from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
 import unittest
 
@@ -37,7 +37,7 @@ class TestAssignOp(AutoScanTest):
         config.set_valid_places({Place(TargetType.Host, PrecisionType.FP32, DataLayoutType.NCHW)})
         yield config, ["assign"], (1e-5, 1e-5)
 
-    def add_skip_pass_case(self):
+    def add_ignore_pass_case(self):
         pass
 
     def test(self, *args, **kwargs):

--- a/lite/tests/unittest_py/op/common/test_assign_op_base.py
+++ b/lite/tests/unittest_py/op/common/test_assign_op_base.py
@@ -20,11 +20,11 @@ import numpy as np
 from functools import partial
 from typing import Optional, List, Callable, Dict, Any, Set
 import unittest
+import hypothesis
+import hypothesis.strategies as st
 
-def sample_program_configs(*args, **kwargs):
-    def generate_input(*args, **kwargs):
-        return np.random.random(kwargs['in_shape']).astype(np.float32)
-
+def sample_program_configs(draw):
+    in_shape = draw(st.lists(st.integers(min_value=1, max_value=8), max_size=2))
     assign_op = OpConfig(
         type = "assign",
         inputs = {"X" : ["input_data"]},
@@ -35,8 +35,7 @@ def sample_program_configs(*args, **kwargs):
         weights={},
         inputs={
             "input_data":
-            TensorConfig(data_gen=partial(generate_input, *args, **kwargs)),
+            TensorConfig(shape=in_shape)
         },
         outputs=["output_data"])
-
-    yield program_config
+    return program_config

--- a/lite/tests/unittest_py/op/common/test_mul_op_base.py
+++ b/lite/tests/unittest_py/op/common/test_mul_op_base.py
@@ -25,11 +25,11 @@ import hypothesis
 from hypothesis import given, settings, seed, example, assume
 import hypothesis.strategies as st
 
-def sample_program_configs(*args, **kwargs):
-    def generate_input(*args, **kwargs):
-        return np.random.random(kwargs['in_shape']).astype(np.float32)
-    def generate_input_y(*args, **kwargs):
-        return np.random.random(kwargs['in_shape']).astype(np.float32)
+def sample_program_configs(draw):
+    in_shape=draw(st.lists(
+        st.integers(
+            min_value=2, max_value=2), min_size=2, max_size=2))
+
     mul_op = OpConfig(
         type = "mul",
         inputs = {"X": ["input_data_x"],
@@ -42,12 +42,12 @@ def sample_program_configs(*args, **kwargs):
         ops=[mul_op],
         weights={
             "input_data_y":
-            TensorConfig(data_gen=partial(generate_input_y, *args, **kwargs)),
+             TensorConfig(shape=in_shape)
         },
         inputs={
             "input_data_x":
-            TensorConfig(data_gen=partial(generate_input, *args, **kwargs)),
+            TensorConfig(shape=in_shape)
         },
         outputs=["output_data"])
 
-    yield program_config
+    return program_config

--- a/lite/tests/unittest_py/op/common/test_mul_op_base.py
+++ b/lite/tests/unittest_py/op/common/test_mul_op_base.py
@@ -26,9 +26,13 @@ from hypothesis import given, settings, seed, example, assume
 import hypothesis.strategies as st
 
 def sample_program_configs(draw):
-    in_shape=draw(st.lists(
+    in_shape1=draw(st.lists(
         st.integers(
-            min_value=2, max_value=2), min_size=2, max_size=2))
+            min_value=20, max_value=200), min_size=2, max_size=2))
+    in_shape2=draw(st.lists(
+        st.integers(
+            min_value=20, max_value=200), min_size=2, max_size=2))
+    assume(in_shape1[1] == in_shape2[0])
 
     mul_op = OpConfig(
         type = "mul",
@@ -42,11 +46,11 @@ def sample_program_configs(draw):
         ops=[mul_op],
         weights={
             "input_data_y":
-             TensorConfig(shape=in_shape)
+             TensorConfig(shape=in_shape2)
         },
         inputs={
             "input_data_x":
-            TensorConfig(shape=in_shape)
+            TensorConfig(shape=in_shape1)
         },
         outputs=["output_data"])
 

--- a/lite/tests/unittest_py/pass/backends/arm/test_conv_active_fuse_pass.py
+++ b/lite/tests/unittest_py/pass/backends/arm/test_conv_active_fuse_pass.py
@@ -34,31 +34,13 @@ class TestConvActiveFusePass(FusePassAutoScanTest):
     def sample_predictor_configs(self):
         config = CxxConfig()
         config.set_valid_places({Place(TargetType.ARM, PrecisionType.FP32, DataLayoutType.NCHW)})
-        yield config, (1e-5, 1e-5)
+        yield config, ["conv2d"], (1e-5, 1e-5)
 
     def add_skip_pass_case(self):
         pass
 
-    @given(
-        in_shape=st.lists(st.integers(min_value=1, max_value=64), min_size=4, max_size=4),
-        weight_shape=st.lists(st.integers(min_value=1, max_value=64), min_size=4, max_size=4),
-        paddings=st.sampled_from([[1, 2], [4, 2]]),
-        dilations=st.sampled_from([[1, 1]]),
-        groups=st.sampled_from([1]),
-        padding_algorithm=st.sampled_from(["VALID", "SAME"]),
-        strides=st.sampled_from([[1, 1], [2, 2]]),
-        threshold=st.floats(min_value=0, max_value=1),
-        alpha=st.floats(min_value=0, max_value=1),
-        scale=st.floats(min_value=0.5, max_value=5),
-        offset=st.floats(min_value=0, max_value=1),
-        )
     def test(self, *args, **kwargs):
-        assume(kwargs["in_shape"][1] == kwargs["weight_shape"][1])
-        assume(kwargs["in_shape"][2] >= kwargs["weight_shape"][2])
-        assume(kwargs["in_shape"][3] >= kwargs["weight_shape"][3])
-        self.add_skip_pass_case()
-        optimized_model = self.run_test(quant=False, *args, **kwargs)
-        self.assert_op_size(4, 3, self.origin_model, optimized_model)
+        self.run_and_statis(quant=False, max_examples=25, passes=["lite_conv_activation_fuse_pass"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/lite/tests/unittest_py/pass/backends/arm/test_conv_active_fuse_pass.py
+++ b/lite/tests/unittest_py/pass/backends/arm/test_conv_active_fuse_pass.py
@@ -36,7 +36,7 @@ class TestConvActiveFusePass(FusePassAutoScanTest):
         config.set_valid_places({Place(TargetType.ARM, PrecisionType.FP32, DataLayoutType.NCHW)})
         yield config, ["conv2d"], (1e-5, 1e-5)
 
-    def add_skip_pass_case(self):
+    def add_ignore_pass_case(self):
         pass
 
     def test(self, *args, **kwargs):

--- a/lite/tests/unittest_py/pass/backends/x86/test_conv_active_fuse_pass.py
+++ b/lite/tests/unittest_py/pass/backends/x86/test_conv_active_fuse_pass.py
@@ -17,7 +17,7 @@ sys.path.append('../../../')
 
 import abc
 import  test_conv_active_fuse_pass_base
-from auto_scan_test import FusePassAutoScanTest, SkipReasons
+from auto_scan_test import FusePassAutoScanTest, IgnoreReasons
 from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
 import unittest
 
@@ -33,7 +33,7 @@ class TestConvActiveFusePass(FusePassAutoScanTest):
     def sample_program_configs(self, draw):
         return test_conv_active_fuse_pass_base.sample_program_configs(draw)
 
-    def add_skip_pass_case(self):
+    def add_ignore_pass_case(self):
         pass
 
     def test(self, *args, **kwargs):

--- a/lite/tests/unittest_py/pass/backends/x86/test_conv_active_fuse_pass.py
+++ b/lite/tests/unittest_py/pass/backends/x86/test_conv_active_fuse_pass.py
@@ -16,7 +16,8 @@ sys.path.append('../../common')
 sys.path.append('../../../')
 
 import abc
-from test_conv_active_fuse_pass_base import TestConvActiveFusePassBase
+import  test_conv_active_fuse_pass_base
+from auto_scan_test import FusePassAutoScanTest, SkipReasons
 from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
 import unittest
 
@@ -24,35 +25,19 @@ import hypothesis
 from hypothesis import given, settings, seed, example, assume
 import hypothesis.strategies as st
 
-class TestConvActiveFusePass(TestConvActiveFusePassBase):
+class TestConvActiveFusePass(FusePassAutoScanTest):
     def sample_predictor_configs(self):
         config = CxxConfig()
         config.set_valid_places({Place(TargetType.X86, PrecisionType.FP32, DataLayoutType.NCHW)})
-        yield config, (1e-5, 1e-5)
+        yield config, ["conv2d"], (1e-5, 1e-5)
+    def sample_program_configs(self, draw):
+        return test_conv_active_fuse_pass_base.sample_program_configs(draw)
 
     def add_skip_pass_case(self):
         pass
 
-    @given(
-        in_shape=st.lists(st.integers(min_value=1, max_value=64), min_size=4, max_size=4),
-        weight_shape=st.lists(st.integers(min_value=1, max_value=64), min_size=4, max_size=4),
-        paddings=st.sampled_from([[1, 2], [4, 2]]),
-        dilations=st.sampled_from([[1, 1]]),
-        groups=st.sampled_from([1]),
-        padding_algorithm=st.sampled_from(["VALID", "SAME"]),
-        strides=st.sampled_from([[1, 1], [2, 2]]),
-        threshold=st.floats(min_value=0, max_value=1),
-        alpha=st.floats(min_value=0, max_value=1),
-        scale=st.floats(min_value=0.5, max_value=5),
-        offset=st.floats(min_value=0, max_value=1),
-        )
     def test(self, *args, **kwargs):
-        assume(kwargs["in_shape"][1] == kwargs["weight_shape"][1])
-        assume(kwargs["in_shape"][2] >= kwargs["weight_shape"][2])
-        assume(kwargs["in_shape"][3] >= kwargs["weight_shape"][3])
-        self.add_skip_pass_case()
-        optimized_model = self.run_test(quant=False, *args, **kwargs)
-        self.assert_op_size(4, 3, self.origin_model, optimized_model)
+        self.run_and_statis(quant=False, max_examples=25, passes=["lite_conv_activation_fuse_pass"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/lite/tests/unittest_py/program_config.py
+++ b/lite/tests/unittest_py/program_config.py
@@ -34,17 +34,24 @@ class TensorConfig:
 
     def __init__(self,
                  lod: Optional[List[List[int]]]=None,
-                 data_gen: Optional[Callable[..., np.array]]=None):
+                 data_gen: Optional[Callable[..., np.array]]=None,
+                 shape: Optional[List[List[int]]]=None):
         '''
         shape: The shape of the tensor.
         dtype: The data type of the tensor.
         data: The value of WeightVar. for input, it should be None 
         '''
         self.lod = lod
-        self.data_gen = data_gen
-        self.data = data_gen()
-        self.dtype = data_gen().dtype
-        self.shape = data_gen().shape
+        if data_gen is not None:
+            self.data_gen = data_gen
+            self.data = data_gen()
+            self.dtype = data_gen().dtype
+            self.shape = data_gen().shape
+        else:
+            assert shape is not None, "While data_gen is not defined, shape must not be None"
+            self.data = np.random.normal(0.0, 1.0, shape).astype(np.float32)
+            self.shape = shape
+            self.dtype = self.data.dtype
 
     def __repr__(self):
         return str({'shape': self.shape, 'lod': self.lod, 'dtype': self.dtype})
@@ -57,11 +64,15 @@ class OpConfig:
                  type: str,
                  inputs: Dict[str, List[str]],
                  outputs: Dict[str, List[str]],
-                 attrs: Dict[str, Any]):
+                 attrs: Dict[str, Any]=None,
+                 **kwargs):
         self.type = type
         self.inputs = inputs
         self.outputs = outputs
         self.attrs = attrs
+        if self.attrs is None:
+            self.attrs = dict()
+        self.attrs.update(kwargs)
 
     def __repr__(self):
         log_str = self.type
@@ -379,11 +390,6 @@ def create_quant_model(model,
         feed_vars, fetch_targets, executor=exe, program=main_program)
     return serialized_program, serialized_params
 
-
-
-
-
-
 from typing import Optional
 from enum import Enum
 class TargetType(Enum):
@@ -422,7 +428,6 @@ class DataLayoutType(Enum):
 
 def Place(target_type:TargetType, precision_type: Optional[PrecisionType]=None, data_layout:Optional[DataLayoutType] = None):
     place = target_type.name
-    print("target_type.name:" + target_type.name)
     if precision_type != None:
         place = place+ "," + precision_type.name
         if data_layout != None:

--- a/lite/tests/unittest_py/requirements.txt
+++ b/lite/tests/unittest_py/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.20
 hypothesis
 paddlepaddle
 rpyc
+wheel

--- a/lite/tests/unittest_py/rpc_service/server.py
+++ b/lite/tests/unittest_py/rpc_service/server.py
@@ -57,19 +57,7 @@ class RPCService(rpyc.Service):
         '''
         Test a single case.
         '''
-        config = ParsePaddleLiteConfig(self, config_str)
-        config.set_model_buffer(model, len(model), params, len(params))
-        predictor = create_paddle_predictor(config)
-        for name in inputs:
-            input_tensor = predictor.get_input_by_name(name)
-            input_tensor.from_numpy(inputs[name]['data'])
-            if inputs[name]['lod'] is not None:
-                input_tensor.set_lod(inputs[name]['lod'])
-        predictor.run()
-        result = {}
-        for out_name in predictor.get_output_names():
-            result[out_name] = predictor.get_output_by_name(out_name).numpy()
-
+        # 1. store original model
         abs_dir = os.path.abspath(os.path.dirname(__file__))
         self.cache_dir = os.path.join(abs_dir,
                                       str(self.__module__) + '_cache_dir')
@@ -81,23 +69,29 @@ class RPCService(rpyc.Service):
             f.write(model)
         with open(self.cache_dir + "/params", "wb") as f:
             f.write(params)
-        opt=Opt()
-        opt.set_model_dir(self.cache_dir)
-        valid_targets = ""
-        for place_str in config_str["valid_targets"]:
-            infos = ''.join(place_str.split()).split(",")
-            valid_targets += infos[0].lower()
-            valid_targets += ","
-        opt.set_valid_places(valid_targets)
-        opt.set_model_type("protobuf")
-        opt.set_optimize_out(self.cache_dir)
-        opt.run()
-        with open(self.cache_dir + "/model", "rb") as f:
-            model = f.read()
-        with open(self.cache_dir + "/model", "rb") as f:
-            model = f.read()
+        # 2. run inference
+        config = ParsePaddleLiteConfig(self, pred_config)
+        config.set_model_buffer(model, len(model), params, len(params))
+        predictor = create_paddle_predictor(config)
+
+        for name in inputs:
+            input_tensor = predictor.get_input_by_name(name)
+            input_tensor.from_numpy(inputs[name]['data'])
+            if inputs[name]['lod'] is not None:
+                input_tensor.set_lod(inputs[name]['lod'])
+        predictor.run()
+        # 3. inference results
+        result = {}
+        for out_name in predictor.get_output_names():
+            result[out_name] = predictor.get_output_by_name(out_name).numpy()
         result_res = copy.deepcopy(result)
+        # 4. optimized model
+        predictor.save_optimized_pb_model(self.cache_dir+ "/"+ self.passes[-1])
+        with open(self.cache_dir + "/" + self.passes[-1] + "/model", "rb") as f:
+            model = f.read()
+
         return result_res, model
+
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/rpc_service/server.py
+++ b/lite/tests/unittest_py/rpc_service/server.py
@@ -70,7 +70,7 @@ class RPCService(rpyc.Service):
         with open(self.cache_dir + "/params", "wb") as f:
             f.write(params)
         # 2. run inference
-        config = ParsePaddleLiteConfig(self, pred_config)
+        config = ParsePaddleLiteConfig(self, config_str)
         config.set_model_buffer(model, len(model), params, len(params))
         predictor = create_paddle_predictor(config)
 
@@ -86,8 +86,8 @@ class RPCService(rpyc.Service):
             result[out_name] = predictor.get_output_by_name(out_name).numpy()
         result_res = copy.deepcopy(result)
         # 4. optimized model
-        predictor.save_optimized_pb_model(self.cache_dir+ "/"+ self.passes[-1])
-        with open(self.cache_dir + "/" + self.passes[-1] + "/model", "rb") as f:
+        predictor.save_optimized_pb_model(self.cache_dir+ "/opt_model")
+        with open(self.cache_dir + "/opt_model/model", "rb") as f:
             model = f.read()
 
         return result_res, model


### PR DESCRIPTION
- AutoScan 补充统计学测试数据： 执行完毕后会显示 构造的模型数量、成功执行的数量、不规范的数量
![image](https://user-images.githubusercontent.com/45189361/143682805-0a702e83-9723-4b0d-98b1-9dacacc605a5.png)
- 修改Pass 有效性的检查方法： 在`sample_predictor_config` 中新增输出值`list[op_name]`，表示pass 执行后产生的新的融合OP、单测执行时会检测优化后的模型中是否含有这些融合OP
``` python
# example: lite/tests/unittest_py/pass/common/test_conv_active_fuse_pass_base.py
    def sample_predictor_configs(self):
        config = CxxConfig()
        config.set_valid_places({Place(TargetType.ARM, PrecisionType.FP32, DataLayoutType.NCHW)})
        yield config, (1e-5, 1e-5)
        yield config, ["conv2d"], (1e-5, 1e-5)
# 这里的["conv2d"] 指的是pass融合之后的模型中含有的算子名称
```
- 自动生成测试用例的方法改进: 对hypothesis的库的调用更简洁
```Python
# example : test_assign_op_base.py
def sample_program_configs(draw):
    in_shape = draw(st.lists(st.integers(min_value=1, max_value=8), max_size=2))
    assign_op = OpConfig(
        type = "assign",
        inputs = {"X" : ["input_data"]},
        outputs = {"Out": ["output_data"]},
        attrs = {})
    program_config = ProgramConfig(
        ops=[assign_op],
        weights={},
        inputs={
            "input_data":
            TensorConfig(shape=in_shape)
        },
        outputs=["output_data"])
    return program_config
```
- API名称修改：
    - `add_skip_pass_case` ---> `add_ignore_check_case`
    - `add_skip_case` --> `add_ignore_case`
    - `SkipReasons`-->`IgnoreReasons`
- 新增(内部调试接口）python API 接口： `save_optimized_pb_model ` 将优化后模型保存为pb格式 