### PR TITLE
Fix build_macos.sh err & support opencl on mobilenetv1_full_api.py

### DIFF
--- a/lite/demo/python/mobilenetv1_full_api.py
+++ b/lite/demo/python/mobilenetv1_full_api.py
@@ -31,6 +31,8 @@ parser.add_argument(
     "--model_file", default="", type=str, help="Model file")
 parser.add_argument(
     "--param_file", default="", type=str, help="Combined model param file")
+parser.add_argument(
+    "--enable_opencl", action="store_true", help="Enable OpenCL or not")
 
 def RunModel(args):
     # 1. Set config information
@@ -40,8 +42,21 @@ def RunModel(args):
         config.set_param_file(args.param_file)
     else:
         config.set_model_dir(args.model_dir)
+
     # For arm platform (armlinux), you can set places = [Place(TargetType.ARM, PrecisionType.FP32)]
-    places = [Place(TargetType.X86, PrecisionType.FP32)]
+    if args.enable_opencl:
+        places = [Place(TargetType.OpenCL, PrecisionType.FP16, DataLayoutType.ImageDefault),
+                  Place(TargetType.OpenCL, PrecisionType.FP16, DataLayoutType.ImageFolder),
+                  Place(TargetType.OpenCL, PrecisionType.FP32, DataLayoutType.NCHW),
+                  Place(TargetType.OpenCL, PrecisionType.Any, DataLayoutType.ImageDefault),
+                  Place(TargetType.OpenCL, PrecisionType.Any, DataLayoutType.ImageFolder),
+                  Place(TargetType.OpenCL, PrecisionType.Any, DataLayoutType.NCHW),
+                  Place(TargetType.X86, PrecisionType.FP32),
+                  Place(TargetType.ARM, PrecisionType.FP32),
+                  Place(TargetType.Host, PrecisionType.FP32)]
+    else:
+        places = [Place(TargetType.X86, PrecisionType.FP32)]
+
     config.set_valid_places(places)
 
     # 2. Create paddle predictor

--- a/lite/tools/build_macos.sh
+++ b/lite/tools/build_macos.sh
@@ -29,9 +29,11 @@ WITH_PROFILE=OFF
 WITH_PRECISION_PROFILE=OFF
 WITH_BENCHMARK=OFF
 WITH_LTO=OFF
+WITH_TESTING=OFF
 BUILD_ARM82_FP16=OFF
 BUILD_ARM82_INT8_SDOT=OFF
 PYTHON_EXECUTABLE_OPTION=""
+PY_VERSION=""
 workspace=$PWD/$(dirname $0)/../../
 OPTMODEL_DIR=""
 IOS_DEPLOYMENT_TARGET=11.0
@@ -222,8 +224,9 @@ function make_x86 {
 
   if [ ${BUILD_PYTHON} == "ON" ]; then
     BUILD_EXTRA=ON
+    LITE_ON_TINY_PUBLISH=OFF
   fi
-
+ 
   if [ ! -d third-party ]; then
     git checkout third-party
   fi


### PR DESCRIPTION
如下命令编译通过：
```
./lite/tools/build_macos.sh  --with_opencl=ON --with_python=ON --python_executable=`which python3.7` --python_version=3.7 --with_log=ON  x86
```

安装完 whl 包后，进入 lite/demo/python/ 下，执行：
```
python3.7 mobilenetv1_full_api.py --model_dir=/path/to/mobilenetv1_inference --enable_opencl
```
程序会在 GPU 上执行。