### PR TITLE
[OpenCL]Fix matmul bug

### DIFF
--- a/lite/kernels/opencl/matmul_image_compute.cc
+++ b/lite/kernels/opencl/matmul_image_compute.cc
@@ -412,10 +412,12 @@ class MatMulV2ImageCompute : public KernelLite<TARGET(kOpenCL),
                           local_work_size_[1],
                           UP_DIV(m_, 4));
         } else {
-          local_work_size_ = cl::NDRange(8, 4, 16);
-          if (device_version.find("Adreno(TM) 506") != std::string::npos) {
-            local_work_size_ = cl::NDRange(4, 4, 16);
-          }
+          size_t max_work_group_size = 0;
+          kernel_.getWorkGroupInfo<size_t>(CLRuntime::Global()->device(),
+                                           CL_KERNEL_WORK_GROUP_SIZE,
+                                           &max_work_group_size);
+          local_work_size_ = cl::NDRange(
+              std::min(static_cast<int>(max_work_group_size / 64), 8), 4, 16);
           global_work_size_ =
               cl::NDRange(m_, local_work_size_[1], UP_DIV(n_, 4));
           if (is_mali_ || is_apple_m1_) {


### PR DESCRIPTION
oppo R11s的GPU为OpenCL 2.0 Adreno(TM) 512，CL_KERNEL_WORK_GROUP_SIZE 为 288，之前设置的lws超出此大小
