### PR TITLE
[HuaweiKirinNPU] Fix the converter of fc op to for Harmony OS

### DIFF
--- a/lite/kernels/npu/bridges/fc_op.cc
+++ b/lite/kernels/npu/bridges/fc_op.cc
@@ -82,6 +82,7 @@ int FCConverter(void* ctx, OpLite* op, KernelBase* kernel) {
   auto fc_op = fc_node->data<ge::op::FullConnection>();
   fc_op->set_input_x(*reshaped_input_node->data());
   fc_op->set_input_w(*trans_w_node->data());
+  fc_op->set_attr_num_output(n);
 
   // Add bias node if bias tensor exists
   if (HasInputArg(op_info, scope, "Bias")) {


### PR DESCRIPTION
## 问题分析
v2.9分支的android demo，在华为手机升级HarmonyOS后推理失败。
Paddle Lite 日志：
![image](https://user-images.githubusercontent.com/29272811/150710491-9bbc9021-425a-4126-a89f-c71fa5f556db.png)


Logcat 日志：
![image](https://user-images.githubusercontent.com/29272811/150710443-047e14fe-5611-4c40-b944-782c66098039.png)

原因分析：
* 主操作系统升级会同步升级手机内置的HiAI DDK版本（ROM侧）。
* ROM侧HiAI升级后，其框架层面代码将对FC算子的num_output属性进行强制检查（如不设置则默认为0），导致模型生成失败。
![image](https://user-images.githubusercontent.com/29272811/150483771-c67345ef-7e0f-4f65-b21d-9ca4f6ac0f8d.png)
