### PR TITLE
Change the third-party dependency pybind11 to a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "third-party/glog"]
 	path = third-party/glog
 	url = https://github.com/google/glog.git
+[submodule "third-party/pybind"]
+	path = third-party/pybind
+	url = https://github.com/pybind/pybind11.git

--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -18,16 +18,16 @@ endif()
 
 include(ExternalProject)
 
-set(PYBIND_SOURCE_DIR ${THIRD_PARTY_PATH}/pybind)
+set(PYBIND_SOURCE_DIR ${CMAKE_SOURCE_DIR}/third-party/pybind)
 
-include_directories(${PYBIND_SOURCE_DIR}/src/extern_pybind/include)
+include_directories(${PYBIND_SOURCE_DIR}/include)
 
 ExternalProject_Add(
         extern_pybind
         ${EXTERNAL_PROJECT_LOG_ARGS}
-        GIT_REPOSITORY  "https://github.com/pybind/pybind11.git"
-        GIT_TAG         "v2.6.0"
-        PREFIX          ${PYBIND_SOURCE_DIR}
+        GIT_REPOSITORY  ""
+        GIT_TAG         8de7772cc72daca8e947b79b83fea46214931604
+        SOURCE_DIR      ${PYBIND_SOURCE_DIR}
         UPDATE_COMMAND  ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND     ""

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -96,7 +96,7 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 #####################################################################################################
 # url that stores third-party tar.gz file to accelerate third-party lib installation
 readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
-readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
+readonly THIRDPARTY_TAR=third-party-91a9ab3.tar.gz
 
 # absolute path of Paddle-Lite.
 readonly workspace=$PWD/$(dirname $0)/../../

--- a/lite/tools/build_macos.sh
+++ b/lite/tools/build_macos.sh
@@ -47,7 +47,7 @@ readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
 #####################################################################################################
 # url that stores third-party tar.gz file to accelerate third-party lib installation
 readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
-readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
+readonly THIRDPARTY_TAR=third-party-91a9ab3.tar.gz
 
 # on mac environment, we should expand the maximum file num to compile successfully
 os_name=`uname -s`

--- a/lite/tools/build_windows.bat
+++ b/lite/tools/build_windows.bat
@@ -24,7 +24,7 @@ set ARCH=""
 set WITH_STRIP=OFF
 set OPTMODEL_DIR=""
 set THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
-set THIRDPARTY_TAR=third-party-801f670.tar.gz
+set THIRDPARTY_TAR=third-party-91a9ab3.tar.gz
 
 set workspace=%source_path%
 set /a cores=%number_of_processors%-2 > null

--- a/lite/tools/ci_build.sh
+++ b/lite/tools/ci_build.sh
@@ -13,7 +13,7 @@ readonly common_flags="-DWITH_PYTHON=OFF -DWITH_TESTING=ON -DLITE_WITH_ARM=OFF"
 
 # url that stores third-party tar.gz file to accelerate third-party lib installation
 readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
-readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
+readonly THIRDPARTY_TAR=third-party-91a9ab3.tar.gz
 
 readonly workspace=$PWD
 

--- a/lite/tools/ci_test.sh
+++ b/lite/tools/ci_test.sh
@@ -8,7 +8,7 @@ LITE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)"
 
 # url that stores third-party tar.gz file to accelerate third-party lib installation
 readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
-readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
+readonly THIRDPARTY_TAR=third-party-91a9ab3.tar.gz
 readonly workspace=$PWD
 
 NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}

--- a/tools/ci_tools/ci_nn_accelerators_unit_test.sh
+++ b/tools/ci_tools/ci_nn_accelerators_unit_test.sh
@@ -8,7 +8,7 @@ LITE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)"
 
 # url that stores third-party tar.gz file to accelerate third-party lib installation
 readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
-readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
+readonly THIRDPARTY_TAR=third-party-91a9ab3.tar.gz
 readonly workspace=$PWD
 
 NUM_CORES_FOR_COMPILE=${LITE_BUILD_THREADS:-8}

--- a/tools/ci_tools/utils.sh
+++ b/tools/ci_tools/utils.sh
@@ -11,7 +11,7 @@ OFF_COLOR='\E[0m'      # off color
 
 # URL that stores third-party tar.gz file to accelerate third-party lib installation
 readonly THIRDPARTY_URL=https://paddlelite-data.bj.bcebos.com/third_party_libs/
-readonly THIRDPARTY_TAR=third-party-801f670.tar.gz
+readonly THIRDPARTY_TAR=third-party-91a9ab3.tar.gz
 
 # wget wrapper for download file from Baidu bcebos
 function wget_wrapper() {


### PR DESCRIPTION
本pr将依赖的pybind11第三方库从external_project放入子仓库模块中，并更新离线安装包。
[参考pr](https://github.com/PaddlePaddle/Paddle-Lite/pull/8373/files)