### PR TITLE
[NNAdapter][TIM-VX] Fix dropout op for quant models.

### DIFF
--- a/lite/kernels/nnadapter/converter/dropout.cc
+++ b/lite/kernels/nnadapter/converter/dropout.cc
@@ -37,7 +37,6 @@ int ConvertDropout(Converter* converter, OpInfo* op, Scope* scope) {
   // Output
   auto output_name = op->Output("Out").front();
   auto output_scale_name = "Out0_scale";
-  float prob_scale = scale / 127;
   std::vector<float> output_scales;
   if (op->HasOutputScale(output_scale_name, true)) {
     output_scales = op->GetOutputScale(output_scale_name, true);
@@ -49,8 +48,8 @@ int ConvertDropout(Converter* converter, OpInfo* op, Scope* scope) {
   // Prob operand
   NNAdapterOperand* prob_operand = nullptr;
   if (x_scales.size() > 0) {
-    prob_operand =
-        converter->AddConstantOperand(static_cast<int8_t>(127), {prob_scale});
+    prob_operand = converter->AddConstantOperand(
+        static_cast<int8_t>(scale > 0.0f ? 1 : -1), {fabsf(scale)});
   } else {
     prob_operand = converter->AddConstantOperand(scale);
   }

--- a/lite/kernels/nnadapter/converter/dropout.cc
+++ b/lite/kernels/nnadapter/converter/dropout.cc
@@ -37,6 +37,7 @@ int ConvertDropout(Converter* converter, OpInfo* op, Scope* scope) {
   // Output
   auto output_name = op->Output("Out").front();
   auto output_scale_name = "Out0_scale";
+  float prob_scale = scale / 127;
   std::vector<float> output_scales;
   if (op->HasOutputScale(output_scale_name, true)) {
     output_scales = op->GetOutputScale(output_scale_name, true);
@@ -46,7 +47,13 @@ int ConvertDropout(Converter* converter, OpInfo* op, Scope* scope) {
   // Input operand
   auto input_operand = converter->AddInputOperand(scope, x_name, {}, x_scales);
   // Prob operand
-  auto prob_operand = converter->AddConstantOperand(scale);
+  NNAdapterOperand* prob_operand = nullptr;
+  if (x_scales.size() > 0) {
+    prob_operand =
+        converter->AddConstantOperand(static_cast<int8_t>(127), {prob_scale});
+  } else {
+    prob_operand = converter->AddConstantOperand(scale);
+  }
   // Fuse code operand
   auto fuse_code_operand =
       converter->AddConstantOperand(static_cast<int32_t>(NNADAPTER_FUSED_NONE));


### PR DESCRIPTION
## Dropout 算子缺失量化处理导致组网失败
![01e1ba0cb53ab8704e06949b83bd6306](https://user-images.githubusercontent.com/29272811/147657913-3b3bb6c8-f4b1-45cf-88d7-22d3941f7e93.png)

![c6a79b251285e26e0acae875b6feb6c8](https://user-images.githubusercontent.com/29272811/147658057-de83ea39-824c-4511-9c20-6eef96ba2811.png)
