### PR TITLE
add common con support 3x3s12,5x5s12,7x7s12, fix leaky_relu bug, optimize direct con by exchange loop

### DIFF
--- a/lite/backends/x86/math/conv_direct_fp32.cc
+++ b/lite/backends/x86/math/conv_direct_fp32.cc
@@ -525,25 +525,25 @@ void conv_direct_transpose_out(int bs,
                                     row0,
                                     _mm256_cmp_ps(row0, vzero, _CMP_GT_OS));
             row1 = _mm256_blendv_ps(_mm256_mul_ps(row1, vscale),
-                                    row0,
+                                    row1,
                                     _mm256_cmp_ps(row1, vzero, _CMP_GT_OS));
             row2 = _mm256_blendv_ps(_mm256_mul_ps(row2, vscale),
-                                    row0,
+                                    row2,
                                     _mm256_cmp_ps(row2, vzero, _CMP_GT_OS));
             row3 = _mm256_blendv_ps(_mm256_mul_ps(row3, vscale),
-                                    row0,
+                                    row3,
                                     _mm256_cmp_ps(row3, vzero, _CMP_GT_OS));
             row4 = _mm256_blendv_ps(_mm256_mul_ps(row4, vscale),
-                                    row0,
+                                    row4,
                                     _mm256_cmp_ps(row4, vzero, _CMP_GT_OS));
             row5 = _mm256_blendv_ps(_mm256_mul_ps(row5, vscale),
-                                    row0,
+                                    row5,
                                     _mm256_cmp_ps(row5, vzero, _CMP_GT_OS));
             row6 = _mm256_blendv_ps(_mm256_mul_ps(row6, vscale),
-                                    row0,
+                                    row6,
                                     _mm256_cmp_ps(row6, vzero, _CMP_GT_OS));
             row7 = _mm256_blendv_ps(_mm256_mul_ps(row7, vscale),
-                                    row0,
+                                    row7,
                                     _mm256_cmp_ps(row7, vzero, _CMP_GT_OS));
 #else
             __m128 vzero = _mm_set1_ps(0.f);
@@ -552,13 +552,13 @@ void conv_direct_transpose_out(int bs,
                                  row0,
                                  _mm_cmp_ps(row0, vzero, _CMP_GT_OS));
             row1 = _mm_blendv_ps(_mm_mul_ps(row1, vscale),
-                                 row0,
+                                 row1,
                                  _mm_cmp_ps(row1, vzero, _CMP_GT_OS));
             row2 = _mm_blendv_ps(_mm_mul_ps(row2, vscale),
-                                 row0,
+                                 row2,
                                  _mm_cmp_ps(row2, vzero, _CMP_GT_OS));
             row3 = _mm_blendv_ps(_mm_mul_ps(row3, vscale),
-                                 row0,
+                                 row3,
                                  _mm_cmp_ps(row3, vzero, _CMP_GT_OS));
 #endif
           } else if (active_type == lite_api::ActivationType::kHardSwish) {

--- a/lite/backends/x86/math/conv_direct_fp32.h
+++ b/lite/backends/x86/math/conv_direct_fp32.h
@@ -55,14 +55,14 @@ struct conv_direct : lite::jit::gen::JitCode {
 };
 
 void conv_direct_transpose_out(int bs,
-                                    int oc,
-                                    int oh,
-                                    int ow,
-                                    float* o_data,
-                                    float* trans_out,
-                                    const float* bias,
-                                    lite_api::ActivationType active_type,
-                                    operators::ActivationParam act_param);
+                               int oc,
+                               int oh,
+                               int ow,
+                               float* o_data,
+                               float* trans_out,
+                               const float* bias,
+                               lite_api::ActivationType active_type,
+                               operators::ActivationParam act_param);
 
 }  // namespace math
 }  // namespace x86

--- a/lite/backends/x86/math/conv_direct_fp32.h
+++ b/lite/backends/x86/math/conv_direct_fp32.h
@@ -20,8 +20,8 @@ namespace lite {
 namespace x86 {
 namespace math {
 
-struct conv_direct_3x3s2 : lite::jit::gen::JitCode {
-  conv_direct_3x3s2();
+struct conv_direct : lite::jit::gen::JitCode {
+  conv_direct();
   void generate_code(int ic,
                      int ih,
                      int iw,
@@ -30,9 +30,12 @@ struct conv_direct_3x3s2 : lite::jit::gen::JitCode {
                      int oh,
                      int ow,
                      int ph,
-                     int pw);
+                     int pw,
+                     int wh,
+                     int ww,
+                     int stridew);
   virtual void genCode() {}
-  virtual ~conv_direct_3x3s2() {}
+  virtual ~conv_direct() {}
   void run(const float* i_data,
            const float* trans_weight,
            float* trans_out,
@@ -45,10 +48,13 @@ struct conv_direct_3x3s2 : lite::jit::gen::JitCode {
            int oh,
            int ow,
            int ph,
-           int pw);
+           int pw,
+           int wh,
+           int ww,
+           int strideh);
 };
 
-void conv_direct_3x3s2_tranpose_out(int bs,
+void conv_direct_transpose_out(int bs,
                                     int oc,
                                     int oh,
                                     int ow,

--- a/lite/kernels/x86/conv_compute.cc
+++ b/lite/kernels/x86/conv_compute.cc
@@ -98,7 +98,7 @@ void Conv2dCompute<PRECISION(kFloat), PRECISION(kFloat)>::PrepareForRun() {
   bool pad_all_equal = (paddings[0] == paddings[1]) &&
                        (paddings[1] == paddings[2]) &&
                        (paddings[2] == paddings[3]);
-  bool flag_p01 = (paddings[0] == 0 || paddings[0] == 1);
+  bool flag_p = paddings[0] <= stride_h;
 
   //! select conv impl
   if (dw_kernel && kps_equal && flag_dw &&
@@ -107,10 +107,12 @@ void Conv2dCompute<PRECISION(kFloat), PRECISION(kFloat)>::PrepareForRun() {
     VLOG(3) << "invoking conv_depthwise_3x3p0p1 or conv_depthwise_5x5";
   }
 
-  if (output_channel % 8 == 0 && groups == 1 && kernel_h == 3 &&
-      stride_h == 2 && nodilations && kps_equal && pad_all_equal && flag_p01) {
+  // support 3x3s1p01,5x5s1p01,7x7s1p01
+  //  3x3s2p012,5x5s1p012,7x7s1p012
+  if (output_channel % 8 == 0 && groups == 1 && (kernel_h == 3 || kernel_h == 5 || kernel_h == 7) &&
+      (stride_h == 2 || stride_h == 1) && nodilations && kps_equal && pad_all_equal && flag_p) {
     impl_ = new DirectConv<PRECISION(kFloat), PRECISION(kFloat)>();
-    VLOG(3) << "invoking directConv  3x3s2";
+    VLOG(3) << "invoking directConv";
   }
 
   if (impl_) {

--- a/lite/kernels/x86/conv_compute.cc
+++ b/lite/kernels/x86/conv_compute.cc
@@ -109,8 +109,10 @@ void Conv2dCompute<PRECISION(kFloat), PRECISION(kFloat)>::PrepareForRun() {
 
   // support 3x3s1p01,5x5s1p01,7x7s1p01
   //  3x3s2p012,5x5s1p012,7x7s1p012
-  if (output_channel % 8 == 0 && groups == 1 && (kernel_h == 3 || kernel_h == 5 || kernel_h == 7) &&
-      (stride_h == 2 || stride_h == 1) && nodilations && kps_equal && pad_all_equal && flag_p) {
+  if (output_channel % 8 == 0 && groups == 1 &&
+      (kernel_h == 3 || kernel_h == 5 || kernel_h == 7) &&
+      (stride_h == 2 || stride_h == 1) && nodilations && kps_equal &&
+      pad_all_equal && flag_p) {
     impl_ = new DirectConv<PRECISION(kFloat), PRECISION(kFloat)>();
     VLOG(3) << "invoking directConv";
   }

--- a/lite/kernels/x86/conv_direct.cc
+++ b/lite/kernels/x86/conv_direct.cc
@@ -14,7 +14,7 @@
 
 #include "lite/kernels/x86/conv_direct.h"
 #include <cmath>
-#include "lite/backends/x86/math/conv3x3s2_direct_fp32.h"
+#include "lite/backends/x86/math/conv_direct_fp32.h"
 #include "lite/backends/x86/math/conv_bias.h"
 namespace paddle {
 namespace lite {
@@ -24,8 +24,8 @@ namespace x86 {
 template <>
 void DirectConv<PRECISION(kFloat), PRECISION(kFloat)>::Run() {
   auto& param = this->Param<param_t>();
-  CHECK_EQ(param.strides[0], 2);
-  CHECK_EQ(param.strides[1], 2);
+  //CHECK_EQ(param.strides[0], 2);
+  //CHECK_EQ(param.strides[1], 2);
   // auto& ctx = this->ctx_->template As<X86Context>();
 
   const auto* i_data = param.x->data<float>();
@@ -35,6 +35,9 @@ void DirectConv<PRECISION(kFloat), PRECISION(kFloat)>::Run() {
   auto x_dims = param.x->dims();
   auto w_dims = param.filter->dims();
   auto o_dims = param.output->dims();
+
+  int wh = param.filter->dims()[2];
+  int ww = param.filter->dims()[3];
 
   const int ph = (*(param.paddings))[0];
   const int pw = (*(param.paddings))[2];
@@ -64,9 +67,12 @@ void DirectConv<PRECISION(kFloat), PRECISION(kFloat)>::Run() {
              oh,
              ow,
              ph,
-             pw);
+             pw,
+             wh,
+             ww,
+             param.strides[0]);
 
-  lite::x86::math::conv_direct_3x3s2_tranpose_out(bs,
+  lite::x86::math::conv_direct_transpose_out(bs,
                                                   oc,
                                                   oh,
                                                   ow,

--- a/lite/kernels/x86/conv_direct.cc
+++ b/lite/kernels/x86/conv_direct.cc
@@ -14,8 +14,8 @@
 
 #include "lite/kernels/x86/conv_direct.h"
 #include <cmath>
-#include "lite/backends/x86/math/conv_direct_fp32.h"
 #include "lite/backends/x86/math/conv_bias.h"
+#include "lite/backends/x86/math/conv_direct_fp32.h"
 namespace paddle {
 namespace lite {
 namespace kernels {
@@ -24,8 +24,8 @@ namespace x86 {
 template <>
 void DirectConv<PRECISION(kFloat), PRECISION(kFloat)>::Run() {
   auto& param = this->Param<param_t>();
-  //CHECK_EQ(param.strides[0], 2);
-  //CHECK_EQ(param.strides[1], 2);
+  // CHECK_EQ(param.strides[0], 2);
+  // CHECK_EQ(param.strides[1], 2);
   // auto& ctx = this->ctx_->template As<X86Context>();
 
   const auto* i_data = param.x->data<float>();
@@ -73,14 +73,14 @@ void DirectConv<PRECISION(kFloat), PRECISION(kFloat)>::Run() {
              param.strides[0]);
 
   lite::x86::math::conv_direct_transpose_out(bs,
-                                                  oc,
-                                                  oh,
-                                                  ow,
-                                                  o_data,
-                                                  trans_out,
-                                                  b_data,
-                                                  act_param.active_type,
-                                                  act_param);
+                                             oc,
+                                             oh,
+                                             ow,
+                                             o_data,
+                                             trans_out,
+                                             b_data,
+                                             act_param.active_type,
+                                             act_param);
   TargetFree(TARGET(kX86), trans_out);
 }
 }  // namespace x86

--- a/lite/kernels/x86/conv_direct.cc
+++ b/lite/kernels/x86/conv_direct.cc
@@ -24,9 +24,6 @@ namespace x86 {
 template <>
 void DirectConv<PRECISION(kFloat), PRECISION(kFloat)>::Run() {
   auto& param = this->Param<param_t>();
-  // CHECK_EQ(param.strides[0], 2);
-  // CHECK_EQ(param.strides[1], 2);
-  // auto& ctx = this->ctx_->template As<X86Context>();
 
   const auto* i_data = param.x->data<float>();
   const auto* b_data = param.bias ? param.bias->data<float>() : nullptr;

--- a/lite/kernels/x86/conv_direct.h
+++ b/lite/kernels/x86/conv_direct.h
@@ -72,7 +72,8 @@ class DirectConv : public KernelLite<TARGET(kX86), Ptype> {
     int oh = o_dims[2];
     int ow = o_dims[3];
     code_ = new lite::x86::math::conv_direct();
-    code_->generate_code(ic, ih, iw, oc, oc_expand_, oh, ow, ph, pw, wh, ww, param.strides[1]);
+    code_->generate_code(
+        ic, ih, iw, oc, oc_expand_, oh, ow, ph, pw, wh, ww, param.strides[1]);
     code_->ready();
   }
 

--- a/lite/kernels/x86/conv_direct.h
+++ b/lite/kernels/x86/conv_direct.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 #include "lite/backends/x86/math/avx/conv_utils.h"
-#include "lite/backends/x86/math/conv3x3s2_direct_fp32.h"
+#include "lite/backends/x86/math/conv_direct_fp32.h"
 #include "lite/core/context.h"
 #include "lite/core/kernel.h"
 #include "lite/core/target_wrapper.h"
@@ -71,9 +71,8 @@ class DirectConv : public KernelLite<TARGET(kX86), Ptype> {
     int ih = x_dims[2];
     int oh = o_dims[2];
     int ow = o_dims[3];
-
-    code_ = new lite::x86::math::conv_direct_3x3s2();
-    code_->generate_code(ic, ih, iw, oc, oc_expand_, oh, ow, ph, pw);
+    code_ = new lite::x86::math::conv_direct();
+    code_->generate_code(ic, ih, iw, oc, oc_expand_, oh, ow, ph, pw, wh, ww, param.strides[1]);
     code_->ready();
   }
 
@@ -95,7 +94,7 @@ class DirectConv : public KernelLite<TARGET(kX86), Ptype> {
   bool flag_trans_bias_{false};
   std::vector<float> w_scale_;
   int oc_expand_;
-  lite::x86::math::conv_direct_3x3s2* code_;
+  lite::x86::math::conv_direct* code_;
 };
 
 }  // namespace x86


### PR DESCRIPTION

## 3x3s1p1

| 输入               | old  | new  | 时间减少 |
| ------------------ | ---- | ---- | -------- |
| 1,64,56,56：64核   | 2.3  | 1.7  | 26%      |
| 1,128,28,28：128核 | 2.3  | 1.64 | 28%      |
| 1,256,14,14：256核 | 2.36 | 1.6  | 28%      |
| 1,512,7,7：512核   | 3.13 | 1.7  | 45%      |
| 1,16,448,448：16核 | 50   | 10   | 80%      |


## 5x5s2p2

| 输入              | old     | new      | 时间减少 |
| ----------------- | ------- | -------- | -------- |
| 1,3,224,224：32核 | 0.93 ms | 0.516 ms | 44%      |


## 7x7s2p3

- 但其实我测试的是7x7s2p2

| 输入              | old | new | 时间减少 |
| ----------------- | --- | --- | -------- |
| 1,3,224,224：32核 | 1.7 | 0.9 | 47%      |

## resnet

| 模型        | old | new | 时间减少 |
| ----------- | --- | --- | -------- |
| resnet50    | 90  | 80  | 11%      |
| resnet50_vd | 98  | 84  | 14%      |