### PR TITLE
[Metal] fix_scale_op and scale_unittest

### DIFF
--- a/lite/backends/metal/metal_kernel/texture/ScaleKernel.metal
+++ b/lite/backends/metal/metal_kernel/texture/ScaleKernel.metal
@@ -23,7 +23,7 @@ struct ScaleParam {
     MetalActivationParam activationParam;
 };
 
-kernel void scale_before_bias(texture2d_array<ftype, access::read> inTexture[[texture(0)]],
+kernel void bias_after_scale(texture2d_array<ftype, access::read> inTexture[[texture(0)]],
     texture2d_array<ftype, access::write> outTexture[[texture(1)]],
     constant ScaleParam& pm[[buffer(0)]],
     uint3 gid[[thread_position_in_grid]]) {
@@ -38,7 +38,7 @@ kernel void scale_before_bias(texture2d_array<ftype, access::read> inTexture[[te
     outTexture.write(relu, gid.xy, gid.z);
 }
 
-kernel void scale_after_bias(texture2d_array<ftype, access::read> inTexture[[texture(0)]],
+kernel void bias_before_scale(texture2d_array<ftype, access::read> inTexture[[texture(0)]],
     texture2d_array<ftype, access::write> outTexture[[texture(1)]],
     constant ScaleParam& pm[[buffer(0)]],
     uint3 gid[[thread_position_in_grid]]) {

--- a/lite/kernels/metal/image_op/scale_image_compute.mm
+++ b/lite/kernels/metal/image_op/scale_image_compute.mm
@@ -73,9 +73,9 @@ void ScaleImageCompute::setup_without_mps() {
         std::make_shared<MetalBuffer>(metal_context_, sizeof(metal_param), &metal_param);
 
     if (param.bias_after_scale) {
-        function_name_ = "scale_after_bias";
+        function_name_ = "bias_after_scale";
     } else {
-        function_name_ = "scale_before_bias";
+        function_name_ = "bias_before_scale";
     }
     // pipline
     auto backend = (__bridge MetalContextImp*)metal_context_->backend();

--- a/lite/tests/unittest_py/op/test_scale_op.py
+++ b/lite/tests/unittest_py/op/test_scale_op.py
@@ -40,7 +40,6 @@ class TestScaleOp(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 4])
-
         opencl_places = [
             Place(TargetType.OpenCL, PrecisionType.FP16,
                   DataLayoutType.ImageDefault), Place(
@@ -55,7 +54,6 @@ class TestScaleOp(AutoScanTest):
             Place(TargetType.Host, PrecisionType.FP32)
         ]
         self.enable_testing_on_place(places=opencl_places)
-
         metal_places = [
             Place(TargetType.Metal, PrecisionType.FP32,
                   DataLayoutType.MetalTexture2DArray),

--- a/lite/tests/unittest_py/op/test_scale_op.py
+++ b/lite/tests/unittest_py/op/test_scale_op.py
@@ -64,7 +64,7 @@ class TestScaleOp(AutoScanTest):
             Place(TargetType.ARM, PrecisionType.FP32),
             Place(TargetType.Host, PrecisionType.FP32)
         ]
-        #self.enable_testing_on_place(places=metal_places)
+        self.enable_testing_on_place(places=metal_places)
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -149,7 +149,11 @@ class TestScaleOp(AutoScanTest):
         return program_config
 
     def sample_predictor_configs(self):
-        return self.get_predictor_configs(), ["scale"], (1e-5, 1e-5)
+        atol, rtol = 1e-5, 1e-5
+        target_str = self.get_target()
+        if target_str == "Metal":
+            atol, rtol = 1e-2, 1e-2
+        return self.get_predictor_configs(), ["scale"], (atol, rtol)
 
     def add_ignore_pass_case(self):
         pass


### PR DESCRIPTION
修复scale metal diff
diff 原因：bias after before scale 实现顺序出错