### PR TITLE
[Auto_Scan]support test model

### DIFF
--- a/lite/tests/unittest_py/auto_scan_base.py
+++ b/lite/tests/unittest_py/auto_scan_base.py
@@ -49,6 +49,22 @@ parser.add_argument(
     ],
     required=True)
 parser.add_argument(
+    "--url",
+    type=str,
+    help="Address of model download in model test", )
+parser.add_argument(
+    "--file_name",
+    type=str,
+    help="File name of the compressed model package downloaded in the model test",
+)
+parser.add_argument(
+    "--model_name",
+    type=str,
+    help="Model name(That is, the prefix of the compressed package) in model test",
+)
+parser.add_argument(
+    "--input_shapes", help="The tested model's input_shapes", action="append")
+parser.add_argument(
     "--nnadapter_device_names",
     default="",
     type=str,
@@ -131,6 +147,10 @@ class AutoScanBaseTest(unittest.TestCase):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def prepare_input_data(self, draw):
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def sample_predictor_configs(self):
         raise NotImplementedError
 
@@ -148,7 +168,7 @@ class AutoScanBaseTest(unittest.TestCase):
                          predictor_config: CxxConfig) -> bool:
         return True
 
-    def run_test_config(self, model, params, prog_config, pred_config,
+    def run_test_config(self, model, params, pred_config,
                         feed_data) -> Dict[str, np.ndarray]:
         '''
         Test a single case.
@@ -158,17 +178,15 @@ class AutoScanBaseTest(unittest.TestCase):
         self.available_passes_in_framework = self.available_passes_in_framework | set(
             pred_config.pass_builder().all_passes())
 
-        for name, _ in prog_config.inputs.items():
+        for name in feed_data:
             input_tensor = predictor.get_input_handle(name)
             input_tensor.copy_from_cpu(feed_data[name]['data'])
             if feed_data[name]['lod'] is not None:
                 input_tensor.set_lod(feed_data[name]['lod'])
         predictor.run()
         result = {}
-        for out_name, o_name in zip(prog_config.outputs,
-                                    predictor.get_output_names()):
-            result[out_name] = predictor.get_output_handle(o_name).copy_to_cpu(
-            )
+        for o_name in predictor.get_output_names():
+            result[o_name] = predictor.get_output_handle(o_name).copy_to_cpu()
         return result
 
     @abc.abstractmethod
@@ -248,6 +266,14 @@ class AutoScanBaseTest(unittest.TestCase):
     @abc.abstractmethod
     def success_log(self, msg: str):
         logging.info("SUCCESS: " + msg)
+
+    @abc.abstractmethod
+    def is_model_test(self) -> bool:
+        return False
+
+    @abc.abstractmethod
+    def get_model(self, draw):
+        raise NotImplementedError
 
     @abc.abstractmethod
     def create_inference_config(self,
@@ -371,8 +397,8 @@ class AutoScanBaseTest(unittest.TestCase):
                 base_config = self.create_inference_config(ir_optim=False)
                 logging.info('[ProgramConfig]: ' + str(prog_config))
                 results.append(
-                    self.run_test_config(model, params, prog_config,
-                                         base_config, feed_data))
+                    self.run_test_config(model, params, base_config,
+                                         feed_data))
                 if paddle_lite_not_support_flag:
                     gl.set_lite_not_supported_ops(
                         self.get_target(),
@@ -411,6 +437,43 @@ class AutoScanBaseTest(unittest.TestCase):
         self.assertTrue(status)
         gl.set_success_ops(self.get_target(),
                            self.get_nnadapter_device_name(), sys.argv[0])
+
+    def run_model_test(self, inputs_configs=None, model=None, params=None):
+        status = True
+        paddlelite_configs, _, (atol_, rtol_) = self.sample_predictor_configs()
+        for inputs_config in inputs_configs:
+            feed_data = {}
+            for name, tensor_config in inputs_config.items():
+                feed_data[name] = {
+                    'data': tensor_config.data,
+                    'lod': tensor_config.lod
+                }
+
+            results: List[Dict[str, np.ndarray]] = []
+
+            # baseline: cpu no ir_optim run
+            base_config = self.create_inference_config(ir_optim=False)
+            results.append(
+                self.run_test_config(model, params, base_config, feed_data))
+
+            for paddlelite_config in paddlelite_configs:
+                pred_config = paddlelite_config.value()
+
+                try:
+                    result, opt_model_bytes = self.run_lite_config(
+                        model, params, feed_data, pred_config)
+                    results.append(result)
+                    self.assert_tensors_near(atol_, rtol_, results[-1],
+                                             results[0])
+                except Exception as e:
+                    self.fail_log(
+                        self.paddlelite_config_str(pred_config) +
+                        '\033[1;31m \nERROR INFO: {}\033[0m'.format(str(e)))
+                    status = False
+                    break
+                self.success_log('PredictorConfig: ' +
+                                 self.paddlelite_config_str(pred_config))
+            self.assertTrue(status)
 
     def inference_config_str(self, config) -> bool:
         dic = {}
@@ -477,12 +540,15 @@ class AutoScanBaseTest(unittest.TestCase):
                         main_block.op(i).type(), target_, precision_, layout_,
                         current_target_, current_precision_, current_layout_))
 
-    def run_and_statis(self,
-                       quant=False,
-                       max_examples=100,
-                       reproduce=None,
-                       min_success_num=25,
-                       passes=None):
+    def run_and_statis(
+            self,
+            quant=False,
+            max_examples=100,
+            reproduce=None,
+            min_success_num=25,
+            passes=None,
+            model=None,
+            params=None, ):
         self.init_statistical_parameters()
         settings.register_profile(
             "dev",
@@ -507,8 +573,15 @@ class AutoScanBaseTest(unittest.TestCase):
         def program_generator(draw):
             return self.sample_program_configs(draw)
 
+        def inputs_generator(draw):
+            return self.prepare_input_data(draw)
+
         def run_test(prog_config):
             return self.run_test(quant=quant, prog_configs=[prog_config])
+
+        def run_model_test(inputs_configs):
+            return self.run_model_test(
+                inputs_configs=[inputs_configs], model=model, params=params)
 
         # if current unittest is not active on the input targ    paddlelite_not_support_flag = Trueet, we will exit directly.
         gl.set_all_test_ops(self.get_target(),
@@ -524,37 +597,50 @@ class AutoScanBaseTest(unittest.TestCase):
                 "Args Error: Please set nnadapter_device_names when target=nnadapter!"
             )
 
-        generator = st.composite(program_generator)
-        loop_func = given(generator())(run_test)
+        if self.is_model_test():
+            generator = st.composite(inputs_generator)
+            loop_func = given(generator())(run_model_test)
+        else:
+            generator = st.composite(program_generator)
+            loop_func = given(generator())(run_test)
+
         if reproduce is not None:
             loop_func = reproduce(loop_func)
         logging.info("Start to running test of {}".format(type(self)))
         loop_func()
-        logging.info(
-            "===================Statistical Information===================")
-        logging.info("Number of Generated Programs: {}".format(max_examples))
-        logging.info("Number of Predictor Kinds: {}".format(
-            int(self.num_predictor_kinds)))
-        self.assertTrue(self.num_predictor_kinds > 0,
-                        "Number of Predictor Kinds must be greater than 0")
-        logging.info("Number of Ran Programs: {}".format(
-            self.num_ran_programs_list))
-        logging.info("Number of Invalid Programs: {}".format(
-            self.num_invalid_programs_list))
-        logging.info("Number of Ignored Tests: {}".format(
-            self.num_ignore_tests_list))
-        successful_ran_programs = int(
-            (sum(self.num_ran_programs_list) + sum(self.num_ignore_tests_list))
-            / self.num_predictor_kinds)
+        if self.is_model_test():
+            logging.info(
+                "===================Statistical Information===================")
+            logging.info("Number of Input Configs: {}".format(max_examples))
+            logging.info("Number of Predictor Kinds: {}".format(
+                int(self.num_predictor_kinds)))
+        else:
+            logging.info(
+                "===================Statistical Information===================")
+            logging.info("Number of Generated Programs: {}".format(
+                max_examples))
+            logging.info("Number of Predictor Kinds: {}".format(
+                int(self.num_predictor_kinds)))
+            self.assertTrue(self.num_predictor_kinds > 0,
+                            "Number of Predictor Kinds must be greater than 0")
+            logging.info("Number of Ran Programs: {}".format(
+                self.num_ran_programs_list))
+            logging.info("Number of Invalid Programs: {}".format(
+                self.num_invalid_programs_list))
+            logging.info("Number of Ignored Tests: {}".format(
+                self.num_ignore_tests_list))
+            successful_ran_programs = int(
+                (sum(self.num_ran_programs_list) +
+                 sum(self.num_ignore_tests_list)) / self.num_predictor_kinds)
 
-        logging.info(
-            "Number of successfully ran programs approximately equal to {}".
-            format(successful_ran_programs))
-        if successful_ran_programs < min_success_num:
-            logging.fatal(
-                "At least {} programs need to ran successfully, but now only about {} programs satisfied.".
-                format(min_success_num, successful_ran_programs))
-            assert False
+            logging.info(
+                "Number of successfully ran programs approximately equal to {}".
+                format(successful_ran_programs))
+            if successful_ran_programs < min_success_num:
+                logging.fatal(
+                    "At least {} programs need to ran successfully, but now only about {} programs satisfied.".
+                    format(min_success_num, successful_ran_programs))
+                assert False
 
     @abc.abstractmethod
     def run_lite_config(self, model, params, feed_data,

--- a/lite/tests/unittest_py/auto_scan_test.py
+++ b/lite/tests/unittest_py/auto_scan_test.py
@@ -17,6 +17,22 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("--target")
 parser.add_argument(
+    "--url",
+    type=str,
+    help="Address of model download in model test", )
+parser.add_argument(
+    "--file_name",
+    type=str,
+    help="File name of the compressed model package downloaded in the model test",
+)
+parser.add_argument(
+    "--model_name",
+    type=str,
+    help="Model name(That is, the prefix of the compressed package) in model test",
+)
+parser.add_argument(
+    "--input_shapes", help="The tested model's input_shapes", action="append")
+parser.add_argument(
     "--nnadapter_device_names",
     default="",
     type=str,

--- a/lite/tests/unittest_py/model_test/MobileNetV1_test.py
+++ b/lite/tests/unittest_py/model_test/MobileNetV1_test.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import tempfile
+import os
+sys.path.append('../')
+
+from auto_scan_test import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+
+class TestMobileNetV1(AutoScanTest):
+    def __init__(self, *args, **kwargs):
+        AutoScanTest.__init__(self, *args, **kwargs)
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1])
+
+    def is_model_test(self) -> bool:
+        return True
+
+    def get_model(self):
+        # Download and unzip model
+        URL = "https://paddle-inference-dist.bj.bcebos.com/AI-Rank/mobile/MobileNetV1.tar.gz"
+        model_name = "MobileNetV1"
+        file_name = "MobileNetV1.tar.gz"
+
+        # Save model in temporary directory and load model into memory
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.system("wget -P {} {}".format(tmpdirname, URL))
+            os.system("tar -zvxf {0}/{1} -C {0}".format(tmpdirname, file_name))
+            with open("{}/{}/inference.pdmodel".format(tmpdirname, model_name),
+                      "rb") as f:
+                model = f.read()
+            with open("{}/{}/inference.pdiparams".format(
+                    tmpdirname, model_name), "rb") as f:
+                params = f.read()
+            return model, params
+
+    def prepare_input_data(self, draw):
+        ih = draw(st.integers(min_value=32, max_value=512))
+        oh = ih
+        in_shape = [1, 3, ih, oh]
+        inputs = {"inputs": TensorConfig(shape=in_shape)}
+        return inputs
+
+    def sample_predictor_configs(self):
+        return self.get_predictor_configs(), [""], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        model, params = self.get_model()
+        self.run_and_statis(
+            quant=False,
+            model=model,
+            params=params,
+            min_success_num=1,
+            max_examples=10)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[''])

--- a/lite/tests/unittest_py/model_test/model_test_base.py
+++ b/lite/tests/unittest_py/model_test/model_test_base.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import tempfile
+import os
+sys.path.append('../')
+
+import paddle.inference as paddle_infer
+from auto_scan_test import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+
+
+class TestMobileNetV1(AutoScanTest):
+    def __init__(self, *args, **kwargs):
+        AutoScanTest.__init__(self, *args, **kwargs)
+        self.enable_testing_on_place(
+            TargetType.X86,
+            PrecisionType.FP32,
+            DataLayoutType.NCHW,
+            thread=[1, 4])
+
+    def is_model_test(self) -> bool:
+        return True
+
+    def get_model(self):
+        # Download and unzip model
+        URL = self.args.url
+        model_name = self.args.model_name
+        file_name = self.args.file_name
+
+        # Save model in temporary directory and load model into memory
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.system("wget -P {} {}".format(tmpdirname, URL))
+            os.system("tar -zvxf {0}/{1} -C {0}".format(tmpdirname, file_name))
+            with open("{}/{}/inference.pdmodel".format(tmpdirname, model_name),
+                      "rb") as f:
+                model = f.read()
+            with open("{}/{}/inference.pdiparams".format(
+                    tmpdirname, model_name), "rb") as f:
+                params = f.read()
+
+            # acquire input names
+            paddle_config = self.create_inference_config(ir_optim=False)
+            paddle_config.set_model_buffer(model,
+                                           len(model), params, len(params))
+            predictor = paddle_infer.create_predictor(paddle_config)
+            self.input_names = predictor.get_input_names()
+
+            return model, params
+
+    def strList_to_intList(self, input_shape):
+        out = []
+        for i in input_shape.split(","):
+            out.append(int(i))
+        return out
+
+    def prepare_input_data(self, draw):
+        inputs = {}
+        assert len(self.input_names) == len(self.args.input_shapes)
+        for i in range(len(self.input_names)):
+            input_shape = self.strList_to_intList(self.args.input_shapes[i])
+            inputs[self.input_names[i]] = TensorConfig(shape=input_shape)
+        return inputs
+
+    def sample_predictor_configs(self):
+        return self.get_predictor_configs(), [""], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        model, params = self.get_model()
+        self.run_and_statis(
+            quant=False,
+            model=model,
+            params=params,
+            min_success_num=1,
+            max_examples=1)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[''])

--- a/lite/tests/unittest_py/model_test/run_model_test.py
+++ b/lite/tests/unittest_py/model_test/run_model_test.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+# test MobileNetV1 
+URL = "url"
+MODEL_NAME = "model_name"
+FILE_NAME = "file_name"
+INPUT_SHAPES = "input_shapes"
+
+all_configs = []
+
+MobileNetV1_config = {
+    "url":
+    "https://paddle-inference-dist.bj.bcebos.com/AI-Rank/mobile/MobileNetV1.tar.gz",
+    "model_name": "MobileNetV1",
+    "file_name": "MobileNetV1.tar.gz",
+    "input_shapes": ["1,3,512,512"]
+}
+
+MobileNetV2_config = {
+    "url":
+    "https://paddle-inference-dist.bj.bcebos.com/AI-Rank/mobile/MobileNetV2.tar.gz",
+    "model_name": "MobileNetV2",
+    "file_name": "MobileNetV2.tar.gz",
+    "input_shapes": ["1,3,512,512"]
+}
+
+all_configs.append(MobileNetV1_config)
+all_configs.append(MobileNetV2_config)
+
+for config in all_configs:
+    input_info_str = ""
+    for input_shape in config[INPUT_SHAPES]:
+        input_info_str = input_info_str + " --input_shapes={}".format(
+            input_shape)
+    command = "python3.7 {}/model_test_base.py --target=X86 --url={} --model_name={} --file_name={} {}".format(
+        os.getcwd(), config[URL], config[MODEL_NAME], config[FILE_NAME],
+        input_info_str)
+    print(command)
+    os.system(command)


### PR DESCRIPTION
框架支持模型测试：
新增目录：model_test
运行方式（x86机器上）：python3.x MobileNetV1_test.py  --target=X86 #测试MobileNetV1模型。
新增模型测试的方法，以MobileNetV1为例，新增一个单测文件：
```python
class TestMobileNetV1(AutoScanTest):
    def __init__(self, *args, **kwargs):
        AutoScanTest.__init__(self, *args, **kwargs)
        self.enable_testing_on_place(
            TargetType.X86,
            PrecisionType.FP32,
            DataLayoutType.NCHW,
            thread=[1])

    def is_model_test(self) -> bool:
        return True

    def get_model(self):
        # Download and unzip model
        URL = "https://paddle-inference-dist.bj.bcebos.com/AI-Rank/mobile/MobileNetV1.tar.gz"
        model_name = "MobileNetV1"
        file_name = "MobileNetV1.tar.gz"

        # Save model in temporary directory and load model into memory
        with tempfile.TemporaryDirectory() as tmpdirname:
            os.system("wget -P {} {}".format(tmpdirname, URL))
            os.system("tar -zvxf {0}/{1} -C {0}".format(tmpdirname, file_name))
            with open("{}/{}/inference.pdmodel".format(tmpdirname, model_name),
                      "rb") as f:
                model = f.read()
            with open("{}/{}/inference.pdiparams".format(
                    tmpdirname, model_name), "rb") as f:
                params = f.read()
            return model, params

    def prepare_input_data(self, draw):
        ih = draw(st.integers(min_value=32, max_value=512))
        oh = ih
        in_shape = [1, 3, ih, oh]
        inputs = {"inputs": TensorConfig(shape=in_shape)}
        return inputs

    def sample_predictor_configs(self):
        return self.get_predictor_configs(), [""], (1e-5, 1e-5)

    def add_ignore_pass_case(self):
        pass

    def test(self, *args, **kwargs):
        model, params = self.get_model()
        self.run_and_statis(
            quant=False,
            model=model,
            params=params,
            min_success_num=1,
            max_examples=10)
```
对于模型单测，主要是需要定义函数 get_model()来获取模型， 模型下载到一个临时目录下，单测运行完后临时目录会自动清理，
prepare_input_data 用来定义输入，以字典的方式定义输入名称和数据。


上面的内容保持不变，对于一些个性化的测试有帮助。在上面的基础上，增加一个model_test_base.py文件，需要传入模型下载地址相关内容以及输入的shape信息。
为了更自动化，新增一个脚本run_model_test.py，该脚本内部会调用model_test_base.py，并传入所有需要的参数信息。
因此通用化增加一个模型单测只需在run_model_test.py增加一个配置：
```python
MobileNetV1_config = {
    "url":
    "https://paddle-inference-dist.bj.bcebos.com/AI-Rank/mobile/MobileNetV1.tar.gz",
    "model_name": "MobileNetV1",
    "file_name": "MobileNetV1.tar.gz",
    "input_shapes": ["1,3,512,512"]
}

MobileNetV2_config = {
    "url":
    "https://paddle-inference-dist.bj.bcebos.com/AI-Rank/mobile/MobileNetV2.tar.gz",
    "model_name": "MobileNetV2",
    "file_name": "MobileNetV2.tar.gz",
    "input_shapes": ["1,3,512,512"]
}
```
测试方法：x86环境： python3.7  run_model_test.py  