### PR TITLE
[OpenCL] Fix expand/keepdims_convert_pass, enhance reduce_mean py ut

### DIFF
--- a/lite/core/optimizer/mir/fusion/keepdims_convert_fuser.cc
+++ b/lite/core/optimizer/mir/fusion/keepdims_convert_fuser.cc
@@ -31,15 +31,17 @@ void KeepdimsConvertFuser::BuildPattern() {
   auto attr_names = attr_names_;
   auto op_teller = [&](const Node* node) -> bool {
     const std::vector<std::string> attr_names{"keep_dim", "keepdims"};
+    // Convert false to true when the above attribute exists and it's false.
+    // Note the attribute is false by default when the attribute doesn't exist.
     auto* op_desc = const_cast<Node*>(node)->AsStmt().op_info();
     for (auto attr_name : attr_names) {
       if (op_desc->HasAttr(attr_name)) {
-        if (!op_desc->GetAttr<bool>(attr_name)) {
-          return true;
+        if (op_desc->GetAttr<bool>(attr_name)) {
+          return false;
         }
       }
     }
-    return false;
+    return true;
   };
 
   auto* op = OpNode("op", op_type_)
@@ -79,11 +81,9 @@ void KeepdimsConvertFuser::InsertNewNode(SSAGraph* graph,
   // Update Out arg name
   auto op_desc = inst->mutable_op_info();
   for (auto attr_name : attr_names_) {
-    if (op_desc->HasAttr(attr_name)) {
-      op_desc->SetAttr(attr_name, true);
-      op_desc->SetOutput("Out", {new_input_name_});
-      break;
-    }
+    op_desc->SetAttr(attr_name, true);
+    op_desc->SetOutput("Out", {new_input_name_});
+    break;
   }
 
   IR_NODE_LINK_TO(matched.at("op"), new_input_arg);

--- a/lite/core/optimizer/mir/fusion/keepdims_convert_fuser.cc
+++ b/lite/core/optimizer/mir/fusion/keepdims_convert_fuser.cc
@@ -83,7 +83,6 @@ void KeepdimsConvertFuser::InsertNewNode(SSAGraph* graph,
   for (auto attr_name : attr_names_) {
     op_desc->SetAttr(attr_name, true);
     op_desc->SetOutput("Out", {new_input_name_});
-    break;
   }
 
   IR_NODE_LINK_TO(matched.at("op"), new_input_arg);

--- a/lite/kernels/opencl/expand_image_compute.cc
+++ b/lite/kernels/opencl/expand_image_compute.cc
@@ -164,9 +164,9 @@ class ExpandComputeImage2D : public KernelLite<TARGET(kOpenCL),
     CL_CHECK_FATAL(status);
     status = kernel.setArg(11, *out_img);
     CL_CHECK_FATAL(status);
-    status = kernel.setArg(12, x_dims[1]);
+    status = kernel.setArg(12, static_cast<int>(x_dims[1]));
     CL_CHECK_FATAL(status);
-    status = kernel.setArg(13, out_dims[1]);
+    status = kernel.setArg(13, static_cast<int>(out_dims[1]));
     CL_CHECK_FATAL(status);
 
     status = EnqueueNDRangeKernel(context,

--- a/lite/kernels/opencl/reduce_mean_image_compute.cc
+++ b/lite/kernels/opencl/reduce_mean_image_compute.cc
@@ -39,6 +39,10 @@ class ReduceMeanComputeImage2D : public KernelLite<TARGET(kOpenCL),
     reduce_mean_param_ = param_.get_mutable<param_t>();
     auto& x_dims = reduce_mean_param_->X->dims();
     auto& dim = reduce_mean_param_->dim;
+    bool keep_dim = reduce_mean_param_->keep_dim;
+    CHECK(keep_dim) << "OpenCL reduce kernel only support keep_dim=true. "
+                       "keep_dim=false case will be converted by "
+                       "keepdims_convert_pass.";
 
     // padding to 4-dims
     in_nchw_ = x_dims.Vectorize();

--- a/lite/tests/unittest_py/op/test_reduce_mean_op.py
+++ b/lite/tests/unittest_py/op/test_reduce_mean_op.py
@@ -61,9 +61,15 @@ class TestReduceMeanOp(AutoScanTest):
                 st.integers(
                     min_value=1, max_value=10), min_size=4, max_size=4))
         keep_dim = draw(st.booleans())
-        axis = draw(st.integers(min_value=-1, max_value=3))
-        assume(axis < len(in_shape))
+        axis_type = draw(st.sampled_from(["int", "list"]))
+        axis_int = draw(st.integers(min_value=-1, max_value=3))
+        axis_list = draw(
+            st.sampled_from([[2, 3], [1, 2], [0, 1], [1, 2, 3], [0, 1, 2]]))
 
+        if axis_type == "int":
+            axis = axis_int
+        else:
+            axis = axis_list
         if isinstance(axis, int):
             axis = [axis]
         reduce_all_data = True if axis == None or axis == [] else False


### PR DESCRIPTION
- tf2pd_efficientnet: expand 算子setArgs 参数类型不对，在手机上运行报错，在 macos 上运行正常，已修复
- tf2pd_mnasnet：arg_max 算子中没有 keepdims 属性，之前的 pass 不支持这种 case；reduce_mean 算子中的 keep_dim 没有更新，已修复
- 在 reduce_mean python 单测中新增 axis 为 list 的情况