### PR TITLE
[NNAdapter][TensorRT] int8 calibration

### DIFF
--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/utility/utility.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/utility/utility.h
@@ -223,6 +223,13 @@ bool ReadFile(const std::string& path, std::vector<uint8_t>* buffer);
 // Write an uint8_t array to a file
 bool WriteFile(const std::string& path, const std::vector<uint8_t>& buffer);
 
+// Read string line by ling from a file
+std::vector<std::string> ReadLines(const std::string& filename);
+
+// Write string line by ling to a file
+void WriteLines(const std::vector<std::string>& lines,
+                const std::string& filename);
+
 inline int64_t GetCurrentUS() {
   struct timeval time;
   gettimeofday(&time, NULL);

--- a/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/CMakeLists.txt
+++ b/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/CMakeLists.txt
@@ -23,7 +23,7 @@ include(dependencies.cmake)
 aux_source_directory(converter CONVERTERS)
 aux_source_directory(optimizer OPTIMIZERS)
 aux_source_directory(converter/plugin PLUGINS)
-set(SRCS engine.cc utility.cc ${OPTIMIZERS} ${CONVERTERS} ${PLUGINS} driver.cc)
+set(SRCS engine.cc utility.cc ${OPTIMIZERS} ${CONVERTERS} ${PLUGINS} driver.cc calibrator.cc)
 set(DEPS ${NNADAPTER_OPERATIONS}
          ${NNADAPTER_UTILITIES}
          ${${DEVICE_NAME}_deps}

--- a/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/calibrator.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/calibrator.cc
@@ -1,0 +1,131 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "driver/nvidia_tensorrt/calibrator.h"
+#include <functional>
+#include <map>
+#include <numeric>
+#include "utility/string.h"
+#include "utility/utility.h"
+
+namespace nnadapter {
+namespace nvidia_tensorrt {
+
+Int8EntropyCalibrator::Int8EntropyCalibrator(int batch_size,
+                                             std::string dataset_path,
+                                             std::string table_path)
+    : batch_size_(batch_size),
+      dataset_path_(dataset_path),
+      table_path_(table_path),
+      index_(0) {
+  if (!dataset_path.empty()) {
+    // Parser dataset file names
+    std::string dataset_file = dataset_path + "/lists.txt";
+    auto lists = ReadLines(dataset_file);
+    NNADAPTER_CHECK(!lists.empty()) << "Dataset list file:" << dataset_file
+                                    << " has no data.";
+    if (lists.size() < static_cast<size_t>(batch_size)) {
+      NNADAPTER_LOG(WARNING) << "Input file is not enough. Only receive "
+                             << lists.size() << " batch input.";
+    }
+    lists.resize(static_cast<int>(lists.size() / batch_size) * batch_size);
+    input_file_names_.resize(string_split(lists.front(), ";").size());
+    for (size_t i = 0; i < lists.size(); i++) {
+      auto input_info = string_split(lists.at(i), ";");
+      NNADAPTER_CHECK_EQ(input_info.size(), input_file_names_.size());
+      for (size_t j = 0; j < input_info.size(); j++) {
+        auto file_name = string_split(input_info.at(j), ":").back();
+        input_file_names_.at(j).push_back(file_name);
+      }
+    }
+    // Malloc input buffer
+    auto input_info = string_split(lists.front(), ";");
+    for (size_t i = 0; i < input_info.size(); i++) {
+      auto shape =
+          string_split<int>(string_split(input_info.at(i), ":").at(0), ",");
+      auto precision = string_split(input_info.at(i), ":").at(1);
+      std::map<std::string, int> precision_length_map{
+          {"float32", 4}, {"float16", 2}, {"int8", 1}};
+      int size = std::accumulate(
+                     shape.begin(), shape.end(), 1, std::multiplies<int>()) *
+                 precision_length_map.at(precision);
+      void* data_ptr{nullptr};
+      NNADAPTER_CHECK_EQ(cudaMalloc(&data_ptr, size), cudaSuccess);
+      std::shared_ptr<void> device_buffer(data_ptr, [](void* ptr) {
+        NNADAPTER_CHECK_EQ(cudaFree(ptr), cudaSuccess);
+      });
+      device_buffers_.push_back(device_buffer);
+    }
+  }
+}
+
+bool Int8EntropyCalibrator::getBatch(void* bindings[],
+                                     const char* names[],
+                                     int nbBindings) {
+  // TODO(zhupengyang): support multi inputs
+  NNADAPTER_CHECK_EQ(nbBindings, 1);
+  if (static_cast<size_t>(index_) >= input_file_names_.at(0).size()) {
+    return false;
+  }
+  std::vector<uint8_t> host_buffer;
+  for (int i = 0; i < batch_size_; i++) {
+    std::vector<uint8_t> host_data;
+    std::string file_path =
+        dataset_path_ + "/" + input_file_names_.at(0).at(index_ + i);
+    NNADAPTER_CHECK(ReadFile(file_path, &host_data));
+    host_buffer.insert(host_buffer.end(), host_data.begin(), host_data.end());
+  }
+  void* device_buffer = device_buffers_.at(0).get();
+  NNADAPTER_CHECK_EQ(cudaMemcpy(device_buffer,
+                                host_buffer.data(),
+                                host_buffer.size(),
+                                cudaMemcpyHostToDevice),
+                     cudaSuccess);
+  bindings[0] = device_buffer;
+  index_ += batch_size_;
+  return true;
+}
+
+const void* Int8EntropyCalibrator::readCalibrationCache(size_t& length) {
+  if (table_path_.empty()) {
+    NNADAPTER_LOG(WARNING) << "No calibration table file is set. New "
+                              "calibration table will be generated.";
+  }
+  if (!ReadFile(table_path_, &table_)) {
+    NNADAPTER_LOG(WARNING) << "Read calibration table file failed. New "
+                              "calibration table will be generated.";
+    return nullptr;
+  }
+  NNADAPTER_LOG(INFO) << "Read calibration table file from " << table_path_
+                      << " success.";
+  length = table_.size();
+  return table_.data();
+}
+
+void Int8EntropyCalibrator::writeCalibrationCache(const void* cache,
+                                                  size_t length) {
+  if (table_path_.empty()) {
+    NNADAPTER_LOG(WARNING) << "No calibration table will be saved because "
+                              "table_path is not found.";
+    return;
+  }
+  auto data = reinterpret_cast<const uint8_t*>(cache);
+  table_ = std::vector<uint8_t>(data, data + length);
+  NNADAPTER_CHECK(WriteFile(table_path_, table_));
+  NNADAPTER_LOG(INFO) << "Write calibration table to " << table_path_
+                      << " success.";
+}
+
+}  // namespace nvidia_tensorrt
+}  // namespace nnadapter

--- a/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/calibrator.h
+++ b/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/calibrator.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <memory>
+#include <string>
+#include <vector>
+#include "driver/nvidia_tensorrt/utility.h"
+#include "utility/logging.h"
+
+namespace nnadapter {
+namespace nvidia_tensorrt {
+
+class Int8EntropyCalibrator : public nvinfer1::IInt8EntropyCalibrator2 {
+ public:
+  Int8EntropyCalibrator(int batch_size,
+                        std::string dataset_path,
+                        std::string table_path);
+  virtual ~Int8EntropyCalibrator() {}
+
+  int getBatchSize() const override { return batch_size_; }
+  bool getBatch(void* bindings[], const char* names[], int nbBindings) override;
+  const void* readCalibrationCache(size_t& length) override;
+  void writeCalibrationCache(const void* cache, size_t length) override;
+
+ private:
+  int batch_size_{1};
+  std::string dataset_path_;
+  std::string table_path_;
+  int index_{0};
+  std::vector<std::vector<std::string>> input_file_names_;
+  std::vector<std::shared_ptr<void>> device_buffers_;
+  std::vector<uint8_t> table_;
+};
+
+}  // namespace nvidia_tensorrt
+}  // namespace nnadapter

--- a/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/engine.h
+++ b/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/engine.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "driver/nvidia_tensorrt/calibrator.h"
 #include "driver/nvidia_tensorrt/utility.h"
 #include "utility/logging.h"
 
@@ -40,6 +41,8 @@ class Context {
   int DeviceId() { return device_id_; }
   PrecisionMode Precision() { return precision_; }
   bool GpuFallback() { return gpu_fallback_; }
+  std::string CalibrationDatasetPath() { return calibration_dataset_path_; }
+  std::string CalibrationTablePath() { return calibration_table_path_; }
 
  private:
   void* device_{nullptr};
@@ -48,6 +51,8 @@ class Context {
   int device_id_{0};
   PrecisionMode precision_{kFloat32};
   bool gpu_fallback_{true};
+  std::string calibration_dataset_path_;
+  std::string calibration_table_path_;
 };
 
 struct Deleter {
@@ -94,6 +99,7 @@ class Program {
   std::unique_ptr<nvinfer1::IRuntime, Deleter> runtime_;
   std::unique_ptr<nvinfer1::ICudaEngine, Deleter> engine_;
   std::unique_ptr<nvinfer1::IExecutionContext, Deleter> execution_context_;
+  std::unique_ptr<Int8EntropyCalibrator> calibrator_;
   std::vector<std::shared_ptr<void>> device_buffers_;
   std::map<core::Operand*, std::vector<nvinfer1::ITensor*>> tensors_;
   std::vector<int> input_indices_;

--- a/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/utility.h
+++ b/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/utility.h
@@ -38,6 +38,16 @@ namespace nvidia_tensorrt {
 // Whether to allow gpu fallback, for example: "0", "1"
 #define NVIDIA_TENSORRT_GPU_FALLBACK "NVIDIA_TENSORRT_GPU_FALLBACK"
 
+// Path to calibration dataset, for example: "/home/demo/dataset"
+// The path containers following files: "list.txt", "input0_0",...
+#define NVIDIA_TENSORRT_CALIBRATION_DATASET_PATH \
+  "NVIDIA_TENSORRT_CALIBRATION_DATASET_PATH"
+
+// Path to calibration table, for example:
+// "/home/demo/dataset/calibration_table"
+#define NVIDIA_TENSORRT_CALIBRATION_TABLE_PATH \
+  "NVIDIA_TENSORRT_CALIBRATION_TABLE_PATH"
+
 typedef enum {
   kFloat32 = 0,
   kFloat16 = 1,

--- a/lite/backends/nnadapter/nnadapter/src/utility/utility.cc
+++ b/lite/backends/nnadapter/nnadapter/src/utility/utility.cc
@@ -15,6 +15,7 @@
 #if defined(__ARM_NEON) || defined(__ARM_NEON__)
 #include <arm_neon.h>
 #endif
+#include "fstream"
 #include "utility/debug.h"
 #include "utility/micros.h"
 #include "utility/string.h"
@@ -546,6 +547,31 @@ NNADAPTER_EXPORT bool WriteFile(const std::string& path,
   }
   fclose(fp);
   return true;
+}
+
+NNADAPTER_EXPORT std::vector<std::string> ReadLines(
+    const std::string& filename) {
+  std::ifstream ifile(filename.c_str());
+  if (!ifile.is_open()) {
+    NNADAPTER_LOG(FATAL) << "Open file: [" << filename << "] failed.";
+  }
+  std::vector<std::string> res;
+  std::string tmp;
+  while (getline(ifile, tmp)) res.push_back(tmp);
+  ifile.close();
+  return res;
+}
+
+NNADAPTER_EXPORT void WriteLines(const std::vector<std::string>& lines,
+                                 const std::string& filename) {
+  std::ofstream ofile(filename.c_str());
+  if (!ofile.is_open()) {
+    NNADAPTER_LOG(FATAL) << "Open file: [" << filename << "] failed.";
+  }
+  for (const auto& line : lines) {
+    ofile << line << "\n";
+  }
+  ofile.close();
 }
 
 NNADAPTER_EXPORT std::string GetStringFromEnv(const std::string& str,

--- a/lite/core/optimizer/mir/subgraph/subgraph_pass.cc
+++ b/lite/core/optimizer/mir/subgraph/subgraph_pass.cc
@@ -117,7 +117,7 @@ bool NNAdapterSubgraphOpTeller(const std::string& device_name,
       auto output_channel_size = filter_dims[0];
       auto groups = op_info->GetAttr<int>("groups");
       int multiplier = output_channel_size / groups;
-      if (multiplier != 1) return false;
+      if (groups != 1 && multiplier != 1) return false;
     }
   }
   return true;


### PR DESCRIPTION
# 支持 TensorRT int8
## 参数说明
- NVIDIA_TENSORRT_PRECISION 指定计算精度，例如：NVIDIA_TENSORRT_PRECISION=int8
- NVIDIA_TENSORRT_CALIBRATION_DATASET_PATH 指定校准数据集路径，例如：NVIDIA_TENSORRT_CALIBRATION_DATASET_PATH=/home/calibration_dataset
```
# 校准数据集路径下需要包括 "lists.txt" 和 "输入数据的二进制文件"
lists.txt
input0_1
input0_2
...
# 其中 "lists.txt" 文件名固定。格式为文本文件。
# 不同输入以 ";" 分隔，同一个输入的不同信息之间以 ":" 分隔，输入的dims之间以 "," 分隔
# 数据格式如下：
in0_dim0,in0_dim1,in0_dim2:in0_precision:in0_file;in1_dim0,in1_dim1,in1_dim2:in1_precision:in1_file
# lists.txt 格式举例如下：
1,3,224,224:float32:input0_0
1,3,224,224:float32:input0_1
...
# "输入数据的二进制文件" 表示单个输入的单个batch的数据，注意：目前仅支持单个batch的数据
```
[dataset 示例数据](https://paddlelite-demo.bj.bcebos.com/tmp/zhupengyang/NvidiaTensorrt/calibration_dataset.tgz)
- NVIDIA_TENSORRT_CALIBRATION_TABLE_PATH 校准表文件路径，例如：NVIDIA_TENSORRT_CALIBRATION_TABLE_PATH=/home/model/calibration_table
## 行为说明
- 如果未指定精度为 int8，校准数据集和校准表路径无效
- 如果指定校准表路径，且文件不为空，则从校准表路径读取校准表
- 如果未指定校准表路径，或者校准表文件不存在，则从校准数据集进行校准。如果校准表路径有效，则保存到校准表路径
## TODO
- 仅支持单个输入的模型