### PR TITLE
[OpenCL][ut_bugs]fix_opencl_split_bugs test=develop

### DIFF
--- a/lite/tests/unittest_py/op/test_split_op.py
+++ b/lite/tests/unittest_py/op/test_split_op.py
@@ -206,12 +206,13 @@ class TestSplitOp(AutoScanTest):
         max_examples = 50
         if target_str == "OpenCL":
             # Make sure to generate enough valid cases for OpenCL
-            max_examples = 500
+            max_examples = 100
         if target_str == "Metal":
             # Make sure to generate enough valid cases for OpenCL
             max_examples = 500
 
-        self.run_and_statis(quant=False, min_success_num=25, max_examples=100)
+        self.run_and_statis(
+            quant=False, min_success_num=25, max_examples=max_examples)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_split_op.py
+++ b/lite/tests/unittest_py/op/test_split_op.py
@@ -110,10 +110,7 @@ class TestSplitOp(AutoScanTest):
 
         def generate_input(*args, **kwargs):
             if input_type == "float32":
-                input = np.random.normal(0.0, 1.0, in_shape).astype(np.float32)
-                print("input = ", input)
-                return input
-                # return np.random.normal(0.0, 1.0, in_shape).astype(np.float32)
+                return np.random.normal(0.0, 1.0, in_shape).astype(np.float32)
             elif input_type == "int32":
                 return np.random.normal(0.0, 1.0, in_shape).astype(np.int32)
             elif input_type == "int64":
@@ -214,12 +211,7 @@ class TestSplitOp(AutoScanTest):
             # Make sure to generate enough valid cases for OpenCL
             max_examples = 500
 
-        self.run_and_statis(
-            quant=False,
-            min_success_num=25,
-            max_examples=100,
-            # reproduce=reproduce_failure('6.27.0', b'AAIEAAABAgAA')
-        )
+        self.run_and_statis(quant=False, min_success_num=25, max_examples=100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
当前修复原有kernel的diff并且扩展支持输入1 2 3 4维，对应axis=0 1 2 3，唯一的限制是输出tensor个数仍为2，是否需要支持多个tensor的split输出需要后续讨论必要性。