### PR TITLE
[NNAdapter] Avoid stripping the exported symbols on tiny publish mode

### DIFF
--- a/lite/backends/nnadapter/nnadapter/src/driver/configuration.cmake
+++ b/lite/backends/nnadapter/nnadapter/src/driver/configuration.cmake
@@ -17,6 +17,9 @@
 # Enable throwing exception when check failed in logging.cc
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions -fasynchronous-unwind-tables -funwind-tables")
 
+# Avoid the export symbols being stripped, which will cause 'undefined reference' errors when HAL is compiled independently.
+string(REPLACE "-Wl,--exclude-libs,ALL" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
 # CANN libraries only supports old ABI of libstdc++, so need to set -D_GLIBCXX_USE_CXX11_ABI=0
 # and the common modules(utility and optimizer) needs to be compiled and linked separately if 
 # the version of GCC greater than 5.0

--- a/lite/backends/nnadapter/nnadapter/src/driver/fake_device/build.sh
+++ b/lite/backends/nnadapter/nnadapter/src/driver/fake_device/build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+# Settings only for Android
+ANDROID_NDK=/opt/android-ndk-r17c # docker
+#ANDROID_NDK=/Users/hongming/Library/android-ndk-r17c # macOS
+
+# For TARGET_OS=android, TARGET_ABI=arm64-v8a/armeabi-v7a.
+# For TARGET_OS=linux, TARGET_ABI=arm64/armhf/amd64.
+TARGET_OS=linux
+if [ -n "$1" ]; then
+  TARGET_OS=$1
+fi
+
+TARGET_ABI=arm64
+if [ -n "$2" ]; then
+  TARGET_ABI=$2
+fi
+
+function readlinkf() {
+  perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+# Set the corresponding libnnadapter.so path and include director for the current TARGET_OS and TARGET_ABI.
+NNADAPTER_RUNTIME_INCLUDE_DIRECTORY=$(readlinkf ../../$TARGET_OS/$TARGET_ABI/lib/builtin_device/include)
+NNADAPTER_RUNTIME_LIBRARY_PATH=$(readlinkf ../../${TARGET_OS}/$TARGET_ABI/lib/builtin_device/libnnadapter.so)
+# Set the output directory of the NNAdapter driver HAL library.
+NNADAPTER_DRIVER_LIBRARY_DIRECTORY=$(readlinkf ../../$TARGET_OS/$TARGET_ABI/lib/fake_device)
+
+# Initialize the cmake compilation environment for the current TARGET_OS and TARGET_ABI.
+CMAKE_COMMAND_ARGS="-DCMAKE_VERBOSE_MAKEFILE=ON -DNNADAPTER_WITH_STANDALONE=ON -DNNADAPTER_STANDALONE_RUNTIME_INCLUDE_DIRECTORY=$NNADAPTER_RUNTIME_INCLUDE_DIRECTORY -DNNADAPTER_STANDALONE_RUNTIME_LIBRARY_PATH=$NNADAPTER_RUNTIME_LIBRARY_PATH"
+if [[ $TARGET_OS == "linux" ]]; then
+  CMAKE_COMMAND_ARGS="$CMAKE_COMMAND_ARGS -DCMAKE_SYSTEM_NAME=Linux"
+  if [[ $TARGET_ABI == "arm64" ]]; then
+    CMAKE_COMMAND_ARGS="$CMAKE_COMMAND_ARGS -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++"
+  elif [[ $TARGET_ABI == "armhf" ]]; then
+    CMAKE_COMMAND_ARGS="$CMAKE_COMMAND_ARGS -DCMAKE_SYSTEM_PROCESSOR=arm -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++"
+  elif [[ $TARGET_ABI == "amd64" ]]; then
+    CMAKE_COMMAND_ARGS="$CMAKE_COMMAND_ARGS -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
+  else
+    echo "'linux' only supports 'arm64', 'armhf' and 'amd64'."
+    exit -1
+  fi
+elif [[ $TARGET_OS == "android" ]]; then
+  if [[ $TARGET_ABI == "arm64-v8a" ]]; then
+    ANDROID_NATIVE_API_LEVEL=android-23
+  elif [[ $TARGET_ABI == "armeabi-v7a" ]]; then
+    ANDROID_NATIVE_API_LEVEL=android-21
+  else
+    echo "'android' only supports 'arm64-v8a' and 'armeabi-v7a'."
+    exit -1
+  fi
+  CMAKE_COMMAND_ARGS="$CMAKE_COMMAND_ARGS -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake -DANDROID_NDK=${ANDROID_NDK} -DANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL} -DANDROID_STL=c++_shared -DANDROID_ABI=${TARGET_ABI} -DANDROID_ARM_NEON=TRUE"
+else
+  echo "Unknown $TARGET_OS, only supports 'linux' and 'android'."
+fi
+
+# Create a temporary build directory, build and copy the generated dynamic libraries to the target driver HAL directory.
+BUILD_DIR=build.$TARGET_OS.$TARGET_ABI
+
+rm -rf $BUILD_DIR
+mkdir $BUILD_DIR
+cd $BUILD_DIR
+cmake $CMAKE_COMMAND_ARGS ..
+make
+
+cp -rf *.so $NNADAPTER_DRIVER_LIBRARY_DIRECTORY

--- a/lite/backends/nnadapter/nnadapter/src/operation/adaptive_pool2d.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/adaptive_pool2d.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateAdaptivePool2D(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateAdaptivePool2D(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareAdaptivePool2D(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareAdaptivePool2D(core::Operation* operation) {
   ADAPTIVE_POOL_2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -40,7 +43,7 @@ int PrepareAdaptivePool2D(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteAdaptivePool2D(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteAdaptivePool2D(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/arg_min_max.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/arg_min_max.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateArgMinMax(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateArgMinMax(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareArgMinMax(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareArgMinMax(core::Operation* operation) {
   ARG_MIN_MAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -58,7 +61,7 @@ int PrepareArgMinMax(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteArgMinMax(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteArgMinMax(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/assign.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/assign.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateAssign(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateAssign(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareAssign(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareAssign(core::Operation* operation) {
   ASSIGN_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +36,7 @@ int PrepareAssign(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteAssign(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteAssign(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/batch_normalization.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/batch_normalization.cc
@@ -16,17 +16,19 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateBatchNormalization(const core::Operation* operation) {
+NNADAPTER_EXPORT bool ValidateBatchNormalization(
+    const core::Operation* operation) {
   return false;
 }
 
-int PrepareBatchNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareBatchNormalization(core::Operation* operation) {
   BATCH_NORMALIZATION_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -35,7 +37,7 @@ int PrepareBatchNormalization(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteBatchNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteBatchNormalization(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/binary_logical_op.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/binary_logical_op.cc
@@ -17,15 +17,19 @@
 #include "operation/elementwise.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateBinaryLogicalOp(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateBinaryLogicalOp(
+    const core::Operation* operation) {
+  return false;
+}
 
-int PrepareBinaryLogicalOp(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareBinaryLogicalOp(core::Operation* operation) {
   BINARY_LOGICAL_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -36,7 +40,7 @@ int PrepareBinaryLogicalOp(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteBinaryLogicalOp(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteBinaryLogicalOp(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/cast.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/cast.cc
@@ -17,15 +17,18 @@
 #include "utility/debug.h"
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateCast(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateCast(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareCast(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareCast(core::Operation* operation) {
   CAST_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -36,7 +39,7 @@ int PrepareCast(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteCast(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteCast(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/channel_shuffle.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/channel_shuffle.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateChannelShuffle(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateChannelShuffle(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareChannelShuffle(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareChannelShuffle(core::Operation* operation) {
   CHANNEL_SHUFFLE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +36,7 @@ int PrepareChannelShuffle(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteChannelShuffle(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteChannelShuffle(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/clip.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/clip.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateClip(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateClip(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareClip(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareClip(core::Operation* operation) {
   CLIP_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +36,7 @@ int PrepareClip(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteClip(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteClip(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/comparisons.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/comparisons.cc
@@ -18,15 +18,18 @@
 #include "operation/elementwise.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateComparisons(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateComparisons(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareComparisons(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareComparisons(core::Operation* operation) {
   COMPARISONS_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -38,7 +41,7 @@ int PrepareComparisons(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteComparisons(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteComparisons(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/concat.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/concat.cc
@@ -19,15 +19,18 @@
 #include "utility/debug.h"
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateConcat(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateConcat(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareConcat(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareConcat(core::Operation* operation) {
   CONCAT_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -136,7 +139,7 @@ int PrepareConcat(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteConcat(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteConcat(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/conv2d.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/conv2d.cc
@@ -72,9 +72,11 @@ CalcConv2DOutputSize(int32_t input_size,
          1;
 }
 
-bool ValidateConv2D(const core::Operation* operation) { return true; }
+NNADAPTER_EXPORT bool ValidateConv2D(const core::Operation* operation) {
+  return true;
+}
 
-int PrepareConv2D(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareConv2D(core::Operation* operation) {
   CONV_2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -108,7 +110,7 @@ int PrepareConv2D(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteConv2D(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteConv2D(core::Operation* operation) {
   CONV_2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Allocate and calculate the output operands

--- a/lite/backends/nnadapter/nnadapter/src/operation/conv2d_transpose.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/conv2d_transpose.cc
@@ -47,9 +47,12 @@ CalcConv2DTransposeOutputSize(int32_t input_size,
          pad_bottom_or_right + dkernel;
 }
 
-bool ValidateConv2DTranspose(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateConv2DTranspose(
+    const core::Operation* operation) {
+  return false;
+}
 
-int PrepareConv2DTranspose(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareConv2DTranspose(core::Operation* operation) {
   CONV_2D_TRANSPOSE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -93,7 +96,7 @@ int PrepareConv2DTranspose(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteConv2DTranspose(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteConv2DTranspose(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/cum_sum.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/cum_sum.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateCumSum(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateCumSum(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareCumSum(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareCumSum(core::Operation* operation) {
   CUM_SUM_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +36,7 @@ int PrepareCumSum(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteCumSum(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteCumSum(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/deformable_conv2d.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/deformable_conv2d.cc
@@ -36,11 +36,12 @@ NNADAPTER_EXPORT int32_t DeformableConvOutputSize(int32_t input_size,
   return (input_size + (pad_left + pad_right) - dkernel) / stride + 1;
 }
 
-bool ValidateDeformableConv2D(const core::Operation* operation) {
+NNADAPTER_EXPORT bool ValidateDeformableConv2D(
+    const core::Operation* operation) {
   return false;
 }
 
-int PrepareDeformableConv2D(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareDeformableConv2D(core::Operation* operation) {
   DEFORMABLE_CONV_2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -72,7 +73,7 @@ int PrepareDeformableConv2D(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteDeformableConv2D(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteDeformableConv2D(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/dequantize.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/dequantize.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateDequantize(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateDequantize(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareDequantize(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareDequantize(core::Operation* operation) {
   DEQUANTIZE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -34,7 +37,7 @@ int PrepareDequantize(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteDequantize(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteDequantize(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/elementwise.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/elementwise.cc
@@ -74,9 +74,11 @@ NNADAPTER_EXPORT void CalcEltwiseBinaryOperationsOutputSize(
   }
 }
 
-bool ValidateElementwise(const core::Operation* operation) { return true; }
+NNADAPTER_EXPORT bool ValidateElementwise(const core::Operation* operation) {
+  return true;
+}
 
-int PrepareElementwise(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareElementwise(core::Operation* operation) {
   ELEMENTWISE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -106,7 +108,7 @@ int PrepareElementwise(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteElementwise(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteElementwise(core::Operation* operation) {
   NNADAPTER_LOG(FATAL) << OperationTypeToString(operation->type)
                        << " is not implemented!";
   return NNADAPTER_FEATURE_NOT_SUPPORTED;

--- a/lite/backends/nnadapter/nnadapter/src/operation/expand.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/expand.cc
@@ -69,9 +69,11 @@ NNADAPTER_EXPORT void UpdateExpandInferOutputShape(
   }
 }
 
-bool ValidateExpand(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateExpand(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareExpand(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareExpand(core::Operation* operation) {
   EXPAND_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -117,7 +119,7 @@ int PrepareExpand(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteExpand(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteExpand(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/fill.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/fill.cc
@@ -17,15 +17,18 @@
 #include "utility/debug.h"
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateFill(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateFill(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareFill(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareFill(core::Operation* operation) {
   FILL_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -72,7 +75,7 @@ int PrepareFill(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteFill(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteFill(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/fill_like.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/fill_like.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateFillLike(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateFillLike(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareFillLike(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareFillLike(core::Operation* operation) {
   FILL_LIKE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -34,7 +37,7 @@ int PrepareFillLike(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteFillLike(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteFillLike(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/flatten.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/flatten.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateFlatten(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateFlatten(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareFlatten(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareFlatten(core::Operation* operation) {
   FLATTEN_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -73,7 +76,7 @@ int PrepareFlatten(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteFlatten(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteFlatten(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/fully_connected.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/fully_connected.cc
@@ -18,15 +18,18 @@
 #include "operation/math/fully_connected.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateFullyConnected(const core::Operation* operation) { return true; }
+NNADAPTER_EXPORT bool ValidateFullyConnected(const core::Operation* operation) {
+  return true;
+}
 
-int PrepareFullyConnected(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareFullyConnected(core::Operation* operation) {
   FULLY_CONNECTED_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -81,7 +84,7 @@ int PrepareFullyConnected(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteFullyConnected(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteFullyConnected(core::Operation* operation) {
   FULLY_CONNECTED_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Allocate and calculate the output operands

--- a/lite/backends/nnadapter/nnadapter/src/operation/gather.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/gather.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateGather(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateGather(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareGather(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareGather(core::Operation* operation) {
   GATHER_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -57,7 +60,7 @@ int PrepareGather(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteGather(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteGather(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/gelu.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/gelu.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateGelu(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateGelu(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareGelu(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareGelu(core::Operation* operation) {
   GELU_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +36,7 @@ int PrepareGelu(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteGelu(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteGelu(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/grid_sample.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/grid_sample.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateGridSample(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateGridSample(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareGridSample(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareGridSample(core::Operation* operation) {
   GRID_SAMPLE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -57,7 +60,7 @@ int PrepareGridSample(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteGridSample(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteGridSample(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/group_normalization.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/group_normalization.cc
@@ -16,17 +16,19 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateGroupNormalization(const core::Operation* operation) {
+NNADAPTER_EXPORT bool ValidateGroupNormalization(
+    const core::Operation* operation) {
   return false;
 }
 
-int PrepareGroupNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareGroupNormalization(core::Operation* operation) {
   GROUP_NORMALIZATION_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -35,7 +37,7 @@ int PrepareGroupNormalization(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteGroupNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteGroupNormalization(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/hard_sigmoid_swish.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/hard_sigmoid_swish.cc
@@ -16,17 +16,19 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateHardSigmoidSwish(const core::Operation* operation) {
+NNADAPTER_EXPORT bool ValidateHardSigmoidSwish(
+    const core::Operation* operation) {
   return false;
 }
 
-int PrepareHardSigmoidSwish(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareHardSigmoidSwish(core::Operation* operation) {
   HARD_SIGMOID_SWISH_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -35,7 +37,7 @@ int PrepareHardSigmoidSwish(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteHardSigmoidSwish(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteHardSigmoidSwish(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/instance_normalization.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/instance_normalization.cc
@@ -16,17 +16,19 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateInstanceNormalization(const core::Operation* operation) {
+NNADAPTER_EXPORT bool ValidateInstanceNormalization(
+    const core::Operation* operation) {
   return false;
 }
 
-int PrepareInstanceNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareInstanceNormalization(core::Operation* operation) {
   INSTANCE_NORMALIZATION_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -35,7 +37,7 @@ int PrepareInstanceNormalization(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteInstanceNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteInstanceNormalization(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/layer_normalization.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/layer_normalization.cc
@@ -16,17 +16,19 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateLayerNormalization(const core::Operation* operation) {
+NNADAPTER_EXPORT bool ValidateLayerNormalization(
+    const core::Operation* operation) {
   return false;
 }
 
-int PrepareLayerNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareLayerNormalization(core::Operation* operation) {
   LAYER_NORMALIZATION_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -35,7 +37,7 @@ int PrepareLayerNormalization(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteLayerNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteLayerNormalization(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/leaky_relu.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/leaky_relu.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateLeakyRelu(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateLeakyRelu(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareLeakyRelu(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareLeakyRelu(core::Operation* operation) {
   LEAKY_RELU_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +36,7 @@ int PrepareLeakyRelu(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteLeakyRelu(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteLeakyRelu(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/lp_normalization.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/lp_normalization.cc
@@ -16,15 +16,19 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateLpNormalization(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateLpNormalization(
+    const core::Operation* operation) {
+  return false;
+}
 
-int PrepareLpNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareLpNormalization(core::Operation* operation) {
   LP_NORMALIZATION_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +37,7 @@ int PrepareLpNormalization(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteLpNormalization(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteLpNormalization(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/mat_mul.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/mat_mul.cc
@@ -17,15 +17,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateMatMul(const core::Operation* operation) { return true; }
+NNADAPTER_EXPORT bool ValidateMatMul(const core::Operation* operation) {
+  return true;
+}
 
-int PrepareMatMul(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareMatMul(core::Operation* operation) {
   MAT_MUL_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -124,7 +127,7 @@ int PrepareMatMul(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteMatMul(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteMatMul(core::Operation* operation) {
   NNADAPTER_LOG(FATAL) << OperationTypeToString(operation->type)
                        << " is not implemented!";
   return NNADAPTER_FEATURE_NOT_SUPPORTED;

--- a/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
@@ -17,15 +17,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateMeshgrid(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateMeshgrid(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareMeshgrid(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareMeshgrid(core::Operation* operation) {
   MESHGRID_OPERATION_EXTRACT_INPUTS_OUTPUTS
   for (auto output_operand : output_operands) {
     output_operand->type.dimensions.count = input_count;
@@ -68,7 +71,7 @@ int PrepareMeshgrid(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteMeshgrid(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteMeshgrid(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/pad.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/pad.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidatePad(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidatePad(const core::Operation* operation) {
+  return false;
+}
 
-int PreparePad(core::Operation* operation) {
+NNADAPTER_EXPORT int PreparePad(core::Operation* operation) {
   PAD_OPERATION_EXTRACT_INPUTS_OUTPUTS
   NNADAPTER_CHECK(IsConstantOperand(pads_operand))
       << "Only support constant pads now.";
@@ -60,7 +63,7 @@ int PreparePad(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecutePad(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecutePad(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/pool2d.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/pool2d.cc
@@ -77,9 +77,11 @@ NNADAPTER_EXPORT int32_t CalPoolOutputSize(int32_t input_size,
   return output_size;
 }
 
-bool ValidatePool2D(const core::Operation* operation) { return true; }
+NNADAPTER_EXPORT bool ValidatePool2D(const core::Operation* operation) {
+  return true;
+}
 
-int PreparePool2D(core::Operation* operation) {
+NNADAPTER_EXPORT int PreparePool2D(core::Operation* operation) {
   POOL_2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -118,7 +120,7 @@ int PreparePool2D(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecutePool2D(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecutePool2D(core::Operation* operation) {
   POOL_2D_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Allocate and calculate the output operands

--- a/lite/backends/nnadapter/nnadapter/src/operation/prelu.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/prelu.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidatePRelu(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidatePRelu(const core::Operation* operation) {
+  return false;
+}
 
-int PreparePRelu(core::Operation* operation) {
+NNADAPTER_EXPORT int PreparePRelu(core::Operation* operation) {
   PRELU_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +36,7 @@ int PreparePRelu(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecutePRelu(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecutePRelu(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/prior_box.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/prior_box.cc
@@ -16,14 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
-bool ValidatePriorBox(const core::Operation* operation) { return false; }
 
-int PreparePriorBox(core::Operation* operation) {
+NNADAPTER_EXPORT bool ValidatePriorBox(const core::Operation* operation) {
+  return false;
+}
+
+NNADAPTER_EXPORT int PreparePriorBox(core::Operation* operation) {
   PRIOR_BOX_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -87,7 +91,7 @@ int PreparePriorBox(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecutePriorBox(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecutePriorBox(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/quantize.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/quantize.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateQuantize(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateQuantize(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareQuantize(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareQuantize(core::Operation* operation) {
   QUANTIZE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -42,7 +45,7 @@ int PrepareQuantize(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteQuantize(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteQuantize(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/range.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/range.cc
@@ -17,6 +17,7 @@
 #include "utility/debug.h"
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
@@ -37,9 +38,11 @@ void GetRangeOperandValue(core::Operand* operand, int64_t* data) {  // NOLINT
   }
 }
 
-bool ValidateRange(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateRange(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareRange(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareRange(core::Operation* operation) {
   RANGE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -69,7 +72,7 @@ int PrepareRange(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteRange(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteRange(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/reduce.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/reduce.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateReduce(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateReduce(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareReduce(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareReduce(core::Operation* operation) {
   REDUCE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -84,7 +87,7 @@ int PrepareReduce(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteReduce(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteReduce(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/reshape.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/reshape.cc
@@ -18,15 +18,18 @@
 #include "utility/debug.h"
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateReshape(const core::Operation* operation) { return true; }
+NNADAPTER_EXPORT bool ValidateReshape(const core::Operation* operation) {
+  return true;
+}
 
-int PrepareReshape(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareReshape(core::Operation* operation) {
   RESHAPE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -98,7 +101,7 @@ int PrepareReshape(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteReshape(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteReshape(core::Operation* operation) {
   RESHAPE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Allocate and calculate the output operands

--- a/lite/backends/nnadapter/nnadapter/src/operation/resize.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/resize.cc
@@ -17,6 +17,7 @@
 #include "utility/debug.h"
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
@@ -72,9 +73,11 @@ void CopyShapeDimensionTypeToOutput(core::Operand* shape_operand,
   }
 }
 
-bool ValidateResize(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateResize(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareResize(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareResize(core::Operation* operation) {
   auto& input_operands = operation->input_operands;
   auto& output_operands = operation->output_operands;
   auto input_count = input_operands.size();
@@ -150,7 +153,7 @@ int PrepareResize(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteResize(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteResize(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/roi_align.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/roi_align.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateRoiAlign(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateRoiAlign(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareRoiAlign(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareRoiAlign(core::Operation* operation) {
   ROI_ALIGN_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -55,7 +58,7 @@ int PrepareRoiAlign(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteRoiAlign(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteRoiAlign(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/shape.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/shape.cc
@@ -17,15 +17,18 @@
 #include "utility/debug.h"
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateShape(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateShape(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareShape(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareShape(core::Operation* operation) {
   SHAPE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -41,7 +44,7 @@ int PrepareShape(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteShape(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteShape(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/slice.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/slice.cc
@@ -27,9 +27,11 @@
 namespace nnadapter {
 namespace operation {
 
-bool ValidateSlice(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateSlice(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareSlice(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareSlice(core::Operation* operation) {
   SLICE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -85,7 +87,7 @@ int PrepareSlice(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteSlice(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteSlice(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/softmax.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/softmax.cc
@@ -17,15 +17,18 @@
 #include "operation/math/softmax.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateSoftmax(const core::Operation* operation) { return true; }
+NNADAPTER_EXPORT bool ValidateSoftmax(const core::Operation* operation) {
+  return true;
+}
 
-int PrepareSoftmax(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareSoftmax(core::Operation* operation) {
   SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -34,7 +37,7 @@ int PrepareSoftmax(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteSoftmax(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteSoftmax(core::Operation* operation) {
   SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Allocate and calculate the output operands

--- a/lite/backends/nnadapter/nnadapter/src/operation/softplus.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/softplus.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateSoftplus(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateSoftplus(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareSoftplus(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareSoftplus(core::Operation* operation) {
   SOFTPLUS_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +36,7 @@ int PrepareSoftplus(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteSoftplus(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteSoftplus(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/split.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/split.cc
@@ -17,15 +17,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateSplit(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateSplit(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareSplit(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareSplit(core::Operation* operation) {
   SPLIT_OPERATION_EXTRACT_INPUTS_OUTPUTS
   NNADAPTER_CHECK(IsConstantOperand(axis_operand));
   NNADAPTER_CHECK(IsConstantOperand(split_operand));
@@ -47,7 +50,7 @@ int PrepareSplit(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteSplit(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteSplit(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/squeeze.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/squeeze.cc
@@ -24,9 +24,11 @@
 namespace nnadapter {
 namespace operation {
 
-bool ValidateSqueeze(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateSqueeze(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareSqueeze(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareSqueeze(core::Operation* operation) {
   SQUEEZE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -90,7 +92,7 @@ int PrepareSqueeze(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteSqueeze(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteSqueeze(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/stack.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/stack.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateStack(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateStack(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareStack(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareStack(core::Operation* operation) {
   STACK_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -52,7 +55,7 @@ int PrepareStack(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteStack(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteStack(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/sum.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/sum.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateSum(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateSum(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareSum(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareSum(core::Operation* operation) {
   SUM_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -34,7 +37,7 @@ int PrepareSum(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteSum(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteSum(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/tile.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/tile.cc
@@ -18,15 +18,18 @@
 #include "utility/debug.h"
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateTile(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateTile(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareTile(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareTile(core::Operation* operation) {
   TILE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -88,7 +91,7 @@ int PrepareTile(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteTile(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteTile(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/top_k.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/top_k.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateTopK(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateTopK(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareTopK(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareTopK(core::Operation* operation) {
   TOP_K_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -46,7 +49,7 @@ int PrepareTopK(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteTopK(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteTopK(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/transpose.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/transpose.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateTranspose(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateTranspose(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareTranspose(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareTranspose(core::Operation* operation) {
   TRANSPOSE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -46,7 +49,7 @@ int PrepareTranspose(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteTranspose(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteTranspose(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/unary_activations.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/unary_activations.cc
@@ -16,17 +16,19 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateUnaryActivations(const core::Operation* operation) {
+NNADAPTER_EXPORT bool ValidateUnaryActivations(
+    const core::Operation* operation) {
   return false;
 }
 
-int PrepareUnaryActivations(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareUnaryActivations(core::Operation* operation) {
   UNARY_ACTIVATIONS_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -35,7 +37,7 @@ int PrepareUnaryActivations(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteUnaryActivations(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteUnaryActivations(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/unary_logical_op.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/unary_logical_op.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateUnaryLogicalOp(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateUnaryLogicalOp(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareUnaryLogicalOp(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareUnaryLogicalOp(core::Operation* operation) {
   UNARY_LOGICAL_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -33,7 +36,7 @@ int PrepareUnaryLogicalOp(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteUnaryLogicalOp(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteUnaryLogicalOp(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/unsqueeze.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/unsqueeze.cc
@@ -16,15 +16,18 @@
 #include "core/types.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
 
 namespace nnadapter {
 namespace operation {
 
-bool ValidateUnsqueeze(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateUnsqueeze(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareUnsqueeze(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareUnsqueeze(core::Operation* operation) {
   UNSQUEEZE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -55,7 +58,7 @@ int PrepareUnsqueeze(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteUnsqueeze(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteUnsqueeze(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/where.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/where.cc
@@ -25,9 +25,11 @@
 namespace nnadapter {
 namespace operation {
 
-bool ValidateWhere(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateWhere(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareWhere(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareWhere(core::Operation* operation) {
   WHERE_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape and type of output operands
@@ -38,7 +40,7 @@ int PrepareWhere(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteWhere(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteWhere(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/yolo_box.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/yolo_box.cc
@@ -18,14 +18,18 @@
 #include "utility/debug.h"
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/modeling.h"
 #include "utility/utility.h"
+
 namespace nnadapter {
 namespace operation {
 
-bool ValidateYoloBox(const core::Operation* operation) { return false; }
+NNADAPTER_EXPORT bool ValidateYoloBox(const core::Operation* operation) {
+  return false;
+}
 
-int PrepareYoloBox(core::Operation* operation) {
+NNADAPTER_EXPORT int PrepareYoloBox(core::Operation* operation) {
   YOLO_BOX_OPERATION_EXTRACT_INPUTS_OUTPUTS
 
   // Infer the shape of boxes and scores
@@ -60,7 +64,7 @@ int PrepareYoloBox(core::Operation* operation) {
   return NNADAPTER_NO_ERROR;
 }
 
-int ExecuteYoloBox(core::Operation* operation) {
+NNADAPTER_EXPORT int ExecuteYoloBox(core::Operation* operation) {
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/utility/cache.cc
+++ b/lite/backends/nnadapter/nnadapter/src/utility/cache.cc
@@ -14,6 +14,7 @@
 
 #include "utility/cache.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 #include "utility/string.h"
 #include "utility/utility.h"
 
@@ -25,7 +26,7 @@ static const uint32_t NNADAPTER_CACHE_VERSION_CODE = 1;
 
 static inline uint64_t align4(uint64_t size) { return (size + 3) & ~3; }
 
-void Cache::Clear() { entries_.clear(); }
+NNADAPTER_EXPORT void Cache::Clear() { entries_.clear(); }
 
 bool Cache::Set(const std::string& key, const std::vector<uint8_t>& value) {
   if (entries_.count(key)) return false;
@@ -33,7 +34,9 @@ bool Cache::Set(const std::string& key, const std::vector<uint8_t>& value) {
   return true;
 }
 
-bool Cache::Set(const std::string& key, const void* value, uint64_t size) {
+NNADAPTER_EXPORT bool Cache::Set(const std::string& key,
+                                 const void* value,
+                                 uint64_t size) {
   if (entries_.count(key)) return false;
   entries_[key] = std::vector<uint8_t>();
   entries_[key].resize(size);
@@ -41,32 +44,36 @@ bool Cache::Set(const std::string& key, const void* value, uint64_t size) {
   return true;
 }
 
-bool Cache::Set(const std::string& key, const std::string& value) {
+NNADAPTER_EXPORT bool Cache::Set(const std::string& key,
+                                 const std::string& value) {
   if (entries_.count(key)) return false;
   entries_[key] = std::vector<uint8_t>(value.begin(), value.end());
   return true;
 }
 
-bool Cache::Get(const std::string& key, std::vector<uint8_t>* value) {
+NNADAPTER_EXPORT bool Cache::Get(const std::string& key,
+                                 std::vector<uint8_t>* value) {
   if (!entries_.count(key)) return false;
   *value = entries_[key];
   return true;
 }
 
-bool Cache::Get(const std::string& key, void* value, uint64_t size) {
+NNADAPTER_EXPORT bool Cache::Get(const std::string& key,
+                                 void* value,
+                                 uint64_t size) {
   if (!entries_.count(key)) return false;
   if (entries_[key].size() != size) return false;
   memcpy(value, entries_[key].data(), size);
   return true;
 }
 
-bool Cache::Get(const std::string& key, std::string* value) {
+NNADAPTER_EXPORT bool Cache::Get(const std::string& key, std::string* value) {
   if (!entries_.count(key)) return false;
   value->assign(entries_[key].begin(), entries_[key].end());
   return true;
 }
 
-uint64_t Cache::GetSerializedSize() {
+NNADAPTER_EXPORT uint64_t Cache::GetSerializedSize() {
   auto size = align4(sizeof(CacheHeader));
   for (const auto& e : entries_) {
     size += align4(sizeof(EntryHeader) + e.first.size() + e.second.size());
@@ -74,7 +81,7 @@ uint64_t Cache::GetSerializedSize() {
   return size;
 }
 
-bool Cache::Serialize(void* buffer, uint64_t size) {
+NNADAPTER_EXPORT bool Cache::Serialize(void* buffer, uint64_t size) {
   if (size < GetSerializedSize()) {
     NNADAPTER_LOG(ERROR) << "No enough space, expected " << GetSerializedSize()
                          << " but recevied " << size << " bytes.";
@@ -113,7 +120,7 @@ bool Cache::Serialize(void* buffer, uint64_t size) {
   return true;
 }
 
-bool Cache::Deserialize(void* buffer, uint64_t size) {
+NNADAPTER_EXPORT bool Cache::Deserialize(void* buffer, uint64_t size) {
   Clear();
   auto aligned_cache_header_size = align4(sizeof(CacheHeader));
   if (size < aligned_cache_header_size) {

--- a/lite/backends/nnadapter/nnadapter/src/utility/hints.cc
+++ b/lite/backends/nnadapter/nnadapter/src/utility/hints.cc
@@ -14,16 +14,18 @@
 
 #include "utility/hints.h"
 #include "utility/logging.h"
+#include "utility/micros.h"
 
 namespace nnadapter {
 
-void ClearTemporaryShape(void** handler) {
+NNADAPTER_EXPORT void ClearTemporaryShape(void** handler) {
   NNADAPTER_CHECK(*handler);
   free(*handler);
   *handler = nullptr;
 }
 
-NNAdapterOperandDimensionType* GetTemporaryShape(core::Operand* operand) {
+NNADAPTER_EXPORT NNAdapterOperandDimensionType* GetTemporaryShape(
+    core::Operand* operand) {
   return operand->hints[NNADAPTER_OPERAND_HINTS_KEY_TEMPORARY_SHAPE].handler
              ? reinterpret_cast<NNAdapterOperandDimensionType*>(
                    operand->hints[NNADAPTER_OPERAND_HINTS_KEY_TEMPORARY_SHAPE]
@@ -31,8 +33,8 @@ NNAdapterOperandDimensionType* GetTemporaryShape(core::Operand* operand) {
              : nullptr;
 }
 
-void SetTemporaryShape(core::Operand* operand,
-                       const NNAdapterOperandDimensionType type) {
+NNADAPTER_EXPORT void SetTemporaryShape(
+    core::Operand* operand, const NNAdapterOperandDimensionType type) {
   auto ptr = malloc(sizeof(NNAdapterOperandDimensionType));
   memcpy(ptr, &type, sizeof(NNAdapterOperandDimensionType));
   operand->hints[NNADAPTER_OPERAND_HINTS_KEY_TEMPORARY_SHAPE].handler = ptr;

--- a/lite/backends/nnadapter/nnadapter/src/utility/logging.cc
+++ b/lite/backends/nnadapter/nnadapter/src/utility/logging.cc
@@ -14,6 +14,7 @@
 
 #include "utility/logging.h"
 #include <iomanip>
+#include "utility/micros.h"
 
 namespace nnadapter {
 namespace logging {
@@ -51,15 +52,15 @@ void gen_log(std::ostream& log_stream_,
   }
 }
 
-LogMessage::LogMessage(const char* file,
-                       const char* func,
-                       int lineno,
-                       const char* level)
+NNADAPTER_EXPORT LogMessage::LogMessage(const char* file,
+                                        const char* func,
+                                        int lineno,
+                                        const char* level)
     : level_(level) {
   gen_log(log_stream_, file, func, lineno, level);
 }
 
-LogMessage::~LogMessage() {
+NNADAPTER_EXPORT LogMessage::~LogMessage() {
   log_stream_ << '\n';
 #if defined(ANDROID) || defined(__ANDROID__)
   if (level_ == "I") {
@@ -76,7 +77,7 @@ LogMessage::~LogMessage() {
   fprintf(stderr, "%s", log_stream_.str().c_str());
 }
 
-LogMessageFatal::~LogMessageFatal() noexcept(false) {
+NNADAPTER_EXPORT LogMessageFatal::~LogMessageFatal() noexcept(false) {
   log_stream_ << '\n';
 #if defined(ANDROID) || defined(__ANDROID__)
   ANDROID_LOG_F(log_stream_.str().c_str());
@@ -86,10 +87,10 @@ LogMessageFatal::~LogMessageFatal() noexcept(false) {
   abort();
 }
 
-VLogMessage::VLogMessage(const char* file,
-                         const char* func,
-                         int lineno,
-                         const int32_t level_int) {
+NNADAPTER_EXPORT VLogMessage::VLogMessage(const char* file,
+                                          const char* func,
+                                          int lineno,
+                                          const int32_t level_int) {
   const char* GLOG_v = std::getenv("GLOG_v");
   GLOG_v_int = (GLOG_v && atoi(GLOG_v) > 0) ? atoi(GLOG_v) : 0;
   this->level_int = level_int;
@@ -100,7 +101,7 @@ VLogMessage::VLogMessage(const char* file,
   gen_log(log_stream_, file, func, lineno, level);
 }
 
-VLogMessage::~VLogMessage() {
+NNADAPTER_EXPORT VLogMessage::~VLogMessage() {
   if (GLOG_v_int < this->level_int) {
     return;
   }


### PR DESCRIPTION
1. 解决因 libnnadapter.so 内部导出符号的丢失而导致的在独立编译 HAL 时出现 "undefined reference" 的错误；
2. 解决部分接口导出符号缺失的问题。