### PR TITLE
[OpTestPy] Support opencl on concat

### DIFF
--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -42,7 +42,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
     axis_ = concat_param_->axis;
     auto* axis_tensor = concat_param_->axis_tensor;
     if (axis_tensor != nullptr) {
-      auto* d_image = GET_DATA_GPU(axis_tensor);
+      auto* d_image = DATA_GPU(axis_tensor);
       cl::Image2D* cl_image = static_cast<cl::Image2D*>(d_image);
       size_t cl_image2d_width, cl_image2d_height;
       cl_image->getImageInfo(CL_IMAGE_WIDTH, &cl_image2d_width);
@@ -51,14 +51,14 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       const bool fp16_support =
           CLRuntime::Global()->get_precision() == lite_api::CL_PRECISION_FP16;
       if (fp16_support) {
-        auto* h_image = static_cast<float*>(TargetWrapperCL::MapImage(
-            d_image, cl_image2d_width, cl_image2d_height, 0, 0));
-        axis_ = h_image[0];
-        TargetWrapperCL::Unmap(d_image, h_image);
-      } else {
         auto* h_image = static_cast<half_t*>(TargetWrapperCL::MapImage(
             d_image, cl_image2d_width, cl_image2d_height, 0, 0));
         axis_ = Half2Float(h_image[0]);
+        TargetWrapperCL::Unmap(d_image, h_image);
+      } else {
+        auto* h_image = static_cast<float*>(TargetWrapperCL::MapImage(
+            d_image, cl_image2d_width, cl_image2d_height, 0, 0));
+        axis_ = h_image[0];
         TargetWrapperCL::Unmap(d_image, h_image);
       }
     }

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -23,6 +23,7 @@
 #include "lite/core/profile/profiler.h"
 #endif
 #include "lite/backends/opencl/cl_utility.h"
+#include "lite/backends/opencl/target_wrapper.h"
 
 namespace paddle {
 namespace lite {
@@ -39,6 +40,28 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
     auto& context = ctx_->As<OpenCLContext>();
     concat_param_ = param_.get_mutable<param_t>();
     axis_ = concat_param_->axis;
+    auto* axis_tensor = concat_param_->axis_tensor;
+    if (axis_tensor != nullptr) {
+      auto* d_image = GET_DATA_GPU(axis_tensor);
+      cl::Image2D* cl_image = static_cast<cl::Image2D*>(d_image);
+      size_t cl_image2d_width, cl_image2d_height;
+      cl_image->getImageInfo(CL_IMAGE_WIDTH, &cl_image2d_width);
+      cl_image->getImageInfo(CL_IMAGE_HEIGHT, &cl_image2d_height);
+
+      const bool fp16_support =
+          CLRuntime::Global()->get_precision() == lite_api::CL_PRECISION_FP16;
+      if (fp16_support) {
+        auto* h_image = static_cast<float*>(TargetWrapperCL::MapImage(
+            d_image, cl_image2d_width, cl_image2d_height, 0, 0));
+        axis_ = h_image[0];
+        TargetWrapperCL::Unmap(d_image, h_image);
+      } else {
+        auto* h_image = static_cast<half_t*>(TargetWrapperCL::MapImage(
+            d_image, cl_image2d_width, cl_image2d_height, 0, 0));
+        axis_ = Half2Float(h_image[0]);
+        TargetWrapperCL::Unmap(d_image, h_image);
+      }
+    }
     axis_ = axis_ >= 0 ? axis_ : axis_ + concat_param_->x[0]->dims().size();
 
     auto inputs = concat_param_->x;

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -67,37 +67,27 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
     auto inputs = concat_param_->x;
     auto output_tensor_dims = concat_param_->output->dims();
 
-    if (output_tensor_dims.size() < 4) {
-      if (output_tensor_dims.size() - axis_ == 1) {
-        // width
-        width_ = output_tensor_dims[1];  // c
-        flag_ = 3;
-      } else {
-        // height
-        width_ = output_tensor_dims[0];  // n
-        flag_ = 2;
-      }
-    } else {
-      switch (axis_) {
-        case 0:
-          width_ = output_tensor_dims[2];  // h
-          flag_ = 0;
-          break;
-        case 1:                            // channel
-          width_ = output_tensor_dims[3];  // w
-          flag_ = 1;
-          break;
-        case 2:                            // height
-          width_ = output_tensor_dims[0];  // n
-          flag_ = 2;
-          break;
-        case 3:                            // width
-          width_ = output_tensor_dims[1];  // c
-          flag_ = 3;
-          break;
-        default:
-          LOG(FATAL) << "Unsupported axis:" << axis_;
-      }
+    std::vector<size_t> new_dims = {1, 1, 1, 1};
+    size_t offset = 4 - output_tensor_dims.size();
+    for (auto i = 0; i < output_tensor_dims.size(); ++i) {
+      new_dims[offset + i] = output_tensor_dims[i];
+    }
+    flag_ = offset + axis_;
+    switch (flag_) {
+      case 0:
+        width_ = new_dims[2];
+        break;
+      case 1:
+        width_ = new_dims[3];
+        break;
+      case 2:
+        width_ = new_dims[0];
+        break;
+      case 3:
+        width_ = new_dims[1];
+        break;
+      default:
+        LOG(FATAL) << "Unsupported axis:" << axis_;
     }
 
     for (auto& input : inputs) {

--- a/lite/tests/unittest_py/op/test_concat_op.py
+++ b/lite/tests/unittest_py/op/test_concat_op.py
@@ -69,13 +69,24 @@ class TestConcatOp(AutoScanTest):
         in_shape1 = draw(
             st.lists(
                 st.integers(
-                    min_value=1, max_value=20), min_size=1, max_size=4))
-        in_shape2 = in_shape1
-        axis = draw(st.integers(min_value=-1, max_value=len(in_shape1) - 1))
+                    min_value=1, max_value=100),
+                min_size=1,
+                max_size=4))
+        in_shape2 = draw(
+            st.lists(
+                st.integers(
+                    min_value=1, max_value=100),
+                min_size=1,
+                max_size=4))
+        axis = draw(st.sampled_from([-1, 0, 1, 2, 3]))
         has_axis_tensor = draw(st.booleans())
+        assume(len(in_shape1) == len(in_shape2))
+        assume(axis < len(in_shape1))
         for i in range(-1, len(in_shape1)):
             if i == axis:
-                in_shape2[i] = draw(st.integers(min_value=1, max_value=20))
+                continue
+            else:
+                assume(in_shape1[i] == in_shape2[i])
 
         def generate_input1(*args, **kwargs):
             return np.random.random(in_shape1).astype(np.float32)

--- a/lite/tests/unittest_py/op/test_concat_op.py
+++ b/lite/tests/unittest_py/op/test_concat_op.py
@@ -160,13 +160,13 @@ class TestConcatOp(AutoScanTest):
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()
-        max_examples = 25
+        max_examples = 50
         if target_str == "OpenCL":
             # Make sure to generate enough valid cases for OpenCL
             max_examples = 100
 
         self.run_and_statis(
-            quant=False, min_success_num=25, max_examples=max_examples)
+            quant=False, min_success_num=50, max_examples=max_examples)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_concat_op.py
+++ b/lite/tests/unittest_py/op/test_concat_op.py
@@ -69,24 +69,13 @@ class TestConcatOp(AutoScanTest):
         in_shape1 = draw(
             st.lists(
                 st.integers(
-                    min_value=1, max_value=100),
-                min_size=1,
-                max_size=4))
-        in_shape2 = draw(
-            st.lists(
-                st.integers(
-                    min_value=1, max_value=100),
-                min_size=1,
-                max_size=4))
-        axis = draw(st.sampled_from([0, 1, 2, 3]))
+                    min_value=1, max_value=20), min_size=1, max_size=4))
+        in_shape2 = in_shape1
+        axis = draw(st.integers(min_value=-1, max_value=len(in_shape1) - 1))
         has_axis_tensor = draw(st.booleans())
-        assume(len(in_shape1) == len(in_shape2))
-        assume(axis < len(in_shape1))
-        for i in range(0, len(in_shape1)):
+        for i in range(-1, len(in_shape1)):
             if i == axis:
-                continue
-            else:
-                assume(in_shape1[i] == in_shape2[i])
+                in_shape2[i] = draw(st.integers(min_value=1, max_value=20))
 
         def generate_input1(*args, **kwargs):
             return np.random.random(in_shape1).astype(np.float32)


### PR DESCRIPTION
- 单测中支持输入为`AxisTensor`的 case
- 丰富单测，可支持 2-6 个 inputs