### PR TITLE
Modify Auto_Scan op single test

### DIFF
--- a/lite/tests/unittest_py/global_var_model.py
+++ b/lite/tests/unittest_py/global_var_model.py
@@ -39,7 +39,14 @@ statics_data = {
         "OpenCL": set(),
         "Metal": set()
     },
-    "not_supported_ops": {
+    "lite_not_supported_ops": {
+        "Host": set(),
+        "X86": set(),
+        "ARM": set(),
+        "OpenCL": set(),
+        "Metal": set()
+    },
+    "paddle_not_supported_ops": {
         "Host": set(),
         "X86": set(),
         "ARM": set(),
@@ -78,8 +85,12 @@ def set_out_diff_ops(target, op):
     set_value("out_diff_ops", target, op)
 
 
-def set_not_supported_ops(target, op):
-    set_value("not_supported_ops", target, op)
+def set_lite_not_supported_ops(target, op):
+    set_value("lite_not_supported_ops", target, op)
+
+
+def set_paddle_not_supported_ops(target, op):
+    set_value("paddle_not_supported_ops", target, op)
 
 
 def display():
@@ -90,21 +101,27 @@ def display():
 
     for target in targets:
         all_test_ops = statics_data["all_test_ops"][target]
-        not_supported_ops = statics_data["not_supported_ops"][target]
+        lite_not_supported_ops = statics_data["lite_not_supported_ops"][target]
+        paddle_not_supported_ops = statics_data["paddle_not_supported_ops"][
+            target]
         out_diff_ops = statics_data["out_diff_ops"][target]
         success_ops = statics_data["success_ops"][
-            target] - not_supported_ops - out_diff_ops
+            target] - lite_not_supported_ops - out_diff_ops - paddle_not_supported_ops
 
         print("Target =", target)
         print("Number of test =", len(all_test_ops))
         print("Number of success =", len(success_ops))
-        print("Number of not supported =", len(not_supported_ops))
+        print("Number of paddle not supported =",
+              len(paddle_not_supported_ops))
+        print("Number of lite not supported =", len(lite_not_supported_ops))
         print("Number of output diff =", len(out_diff_ops))
         print("\nDetails:")
         print("Success:")
         print(list(success_ops))
-        print("\nNot supported:")
-        print(list(not_supported_ops))
+        print("\npaddle Not supported:")
+        print(list(paddle_not_supported_ops))
+        print("\nlite Not supported:")
+        print(list(lite_not_supported_ops))
         print("\nOutput diff:")
         print(list(out_diff_ops))
         print("\n")

--- a/lite/tests/unittest_py/op/test_abs_op.py
+++ b/lite/tests/unittest_py/op/test_abs_op.py
@@ -51,10 +51,6 @@ class TestAbsOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        in_shape = list(program_config.inputs["input_data"].shape)
-        if predictor_config.target() == TargetType.OpenCL:
-            if len(in_shape) != 4:
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -82,14 +78,7 @@ class TestAbsOp(AutoScanTest):
         pass
 
     def test(self, *args, **kwargs):
-        target_str = self.get_target()
-        max_examples = 25
-        if target_str == "OpenCL":
-            # Make sure to generate enough valid cases for OpenCL
-            max_examples = 100
-
-        self.run_and_statis(
-            quant=False, min_success_num=25, max_examples=max_examples)
+        self.run_and_statis(quant=False, min_success_num=25, max_examples=25)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_batch_norm_op.py
+++ b/lite/tests/unittest_py/op/test_batch_norm_op.py
@@ -68,10 +68,6 @@ class TestBatchNormOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        x_shape = list(program_config.inputs["input_data"].shape)
-        if predictor_config.target() == TargetType.Metal:
-            if x_shape[0] != 1:
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -151,7 +147,16 @@ class TestBatchNormOp(AutoScanTest):
         return self.get_predictor_configs(), ["batch_norm"], (atol, rtol)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            x_shape = list(program_config.inputs["input_data"].shape)
+            if predictor_config.target() == TargetType.Metal:
+                if x_shape[0] != 1:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.ACCURACY_ERROR,
+            "The op output has diff in a specific case. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_box_coder_op.py
+++ b/lite/tests/unittest_py/op/test_box_coder_op.py
@@ -66,13 +66,6 @@ class TestBoxCoderOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        if predictor_config.target() == TargetType.OpenCL:
-            if program_config.ops[0].attrs[
-                    "code_type"] == "encode_center_size" or program_config.ops[
-                        0].attrs["axis"] != 0 or program_config.ops[0].attrs[
-                            "box_normalized"] == False or "PriorBoxVar" not in program_config.ops[
-                                0].inputs:
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -145,6 +138,15 @@ class TestBoxCoderOp(AutoScanTest):
 
     def add_ignore_pass_case(self):
         def teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.OpenCL:
+                if program_config.ops[0].attrs[
+                        "code_type"] == "encode_center_size" or program_config.ops[
+                            0].attrs["axis"] != 0 or program_config.ops[0].attrs[
+                                "box_normalized"] == False or "PriorBoxVar" not in program_config.ops[
+                                    0].inputs:
+                    return True
+
+        def teller2(program_config, predictor_config):
             if predictor_config.target() == TargetType.ARM:
                 if program_config.ops[0].attrs[
                         "code_type"] == "encode_center_size":
@@ -152,10 +154,13 @@ class TestBoxCoderOp(AutoScanTest):
             return False
 
         self.add_ignore_check_case(
-            teller1, IgnoreReasons.ACCURACY_ERROR,
+            teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite is not supported on opencl. We need to fix it as soon as possible."
+        )
+        self.add_ignore_check_case(
+            teller2, IgnoreReasons.ACCURACY_ERROR,
             "The op output has diff in a specific case on arm. We need to fix it as soon as possible."
         )
-        pass
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_concat_op.py
+++ b/lite/tests/unittest_py/op/test_concat_op.py
@@ -69,21 +69,6 @@ class TestConcatOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        target_type = predictor_config.target()
-        input_shape = program_config.inputs["input_data0"].shape
-        if target_type == TargetType.OpenCL:
-            if "AxisTensor" in program_config.ops[0].inputs:
-                return False
-            if len(input_shape) == 3 and program_config.ops[0].attrs[
-                    "axis"] == 0:
-                for v in program_config.inputs.values():
-                    if v.shape[0] % 4 != 0:
-                        return False
-        if target_type == TargetType.Metal:
-            if "AxisTensor" in program_config.ops[0].inputs:
-                return False
-            if len(input_shape) != 4:
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -175,7 +160,35 @@ class TestConcatOp(AutoScanTest):
         return self.get_predictor_configs(), ["concat"], (atol, rtol)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            input_shape = program_config.inputs["input_data0"].shape
+            if target_type == TargetType.OpenCL:
+                if "AxisTensor" in program_config.ops[0].inputs:
+                    return True
+                if len(input_shape) == 3 and program_config.ops[0].attrs[
+                        "axis"] == 0:
+                    for v in program_config.inputs.values():
+                        if v.shape[0] % 4 != 0:
+                            return True
+
+        def _teller2(program_config, predictor_config):
+            target_type = predictor_config.target()
+            input_shape = program_config.inputs["input_data0"].shape
+            if target_type == TargetType.Metal:
+                if "AxisTensor" in program_config.ops[0].inputs:
+                    return True
+                if len(input_shape) != 4:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite is not supported on metal. We need to fix it as soon as possible."
+        )
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite is not supported on metal. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_cumsum_op.py
+++ b/lite/tests/unittest_py/op/test_cumsum_op.py
@@ -38,8 +38,6 @@ class TestCumsumOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        if program_config.ops[0].attrs['reverse'] == True:
-            return False
         return True
 
     def sample_program_configs(self, draw):
@@ -80,8 +78,7 @@ class TestCumsumOp(AutoScanTest):
     def add_ignore_pass_case(self):
         def reverse_attr_not_support_teller(program_config, predictor_config):
             if program_config.ops[0].attrs['reverse'] == True:
-                return False
-            return True
+                return True
 
         self.add_ignore_check_case(
             reverse_attr_not_support_teller,

--- a/lite/tests/unittest_py/op/test_dropout_op.py
+++ b/lite/tests/unittest_py/op/test_dropout_op.py
@@ -161,6 +161,21 @@ class TestDropoutOp(AutoScanTest):
             "The dropout op's output has diff with paddle when the attr['is_test'] == false."
         )
 
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data_x"].shape)
+            dropout_implementation = program_config.ops[0].attrs[
+                "dropout_implementation"]
+            if target_type == TargetType.Metal:
+                if in_x_shape[0] != 1 or len(in_x_shape) != 4 \
+                    or dropout_implementation != 'downgrade_in_infer':
+                    return False
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.ACCURACY_ERROR,
+            "The op output has diff in a specific case on metal. We need to fix it as soon as possible."
+        )
+
     def test(self, *args, **kwargs):
         target_str = self.get_target()
         max_examples = 300

--- a/lite/tests/unittest_py/op/test_elementwise_add_op.py
+++ b/lite/tests/unittest_py/op/test_elementwise_add_op.py
@@ -106,8 +106,6 @@ class TestElementwiseAddOp(AutoScanTest):
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
         target_type = predictor_config.target()
-        in_x_shape = list(program_config.inputs["input_data_x"].shape)
-        in_y_shape = list(program_config.inputs["input_data_y"].shape)
         input_data_type = program_config.inputs["input_data_x"].dtype
         # Check config
         if target_type in [TargetType.ARM]:
@@ -123,18 +121,6 @@ class TestElementwiseAddOp(AutoScanTest):
             if predictor_config.precision(
             ) == PrecisionType.INT32 and input_data_type != np.int32:
                 return False
-
-        if target_type == TargetType.ARM:
-            if input_data_type == np.int64:
-                err_msg = "Elementwise_add op on this backend will crash with int64 dtype, we should fix it as soon as possible!"
-                return False
-        if target_type == TargetType.Metal:
-            if input_data_type != np.float32 \
-                or in_x_shape != in_y_shape \
-                or len(in_x_shape) == 3 \
-                or in_x_shape[0] != 1:
-                return False
-
         return True
 
     def sample_program_configs(self, draw):
@@ -195,7 +181,33 @@ class TestElementwiseAddOp(AutoScanTest):
         return self.get_predictor_configs(), ["elementwise_add"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            input_data_type = program_config.inputs["input_data_x"].dtype
+            in_x_shape = list(program_config.inputs["input_data_x"].shape)
+            in_y_shape = list(program_config.inputs["input_data_y"].shape)
+            if target_type == TargetType.Metal:
+                if input_data_type != np.float32 \
+                    or in_x_shape != in_y_shape \
+                    or len(in_x_shape) == 3 \
+                    or in_x_shape[0] != 1:
+                    return True
+
+        def _teller2(program_config, predictor_config):
+            target_type = predictor_config.target()
+            input_data_type = program_config.inputs["input_data_x"].dtype
+            if target_type == TargetType.ARM:
+                if input_data_type == np.int64:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on metal. We need to fix it as soon as possible."
+        )
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Elementwise_add op on this backend will crash with int64 dtype, we should fix it as soon as possible!"
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_elementwise_div_op.py
+++ b/lite/tests/unittest_py/op/test_elementwise_div_op.py
@@ -85,13 +85,6 @@ class TestElementwiseDivOp(AutoScanTest):
             if predictor_config.precision(
             ) == PrecisionType.INT32 and input_data_type != np.int32:
                 return False
-        if target_type == TargetType.Metal:
-            if input_data_type != np.float32 \
-                or in_x_shape != in_y_shape \
-                or len(in_x_shape) == 3 \
-                or in_x_shape[0] != 1:
-                return False
-
         return True
 
     def sample_program_configs(self, draw):
@@ -157,7 +150,22 @@ class TestElementwiseDivOp(AutoScanTest):
         return self.get_predictor_configs(), ["elementwise_div"], (atol, rtol)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            input_data_type = program_config.inputs["input_data_x"].dtype
+            in_x_shape = list(program_config.inputs["input_data_x"].shape)
+            in_y_shape = list(program_config.inputs["input_data_y"].shape)
+            if target_type == TargetType.Metal:
+                if input_data_type != np.float32 \
+                    or in_x_shape != in_y_shape \
+                    or len(in_x_shape) == 3 \
+                    or in_x_shape[0] != 1:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on metal. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_elementwise_sub_op.py
+++ b/lite/tests/unittest_py/op/test_elementwise_sub_op.py
@@ -84,12 +84,6 @@ class TestElementwiseSubOp(AutoScanTest):
             if predictor_config.precision(
             ) == PrecisionType.INT32 and input_data_type != np.int32:
                 return False
-        if target_type == TargetType.Metal:
-            if input_data_type != np.float32 \
-                or in_x_shape != in_y_shape \
-                or len(in_x_shape) == 3 \
-                or in_x_shape[0] != 1:
-                return False
 
         return True
 
@@ -157,8 +151,25 @@ class TestElementwiseSubOp(AutoScanTest):
             return False
 
         self.add_ignore_check_case(
-            teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            teller1, IgnoreReasons.ACCURACY_ERROR,
             "The elementwise_sub op's result is different from paddle in some case, we should fix it as soon as possible!"
+        )
+
+        def _teller2(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data_x"].shape)
+            in_y_shape = list(program_config.inputs["input_data_y"].shape)
+            input_data_type = program_config.inputs["input_data_x"].dtype
+            if target_type == TargetType.Metal:
+                if input_data_type != np.float32 \
+                    or in_x_shape != in_y_shape \
+                    or len(in_x_shape) == 3 \
+                    or in_x_shape[0] != 1:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on Metal. We need to fix it as soon as possible."
         )
 
     def test(self, *args, **kwargs):

--- a/lite/tests/unittest_py/op/test_equal_op.py
+++ b/lite/tests/unittest_py/op/test_equal_op.py
@@ -50,6 +50,7 @@ class TestEqualOp(AutoScanTest):
         target_type = predictor_config.target()
         in_x_shape = list(program_config.inputs["input_data_x"].shape)
         input_data_type = program_config.inputs["input_data_x"].dtype
+        # check config
         if predictor_config.precision(
         ) == PrecisionType.INT64 and input_data_type != np.int64:
             return False
@@ -59,9 +60,7 @@ class TestEqualOp(AutoScanTest):
         if predictor_config.precision(
         ) == PrecisionType.INT32 and input_data_type != np.int32:
             return False
-        if target_type == TargetType.Metal:
-            if len(in_x_shape) != 4 or in_x_shape[0] != 1:
-                return False
+
         return True
 
     def sample_program_configs(self, draw):

--- a/lite/tests/unittest_py/op/test_expand_op.py
+++ b/lite/tests/unittest_py/op/test_expand_op.py
@@ -54,10 +54,6 @@ class TestExpandOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        in_dtype = program_config.inputs["input_data"].dtype
-        #wait for atuo_scan_base bug fix 
-        if "float32" != in_dtype:
-            return False
         return True
 
     def sample_program_configs(self, draw):
@@ -154,7 +150,29 @@ class TestExpandOp(AutoScanTest):
         return self.get_predictor_configs(), ["expand"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_dtype = program_config.inputs["input_data"].dtype
+            if target_type == TargetType.OpenCL:
+                if "float32" != in_dtype:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.ACCURACY_ERROR,
+            "The op output has diff in a specific case on OpenCL. We need to fix it as soon as possible."
+        )
+
+        def _teller2(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_dtype = program_config.inputs["input_data"].dtype
+            if target_type == TargetType.Host:
+                if "float32" != in_dtype:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on Host. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=100)

--- a/lite/tests/unittest_py/op/test_flatten_op.py
+++ b/lite/tests/unittest_py/op/test_flatten_op.py
@@ -59,14 +59,6 @@ class TestFlattenOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        target_type = predictor_config.target()
-        in_shape = list(program_config.inputs["input_data"].shape)
-        axis = program_config.ops[0].attrs["axis"]
-        if target_type == TargetType.Metal:
-            if len(in_shape) != 4 \
-                or in_shape[0] != 1 \
-                or axis != 1:
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -123,7 +115,20 @@ class TestFlattenOp(AutoScanTest):
         return self.get_predictor_configs(), ["flatten"], (atol, rtol)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_shape = list(program_config.inputs["input_data"].shape)
+            axis = program_config.ops[0].attrs["axis"]
+            if target_type == TargetType.Metal:
+                if len(in_shape) != 4 \
+                    or in_shape[0] != 1 \
+                    or axis != 1:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on metal. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_gather_nd_op.py
+++ b/lite/tests/unittest_py/op/test_gather_nd_op.py
@@ -39,11 +39,6 @@ class TestGatherNdOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        in_dtype = program_config.inputs["input_data"].dtype
-
-        #wait for atuo_scan_base bug fix 
-        if "float32" != in_dtype:
-            return False
         return True
 
     def sample_program_configs(self, draw):
@@ -105,7 +100,17 @@ class TestGatherNdOp(AutoScanTest):
         return self.get_predictor_configs(), ["gather_nd"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.Host:
+                in_dtype = program_config.inputs["input_data"].dtype
+                #wait for atuo_scan_base bug fix 
+                if "float32" != in_dtype:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on host. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=300)

--- a/lite/tests/unittest_py/op/test_gather_op.py
+++ b/lite/tests/unittest_py/op/test_gather_op.py
@@ -49,18 +49,10 @@ class TestGatherOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
+        # check config
         in_dtype = program_config.inputs["input_data"].dtype
-        index_dtpye = program_config.inputs["index_data"].dtype
-        in_shape = list(program_config.inputs["input_data"].shape)
-
         if "float32" != in_dtype or "axis_data" not in program_config.inputs:
             return False
-
-        axis_dtpye = program_config.inputs["axis_data"].dtype
-        if predictor_config.target() == TargetType.OpenCL:
-            if "int32" != axis_dtpye or "int32" != index_dtpye or len(
-                    in_shape) != 2:
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -150,7 +142,20 @@ class TestGatherOp(AutoScanTest):
         return self.get_predictor_configs(), ["gather"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            in_dtype = program_config.inputs["input_data"].dtype
+            index_dtpye = program_config.inputs["index_data"].dtype
+            in_shape = list(program_config.inputs["input_data"].shape)
+            axis_dtpye = program_config.inputs["axis_data"].dtype
+            if predictor_config.target() == TargetType.OpenCL:
+                if "int32" != axis_dtpye or "int32" != index_dtpye or len(
+                        in_shape) != 2:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.ACCURACY_ERROR,
+            "The op output has diff in a specific case on opencl. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_generate_proposals_v2_op.py
+++ b/lite/tests/unittest_py/op/test_generate_proposals_v2_op.py
@@ -39,8 +39,9 @@ class TestGenerateProposalsOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        if program_config.ops[1].attrs["pixel_offset"] == True:
-            return False
+        # check config
+        # if program_config.ops[1].attrs["pixel_offset"] == True:
+        #     return False
         return True
 
     def sample_program_configs(self, draw):
@@ -144,11 +145,7 @@ class TestGenerateProposalsOp(AutoScanTest):
             return True
 
         self.add_ignore_check_case(
-            # IgnoreReasonsBase.PADDLE_NOT_IMPLEMENTED
-            # IgnoreReasonsBase.PADDLELITE_NOT_SUPPORT
-            # IgnoreReasonsBase.ACCURACY_ERROR
-            teller1,
-            IgnoreReasons.ACCURACY_ERROR,
+            teller1, IgnoreReasons.ACCURACY_ERROR,
             "The op output has diff. We need to fix it as soon as possible.")
 
     def test(self, *args, **kwargs):

--- a/lite/tests/unittest_py/op/test_greater_op.py
+++ b/lite/tests/unittest_py/op/test_greater_op.py
@@ -41,10 +41,6 @@ class TestAssignOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        in_dtype = program_config.inputs["data_x"].dtype
-
-        if "int32" == in_dtype:
-            return False
         return True
 
     def sample_program_configs(self, draw):
@@ -110,7 +106,16 @@ class TestAssignOp(AutoScanTest):
                                                                           1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.Host:
+                in_dtype = program_config.inputs["data_x"].dtype
+                if "int32" == in_dtype:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on host. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=300)

--- a/lite/tests/unittest_py/op/test_grid_sampler_op.py
+++ b/lite/tests/unittest_py/op/test_grid_sampler_op.py
@@ -58,12 +58,6 @@ class TestGridSamplerOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        if predictor_config.target() == TargetType.OpenCL:
-            if program_config.ops[0].attrs[
-                    "align_corners"] != True or program_config.ops[0].attrs[
-                        "padding_mode"] != "zeros" or program_config.ops[
-                            0].attrs["mode"] != "bilinear":
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -108,12 +102,21 @@ class TestGridSamplerOp(AutoScanTest):
             return True
 
         self.add_ignore_check_case(
-            # IgnoreReasonsBase.PADDLE_NOT_IMPLEMENTED
-            # IgnoreReasonsBase.PADDLELITE_NOT_SUPPORT
-            # IgnoreReasonsBase.ACCURACY_ERROR
-            teller1,
-            IgnoreReasons.ACCURACY_ERROR,
+            teller1, IgnoreReasons.ACCURACY_ERROR,
             "The op output has diff. We need to fix it as soon as possible.")
+
+        def teller2(program_config, predictor_config):
+            if predictor_config.target() == TargetType.OpenCL:
+                if program_config.ops[0].attrs[
+                        "align_corners"] != True or program_config.ops[0].attrs[
+                            "padding_mode"] != "zeros" or program_config.ops[
+                                0].attrs["mode"] != "bilinear":
+                    return True
+
+        self.add_ignore_check_case(
+            teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on opencl. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=300)

--- a/lite/tests/unittest_py/op/test_gru_op.py
+++ b/lite/tests/unittest_py/op/test_gru_op.py
@@ -37,24 +37,24 @@ class TestGruOp(AutoScanTest):
             thread=[1])
 
         # not support
-        # self.enable_testing_on_place(
-        #     TargetType.ARM, 
-        #     PrecisionType.INT8, 
-        #     DataLayoutType.NCHW, 
-        #     thread=[1, 4])
+        self.enable_testing_on_place(
+            TargetType.ARM,
+            PrecisionType.INT8,
+            DataLayoutType.NCHW,
+            thread=[1, 4])
 
         # all cases have precision diff
-        # self.enable_testing_on_place(
-        #     TargetType.ARM,
-        #     PrecisionType.FP16,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2, 4])
+        self.enable_testing_on_place(
+            TargetType.ARM,
+            PrecisionType.FP16,
+            DataLayoutType.NCHW,
+            thread=[1, 2, 4])
 
-        # self.enable_testing_on_place(
-        #     TargetType.ARM,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2, 4])
+        self.enable_testing_on_place(
+            TargetType.ARM,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2, 4])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -128,7 +128,19 @@ class TestGruOp(AutoScanTest):
         return self.get_predictor_configs(), ["gru"], (6e-4, 6e-4)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.ARM:
+                if predictor_config.precision() == PrecisionType.FP32:
+                    return True
+                if predictor_config.precision() == PrecisionType.FP16:
+                    return True
+                if predictor_config.precision() == PrecisionType.INT8:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on opencl. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=50)

--- a/lite/tests/unittest_py/op/test_lrn_op.py
+++ b/lite/tests/unittest_py/op/test_lrn_op.py
@@ -36,16 +36,20 @@ class TestLrnOp(AutoScanTest):
             DataLayoutType.NCHW,
             thread=[1, 4])
         # opencl bug will be fix in the future
-        #opencl_places = [
-        #                  Place(TargetType.OpenCL, PrecisionType.FP16, DataLayoutType.ImageDefault),
-        #                  Place(TargetType.OpenCL, PrecisionType.FP16, DataLayoutType.ImageFolder),
-        #                  Place(TargetType.OpenCL, PrecisionType.FP32, DataLayoutType.NCHW),
-        #                  Place(TargetType.OpenCL, PrecisionType.Any, DataLayoutType.ImageDefault),
-        #                  Place(TargetType.OpenCL, PrecisionType.Any, DataLayoutType.ImageFolder),
-        #                  Place(TargetType.OpenCL, PrecisionType.Any, DataLayoutType.NCHW),
-        #                  Place(TargetType.Host, PrecisionType.FP32)
-        #                 ]
-        #self.enable_testing_on_place(places=opencl_places)
+        opencl_places = [
+            Place(TargetType.OpenCL, PrecisionType.FP16,
+                  DataLayoutType.ImageDefault), Place(
+                      TargetType.OpenCL, PrecisionType.FP16,
+                      DataLayoutType.ImageFolder),
+            Place(TargetType.OpenCL, PrecisionType.FP32, DataLayoutType.NCHW),
+            Place(TargetType.OpenCL, PrecisionType.Any,
+                  DataLayoutType.ImageDefault), Place(
+                      TargetType.OpenCL, PrecisionType.Any,
+                      DataLayoutType.ImageFolder),
+            Place(TargetType.OpenCL, PrecisionType.Any, DataLayoutType.NCHW),
+            Place(TargetType.Host, PrecisionType.FP32)
+        ]
+        self.enable_testing_on_place(places=opencl_places)
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -103,7 +107,14 @@ class TestLrnOp(AutoScanTest):
         return self.get_predictor_configs(), ["lrn"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.OpenCL:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on opencl. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=150)

--- a/lite/tests/unittest_py/op/test_matmul_op.py
+++ b/lite/tests/unittest_py/op/test_matmul_op.py
@@ -33,15 +33,13 @@ class TestMulOp(AutoScanTest):
                                      DataLayoutType.NCHW)
         self.enable_testing_on_place(TargetType.X86, PrecisionType.FP32,
                                      DataLayoutType.NCHW)
-        #self.enable_testing_on_place(TargetType.Metal, PrecisionType.FP32,
+        # self.enable_testing_on_place(TargetType.Metal, PrecisionType.FP32,
         #                             DataLayoutType.NCHW)
         opencl_places = [
             Place(TargetType.OpenCL, PrecisionType.FP16,
-                  DataLayoutType.ImageFolder), Place(
+                  DataLayoutType.ImageDefault), Place(
                       TargetType.OpenCL, PrecisionType.FP16,
-                      DataLayoutType.ImageDefault), Place(
-                          TargetType.OpenCL, PrecisionType.FP16,
-                          DataLayoutType.ImageFolder),
+                      DataLayoutType.ImageFolder),
             Place(TargetType.OpenCL, PrecisionType.FP32, DataLayoutType.NCHW),
             Place(TargetType.OpenCL, PrecisionType.Any,
                   DataLayoutType.ImageDefault), Place(
@@ -137,14 +135,14 @@ class TestMulOp(AutoScanTest):
         return self.get_predictor_configs(), ["matmul"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        def teller1(program_config, predictor_config):
-            return True
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.OpenCL:
+                return True
 
-        if self.get_target() == "OpenCL":
-            self.add_ignore_check_case(
-                teller1, IgnoreReasons.ACCURACY_ERROR,
-                "The op output has diff. We need to fix it as soon as possible."
-            )
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         sample_size = 25

--- a/lite/tests/unittest_py/op/test_matrix_nms_op.py
+++ b/lite/tests/unittest_py/op/test_matrix_nms_op.py
@@ -39,10 +39,6 @@ class TestMatrixNMSOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        x_shape = list(program_config.inputs["input_data_BBoxes"].shape)
-        y_shape = list(program_config.inputs["input_data_Scores"].shape)
-        if x_shape[0] <= y_shape[0]:
-            return False
         return True
 
     def sample_program_configs(self, draw):
@@ -93,6 +89,9 @@ class TestMatrixNMSOp(AutoScanTest):
                 "input_data_Scores": TensorConfig(shape=Y_shape)
             },
             outputs={"output_data"})
+        x_shape = list(program_config.inputs["input_data_BBoxes"].shape)
+        y_shape = list(program_config.inputs["input_data_Scores"].shape)
+        assume(x_shape[0] > y_shape[0])
         return program_config
 
     def sample_predictor_configs(self):

--- a/lite/tests/unittest_py/op/test_meshgrid_op.py
+++ b/lite/tests/unittest_py/op/test_meshgrid_op.py
@@ -31,11 +31,11 @@ class TestMeshgridOp(AutoScanTest):
     def __init__(self, *args, **kwargs):
         AutoScanTest.__init__(self, *args, **kwargs)
         #input tensorlist bugs will be fixed in the future
-        #self.enable_testing_on_place(
-        #    TargetType.Host,
-        #    PrecisionType.FP32,
-        #    DataLayoutType.NCHW,
-        #    thread=[1, 4])
+        self.enable_testing_on_place(
+            TargetType.Host,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 4])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -64,7 +64,14 @@ class TestMeshgridOp(AutoScanTest):
         return self.get_predictor_configs(), ["meshgrid"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.Host:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on host. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=100)

--- a/lite/tests/unittest_py/op/test_multiclass_nms2_op.py
+++ b/lite/tests/unittest_py/op/test_multiclass_nms2_op.py
@@ -39,10 +39,6 @@ class TestMulticlassNms2Op(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        x_shape = list(program_config.inputs["input_data_BBoxes"].shape)
-        y_shape = list(program_config.inputs["input_data_Scores"].shape)
-        if x_shape[0] <= y_shape[0]:
-            return False
         return True
 
     def sample_program_configs(self, draw):
@@ -86,6 +82,9 @@ class TestMulticlassNms2Op(AutoScanTest):
                 "input_data_Scores": TensorConfig(shape=Y_shape)
             },
             outputs={"output_data", "Index"})
+        x_shape = list(program_config.inputs["input_data_BBoxes"].shape)
+        y_shape = list(program_config.inputs["input_data_Scores"].shape)
+        assume(x_shape[0] > y_shape[0])
         return program_config
 
     def sample_predictor_configs(self):

--- a/lite/tests/unittest_py/op/test_multiclass_nms3_op.py
+++ b/lite/tests/unittest_py/op/test_multiclass_nms3_op.py
@@ -40,10 +40,6 @@ class TestMulticlassNms3Op(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        x_shape = list(program_config.inputs["input_data_BBoxes"].shape)
-        y_shape = list(program_config.inputs["input_data_Scores"].shape)
-        if x_shape[0] <= y_shape[0]:
-            return False
         return True
 
     def sample_program_configs(self, draw):
@@ -90,6 +86,9 @@ class TestMulticlassNms3Op(AutoScanTest):
                 "input_data_Scores": TensorConfig(shape=Y_shape)
             },
             outputs={"output_data"})
+        x_shape = list(program_config.inputs["input_data_BBoxes"].shape)
+        y_shape = list(program_config.inputs["input_data_Scores"].shape)
+        assume(x_shape[0] > y_shape[0])
         return program_config
 
     def sample_predictor_configs(self):

--- a/lite/tests/unittest_py/op/test_multiclass_nms_op.py
+++ b/lite/tests/unittest_py/op/test_multiclass_nms_op.py
@@ -39,10 +39,6 @@ class TestMulticlassNmsOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        x_shape = list(program_config.inputs["input_data_BBoxes"].shape)
-        y_shape = list(program_config.inputs["input_data_Scores"].shape)
-        if x_shape[0] <= y_shape[0]:
-            return False
         return True
 
     def sample_program_configs(self, draw):
@@ -85,6 +81,9 @@ class TestMulticlassNmsOp(AutoScanTest):
                 "input_data_Scores": TensorConfig(shape=Y_shape)
             },
             outputs={"output_data"})
+        x_shape = list(program_config.inputs["input_data_BBoxes"].shape)
+        y_shape = list(program_config.inputs["input_data_Scores"].shape)
+        assume(x_shape[0] > y_shape[0])
         return program_config
 
     def sample_predictor_configs(self):

--- a/lite/tests/unittest_py/op/test_nearest_interp_v2_op.py
+++ b/lite/tests/unittest_py/op/test_nearest_interp_v2_op.py
@@ -46,14 +46,14 @@ class TestNearestInterpV2Op(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        in_shape = list(program_config.inputs["input_data_x"].shape)
-        scale_data = program_config.inputs["Scale"].data
-        SizeTensor = list(program_config.inputs["SizeTensor"].shape)
-        # paddle not support fp16
-        if predictor_config.precision() == PrecisionType.FP16:
-            return False
-        if in_shape[2] * scale_data[0] < 1 or in_shape[3] * scale_data[0] < 1:
-            return False
+        # in_shape = list(program_config.inputs["input_data_x"].shape)
+        # scale_data = program_config.inputs["Scale"].data
+        # SizeTensor = list(program_config.inputs["SizeTensor"].shape)
+        # # paddle not support fp16
+        # if predictor_config.precision() == PrecisionType.FP16:
+        #     return False
+        # if in_shape[2] * scale_data[0] < 1 or in_shape[3] * scale_data[0] < 1:
+        #     return False
         return True
 
     def sample_program_configs(self, draw):

--- a/lite/tests/unittest_py/op/test_not_equal_op.py
+++ b/lite/tests/unittest_py/op/test_not_equal_op.py
@@ -42,11 +42,11 @@ class TestNotEqualOp(AutoScanTest):
     def __init__(self, *args, **kwargs):
         AutoScanTest.__init__(self, *args, **kwargs)
         #output bool bugs will be fixed in the future
-        #self.enable_testing_on_place(
-        #    TargetType.Host,
-        #    PrecisionType.FP32,
-        #    DataLayoutType.NCHW,
-        #    thread=[1, 4])
+        # self.enable_testing_on_place(
+        #     TargetType.Host,
+        #     PrecisionType.FP32,
+        #     DataLayoutType.NCHW,
+        #     thread=[1, 4])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,

--- a/lite/tests/unittest_py/op/test_one_hot_v2_op.py
+++ b/lite/tests/unittest_py/op/test_one_hot_v2_op.py
@@ -30,11 +30,11 @@ import hypothesis.strategies as st
 class TestOneHotV2Op(AutoScanTest):
     def __init__(self, *args, **kwargs):
         AutoScanTest.__init__(self, *args, **kwargs)
-        #self.enable_testing_on_place(
-        #    TargetType.Host,
-        #    PrecisionType.FP32,
-        #    DataLayoutType.NCHW,
-        #    thread=[1, 4])
+        self.enable_testing_on_place(
+            TargetType.Host,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 4])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -92,7 +92,14 @@ class TestOneHotV2Op(AutoScanTest):
         return self.get_predictor_configs(), ["one_hot_v2"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.Host:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.ACCURACY_ERROR,
+            "The op output has diff in a specific case on host. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_pixel_shuffle_op.py
+++ b/lite/tests/unittest_py/op/test_pixel_shuffle_op.py
@@ -54,13 +54,13 @@ class TestPixelShuffleOp(AutoScanTest):
         self.enable_testing_on_place(places=opencl_valid_places)
 
         # metal not support now
-        # metal_places = [
-        #     Place(TargetType.Metal, PrecisionType.FP32,
-        #           DataLayoutType.MetalTexture2DArray),
-        #     Place(TargetType.Metal, PrecisionType.FP16,
-        #           DataLayoutType.MetalTexture2DArray)
-        # ]
-        # self.enable_testing_on_place(places=metal_places)
+        metal_places = [
+            Place(TargetType.Metal, PrecisionType.FP32,
+                  DataLayoutType.MetalTexture2DArray),
+            Place(TargetType.Metal, PrecisionType.FP16,
+                  DataLayoutType.MetalTexture2DArray)
+        ]
+        self.enable_testing_on_place(places=metal_places)
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -108,7 +108,14 @@ class TestPixelShuffleOp(AutoScanTest):
         return self.get_predictor_configs(), ["pixel_shuffle"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.Metal:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on metal. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_polygon_box_transform_op.py
+++ b/lite/tests/unittest_py/op/test_polygon_box_transform_op.py
@@ -36,11 +36,11 @@ class TestPolygonBoxTransformOp(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 2])
-        # self.enable_testing_on_place(
-        #     TargetType.X86,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2])
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -80,7 +80,14 @@ class TestPolygonBoxTransformOp(AutoScanTest):
                                                                          1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.X86:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_prelu_op.py
+++ b/lite/tests/unittest_py/op/test_prelu_op.py
@@ -36,11 +36,11 @@ class TestPreluOp(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 2])
-        # self.enable_testing_on_place(
-        #     TargetType.X86,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2])
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2])
         opencl_places = [
             Place(TargetType.OpenCL, PrecisionType.FP16,
                   DataLayoutType.ImageDefault), Place(
@@ -103,7 +103,14 @@ class TestPreluOp(AutoScanTest):
         return self.get_predictor_configs(), ["prelu"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.X86:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_print_op.py
+++ b/lite/tests/unittest_py/op/test_print_op.py
@@ -36,11 +36,11 @@ class TestPrintOp(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 2])
-        # self.enable_testing_on_place(
-        #     TargetType.X86,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2])
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -78,7 +78,14 @@ class TestPrintOp(AutoScanTest):
         return self.get_predictor_configs(), ["print"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.X86:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_prior_box_op.py
+++ b/lite/tests/unittest_py/op/test_prior_box_op.py
@@ -36,11 +36,11 @@ class TestPriorBoxOp(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 2])
-        # self.enable_testing_on_place(
-        #     TargetType.X86,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2])
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -111,7 +111,14 @@ class TestPriorBoxOp(AutoScanTest):
         return self.get_predictor_configs(), ["prior_box"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.X86:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_range_op.py
+++ b/lite/tests/unittest_py/op/test_range_op.py
@@ -36,11 +36,11 @@ class TestRangeOp(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 2])
-        # self.enable_testing_on_place(
-        #     TargetType.X86,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2])
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -107,7 +107,14 @@ class TestRangeOp(AutoScanTest):
         return self.get_predictor_configs(), ["range"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.X86:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_reciprocal_op.py
+++ b/lite/tests/unittest_py/op/test_reciprocal_op.py
@@ -33,11 +33,11 @@ class TestReciprocalOp(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 2])
-        # self.enable_testing_on_place(
-        #     TargetType.X86,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2])
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -65,7 +65,14 @@ class TestReciprocalOp(AutoScanTest):
         return self.get_predictor_configs(), ["reciprocal"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.X86:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_reduce_all_op.py
+++ b/lite/tests/unittest_py/op/test_reduce_all_op.py
@@ -32,11 +32,11 @@ class TestReduceAllOp(AutoScanTest):
     def __init__(self, *args, **kwargs):
         AutoScanTest.__init__(self, *args, **kwargs)
         # not support
-        # self.enable_testing_on_place(
-        #     TargetType.Host,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2])
+        self.enable_testing_on_place(
+            TargetType.Host,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
@@ -83,7 +83,14 @@ class TestReduceAllOp(AutoScanTest):
         return self.get_predictor_configs(), ["reduce_all"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.Host:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_reshape2_op.py
+++ b/lite/tests/unittest_py/op/test_reshape2_op.py
@@ -36,11 +36,11 @@ class TestReshape2Op(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 2])
-        # self.enable_testing_on_place(
-        #     TargetType.X86,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2])
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2])
 
         # opencl
         opencl_places = [
@@ -70,11 +70,6 @@ class TestReshape2Op(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        in_shape = list(program_config.inputs["input_data"].shape)
-        target = predictor_config.target()
-        # opencl has error
-        # if target in [TargetType.OpenCL]:
-        #     return False
         return True
 
     def sample_program_configs(self, draw):
@@ -120,7 +115,14 @@ class TestReshape2Op(AutoScanTest):
         return self.get_predictor_configs(), ["reshape2"], (atol, rtol)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.X86:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_reshape_op.py
+++ b/lite/tests/unittest_py/op/test_reshape_op.py
@@ -36,11 +36,11 @@ class TestReshapeOp(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 2])
-        # self.enable_testing_on_place(
-        #     TargetType.X86,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 2])
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 2])
         opencl_places = [
             Place(TargetType.OpenCL, PrecisionType.FP16,
                   DataLayoutType.ImageDefault), Place(
@@ -95,7 +95,14 @@ class TestReshapeOp(AutoScanTest):
         return self.get_predictor_configs(), ["reshape"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.X86:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_reverse_op.py
+++ b/lite/tests/unittest_py/op/test_reverse_op.py
@@ -73,7 +73,14 @@ class TestReverseOp(AutoScanTest):
         return self.get_predictor_configs(), ["reverse"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.X86:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on x86. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_rsqrt_op.py
+++ b/lite/tests/unittest_py/op/test_rsqrt_op.py
@@ -62,11 +62,7 @@ class TestRsqrtOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        in_shape = list(program_config.inputs["input_data"].shape)
-        target = predictor_config.target()
-        if target == TargetType.OpenCL:
-            if len(in_shape) != 4:
-                return False
+
         return True
 
     def sample_program_configs(self, draw):
@@ -97,7 +93,17 @@ class TestRsqrtOp(AutoScanTest):
         return self.get_predictor_configs(), ["rsqrt"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            in_shape = list(program_config.inputs["input_data"].shape)
+            target = predictor_config.target()
+            if target == TargetType.OpenCL:
+                if len(in_shape) != 4:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on opencl. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_sequence_conv_op.py
+++ b/lite/tests/unittest_py/op/test_sequence_conv_op.py
@@ -34,18 +34,15 @@ class TestSequenceConvOp(AutoScanTest):
             PrecisionType.FP32,
             DataLayoutType.NCHW,
             thread=[1, 4])
-        # self.enable_testing_on_place(
-        #     TargetType.ARM,
-        #     PrecisionType.FP32,
-        #     DataLayoutType.NCHW,
-        #     thread=[1, 4])
+        self.enable_testing_on_place(
+            TargetType.ARM,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 4])
 
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        # if predictor_config.target() == TargetType.ARM:
-        #     print("Output has diff on ARM. Skip.")
-        #     return False
         return True
 
     def sample_program_configs(self, draw):
@@ -115,7 +112,14 @@ class TestSequenceConvOp(AutoScanTest):
         return self.get_predictor_configs(), ["sequence_conv"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            if predictor_config.target() == TargetType.ARM:
+                return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.ACCURACY_ERROR,
+            "The op output has diff in a specific case on arm. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_sequence_expand_as_op.py
+++ b/lite/tests/unittest_py/op/test_sequence_expand_as_op.py
@@ -43,13 +43,6 @@ class TestSequenceExpandAsOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        target_type = predictor_config.target()
-        if target_type == TargetType.ARM:
-            if program_config.inputs["x_data"].dtype != "float32":
-                print(
-                    "The input data type only support float32 on ARM impl. Skip!"
-                )
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -115,7 +108,19 @@ class TestSequenceExpandAsOp(AutoScanTest):
                                                                       1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            if target_type == TargetType.ARM:
+                if program_config.inputs["x_data"].dtype != "float32":
+                    print(
+                        "The input data type only support float32 on ARM impl. Skip!"
+                    )
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.ACCURACY_ERROR,
+            "The op output has diff in a specific case on arm. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_sequence_expand_op.py
+++ b/lite/tests/unittest_py/op/test_sequence_expand_op.py
@@ -38,12 +38,12 @@ class TestSequenceExpandOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        dtype = program_config.inputs["x_data"].dtype
-        if "float32" != dtype:
-            print(
-                "The input data type defined in Paddle can be float32, int32, int64. But input data type only support float32 on Host target in Paddle Lite, while got data type",
-                dtype)
-            return False
+        # dtype = program_config.inputs["x_data"].dtype
+        # if "float32" != dtype:
+        #     print(
+        #         "The input data type defined in Paddle can be float32, int32, int64. But input data type only support float32 on Host target in Paddle Lite, while got data type",
+        #         dtype)
+        #     return False
         return True
 
     def sample_program_configs(self, draw):

--- a/lite/tests/unittest_py/op/test_sequence_pool_op.py
+++ b/lite/tests/unittest_py/op/test_sequence_pool_op.py
@@ -106,7 +106,7 @@ class TestSequenceReshapeOp(AutoScanTest):
         )
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=50)
+        self.run_and_statis(quant=False, max_examples=25)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_sequence_reshape_op.py
+++ b/lite/tests/unittest_py/op/test_sequence_reshape_op.py
@@ -40,6 +40,7 @@ class TestSequenceReshapeOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
+        # check config
         x_dtype = program_config.inputs["input_data"].dtype
         if predictor_config.precision() == PrecisionType.INT64:
             if x_dtype != np.int64:

--- a/lite/tests/unittest_py/op/test_sigmoid_op.py
+++ b/lite/tests/unittest_py/op/test_sigmoid_op.py
@@ -67,10 +67,6 @@ class TestSigmoidOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        x_shape = list(program_config.inputs["input_data"].shape)
-        if predictor_config.target() == TargetType.Metal:
-            if len(x_shape) != 4:
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -106,7 +102,16 @@ class TestSigmoidOp(AutoScanTest):
         return self.get_predictor_configs(), ["sigmoid"], (atol, rtol)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            x_shape = list(program_config.inputs["input_data"].shape)
+            if predictor_config.target() == TargetType.Metal:
+                if len(x_shape) != 4:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Lite does not support this op in a specific case on metal. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_slice_op.py
+++ b/lite/tests/unittest_py/op/test_slice_op.py
@@ -66,12 +66,10 @@ class TestSliceOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
+        # check config
         x_dtype = program_config.inputs["input_data"].dtype
-        if predictor_config.target() == TargetType.ARM \
-        or predictor_config.target() == TargetType.OpenCL \
-        or predictor_config.target() == TargetType.Metal :
-            if x_dtype == np.int32 or x_dtype == np.int64:
-                return False
+        if x_dtype == np.int32 or x_dtype == np.int64:
+            return False
         return True
 
     def sample_program_configs(self, draw):

--- a/lite/tests/unittest_py/op/test_squeeze2_op.py
+++ b/lite/tests/unittest_py/op/test_squeeze2_op.py
@@ -50,6 +50,7 @@ class TestSqueeze2Op(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
+        #check config
         x_dtype = program_config.inputs["input_data"].dtype
         if x_dtype == np.int32 or x_dtype == np.int64:
             return False

--- a/lite/tests/unittest_py/op/test_squeeze_op.py
+++ b/lite/tests/unittest_py/op/test_squeeze_op.py
@@ -50,6 +50,7 @@ class TestSqueezeOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
+        #check config
         x_dtype = program_config.inputs["input_data"].dtype
         if x_dtype == np.int32 or x_dtype == np.int64:
             return False

--- a/lite/tests/unittest_py/op/test_swish_op.py
+++ b/lite/tests/unittest_py/op/test_swish_op.py
@@ -70,10 +70,6 @@ class TestSwishOp(AutoScanTest):
     def is_program_valid(self,
                          program_config: ProgramConfig,
                          predictor_config: CxxConfig) -> bool:
-        x_shape = list(program_config.inputs["input_data"].shape)
-        if predictor_config.target() == TargetType.Metal:
-            if x_shape[0] != 1 or len(x_shape) != 4:
-                return False
         return True
 
     def sample_program_configs(self, draw):
@@ -103,7 +99,16 @@ class TestSwishOp(AutoScanTest):
         return self.get_predictor_configs(), ["swish"], (atol, rtol)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            x_shape = list(program_config.inputs["input_data"].shape)
+            if predictor_config.target() == TargetType.Metal:
+                if x_shape[0] != 1 or len(x_shape) != 4:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.ACCURACY_ERROR,
+            "The op output has diff in a specific case on metal. We need to fix it as soon as possible."
+        )
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_transpose_op.py
+++ b/lite/tests/unittest_py/op/test_transpose_op.py
@@ -129,13 +129,18 @@ class TestTransposeOp(AutoScanTest):
         return self.get_predictor_configs(), ["transpose"], (atol, rtol)
 
     def add_ignore_pass_case(self):
-        def teller1(program_config, predictor_config):
+        def _teller1(program_config, predictor_config):
+            x_shape = list(program_config.inputs["X_data"].shape)
+            axis = program_config.ops[0].attrs["axis"]
+            if predictor_config.target() == TargetType.Metal:
+                if x_shape[0] != 1:
+                    return True
             if predictor_config.target() == TargetType.OpenCL:
                 return True
 
         self.add_ignore_check_case(
-            teller1, IgnoreReasons.ACCURACY_ERROR,
-            "The op output has diff in a specific case. We need to fix it as soon as possible."
+            _teller1, IgnoreReasons.ACCURACY_ERROR,
+            "The op output has diff in a specific case on metal. We need to fix it as soon as possible."
         )
 
     def test(self, *args, **kwargs):


### PR DESCRIPTION
本pr的修改：
1、auto_scan_base修改，修复一些bug。
2、将某些"Invalid pragram"接口中的逻辑，移到ignore接口中或者在sample_progra_config函数中通过assume逻辑过滤。
3、原先在某些后端有问题的算子，直接注释了在"enable_testing_on_place"中的配置。修改后，在ignore中定义对应的ignore reason。

"Invalid pragram" 和 ignore 原则以及测试框架对应的行为：
![image](https://user-images.githubusercontent.com/63448337/149253256-0a60b1e3-8023-4fab-b56f-d2cffcc18889.png)

注意：有些op在某些属性组合下测试是有误差，也有部分是lite不支持（crash）,分别进行了统计
![image](https://user-images.githubusercontent.com/63448337/149253796-ceec1308-cdc8-4b8d-acb7-0ee136724e35.png)
![image](https://user-images.githubusercontent.com/63448337/149253819-d0699639-f90c-4486-9017-5c58d04b74dd.png)
