### PR TITLE
autoscan support cambricon_mlu

### DIFF
--- a/lite/api/python/setup.py.in
+++ b/lite/api/python/setup.py.in
@@ -76,7 +76,8 @@ if '${LITE_WITH_NNADAPTER}' == 'ON':
                     continue
                 lib_file_path = os.path.join(driver_hal_lib_path, lib_name)
                 shutil.copy(lib_file_path, LIB_PATH)
-                command = "patchelf --set-rpath '$ORIGIN/' " + LIB_PATH + "/" + lib_name
+                rpath = os.popen("patchelf --print-rpath " + LIB_PATH + "/" + lib_name).read().strip('\n')
+                command = "patchelf --set-rpath '$ORIGIN/:'" + rpath + " " + LIB_PATH + "/" + lib_name
                 if os.system(command) != 0:
                     raise Exception("patch nnadapter driver hal so failed, command: %s" % command)
                 PACKAGE_DATA['paddlelite.libs'] += [lib_name]

--- a/lite/tests/unittest_py/global_var_model.py
+++ b/lite/tests/unittest_py/global_var_model.py
@@ -26,7 +26,8 @@ statics_data = {
         "OpenCL": set(),
         "Metal": set(),
         "NNAdapter": {
-            "kunlunxin_xtcl": set()
+            "kunlunxin_xtcl": set(),
+            "cambricon_mlu": set()
         }
     },
     "success_ops": {
@@ -36,7 +37,8 @@ statics_data = {
         "OpenCL": set(),
         "Metal": set(),
         "NNAdapter": {
-            "kunlunxin_xtcl": set()
+            "kunlunxin_xtcl": set(),
+            "cambricon_mlu": set()
         }
     },
     "out_diff_ops": {
@@ -46,7 +48,8 @@ statics_data = {
         "OpenCL": set(),
         "Metal": set(),
         "NNAdapter": {
-            "kunlunxin_xtcl": set()
+            "kunlunxin_xtcl": set(),
+            "cambricon_mlu": set()
         }
     },
     "lite_not_supported_ops": {
@@ -56,7 +59,8 @@ statics_data = {
         "OpenCL": set(),
         "Metal": set(),
         "NNAdapter": {
-            "kunlunxin_xtcl": set()
+            "kunlunxin_xtcl": set(),
+            "cambricon_mlu": set()
         }
     },
     "paddle_not_supported_ops": {
@@ -66,7 +70,8 @@ statics_data = {
         "OpenCL": set(),
         "Metal": set(),
         "NNAdapter": {
-            "kunlunxin_xtcl": set()
+            "kunlunxin_xtcl": set(),
+            "cambricon_mlu": set()
         }
     },
 }

--- a/tools/ci_tools/ci_autoscan_nnadapter.sh
+++ b/tools/ci_tools/ci_autoscan_nnadapter.sh
@@ -9,6 +9,7 @@ OS="android"
 ARCH="armv8"
 TOOLCHAIN="gcc"
 NNADAPTER_DEVICE_NAMES=""
+NNADAPTER_CAMBRICON_MLU_SDK_ROOT="/usr/local/neuware"
 # Python version
 PYTHON_VERSION=3.7
 # Absolute path of Paddle-Lite source code.
@@ -85,12 +86,18 @@ function build_and_test {
   cd $WORKSPACE
   # Step1. Compiling python installer
   local cmd_line=""
-  if [ "$NNADAPTER_DEVICE_NAMES" = "kunlunxin_xtcl" ]; then 
-      cmd_line="./lite/tools/build_linux.sh --arch=$ARCH --with_nnadapter=ON --nnadapter_with_kunlunxin_xtcl=ON  --nnadapter_kunlunxin_xtcl_sdk_url=$NNADAPTER_KUNLUNXIN_XTCL_SDK_URL --with_python=ON --python_version=$PYTHON_VERSION"
-  else
-      echo "NNADAPTER_DEVICE_NAMES=$NNADAPTER_DEVICE_NAMES is not support!"
-      exit 1
-  fi
+  case $NNADAPTER_DEVICE_NAMES in
+      "kunlunxin_xtcl")
+          cmd_line="./lite/tools/build_linux.sh --arch=$ARCH --with_nnadapter=ON --nnadapter_with_kunlunxin_xtcl=ON  --nnadapter_kunlunxin_xtcl_sdk_url=$NNADAPTER_KUNLUNXIN_XTCL_SDK_URL --with_python=ON --python_version=$PYTHON_VERSION"
+          ;;
+      "cambricon_mlu")
+          cmd_line="./lite/tools/build_linux.sh --arch=$ARCH --with_nnadapter=ON --nnadapter_with_cambricon_mlu=ON  --nnadapter_cambricon_mlu_sdk_root=$NNADAPTER_CAMBRICON_MLU_SDK_ROOT --with_python=ON --python_version=$PYTHON_VERSION --with_extra=ON --with_log=ON --with_exception=ON full_publish"
+          ;;
+      *)
+          echo "NNADAPTER_DEVICE_NAMES=$NNADAPTER_DEVICE_NAMES is not support!"
+          exit 1
+  esac  
+  
   $cmd_line
 
   # Step2. Checking results: cplus and python inference lib
@@ -147,6 +154,11 @@ function main() {
               NNADAPTER_DEVICE_NAMES="kunlunxin_xtcl"
               shift
               ;;
+          --nnadapter_with_cambricon_mlu=*)
+              NNADAPTER_WITH_CAMBRICON_MLU="${i#*=}"
+              NNADAPTER_DEVICE_NAMES="cambricon_mlu"
+              shift
+              ;;
           --nnadapter_kunlunxin_xtcl_sdk_root=*)
               NNADAPTER_KUNLUNXIN_XTCL_SDK_ROOT="${i#*=}"
               shift
@@ -157,6 +169,10 @@ function main() {
               ;;
           --nnadapter_kunlunxin_xtcl_sdk_env=*)
               NNADAPTER_KUNLUNXIN_XTCL_SDK_ENV="${i#*=}"
+              shift
+              ;;
+          --nnadapter_cambricon_mlu_sdk_root=*)
+              NNADAPTER_CAMBRICON_MLU_SDK_ROOT="${i#*=}"
               shift
               ;;
           *)


### PR DESCRIPTION
+ 更新：
   - 修复 driver hal 依赖的so 原rpath路径被`$ORIGIN/ `覆盖的错误，现在更正为在原有rpath的基础上新增`$ORIGIN/ `搜索路径
   - 增加 autoscan 对 cambricon mlu 的支持
+ 备注：增加rpath的路径：便于用户在使用pip安装Paddle-Lite whl包时，运行不用额外设置Paddle-Lite lib的搜索路径，就可以找到nnadapter driver hal所依赖的so。如果不设置rpath，用户在使用python运行Paddle-Lite时会报找不到lib相关的问题。此修改只适用于driver hal 直接依赖的so，间接依赖的so（例如sdk）还需要用户自己保证运行时库的搜索路径正确。