### PR TITLE
[OpenCL] Fix layer norm running error on mali gpu

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/layer_norm_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/layer_norm_kernel.cl
@@ -47,7 +47,7 @@ __kernel void layer_norm_batch(__read_only image2d_t input,
   avg /= feature_size;
   var = var / feature_size - avg * avg;
 
-  var = sqrt(var + epsilon);
+  var = sqrt(var + CONVERT_TYPE_TO(epsilon, CL_DTYPE));
   int2 pos;
   pos.x = out_c * width + out_w;
   pos.y = out_nh;
@@ -112,7 +112,7 @@ __kernel void layer_norm_chann(__read_only image2d_t input,
   }
   avg /= feature_size;
   var = var / feature_size - avg * avg;
-  var = sqrt(var + epsilon);
+  var = sqrt(var + CONVERT_TYPE_TO(epsilon, CL_DTYPE));
   int2 pos;
   pos.x = out_c * width + out_w;
   pos.y = out_nh;

--- a/lite/kernels/opencl/layer_norm_image_compute.cc
+++ b/lite/kernels/opencl/layer_norm_image_compute.cc
@@ -150,7 +150,7 @@ class LayerNormImageCompute : public KernelLite<TARGET(kOpenCL),
     CL_CHECK_FATAL(status);
     status = kernel.setArg(arg_idx++, height);
     CL_CHECK_FATAL(status);
-    status = kernel.setArg(arg_idx++, y_image_shape["width"]);
+    status = kernel.setArg(arg_idx++, static_cast<int>(y_image_shape["width"]));
     CL_CHECK_FATAL(status);
     status = kernel.setArg(arg_idx++, width);
     CL_CHECK_FATAL(status);


### PR DESCRIPTION
- .cl kernel 在 mali gpu  上运行在线编译 fp16 精度时，在执行 sqrt 时，由于 var 和 epsilon 的数据类型不一致 ，会报错；
- .cc 中的 setArg 函数在 mali/adreno gpu 上执行时均会提示 INVALID_ARG，原因是 y_image_shape["width"] 是 long 类型，setArg 函数不支持该类型数据作为输入。

如上 2 种 case，在单测框架下均无法测出，原因是单测框架是基于 macOS，不同平台下的 OpenCL 实现有差异。