### PR TITLE
Add random method

### DIFF
--- a/lite/tests/unittest_py/auto_scan_test_rpc.py
+++ b/lite/tests/unittest_py/auto_scan_test_rpc.py
@@ -29,9 +29,10 @@ IgnoreReasons = IgnoreReasonsBase
 class AutoScanTest(AutoScanBaseTest):
     def run_lite_config(self, model, params, feed_data,
                         pred_config) -> Dict[str, np.ndarray]:
-        paddle_lite_path=os.path.abspath(__file__)
-        paddlelite_source_path=re.findall(r"(.+?)Paddle-Lite", paddle_lite_path)
-        rpc_port_file = paddlelite_source_path + "/tests/unittest_py/rpc_service/.rpc_port";
+        paddle_lite_path = os.path.abspath(__file__)
+        paddlelite_source_path = re.findall(r"(.+?)Paddle-Lite",
+                                            paddle_lite_path)[0]
+        rpc_port_file = paddlelite_source_path + "Paddle-Lite/lite/tests/unittest_py/rpc_service/.port_id"
         port_id = int(open(rpc_port_file).read())
 
         conn = rpyc.connect("localhost", port_id)

--- a/lite/tests/unittest_py/auto_scan_test_rpc.py
+++ b/lite/tests/unittest_py/auto_scan_test_rpc.py
@@ -19,6 +19,7 @@ import enum
 import unittest
 from typing import Optional, List, Callable, Dict, Any, Set
 import os
+import re
 import paddle
 import rpyc
 import copy

--- a/lite/tests/unittest_py/auto_scan_test_rpc.py
+++ b/lite/tests/unittest_py/auto_scan_test_rpc.py
@@ -29,7 +29,12 @@ IgnoreReasons = IgnoreReasonsBase
 class AutoScanTest(AutoScanBaseTest):
     def run_lite_config(self, model, params, feed_data,
                         pred_config) -> Dict[str, np.ndarray]:
-        conn = rpyc.connect("localhost", 18812)
+        paddle_lite_path=os.path.abspath(__file__)
+        paddlelite_source_path=re.findall(r"(.+?)Paddle-Lite", paddle_lite_path)
+        rpc_port_file = paddlelite_source_path + "/tests/unittest_py/rpc_service/.rpc_port";
+        port_id = int(open(rpc_port_file).read())
+
+        conn = rpyc.connect("localhost", port_id)
         out, model = conn.root.run_lite_model(model, params, feed_data,
                                               pred_config)
         result_res = copy.deepcopy(out)

--- a/lite/tests/unittest_py/op/auto_scan
+++ b/lite/tests/unittest_py/op/auto_scan
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+ARCH=""
+TEST_FILE=""
+
+function get_inputs {
+    # Parse command line.
+    for i in "$@"; do
+        case $i in
+            # armv7 or armv8, default armv8
+            --target=*)
+                ARCH="${i#*=}"
+                shift
+                ;;
+            *)
+                # unknown option
+                TEST_FILE="$i"
+                ;;
+        esac
+    done
+    # compiling result contains light_api lib only, recommanded.
+}
+
+get_inputs $@
+
+if [ $ARCH = "" ] || [ $TEST_FILE = "" ]; then
+  echo "Error input: ./auto_scan test_assign_op.py --target=Host"
+  exit 1
+fi
+
+
+if [ $ARCH = "ARM" ] || [ $ARCH = "OpenCL" ] || [ $ARCH = "Metal" ]; then
+  cd ../rpc_service
+  sh start_rpc_server.sh
+  cd ../op
+  python3.8 $TEST_FILE --target=$ARCH
+else
+  python3.7 $TEST_FILE --target=$ARCH
+fi

--- a/lite/tests/unittest_py/rpc_service/server.py
+++ b/lite/tests/unittest_py/rpc_service/server.py
@@ -115,5 +115,10 @@ class RPCService(rpyc.Service):
 
 
 if __name__ == "__main__":
-    server = ThreadedServer(RPCService, port=18812, hostname='localhost')
+    paddle_lite_path = os.path.abspath(__file__)
+    paddlelite_source_path = re.findall(r"(.+?)Paddle-Lite",
+                                        paddle_lite_path)[0]
+    rpc_port_file = paddlelite_source_path + "Paddle-Lite/lite/tests/unittest_py/rpc_service/.port_id"
+    port_id = int(open(rpc_port_file).read())
+    server = ThreadedServer(RPCService, port=port_id, hostname='localhost')
     server.start()

--- a/lite/tests/unittest_py/rpc_service/server.py
+++ b/lite/tests/unittest_py/rpc_service/server.py
@@ -14,6 +14,7 @@
 
 import rpyc
 import os
+import re
 import shutil
 from rpyc.utils.server import ThreadedServer
 import paddlelite

--- a/lite/tests/unittest_py/rpc_service/start_rpc_server.sh
+++ b/lite/tests/unittest_py/rpc_service/start_rpc_server.sh
@@ -1,5 +1,19 @@
+function rand {
+  min=$1
+  max=$(($2-$min+1))
+  num=$(($RANDOM+1000000000))
+  echo $(($num%$max+$min))
+}
+
+if [[ ! -f '.port_id' ]];then
+  port_id=$(rand 10000 30000)
+  echo $port_id > .port_id
+else
+  port_id=$(cat .port_id)
+fi
+
 # get process-id of current rpc server
-RPC_PID=$(lsof -i:18812 | grep Python | awk -F ' ' '{print $2}')
+RPC_PID=$(lsof -i:$port_id | grep Python | awk -F ' ' '{print $2}')
 # restart rpc server
 if [[ $RPC_PID != "" ]]; then
   kill -9 ${RPC_PID}


### PR DESCRIPTION
``` shell
cd op
./auto_scan test_scale_op.py --target=ARM
```
- 自动生成随机rpc port id 、自动启动rpc 服务，并执行单测
- 随机生成的rpc port id 会保存在rpc_service/.port_id 文件中，下次重启服务不会再次重新随机rpc_port （除非重新clone Paddle-Lite）

```shell
# 其他使用方法：
./auto_scan test_scale_op.py --target=Host
./auto_scan test_scale_op.py --target=X86
./auto_scan test_scale_op.py --target=Metal
./auto_scan test_scale_op.py --target=OpenCL
```