### PR TITLE
[AutoScan] add demo for different precision

### DIFF
--- a/lite/tests/unittest_py/op/test_mul_op.py
+++ b/lite/tests/unittest_py/op/test_mul_op.py
@@ -44,13 +44,10 @@ class TestMulOp(AutoScanTest):
             if x_shape[1] != y_shape[0]:
                 return False
         # {PrecisionType.FP16, PrecisionType.FP32, PrecisionType.FP64, PrecisionType.UINT8, PrecisionType.INT8, PrecisionType.INT16, PrecisionType.INT32, PrecisionType.INT64, PrecisionType.BOOL}
-        print(x_precision)
-        if(x_precision == np.float):
-           print("success")
         if predictor_config.precision() == PrecisionType.FP16 and x_precision != np.float16:
             return False
-        elif predictor_config.precision() == PrecisionType.float and x_precision != np.float:
-            return False
+        elif predictor_config.precision() == PrecisionType.FP32 and x_precision != np.float32:
+           return False
 
         # {DataLayoutType.NCHW, DataLayoutType.NHWC, DataLayoutType.ImageDefault, DataLayoutType.ImageFolder, DataLayoutType.ImageNW, DataLayoutType.Any}
         elif predictor_config.layout() != DataLayoutType.NCHW:

--- a/lite/tests/unittest_py/op/test_mul_op.py
+++ b/lite/tests/unittest_py/op/test_mul_op.py
@@ -18,7 +18,7 @@ sys.path.append('../')
 from auto_scan_test import AutoScanTest, IgnoreReasons
 from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
 import unittest
-
+import paddle.fluid.core as core
 import hypothesis
 from hypothesis import given, settings, seed, example, assume
 import hypothesis.strategies as st
@@ -35,6 +35,7 @@ class TestMulOp(AutoScanTest):
         # get input&output shape, get op attributes
         x_shape = list(program_config.inputs["input_data_x"].shape)
         y_shape = list(program_config.weights["input_data_y"].shape)
+        x_precision = program_config.inputs["input_data_x"].dtype();
         x_num_col_dims = program_config.ops[0].attrs["x_num_col_dims"]
         y_num_col_dims = program_config.ops[0].attrs["y_num_col_dims"]
 
@@ -45,7 +46,7 @@ class TestMulOp(AutoScanTest):
                 return False
         # {PrecisionType.FP16, PrecisionType.FP32, PrecisionType.FP64, PrecisionType.UINT8, PrecisionType.INT8, PrecisionType.INT16, PrecisionType.INT32, PrecisionType.INT64, PrecisionType.BOOL}
         elif predictor_config.precision() == PrecisionType.FP16:
-            if x_num_col_dims > 20:
+            if x_precision != core.VarDesc.VarType.FP16:
                 return False
         # {DataLayoutType.NCHW, DataLayoutType.NHWC, DataLayoutType.ImageDefault, DataLayoutType.ImageFolder, DataLayoutType.ImageNW, DataLayoutType.Any}
         elif predictor_config.layout() != DataLayoutType.NCHW:

--- a/lite/tests/unittest_py/op/test_mul_op.py
+++ b/lite/tests/unittest_py/op/test_mul_op.py
@@ -18,11 +18,10 @@ sys.path.append('../')
 from auto_scan_test import AutoScanTest, IgnoreReasons
 from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
 import unittest
-import paddle.fluid.core as core
 import hypothesis
 from hypothesis import given, settings, seed, example, assume
 import hypothesis.strategies as st
-
+import numpy as np
 
 
 class TestMulOp(AutoScanTest):
@@ -35,7 +34,7 @@ class TestMulOp(AutoScanTest):
         # get input&output shape, get op attributes
         x_shape = list(program_config.inputs["input_data_x"].shape)
         y_shape = list(program_config.weights["input_data_y"].shape)
-        x_precision = program_config.inputs["input_data_x"].dtype();
+        x_precision = program_config.inputs["input_data_x"].dtype;
         x_num_col_dims = program_config.ops[0].attrs["x_num_col_dims"]
         y_num_col_dims = program_config.ops[0].attrs["y_num_col_dims"]
 
@@ -45,9 +44,14 @@ class TestMulOp(AutoScanTest):
             if x_shape[1] != y_shape[0]:
                 return False
         # {PrecisionType.FP16, PrecisionType.FP32, PrecisionType.FP64, PrecisionType.UINT8, PrecisionType.INT8, PrecisionType.INT16, PrecisionType.INT32, PrecisionType.INT64, PrecisionType.BOOL}
-        elif predictor_config.precision() == PrecisionType.FP16:
-            if x_precision != core.VarDesc.VarType.FP16:
-                return False
+        print(x_precision)
+        if(x_precision == np.float):
+           print("success")
+        if predictor_config.precision() == PrecisionType.FP16 and x_precision != np.float16:
+            return False
+        elif predictor_config.precision() == PrecisionType.float and x_precision != np.float:
+            return False
+
         # {DataLayoutType.NCHW, DataLayoutType.NHWC, DataLayoutType.ImageDefault, DataLayoutType.ImageFolder, DataLayoutType.ImageNW, DataLayoutType.Any}
         elif predictor_config.layout() != DataLayoutType.NCHW:
             if y_num_col_dims > 20:

--- a/lite/tests/unittest_py/op/test_mul_op.py
+++ b/lite/tests/unittest_py/op/test_mul_op.py
@@ -44,10 +44,12 @@ class TestMulOp(AutoScanTest):
             if x_shape[1] != y_shape[0]:
                 return False
         # {PrecisionType.FP16, PrecisionType.FP32, PrecisionType.FP64, PrecisionType.UINT8, PrecisionType.INT8, PrecisionType.INT16, PrecisionType.INT32, PrecisionType.INT64, PrecisionType.BOOL}
-        if predictor_config.precision() == PrecisionType.FP16 and x_precision != np.float16:
-            return False
-        elif predictor_config.precision() == PrecisionType.FP32 and x_precision != np.float32:
-           return False
+        target_type = predictor_config.target()
+        if target_type not in [TargetType.OpenCL, TargetType.Metal]:
+            if predictor_config.precision() == PrecisionType.FP16 and in_data_type != np.float16:
+                return False
+            elif  predictor_config.precision() == PrecisionType.FP32 and in_data_type != np.float32:
+                return False
 
         # {DataLayoutType.NCHW, DataLayoutType.NHWC, DataLayoutType.ImageDefault, DataLayoutType.ImageFolder, DataLayoutType.ImageNW, DataLayoutType.Any}
         elif predictor_config.layout() != DataLayoutType.NCHW:


### PR DESCRIPTION
- 如何给不同的`kernel`设置不同精度的输入数据?
```python
    def is_program_valid(self, program_config: ProgramConfig , predictor_config: CxxConfig) -> bool:
        # get input&output shape, get op attributes, get input&output precision
        x_precision = program_config.inputs["input_data_x"].dtype;
        target_type = predictor_config.target()
        # {PrecisionType.FP16, PrecisionType.FP32, PrecisionType.FP64, PrecisionType.UINT8, PrecisionType.INT8, PrecisionType.INT16, PrecisionType.INT32, PrecisionType.INT64, PrecisionType.BOOL}
        if target_type not in [TargetType.OpenCL, TargetType.Metal]:
            if predictor_config.precision() == PrecisionType.FP16 and in_data_type != np.float16:
                return False
            elif  predictor_config.precision() == PrecisionType.FP32 and in_data_type != np.float32:
                return False
```