### PR TITLE
add constraints for convdirect fp16

### DIFF
--- a/lite/kernels/arm/conv_compute.cc
+++ b/lite/kernels/arm/conv_compute.cc
@@ -150,7 +150,7 @@ void ConvCompute<PRECISION(kFP16), PRECISION(kFP16)>::PrepareForRun() {
       ((flag_dw_5x5 && ks_equal) || (flag_dw_3x3 && kps_equal && pads_less))) {
     impl_ = new DepthwiseConv<PRECISION(kFP16), PRECISION(kFP16)>;
   } else if (param.groups == 1 && kw == 3 && sw == 2 && no_dilation &&
-             ks_equal) {
+             chin * chout < 4 * hin * win && ks_equal) {
     impl_ = new DirectConv<PRECISION(kFP16), PRECISION(kFP16)>;
   } else if (param.groups == 1 && kw == 3 && sw == 1 && no_dilation &&
              ks_equal) {


### PR DESCRIPTION
- 3x3s2
- 9a85f6bc：骁龙845

| 输入               | fp16direct | fp16gemm |
| ------------------ | ---------- | -------- |
| 1,3,224,224：32核  | 0.88       | 1.17     |
| 1,128,56,56：128核 | 7.36       | 6.82     |
| 1x256x28x28：256核 | 7.22       | 6.1      |
| 1x512x14x14：512核 | 8.8        | 6.14     |

- 4c4f947c：骁龙865

| 输入               | fp16direct | fp16gemm |
| ------------------ | ---------- | -------- |
| 1,3,224,224：32核  | 0.53       | 0.657    |
| 1,128,56,56：128核 | 4.13       | 3.64     |
| 1x256x28x28：256核 | 4.07       | 3.46     |
| 1x512x14x14：512核 | 4.78       | 3.47     |

- 添加约束后

| 输入    | old   | new   |
| ------- | ----- | ----- |
| 骁龙845 | 172.2 | 167.2 |
| 骁龙865 | 82.1  | 79.7  |