### PR TITLE
[OpenCL]Fix opencl conv bug

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/conv2d_1x1_default_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_1x1_default_kernel.cl
@@ -56,21 +56,27 @@ __kernel void conv2d_1x1_opt(
 
   int2 stride_xy = (int2)(stride, stride);
 
-  int2 ouput_pos_in_one_block0 = (int2)(out_w0, out_nh);
-  int2 in_pos_in_one_block0 =
-      ouput_pos_in_one_block0 * stride_xy + (int2)(offset, offset);
+  int h_id = out_nh % output_height;
+  int n_id = out_nh / output_height;
+  int2 ouput_pos_in_one_block0 = (int2)(out_w0, h_id);
+  int2 in_pos_in_one_block0 = ouput_pos_in_one_block0 * stride_xy +
+                              (int2)(0, n_id * input_height) +
+                              (int2)(offset, offset);
 
-  int2 ouput_pos_in_one_block1 = (int2)(out_w1, out_nh);
-  int2 in_pos_in_one_block1 =
-      ouput_pos_in_one_block1 * stride_xy + (int2)(offset, offset);
+  int2 ouput_pos_in_one_block1 = (int2)(out_w1, h_id);
+  int2 in_pos_in_one_block1 = ouput_pos_in_one_block1 * stride_xy +
+                              (int2)(0, n_id * input_height) +
+                              (int2)(offset, offset);
 
-  int2 ouput_pos_in_one_block2 = (int2)(out_w2, out_nh);
-  int2 in_pos_in_one_block2 =
-      ouput_pos_in_one_block2 * stride_xy + (int2)(offset, offset);
+  int2 ouput_pos_in_one_block2 = (int2)(out_w2, h_id);
+  int2 in_pos_in_one_block2 = ouput_pos_in_one_block2 * stride_xy +
+                              (int2)(0, n_id * input_height) +
+                              (int2)(offset, offset);
 
-  int2 ouput_pos_in_one_block3 = (int2)(out_w3, out_nh);
-  int2 in_pos_in_one_block3 =
-      ouput_pos_in_one_block3 * stride_xy + (int2)(offset, offset);
+  int2 ouput_pos_in_one_block3 = (int2)(out_w3, h_id);
+  int2 in_pos_in_one_block3 = ouput_pos_in_one_block3 * stride_xy +
+                              (int2)(0, n_id * input_height) +
+                              (int2)(offset, offset);
 
 #ifdef BIASE_CH
   CL_DTYPE4 output0 =
@@ -252,16 +258,32 @@ __kernel void conv2d_1x1_opt(
 //}
 #elif defined(PRELU_ELE)  //{
   if (out_w0 < old_w) {
-    alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos0);
+    alpha0 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(outpos_main + out_w0, out_nh % output_height));
   }
   if (out_w1 < old_w) {
-    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos1);
+    alpha1 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(outpos_main + out_w1, out_nh % output_height));
   }
   if (out_w2 < old_w) {
-    alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos2);
+    alpha2 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(outpos_main + out_w2, out_nh % output_height));
   }
   if (out_w3 < old_w) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos3);
+    alpha3 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(outpos_main + out_w3, out_nh % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{
@@ -447,16 +469,32 @@ __kernel void conv2d_1x1_h1w4c1(
 //}
 #elif defined(PRELU_ELE)  //{
   if (out_w0 < old_w) {
-    alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos0);
+    alpha0 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(outpos_main + out_w0, out_nh % output_height));
   }
   if (out_w1 < old_w) {
-    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos1);
+    alpha1 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(outpos_main + out_w1, out_nh % output_height));
   }
   if (out_w2 < old_w) {
-    alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos2);
+    alpha2 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(outpos_main + out_w2, out_nh % output_height));
   }
   if (out_w3 < old_w) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos3);
+    alpha3 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(outpos_main + out_w3, out_nh % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{

--- a/lite/backends/opencl/cl_kernel/image/conv2d_1x1_default_mali_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_1x1_default_mali_kernel.cl
@@ -92,11 +92,15 @@ __kernel void conv2d_1x1_mali_h1w2c1(
   alpha1 = alpha0;
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha0 = READ_IMG_TYPE(
-      CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(out_pos_w0_x, out_pos_y));
+  alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
+                         prelu_alpha,
+                         SAMPLER,
+                         (int2)(out_pos_w0_x, out_pos_y % output_height));
   if (out_w + 1 < output_width) {
-    alpha1 = READ_IMG_TYPE(
-        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(out_pos_w1_x, out_pos_y));
+    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
+                           prelu_alpha,
+                           SAMPLER,
+                           (int2)(out_pos_w1_x, out_pos_y % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{
@@ -231,22 +235,25 @@ __kernel void conv2d_1x1_mali_h1w2c2(
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
                          prelu_alpha,
                          SAMPLER,
-                         (int2)(out_c * old_w + out_w, out_nh));
+                         (int2)(out_c * old_w + out_w, out_nh % output_height));
   if (out_w + 1 < output_width) {
-    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w + 1, out_nh));
+    alpha1 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(out_c * old_w + out_w + 1, out_nh % output_height));
   }
-  alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                         prelu_alpha,
-                         SAMPLER,
-                         (int2)((out_c + 1) * old_w + out_w, out_nh));
+  alpha2 = READ_IMG_TYPE(
+      CL_DTYPE_CHAR,
+      prelu_alpha,
+      SAMPLER,
+      (int2)((out_c + 1) * old_w + out_w, out_nh % output_height));
   if (out_w + 1 < output_width) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)((out_c + 1) * old_w + out_w + 1, out_nh));
+    alpha3 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)((out_c + 1) * old_w + out_w + 1, out_nh % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{
@@ -450,46 +457,53 @@ __kernel void conv2d_1x1_mali_h2w2c2(
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
                          prelu_alpha,
                          SAMPLER,
-                         (int2)(out_c * old_w + out_w, out_nh));
+                         (int2)(out_c * old_w + out_w, out_nh % output_height));
   if (out_w + 1 < output_width) {
-    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w + 1, out_nh));
+    alpha1 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(out_c * old_w + out_w + 1, out_nh % output_height));
   }
   if (out_nh + 1 < output_height) {
-    alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w, out_nh + 1));
+    alpha2 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(out_c * old_w + out_w, (out_nh + 1) % output_height));
   }
   if (out_w + 1 < output_width && out_nh + 1 < output_height) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w + 1, out_nh + 1));
+    alpha3 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(out_c * old_w + out_w + 1, (out_nh + 1) % output_height));
   }
-  alpha4 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                         prelu_alpha,
-                         SAMPLER,
-                         (int2)((out_c + 1) * old_w + out_w, out_nh));
+  alpha4 = READ_IMG_TYPE(
+      CL_DTYPE_CHAR,
+      prelu_alpha,
+      SAMPLER,
+      (int2)((out_c + 1) * old_w + out_w, out_nh % output_height));
   if (out_w + 1 < output_width) {
-    alpha5 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)((out_c + 1) * old_w + out_w + 1, out_nh));
+    alpha5 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)((out_c + 1) * old_w + out_w + 1, out_nh % output_height));
   }
   if (out_nh + 1 < output_height) {
-    alpha6 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)((out_c + 1) * old_w + out_w, out_nh + 1));
+    alpha6 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)((out_c + 1) * old_w + out_w, (out_nh + 1) % output_height));
   }
   if (out_w + 1 < output_width && out_nh + 1 < output_height) {
-    alpha7 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)((out_c + 1) * old_w + out_w + 1, out_nh + 1));
+    alpha7 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)((out_c + 1) * old_w + out_w + 1, (out_nh + 1) % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{

--- a/lite/backends/opencl/cl_kernel/image/conv2d_1x1_opt_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_1x1_opt_kernel.cl
@@ -345,34 +345,39 @@ __kernel void conv2d_1x1_h1w5c1(
 //}
 #elif defined(PRELU_ELE)  //{
   if (out_w < old_w) {
-    alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w), out_nh));
+    alpha0 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w), out_nh % output_height));
   }
   if (out_w1 < old_w) {
-    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w1), out_nh));
+    alpha1 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w1), out_nh % output_height));
   }
   if (out_w2 < old_w) {
-    alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w2), out_nh));
+    alpha2 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w2), out_nh % output_height));
   }
   if (out_w3 < old_w) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w3), out_nh));
+    alpha3 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w3), out_nh % output_height));
   }
   if (out_w4 < old_w) {
-    alpha4 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w4), out_nh));
+    alpha4 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w4), out_nh % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{
@@ -617,46 +622,53 @@ __kernel void conv2d_1x1_h1w7c1(
 //}
 #elif defined(PRELU_ELE)  //{
   if (out_w < old_w) {
-    alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w), out_nh));
+    alpha0 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w), out_nh % output_height));
   }
   if (out_w1 < old_w) {
-    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w1), out_nh));
+    alpha1 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w1), out_nh % output_height));
   }
   if (out_w2 < old_w) {
-    alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w2), out_nh));
+    alpha2 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w2), out_nh % output_height));
   }
   if (out_w3 < old_w) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w3), out_nh));
+    alpha3 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w3), out_nh % output_height));
   }
   if (out_w4 < old_w) {
-    alpha4 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w4), out_nh));
+    alpha4 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w4), out_nh % output_height));
   }
   if (out_w5 < old_w) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w5), out_nh));
+    alpha3 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w5), out_nh % output_height));
   }
   if (out_w6 < old_w) {
-    alpha4 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(mad24(out_c, old_w, out_w6), out_nh));
+    alpha4 = READ_IMG_TYPE(
+        CL_DTYPE_CHAR,
+        prelu_alpha,
+        SAMPLER,
+        (int2)(mad24(out_c, old_w, out_w6), out_nh % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{
@@ -888,24 +900,27 @@ __kernel void conv2d_1x1_h2w2c1(
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
                          prelu_alpha,
                          SAMPLER,
-                         (int2)(out_c * old_w + out_w, out_nh));
+                         (int2)(out_c * old_w + out_w, out_nh % output_height));
   if (out_w1 < output_width) {
-    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w1, out_nh));
+    alpha1 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w1, out_nh % output_height));
   }
   if (out_nh1 < output_height) {
-    alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w, out_nh1));
+    alpha2 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w, out_nh1 % output_height));
   }
   if (out_w1 < output_width && out_nh1 < output_height) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w1, out_nh1));
+    alpha3 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w1, out_nh1 % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{
@@ -1131,46 +1146,53 @@ __kernel void conv2d_1x1_h2w2c2(
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
                          prelu_alpha,
                          SAMPLER,
-                         (int2)(out_c * old_w + out_w, out_nh));
+                         (int2)(out_c * old_w + out_w, out_nh % output_height));
   if (out_w1 < output_width) {
-    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w1, out_nh));
+    alpha1 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w1, out_nh % output_height));
   }
   if (out_nh1 < output_height) {
-    alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w, out_nh1));
+    alpha2 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w, out_nh1 % output_height));
   }
   if (out_w1 < output_width && out_nh1 < output_height) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w1, out_nh1));
+    alpha3 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w1, out_nh1 % output_height));
   }
-  alpha4 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                         prelu_alpha,
-                         SAMPLER,
-                         (int2)(out_c1 * old_w + out_w, out_nh));
+  alpha4 =
+      READ_IMG_TYPE(CL_DTYPE_CHAR,
+                    prelu_alpha,
+                    SAMPLER,
+                    (int2)(out_c1 * old_w + out_w, out_nh % output_height));
   if (out_w1 < output_width) {
-    alpha5 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w1, out_nh));
+    alpha5 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w1, out_nh % output_height));
   }
   if (out_nh1 < output_height) {
-    alpha6 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c1 * old_w + out_w, out_nh1));
+    alpha6 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c1 * old_w + out_w, out_nh1 % output_height));
   }
   if (out_w1 < output_width && out_nh1 < output_height) {
-    alpha7 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c1 * old_w + out_w1, out_nh1));
+    alpha7 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c1 * old_w + out_w1, out_nh1 % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{
@@ -1495,70 +1517,81 @@ __kernel void conv2d_1x1_h2w3c2(
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
                          prelu_alpha,
                          SAMPLER,
-                         (int2)(out_c * old_w + out_w, out_nh));
+                         (int2)(out_c * old_w + out_w, out_nh % output_height));
   if (out_w1 < output_width) {
-    alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w1, out_nh));
+    alpha1 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w1, out_nh % output_height));
   }
   if (out_w2 < output_width) {
-    alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w2, out_nh));
+    alpha2 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w2, out_nh % output_height));
   }
   if (out_nh1 < output_height) {
-    alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w, out_nh1));
+    alpha3 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w, out_nh1 % output_height));
   }
   if (out_w1 < output_width && out_nh1 < output_height) {
-    alpha4 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w1, out_nh1));
+    alpha4 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w1, out_nh1 % output_height));
   }
   if (out_w2 < output_width && out_nh1 < output_height) {
-    alpha5 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w2, out_nh1));
+    alpha5 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w2, out_nh1 % output_height));
   }
-  alpha6 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                         prelu_alpha,
-                         SAMPLER,
-                         (int2)(out_c1 * old_w + out_w, out_nh));
+  alpha6 =
+      READ_IMG_TYPE(CL_DTYPE_CHAR,
+                    prelu_alpha,
+                    SAMPLER,
+                    (int2)(out_c1 * old_w + out_w, out_nh % output_height));
   if (out_w1 < output_width) {
-    alpha7 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w1, out_nh));
+    alpha7 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w1, out_nh % output_height));
   }
   if (out_w2 < output_width) {
-    alpha8 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c * old_w + out_w2, out_nh));
+    alpha8 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c * old_w + out_w2, out_nh % output_height));
   }
   if (out_nh1 < output_height) {
-    alpha9 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_c1 * old_w + out_w, out_nh1));
+    alpha9 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c1 * old_w + out_w, out_nh1 % output_height));
   }
   if (out_w1 < output_width && out_nh1 < output_height) {
-    alpha10 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                            prelu_alpha,
-                            SAMPLER,
-                            (int2)(out_c1 * old_w + out_w1, out_nh1));
+    alpha10 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c1 * old_w + out_w1, out_nh1 % output_height));
   }
   if (out_w2 < output_width && out_nh1 < output_height) {
-    alpha11 = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                            prelu_alpha,
-                            SAMPLER,
-                            (int2)(out_c1 * old_w + out_w2, out_nh1));
+    alpha11 =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_c1 * old_w + out_w2, out_nh1 % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{

--- a/lite/backends/opencl/cl_kernel/image/conv2d_3x3_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_3x3_kernel.cl
@@ -248,7 +248,11 @@ __kernel void conv2d_3x3(__private const int global_size_dim0,
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(out_c, 0));
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos);
+  alpha0 = READ_IMG_TYPE(
+      CL_DTYPE_CHAR,
+      prelu_alpha,
+      SAMPLER,
+      (int2)(out_c * global_size_dim1 + out_w, out_nh % output_height));
 //}
 #elif defined(PRELU_ALL)  //{
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(0, 0));
@@ -293,7 +297,7 @@ __kernel void conv2d_3x3_multi_batch(__private const int item_ch,
   }
 
   // out_width_id_per_blk
-  int out_batch_id = item_h_id / in_h;
+  int out_batch_id = item_h_id / out_h;
   int out_w_base_id = mul24(item_ch_id, out_w);
   int out_w_id0 = item_w_id;
   int out_w_id1 = out_w_id0 + item_w;
@@ -459,33 +463,38 @@ __kernel void conv2d_3x3_multi_batch(__private const int item_ch,
   alpha[4] = alpha[0];
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha[0] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_w_base_id + out_w_id0, item_h_id));
+  alpha[0] =
+      READ_IMG_TYPE(CL_DTYPE_CHAR,
+                    prelu_alpha,
+                    SAMPLER,
+                    (int2)(out_w_base_id + out_w_id0, item_h_id % out_h));
   if (out_w_id1 < out_w) {
-    alpha[1] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id1, item_h_id));
+    alpha[1] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id1, item_h_id % out_h));
   }
   if (out_w_id2 < out_w) {
-    alpha[2] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id2, item_h_id));
+    alpha[2] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id2, item_h_id % out_h));
   }
   if (out_w_id3 < out_w) {
-    alpha[3] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id3, item_h_id));
+    alpha[3] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id3, item_h_id % out_h));
   }
   if (out_w_id4 < out_w) {
-    alpha[4] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id4, item_h_id));
+    alpha[4] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id4, item_h_id % out_h));
   }
 //}
 #elif defined(PRELU_ALL)  //{

--- a/lite/backends/opencl/cl_kernel/image/conv2d_5x5_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_5x5_kernel.cl
@@ -179,7 +179,11 @@ __kernel void conv2d_5x5(__private const int global_size_dim0,
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(out_c, 0));
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos);
+  alpha0 = READ_IMG_TYPE(
+      CL_DTYPE_CHAR,
+      prelu_alpha,
+      SAMPLER,
+      (int2)(out_c * global_size_dim1 + out_w, out_nh % output_height));
 //}
 #elif defined(PRELU_ALL)  //{
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(0, 0));

--- a/lite/backends/opencl/cl_kernel/image/conv2d_5x5_opt_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_5x5_opt_kernel.cl
@@ -350,7 +350,7 @@ __kernel void conv2d_5x5_multi_batch(__private const int item_ch,
   }
 
   // out_width_id_per_blk and out_batch_id
-  int out_batch_id = item_h_id / in_h;
+  int out_batch_id = item_h_id / out_h;
   int out_w_base_id = item_ch_id * out_w;
   int out_w_id0 = item_w_id;
   int out_w_id1 = out_w_id0 + item_w;
@@ -545,33 +545,38 @@ __kernel void conv2d_5x5_multi_batch(__private const int item_ch,
   alpha[4] = alpha[0];
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha[0] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_w_base_id + out_w_id0, item_h_id));
+  alpha[0] =
+      READ_IMG_TYPE(CL_DTYPE_CHAR,
+                    prelu_alpha,
+                    SAMPLER,
+                    (int2)(out_w_base_id + out_w_id0, item_h_id % out_h));
   if (out_w_id1 < out_w) {
-    alpha[1] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id1, item_h_id));
+    alpha[1] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id1, item_h_id % out_h));
   }
   if (out_w_id2 < out_w) {
-    alpha[2] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id2, item_h_id));
+    alpha[2] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id2, item_h_id % out_h));
   }
   if (out_w_id3 < out_w) {
-    alpha[3] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id3, item_h_id));
+    alpha[3] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id3, item_h_id % out_h));
   }
   if (out_w_id4 < out_w) {
-    alpha[4] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id4, item_h_id));
+    alpha[4] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id4, item_h_id % out_h));
   }
 //}
 #elif defined(PRELU_ALL)  //{

--- a/lite/backends/opencl/cl_kernel/image/conv2d_7x7_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_7x7_kernel.cl
@@ -131,7 +131,11 @@ __kernel void conv2d_7x7(__private const int global_size_dim0,
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(out_c, 0));
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos);
+  alpha0 = READ_IMG_TYPE(
+      CL_DTYPE_CHAR,
+      prelu_alpha,
+      SAMPLER,
+      (int2)(out_c * global_size_dim1 + out_w, out_nh % output_height));
 //}
 #elif defined(PRELU_ALL)  //{
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(0, 0));

--- a/lite/backends/opencl/cl_kernel/image/conv2d_7x7_opt_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_7x7_opt_kernel.cl
@@ -291,7 +291,8 @@ __kernel void conv2d_7x7_multi_batch(__private const int item_ch,
   }
 
   // out_width_id_per_blk and out_batch_id
-  int out_batch_id = item_h_id / in_h;
+  int out_batch_id = item_h_id / out_h;
+
   int out_w_base_id = item_ch_id * out_w;
   int out_w_id0 = item_w_id;
   int out_w_id1 = out_w_id0 + item_w;
@@ -410,11 +411,11 @@ __kernel void conv2d_7x7_multi_batch(__private const int item_ch,
           output[4] = mad(input[4].z, filter[2], output[4]);
         }
         if (ch_surplus < 1) {
-          output[0] = mad(input[0].w, filter_trans[3], output[0]);
-          output[1] = mad(input[1].w, filter_trans[3], output[1]);
-          output[2] = mad(input[2].w, filter_trans[3], output[2]);
-          output[3] = mad(input[3].w, filter_trans[3], output[3]);
-          output[4] = mad(input[4].w, filter_trans[3], output[4]);
+          output[0] = mad(input[0].w, filter[3], output[0]);
+          output[1] = mad(input[1].w, filter[3], output[1]);
+          output[2] = mad(input[2].w, filter[3], output[2]);
+          output[3] = mad(input[3].w, filter[3], output[3]);
+          output[4] = mad(input[4].w, filter[3], output[4]);
         }
       }
     }

--- a/lite/backends/opencl/cl_kernel/image/conv2d_7x7_opt_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_7x7_opt_kernel.cl
@@ -430,33 +430,38 @@ __kernel void conv2d_7x7_multi_batch(__private const int item_ch,
   alpha[4] = alpha[0];
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha[0] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                           prelu_alpha,
-                           SAMPLER,
-                           (int2)(out_w_base_id + out_w_id0, item_h_id));
+  alpha[0] =
+      READ_IMG_TYPE(CL_DTYPE_CHAR,
+                    prelu_alpha,
+                    SAMPLER,
+                    (int2)(out_w_base_id + out_w_id0, item_h_id % out_h));
   if (out_w_id1 < out_w) {
-    alpha[1] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id1, item_h_id));
+    alpha[1] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id1, item_h_id % out_h));
   }
   if (out_w_id2 < out_w) {
-    alpha[2] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id2, item_h_id));
+    alpha[2] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id2, item_h_id % out_h));
   }
   if (out_w_id3 < out_w) {
-    alpha[3] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id3, item_h_id));
+    alpha[3] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id3, item_h_id % out_h));
   }
   if (out_w_id4 < out_w) {
-    alpha[4] = READ_IMG_TYPE(CL_DTYPE_CHAR,
-                             prelu_alpha,
-                             SAMPLER,
-                             (int2)(out_w_base_id + out_w_id4, item_h_id));
+    alpha[4] =
+        READ_IMG_TYPE(CL_DTYPE_CHAR,
+                      prelu_alpha,
+                      SAMPLER,
+                      (int2)(out_w_base_id + out_w_id4, item_h_id % out_h));
   }
 //}
 #elif defined(PRELU_ALL)  //{

--- a/lite/backends/opencl/cl_kernel/image/conv2d_common_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_common_kernel.cl
@@ -264,11 +264,6 @@ __kernel void conv2d_common(__private const int global_size_dim0,
   out3 = fuse_scale(out3, 1.f, 0.f, 0.f);
 #endif
 
-  // if (out_channel_block_idx == 0 && out_width_block_idx == 0 && output_bh_idx
-  // == 0){
-  //   printf("~~~%f %f %f %f\n", out0.s0, out0.s1, out0.s2, out0.s3);
-  // }
-
   if (remain >= 4) {
     WRITE_IMG_TYPE(
         CL_DTYPE_CHAR, output, (int2)(output_w_idx, output_bh_idx), out0);

--- a/lite/backends/opencl/cl_kernel/image/conv2d_winograd_3x3s1_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_winograd_3x3s1_kernel.cl
@@ -433,19 +433,19 @@ __kernel void transform_to_output(__read_only image2d_t matrix_m,
   alpha3 = alpha0;
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha0 =
-      READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s0, oy.s0));
+  alpha0 = READ_IMG_TYPE(
+      CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s0, oy.s0 % out_height));
   if (ow.s1 < out_width && oh.s0 < out_height) {
     alpha1 = READ_IMG_TYPE(
-        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s1, oy.s0));
+        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s1, oy.s0 % out_height));
   }
   if (ow.s0 < out_width && oh.s1 < out_height) {
     alpha2 = READ_IMG_TYPE(
-        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s0, oy.s1));
+        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s0, oy.s1 % out_height));
   }
   if (ow.s1 < out_width && oh.s1 < out_height) {
     alpha3 = READ_IMG_TYPE(
-        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s1, oy.s1));
+        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s1, oy.s1 % out_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{
@@ -721,19 +721,19 @@ __kernel void transform_to_output_mali(__read_only image2d_t matrix_m,
   alpha3 = alpha0;
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha0 =
-      READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s0, oy.s0));
+  alpha0 = READ_IMG_TYPE(
+      CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s0, oy.s0 % out_height));
   if (ow.s1 < out_width && oh.s0 < out_height) {
     alpha1 = READ_IMG_TYPE(
-        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s1, oy.s0));
+        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s1, oy.s0 % out_height));
   }
   if (ow.s0 < out_width && oh.s1 < out_height) {
     alpha2 = READ_IMG_TYPE(
-        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s0, oy.s1));
+        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s0, oy.s1 % out_height));
   }
   if (ow.s1 < out_width && oh.s1 < out_height) {
     alpha3 = READ_IMG_TYPE(
-        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s1, oy.s1));
+        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ox.s1, oy.s1 % out_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{

--- a/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
@@ -250,17 +250,18 @@ __kernel void depth_conv2d(__private const int global_size_dim0,
 
   int2 pos_in_input_block =
       (int2)(out_c * input_width, batch_index * input_height);
-  int2 pos_in_filter_block =
-      (int2)(out_c * filter_width, batch_index * filter_height);
+  int2 pos_in_filter_block = (int2)(out_c * filter_width, 0);
   int filter_x = pos_in_filter_block.x;
   int filter_y = pos_in_filter_block.y;
   int input_x_base = pos_in_input_block.x + in_pos_in_one_block.x;
   int input_y_base = pos_in_input_block.y + in_pos_in_one_block.y;
+
   int2 align = {filter_width / 2, filter_height / 2};
   for (int fy = 0; fy < filter_height; ++fy) {
     int y_off = fy * dilation_h - align.y;
     for (int fx = 0; fx < filter_width; ++fx) {
       int x_off = fx * dilation_w - align.x;
+
       CL_DTYPE4 in = SELECT(
           READ_IMG_TYPE(CL_DTYPE_CHAR,
                         input,
@@ -271,6 +272,7 @@ __kernel void depth_conv2d(__private const int global_size_dim0,
             in_pos_in_one_block.y + y_off < 0 ||
             in_pos_in_one_block.x + x_off >= input_width ||
             in_pos_in_one_block.y + y_off >= input_height)));
+
       CL_DTYPE4 f = READ_IMG_TYPE(
           CL_DTYPE_CHAR, filter, SAMPLER, (int2)(filter_x + fx, filter_y + fy));
       output += in * f;

--- a/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
@@ -282,7 +282,11 @@ __kernel void depth_conv2d(__private const int global_size_dim0,
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(out_c, 0));
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos);
+  alpha0 = READ_IMG_TYPE(
+      CL_DTYPE_CHAR,
+      prelu_alpha,
+      SAMPLER,
+      (int2)(out_c * global_size_dim1 + out_w, out_nh % output_height));
 //}
 #else                     //{
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(0, 0));

--- a/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_kernel.cl
@@ -218,7 +218,11 @@ __kernel void depth_conv2d_3x3(
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(out_c, 0));
 //}
 #elif defined(PRELU_ELE)  //{
-  alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, output_pos);
+  alpha0 = READ_IMG_TYPE(
+      CL_DTYPE_CHAR,
+      prelu_alpha,
+      SAMPLER,
+      (int2)(out_c * global_size_dim1 + out_w, out_nh % output_height));
 //}
 #else                     //{
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(0, 0));
@@ -397,10 +401,10 @@ __kernel void depth_conv2d_3x3s1(__private const int ou_ch_blk,
 //}
 #elif defined(PRELU_ELE)  //{
   alpha[0] = READ_IMG_TYPE(
-      CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ou_x, ou_nh_id));
+      CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ou_x, ou_nh_id % ou_h));
   if (ou_col_id + 1 < ou_w) {
     alpha[1] = READ_IMG_TYPE(
-        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ou_x + 1, ou_nh_id));
+        CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(ou_x + 1, ou_nh_id % ou_h));
   }
 //}
 #else                     //{


### PR DESCRIPTION
1. 修复conv fuse prelu, n>1, out has diff 的问题
2. 修复conv2d_1x1_opt kernel, stride>1，读数据的问题
3. 修复conv2d_3x3_multi_batch kernel, conv2d_5x5_multi_batch, conv2d_7x7_multi_batch 获取输出的batch_id 的bug
4. 修复conv2d_7x7_multi_batch通道数为4时，filter取值错误的问题
5. 修复depth_conv2d kernel , 读filter 数据，在多batch情况下，y坐标计算错误的问题