### PR TITLE
[OpenCL]Fix conv PrepareForRun to reduce first frame time

### DIFF
--- a/tools/ci_tools/ci_android_unit_test.sh
+++ b/tools/ci_tools/ci_android_unit_test.sh
@@ -31,7 +31,7 @@ skip_list=("test_model_parser" "test_mobilenetv1" "test_mobilenetv2" \
 # if operating in mac env, we should expand the maximum file num
 os_name=`uname -s`
 if [ ${os_name} == "Darwin" ]; then
-   ulimit -n 1024
+   ulimit -n 10240
 fi
 
 ####################################################################################################


### PR DESCRIPTION
问题背景：在app里多次首帧，发现在PrepareForRun里面的bias的MemcpySync时间非常长
解决方案：修改conv PrepareForRun 里bias 和 filter 在adreno 和 mali gpu上初始化方式。adreno 采用cl_image, mali部分kernel采用cl_buffer
待查问题：mali gpu 每次首帧，部分创建kernel的时间很长