### PR TITLE
update tool class any

### DIFF
--- a/cmake/postproject.cmake
+++ b/cmake/postproject.cmake
@@ -123,7 +123,7 @@ if (LITE_ON_TINY_PUBLISH)
     # 2. strip rtti lib to reduce lib size
     #     2.1 replace typeid by fastTypeId
     #     2.2 replace dynamic_cast by static_cast
-    if(NOT LITE_WITH_NNADAPTER)
+    if ((NOT LITE_WITH_NNADAPTER) AND (NOT LITE_WITH_LOG))
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
     endif()
 endif()


### PR DESCRIPTION
any类的补充：
当初为了压缩体积，any类中删除了typeinfo等信息（因为typeinfo需要rtti支持，会增加库体积大小）。但是删除typeinfo会给debug造成困难，因此，本pr做了一些修复：当编译时打开--with_log开关时，保留typeinfo信息。