### PR TITLE
Fix compiling err on macOS x86

### DIFF
--- a/lite/tools/build_macos.sh
+++ b/lite/tools/build_macos.sh
@@ -231,7 +231,7 @@ function make_x86 {
     BUILD_EXTRA=ON
     LITE_ON_TINY_PUBLISH=OFF
   fi
- 
+
   if [ ! -d third-party ]; then
     git checkout third-party
   fi
@@ -253,7 +253,7 @@ function make_x86 {
             -DLITE_WITH_X86=ON  \
             -DWITH_LITE=ON \
             -DLITE_WITH_LIGHT_WEIGHT_FRAMEWORK=${WITH_LIGHT_WEIGHT_FRAMEWORK} \
-            -DLITE_ON_TINY_PUBLISH=${LITE_ON_TINY_PUBLISH} \
+            -DLITE_ON_TINY_PUBLISH=OFF \
             -DLITE_WITH_PROFILE=${WITH_PROFILE} \
             -DLITE_WITH_PRECISION_PROFILE=${WITH_PRECISION_PROFILE} \
             -DLITE_WITH_ARM=OFF \


### PR DESCRIPTION
执行：
```
 ./lite/tools/build_macos.sh x86
```
编译报错：
```
CMake Error at CMakeLists.txt:122 (message):
  LITE_ON_TINY_PUBLISH=ON must be used with LITE_WITH_ARM=ON
  LITE_WITH_JAVA=ON WITH_TESTING=OFF


-- Configuring incomplete, errors occurred!
```