### PR TITLE
[OpenCL][kernel]fix_transpose_bug

### DIFF
--- a/lite/kernels/opencl/transpose_image_compute.cc
+++ b/lite/kernels/opencl/transpose_image_compute.cc
@@ -104,9 +104,8 @@ class TransposeComputeFloatImage
         } else if (axis_ == std::vector<int>({0, 3, 2, 1})) {
           kernel_func_name_ = "transpose_4d_perm0321";
         } else {
-          LOG(INFO) << "Unsupported axis permutation for current lite OpenCL "
-                       "kernel! ";
-          kernel_func_name_ = "transpose_4d_perm0231";
+          LOG(FATAL) << "Unsupported axis permutation for current lite OpenCL "
+                        "kernel! ";
         }
       } else {
         kernel_func_name_ = "transpose_general_buffer";

--- a/lite/kernels/opencl/transpose_image_compute.cc
+++ b/lite/kernels/opencl/transpose_image_compute.cc
@@ -104,8 +104,9 @@ class TransposeComputeFloatImage
         } else if (axis_ == std::vector<int>({0, 3, 2, 1})) {
           kernel_func_name_ = "transpose_4d_perm0321";
         } else {
-          LOG(FATAL) << "Unsupported axis permutation for current lite OpenCL "
-                        "kernel! ";
+          LOG(INFO) << "Unsupported axis permutation for current lite OpenCL "
+                       "kernel! ";
+          kernel_func_name_ = "transpose_4d_perm0231";
         }
       } else {
         kernel_func_name_ = "transpose_general_buffer";

--- a/lite/tests/unittest_py/op/test_transpose_op.py
+++ b/lite/tests/unittest_py/op/test_transpose_op.py
@@ -93,7 +93,9 @@ class TestTransposeOp(AutoScanTest):
                 st.integers(
                     min_value=0, max_value=3), min_size=4, max_size=4))
 
-        assume(sorted(axis_int32_data) == [0, 1, 2, 3])
+        assume(
+            sorted(axis_int32_data) == [0, 1, 2, 3] and
+            axis_int32_data != [0, 1, 2, 3])
         if (target == "Metal"):
             for i in range(4):
                 for j in range(4):
@@ -135,13 +137,21 @@ class TestTransposeOp(AutoScanTest):
             if predictor_config.target() == TargetType.Metal:
                 if x_shape[0] != 1:
                     return True
-            if predictor_config.target() == TargetType.OpenCL:
-                return True
 
         self.add_ignore_check_case(
             _teller1, IgnoreReasons.ACCURACY_ERROR,
             "The op output has diff in a specific case on metal. We need to fix it as soon as possible."
         )
+
+        def _teller2(program_config, predictor_config):
+            axis = program_config.ops[0].attrs["axis"]
+            if predictor_config.target() == TargetType.OpenCL:
+                if sorted(axis) == [0, 1, 2, 3] and axis[0] != 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Unsupported axis permutation for current lite OpenCL.")
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)


### PR DESCRIPTION
【背景】
py单测检验出来的transpose OpenCL的diff
【当前修复进展】
目前对4维 kernel进行了修复，对于4维NCHW，可以支持对于CHW的所有permutation组合，但是暂时不支持对batch 维度对transpose，本身lite端的模型应该也不会对batch进行transpose吧。。
另外2维HW支持正常，3维CHW的diff也已修复。