### PR TITLE
[OpenCL][Bug]fix conv2d_1x1_h1w4c1 and depth_conv2d bug

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/conv2d_1x1_default_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/conv2d_1x1_default_kernel.cl
@@ -360,21 +360,27 @@ __kernel void conv2d_1x1_h1w4c1(
 
   int2 stride_xy = (int2)(stride, stride);
 
-  int2 ouput_pos_in_one_block0 = (int2)(out_w0, out_nh);
-  int2 in_pos_in_one_block0 =
-      ouput_pos_in_one_block0 * stride_xy + (int2)(offset, offset);
+  int h_id = out_nh % output_height;
+  int n_id = out_nh / output_height;
+  int2 ouput_pos_in_one_block0 = (int2)(out_w0, h_id);
+  int2 in_pos_in_one_block0 = ouput_pos_in_one_block0 * stride_xy +
+                              (int2)(0, n_id * input_height) +
+                              (int2)(offset, offset);
 
-  int2 ouput_pos_in_one_block1 = (int2)(out_w1, out_nh);
-  int2 in_pos_in_one_block1 =
-      ouput_pos_in_one_block1 * stride_xy + (int2)(offset, offset);
+  int2 ouput_pos_in_one_block1 = (int2)(out_w1, h_id);
+  int2 in_pos_in_one_block1 = ouput_pos_in_one_block1 * stride_xy +
+                              (int2)(0, n_id * input_height) +
+                              (int2)(offset, offset);
 
-  int2 ouput_pos_in_one_block2 = (int2)(out_w2, out_nh);
-  int2 in_pos_in_one_block2 =
-      ouput_pos_in_one_block2 * stride_xy + (int2)(offset, offset);
+  int2 ouput_pos_in_one_block2 = (int2)(out_w2, h_id);
+  int2 in_pos_in_one_block2 = ouput_pos_in_one_block2 * stride_xy +
+                              (int2)(0, n_id * input_height) +
+                              (int2)(offset, offset);
 
-  int2 ouput_pos_in_one_block3 = (int2)(out_w3, out_nh);
-  int2 in_pos_in_one_block3 =
-      ouput_pos_in_one_block3 * stride_xy + (int2)(offset, offset);
+  int2 ouput_pos_in_one_block3 = (int2)(out_w3, h_id);
+  int2 in_pos_in_one_block3 = ouput_pos_in_one_block3 * stride_xy +
+                              (int2)(0, n_id * input_height) +
+                              (int2)(offset, offset);
 
 #ifdef BIASE_CH
   CL_DTYPE4 output0 =

--- a/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_basic_kernel.cl
@@ -128,10 +128,14 @@ __kernel void depth_conv2d_common(
     }
   }
 
+  const int out_w_blk4 = out_w_blk << 2;  // [0, W)
+  const int remain = output_width - out_w_blk4;
+  const int out_pos_x = mad24(out_c_blk, output_width, out_w_blk4);
+
   CL_DTYPE4 alpha0, alpha1, alpha2, alpha3;
 #ifdef PRELU_CH  //{
-  alpha0 = READ_IMG_TYPE(
-      CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(out_channel_block_idx, 0));
+  alpha0 =
+      READ_IMG_TYPE(CL_DTYPE_CHAR, prelu_alpha, SAMPLER, (int2)(out_c_blk, 0));
   alpha1 = alpha0;
   alpha2 = alpha0;
   alpha3 = alpha0;
@@ -140,24 +144,24 @@ __kernel void depth_conv2d_common(
   alpha0 = READ_IMG_TYPE(CL_DTYPE_CHAR,
                          prelu_alpha,
                          SAMPLER,
-                         (int2)(out_w_base_id + out_w_id0, output_bh_idx));
-  if (out_w_id1 < output_width) {
+                         (int2)(out_pos_x, out_nh % output_height));
+  if (out_w_blk4 + 1 < output_width) {
     alpha1 = READ_IMG_TYPE(CL_DTYPE_CHAR,
                            prelu_alpha,
                            SAMPLER,
-                           (int2)(out_w_base_id + out_w_id1, output_bh_idx));
+                           (int2)(out_pos_x + 1, out_nh % output_height));
   }
-  if (out_w_id2 < output_width) {
+  if (out_w_blk4 + 2 < output_width) {
     alpha2 = READ_IMG_TYPE(CL_DTYPE_CHAR,
                            prelu_alpha,
                            SAMPLER,
-                           (int2)(out_w_base_id + out_w_id2, output_bh_idx));
+                           (int2)(out_pos_x + 2, out_nh % output_height));
   }
-  if (out_w_id3 < output_width) {
+  if (out_w_blk4 + 3 < output_width) {
     alpha3 = READ_IMG_TYPE(CL_DTYPE_CHAR,
                            prelu_alpha,
                            SAMPLER,
-                           (int2)(out_w_base_id + out_w_id3, output_bh_idx));
+                           (int2)(out_pos_x + 3, out_nh % output_height));
   }
 //}
 #elif defined(PRELU_ALL)  //{
@@ -182,9 +186,6 @@ __kernel void depth_conv2d_common(
   out3 = fuse_scale(out3, 1.f, 0.f, 0.f);
 #endif
 
-  const int out_w_blk4 = out_w_blk << 2;  // [0, W)
-  const int remain = output_width - out_w_blk4;
-  const int out_pos_x = mad24(out_c_blk, output_width, out_w_blk4);
   if (remain >= 4) {
     WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x, out_nh), out0);
     WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(out_pos_x + 1, out_nh), out1);

--- a/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/depthwise_conv2d_kernel.cl
@@ -66,8 +66,7 @@ __kernel void depth_conv2d_3x3(
   int2 pos_in_input_block =
       (int2)(out_c * input_width, batch_index * input_height);
 
-  int2 pos_in_filter_block =
-      (int2)(out_c * filter_width, batch_index * filter_height);
+  int2 pos_in_filter_block = (int2)(out_c * filter_width, 0);
 
   int filter_x = pos_in_filter_block.x;
   int filter_y = pos_in_filter_block.y;

--- a/lite/kernels/opencl/conv_image_compute.cc
+++ b/lite/kernels/opencl/conv_image_compute.cc
@@ -360,10 +360,10 @@ void ConvImageCompute::PrepareForRun() {
     } else if (filter_tensor_c_ == 1 && input_tensor_c_ == output_tensor_c_
 #ifdef DEPTH_CONV_USE_SPL
                &&
-               filter_tensor_h_ != 3
+               (filter_tensor_h_ != 3 || filter_tensor_w_ != 3)
 #endif
 #undef DEPTH_CONV_USE_SPL
-               ) {
+                   ) {
       // common depth_conv2d
       kernel_func_names_.push_back("depth_conv2d");
       kernel_func_paths_.push_back("image/depthwise_conv2d_basic_kernel.cl");


### PR DESCRIPTION
1. 修复 conv2d_1x1_h1w4c1 stride>1 bug
2. 修复 depth_conv2d_common prelu 使用了未定义的变量
3. 修复depthwise_conv2d_3x3 读filter的bug
4. 修复depthwise_conv2d 的调用逻辑
5. 修复完以上bug之后，还存在filter_w==1 && filter_h==1会调用到conv1x1_opt kernel的bug(input:[1 2 2 2], filter:[2 1 1 1]),以及input_w==1 && input_h==1 会调用到fc op的diff, 这属于conv_image_compute 调用逻辑问题，待修复