### PR TITLE
[OPENCL]add opencl device type api, only work when opencl enable

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -73,6 +73,15 @@ bool IsOpenCLBackendValid(bool check_fp16_valid) {
   return opencl_valid;
 }
 
+int GetOpenCLDeviceType() {
+#ifdef LITE_WITH_OPENCL
+  if (IsOpenCLBackendValid()) {
+    return paddle::lite::CLRuntime::Global()->GetGpuType();
+  }
+#endif
+  return -1;
+}
+
 Tensor::Tensor(void *raw) : raw_tensor_(raw) {}
 
 // TODO(Superjomn) refine this by using another `const void* const_raw`;

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -45,6 +45,11 @@ enum class L3CacheSetMethod {
 // return true if current device supports OpenCL model
 LITE_API bool IsOpenCLBackendValid(bool check_fp16_valid = false);
 
+// return current opencl device type,
+// if opencl not enabled or IsOpenCLBackendValid return false, it will return -1
+// UNKNOWN:0, QUALCOMM_ADRENO:1, ARM_MALI:2, IMAGINATION_POWERVR:3, OTHERS:4,
+LITE_API int GetOpenCLDeviceType();
+
 struct LITE_API Tensor {
   explicit Tensor(void* raw);
   explicit Tensor(const void* raw);


### PR DESCRIPTION
add opencl device type api, only work when opencl enable

if opencl not enabled or IsOpenCLBackendValid return false, it will return -1
UNKNOWN:0, QUALCOMM_ADRENO:1, ARM_MALI:2, IMAGINATION_POWERVR:3, OTHERS:4,
