### PR TITLE
[OpenCL][Kernel]fix opencl layer_norm bug

### DIFF
--- a/lite/backends/opencl/cl_kernel/image/scale_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/scale_kernel.cl
@@ -23,8 +23,11 @@ __kernel void scale(__read_only image2d_t input,
   const int y = get_global_id(1);  // image_height
 
   CL_DTYPE4 in = READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(x, y));
-  in = CONVERT_TYPE_TO(scale, CL_DTYPE) * in + CONVERT_TYPE_TO(bias, CL_DTYPE);
-
+  float4 in_f32 = convert_float4(in) * scale + bias;
+  in.x = (CL_DTYPE)(in_f32.x);
+  in.y = (CL_DTYPE)(in_f32.y);
+  in.z = (CL_DTYPE)(in_f32.z);
+  in.w = (CL_DTYPE)(in_f32.w);
   WRITE_IMG_TYPE(CL_DTYPE_CHAR, output, (int2)(x, y), in);
 }
 

--- a/lite/kernels/opencl/layer_norm_image_compute.cc
+++ b/lite/kernels/opencl/layer_norm_image_compute.cc
@@ -49,10 +49,20 @@ class LayerNormImageCompute : public KernelLite<TARGET(kOpenCL),
     auto x_dims = layer_norm_param_->X->dims();
     begin_norm_axis = layer_norm_param_->begin_norm_axis;
     VLOG(4) << "begin_norm_axis: " << begin_norm_axis;
-    if (begin_norm_axis == 1) {
-      kernel_func_name_ = "layer_norm_batch";
-    } else if (begin_norm_axis == 2) {
-      kernel_func_name_ = "layer_norm_chann";
+    if (x_dims.size() == 4) {
+      if (begin_norm_axis == 1) {
+        kernel_func_name_ = "layer_norm_batch";
+      } else if (begin_norm_axis == 2) {
+        kernel_func_name_ = "layer_norm_chann";
+      }
+    } else if (x_dims.size() == 3) {
+      if (begin_norm_axis == 1) {
+        kernel_func_name_ = "layer_norm_chann";
+      } else if (begin_norm_axis == 2) {
+        kernel_func_name_ = "layer_norm_width";
+      }
+    } else {
+      LOG(FATAL) << "unsupported input dim.";
     }
     auto* scale = layer_norm_param_->Scale;
     auto* bias = layer_norm_param_->Bias;
@@ -116,8 +126,8 @@ class LayerNormImageCompute : public KernelLite<TARGET(kOpenCL),
     int batch_size = matrix_dim[0];
     int feature_size = matrix_dim[1];
     epsilon = layer_norm_param_->epsilon;
-    int height = x_dims[2];
-    int width = x_dims[3];
+    int height = x_dims[x_dims.size() - 2];
+    int width = x_dims[x_dims.size() - 1];
 
     int arg_idx = 0;
     auto default_work_size = DefaultGlobalWorkSize(
@@ -150,7 +160,7 @@ class LayerNormImageCompute : public KernelLite<TARGET(kOpenCL),
     CL_CHECK_FATAL(status);
     status = kernel.setArg(arg_idx++, height);
     CL_CHECK_FATAL(status);
-    status = kernel.setArg(arg_idx++, y_image_shape["width"]);
+    status = kernel.setArg(arg_idx++, static_cast<int>(y_image_shape["width"]));
     CL_CHECK_FATAL(status);
     status = kernel.setArg(arg_idx++, width);
     CL_CHECK_FATAL(status);


### PR DESCRIPTION
修复问题：
1. diff问题：layer_norm 3维输入的处理
2. nan问题：fp16下layer_norm读入数据和scale op的数据计算精度有问题。