### PR TITLE
[OpTestPy] Add_unittest_common: softsign sign sequence_softmax sequence_unpad sequence_reverse sequence_reshape

### DIFF
--- a/lite/tests/unittest_py/op/backends/arm/test_sequence_softmax_op.py
+++ b/lite/tests/unittest_py/op/backends/arm/test_sequence_softmax_op.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('../../common')
+sys.path.append('../../../')
+
+import test_sequence_softmax_op_base
+from auto_scan_test_rpc import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+
+class TestSequenceSoftmaxOp(AutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        return True
+
+    def sample_program_configs(self, draw):
+        return test_sequence_softmax_op_base.sample_program_configs(draw)
+
+    def sample_predictor_configs(self):
+        config = CxxConfig()
+        config.set_valid_places({Place(TargetType.ARM, PrecisionType.FP32, DataLayoutType.NCHW)})
+        config.set_threads(1)
+        yield config, ["sequence_softmax"], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        self.run_and_statis(quant=False, max_examples=25)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lite/tests/unittest_py/op/backends/arm/test_sequence_unpad_op.py
+++ b/lite/tests/unittest_py/op/backends/arm/test_sequence_unpad_op.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('../../common')
+sys.path.append('../../../')
+
+import test_sequence_unpad_op_base
+from auto_scan_test_rpc import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+
+class TestSequenceUnpadOp(AutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        return True
+
+    def sample_program_configs(self, draw):
+        return test_sequence_unpad_op_base.sample_program_configs(draw)
+
+    def sample_predictor_configs(self):
+        config = CxxConfig()
+        config.set_valid_places({Place(TargetType.ARM, PrecisionType.FP32, DataLayoutType.NCHW)})
+        config.set_threads(1)
+        yield config, ["sequence_unpad"], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        self.run_and_statis(quant=False, max_examples=25)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lite/tests/unittest_py/op/backends/x86/test_sequence_reshape_op.py
+++ b/lite/tests/unittest_py/op/backends/x86/test_sequence_reshape_op.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('../../common')
+sys.path.append('../../../')
+
+import test_sequence_reshape_op_base
+from auto_scan_test import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+
+
+class TestSequenceReshapeOp(AutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        return True
+
+    def sample_program_configs(self, draw):
+        return test_sequence_reshape_op_base.sample_program_configs(draw)
+
+    def sample_predictor_configs(self):
+        config = CxxConfig()
+        config.set_valid_places({Place(TargetType.X86, PrecisionType.FP32, DataLayoutType.NCHW)})
+        yield config, ["sequence_reshape"], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        self.run_and_statis(quant=False, max_examples=25)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lite/tests/unittest_py/op/backends/x86/test_sequence_reverse_op.py
+++ b/lite/tests/unittest_py/op/backends/x86/test_sequence_reverse_op.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('../../common')
+sys.path.append('../../../')
+
+import test_sequence_reverse_op_base
+from auto_scan_test import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+
+
+class TestSequenceReverseOp(AutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        return True
+
+    def sample_program_configs(self, draw):
+        return test_sequence_reverse_op_base.sample_program_configs(draw)
+
+    def sample_predictor_configs(self):
+        config = CxxConfig()
+        config.set_valid_places({Place(TargetType.X86, PrecisionType.FP32, DataLayoutType.NCHW)})
+        yield config, ["sequence_reverse"], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        self.run_and_statis(quant=False, max_examples=25)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lite/tests/unittest_py/op/common/test_sequence_reshape_op_base.py
+++ b/lite/tests/unittest_py/op/common/test_sequence_reshape_op_base.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('..')
+
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import numpy as np
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import unittest
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+def sample_program_configs(draw):
+    lod_data=draw(st.lists(
+        st.integers(
+            min_value=0, max_value=64), min_size=0, max_size=3))
+    lod_data.append(12)
+    new_dim = draw(st.sampled_from([12]))
+    input_type = draw(st.sampled_from(["type_float", "type_int", "type_int64"]))
+
+    def generate_input(*args, **kwargs):
+        if input_type == "type_float":
+            return np.random.normal(0.0, 1.0, [12, 12]).astype(np.float32)
+        elif input_type == "type_int":
+            return np.random.normal(0.0, 1.0, [12, 12]).astype(np.int32)
+        elif input_type == "type_int64":
+            return np.random.normal(0.0, 1.0, [12, 12]).astype(np.int64)
+
+    ops_config = OpConfig(
+        type = "sequence_reshape",
+        inputs = {
+            "X": ["input_data"]
+        },
+        outputs = {
+            "Out": ["output_data"]
+        },
+        attrs = {
+            "new_dim": new_dim
+        },
+        )
+
+    program_config = ProgramConfig(
+        ops=[ops_config],
+        weights={},
+        inputs={
+            "input_data": 
+            TensorConfig(data_gen=partial(generate_input), lod=[lod_data])
+        },
+        outputs=["output_data"])
+
+    return program_config

--- a/lite/tests/unittest_py/op/common/test_sequence_reverse_op_base.py
+++ b/lite/tests/unittest_py/op/common/test_sequence_reverse_op_base.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('..')
+
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import numpy as np
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import unittest
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+def sample_program_configs(draw):
+    in_shape=draw(st.lists(
+        st.integers(
+            min_value=1, max_value=64), min_size=1, max_size=3))
+    in_shape.insert(0, 10)
+    lod_data = draw(st.sampled_from([[[0, 0, 10]], [[2, 0, 10]], [[1, 0, 10]], [[0, 1, 0, 10]]]))
+
+    def generate_input(*args, **kwargs):
+        return np.random.uniform(0.1, 1, in_shape).astype('float32')
+
+    ops_config = OpConfig(
+        type = "sequence_reverse",
+        inputs = {
+            "X": ["input_data"]
+        },
+        outputs = {
+            "Y": ["output_data"]
+        },
+        attrs = {}
+        )
+
+    program_config = ProgramConfig(
+        ops=[ops_config],
+        weights={},
+        inputs={
+            "input_data": 
+            TensorConfig(data_gen=partial(generate_input), lod=lod_data)
+        },
+        outputs=["output_data"])
+
+    return program_config

--- a/lite/tests/unittest_py/op/common/test_sequence_softmax_op_base.py
+++ b/lite/tests/unittest_py/op/common/test_sequence_softmax_op_base.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('..')
+
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import numpy as np
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import unittest
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+def sample_program_configs(draw):
+    in_shape = draw(st.lists(
+        st.integers(
+            min_value=1, max_value=1), min_size=0, max_size=3))
+    in_shape.insert(0, 110)
+    lod_data = draw(st.sampled_from([[[0, 110]], [[0, 0, 110]], 
+            [[0, 1, 110]], [[0, 0, 1, 110]],[[0, 1, 1, 110]]]))
+
+    def generate_input(*args, **kwargs):
+        return np.random.uniform(0.1, 1, in_shape).astype('float32')
+
+    ops_config = OpConfig(
+        type = "sequence_softmax",
+        inputs = {
+            "X": ["input_data"],
+        },
+        outputs = {
+            "Out": ["output_data"]
+        },
+        attrs = {}
+        )
+
+    program_config = ProgramConfig(
+        ops=[ops_config],
+        weights={},
+        inputs={
+            "input_data": 
+            TensorConfig(data_gen=partial(generate_input), lod=lod_data)
+        },
+        outputs=["output_data"])
+
+    return program_config

--- a/lite/tests/unittest_py/op/common/test_sequence_unpad_op_base.py
+++ b/lite/tests/unittest_py/op/common/test_sequence_unpad_op_base.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('..')
+
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import numpy as np
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import unittest
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+def sample_program_configs(draw):
+    length = draw(st.lists(
+        st.integers(
+            min_value=1, max_value=5), min_size=4, max_size=10))
+    in_shape = draw(st.lists(
+        st.integers(
+            min_value=5, max_value=10), min_size=1, max_size=3))
+    in_shape.insert(0, len(length))
+
+    def generate_input(*args, **kwargs):
+        return np.random.uniform(0.1, 1, in_shape).astype('float32')
+
+    def generate_length(*args, **kwargs):
+        return np.array(length).astype('int64')
+
+    ops_config = OpConfig(
+        type = "sequence_unpad",
+        inputs = {
+            "X": ["input_data"],
+            "Length": ["length_data"],
+        },
+        outputs = {
+            "Out": ["output_data"]
+        },
+        attrs = {}
+        )
+
+    program_config = ProgramConfig(
+        ops=[ops_config],
+        weights={},
+        inputs={
+            "input_data": 
+            TensorConfig(data_gen=partial(generate_input)),
+            "length_data":
+            TensorConfig(data_gen=partial(generate_length))
+        },
+        outputs=["output_data"])
+
+    return program_config

--- a/lite/tests/unittest_py/op/common/test_sign_op_base.py
+++ b/lite/tests/unittest_py/op/common/test_sign_op_base.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('..')
+
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import numpy as np
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import unittest
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+def sample_program_configs(draw):
+    in_shape = draw(st.lists(
+        st.integers(
+            min_value=1, max_value=64), min_size=1, max_size=4))
+
+    def generate_input(*args, **kwargs):
+        return np.random.uniform(-10, 10, in_shape).astype(np.float32)
+
+    ops_config = OpConfig(
+        type = "sign",
+        inputs = {
+            "X": ["input_data"]
+        },
+        outputs = {
+            "Out": ["output_data"]
+        },
+        attrs = {}
+        )
+
+    program_config = ProgramConfig(
+        ops=[ops_config],
+        weights={},
+        inputs={
+            "input_data": 
+            TensorConfig(data_gen=partial(generate_input))
+        },
+        outputs=["output_data"])
+
+    return program_config

--- a/lite/tests/unittest_py/op/common/test_softsign_op_base.py
+++ b/lite/tests/unittest_py/op/common/test_softsign_op_base.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('..')
+
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import numpy as np
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import unittest
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+def sample_program_configs(draw):
+    in_shape = draw(st.lists(
+        st.integers(
+            min_value=1, max_value=64), min_size=1, max_size=4))
+
+    def generate_input(*args, **kwargs):
+        return np.random.uniform(-1, 1, in_shape).astype(np.float32)
+
+    ops_config = OpConfig(
+        type = "softsign",
+        inputs = {
+            "X": ["input_data"]
+        },
+        outputs = {
+            "Out": ["output_data"]
+        },
+        attrs = {}
+        )
+
+    program_config = ProgramConfig(
+        ops=[ops_config],
+        weights={},
+        inputs={
+            "input_data": 
+            TensorConfig(data_gen=partial(generate_input))
+        },
+        outputs=["output_data"])
+
+    return program_config


### PR DESCRIPTION
softsign : 仅x86支持
sign：无设备支持
sequence_softmax： The first dimension of Input(X) should be equal to the sum of all sequences' lengths第一维应该和sequences和相等，但是只支持sequences最后一维与输入第一维相等，不能计算总和


