### PR TITLE
[NvidiaTensorrt] fix cmake

### DIFF
--- a/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/CMakeLists.txt
+++ b/lite/backends/nnadapter/nnadapter/src/driver/nvidia_tensorrt/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 enable_language(CUDA)
 


### PR DESCRIPTION
- 增加默认的 cuda/cudnn/tensorrt 查找路径
- 修改最低cmake版本为3.12