### PR TITLE
[sparse_conv] add profile information for sparse_conv_op

### DIFF
--- a/lite/operators/sparse_conv_op.h
+++ b/lite/operators/sparse_conv_op.h
@@ -40,7 +40,7 @@ class SparseConvOp : public OpLite {
 
 #ifdef LITE_WITH_PROFILE
   void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter* ch) {
-    auto filter_dims = param_.filter->dims();
+    auto filter_dims = param_.oc_nonzeros->dims();
     auto input_dims = param_.x->dims();
     auto output_dims = param_.output->dims();
     ch->input_shape = ch->DimToStr(input_dims);
@@ -59,10 +59,6 @@ class SparseConvOp : public OpLite {
     ch->macs = 2.f *
                output_dims.production() * input_dims[1] / param_.groups;
 
-    if (!param_.fuse_elementwise_op_type.empty()) {
-      ch->remark += param_.fuse_elementwise_op_type;
-      ch->macs += 1.0f * output_dims.production();
-    }
   }
 #endif
 

--- a/lite/operators/sparse_conv_op.h
+++ b/lite/operators/sparse_conv_op.h
@@ -43,7 +43,8 @@ class SparseConvOp : public OpLite {
     auto filter_dims = param_.oc_nonzeros->dims();
     auto input_dims = param_.x->dims();
     auto output_dims = param_.output->dims();
-    ch->input_shape = ch->DimToStr(input_dims);
+    ch->input_shape =
+        std::to_string(input_dims[1]) + "x" + ch->DimToStr(input_dims) + "x1x1";
     ch->output_shape = ch->DimToStr(output_dims);
     ch->filter_shape = ch->DimToStr(filter_dims);
     ch->remark = std::to_string(1) + "x" + std::to_string(1) + "p" +
@@ -53,7 +54,8 @@ class SparseConvOp : public OpLite {
                  std::to_string((*param_.dilations)[0]) +
                  (param_.bias ? "Bias" : "") +
                  ActivationTypeToStr(param_.activation_param.active_type);
-    // MACs = 2.f * kw * kh * batchsize * out_c * out_h * out_w * in_c / group
+    // MACs = 2.f * kw(1) * kh(1) * batchsize * out_c * out_h * out_w * in_c /
+    // group
     // GMACs = 1e-9f * MACs
     // GMACPS = 1e-6f * MACs / predict_ms
     ch->macs = 2.f * output_dims.production() * input_dims[1] / param_.groups;

--- a/lite/operators/sparse_conv_op.h
+++ b/lite/operators/sparse_conv_op.h
@@ -43,10 +43,10 @@ class SparseConvOp : public OpLite {
     auto filter_dims = param_.oc_nonzeros->dims();
     auto input_dims = param_.x->dims();
     auto output_dims = param_.output->dims();
-    ch->input_shape =
-        std::to_string(input_dims[1]) + "x" + ch->DimToStr(input_dims) + "x1x1";
+    ch->input_shape = ch->DimToStr(input_dims);
     ch->output_shape = ch->DimToStr(output_dims);
-    ch->filter_shape = ch->DimToStr(filter_dims);
+    ch->filter_shape = ch->DimToStr(filter_dims) + "x" +
+                       std::to_string(input_dims[1]) + "x1x1";
     ch->remark = std::to_string(1) + "x" + std::to_string(1) + "p" +
                  std::to_string((*param_.paddings)[0]) + "s" +
                  std::to_string(param_.strides[0]) + "g" +

--- a/lite/operators/sparse_conv_op.h
+++ b/lite/operators/sparse_conv_op.h
@@ -38,6 +38,34 @@ class SparseConvOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
+#ifdef LITE_WITH_PROFILE
+  void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter* ch) {
+    auto filter_dims = param_.filter->dims();
+    auto input_dims = param_.x->dims();
+    auto output_dims = param_.output->dims();
+    ch->input_shape = ch->DimToStr(input_dims);
+    ch->output_shape = ch->DimToStr(output_dims);
+    ch->filter_shape = ch->DimToStr(filter_dims);
+    ch->remark =
+        std::to_string(1) + "x" + std::to_string(1) +
+        "p" + std::to_string((*param_.paddings)[0]) + "s" +
+        std::to_string(param_.strides[0]) + "g" +
+        std::to_string(param_.groups) + "d" +
+        std::to_string((*param_.dilations)[0]) + (param_.bias ? "Bias" : "") +
+        ActivationTypeToStr(param_.activation_param.active_type);
+    // MACs = 2.f * kw * kh * batchsize * out_c * out_h * out_w * in_c / group
+    // GMACs = 1e-9f * MACs
+    // GMACPS = 1e-6f * MACs / predict_ms
+    ch->macs = 2.f *
+               output_dims.production() * input_dims[1] / param_.groups;
+
+    if (!param_.fuse_elementwise_op_type.empty()) {
+      ch->remark += param_.fuse_elementwise_op_type;
+      ch->macs += 1.0f * output_dims.production();
+    }
+  }
+#endif
+
   bool AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) override {
     auto X = op_desc.Input("Input").front();
     auto NonZeroWeights = op_desc.Input("NonZeroWeights").front();

--- a/lite/operators/sparse_conv_op.h
+++ b/lite/operators/sparse_conv_op.h
@@ -46,19 +46,17 @@ class SparseConvOp : public OpLite {
     ch->input_shape = ch->DimToStr(input_dims);
     ch->output_shape = ch->DimToStr(output_dims);
     ch->filter_shape = ch->DimToStr(filter_dims);
-    ch->remark =
-        std::to_string(1) + "x" + std::to_string(1) +
-        "p" + std::to_string((*param_.paddings)[0]) + "s" +
-        std::to_string(param_.strides[0]) + "g" +
-        std::to_string(param_.groups) + "d" +
-        std::to_string((*param_.dilations)[0]) + (param_.bias ? "Bias" : "") +
-        ActivationTypeToStr(param_.activation_param.active_type);
+    ch->remark = std::to_string(1) + "x" + std::to_string(1) + "p" +
+                 std::to_string((*param_.paddings)[0]) + "s" +
+                 std::to_string(param_.strides[0]) + "g" +
+                 std::to_string(param_.groups) + "d" +
+                 std::to_string((*param_.dilations)[0]) +
+                 (param_.bias ? "Bias" : "") +
+                 ActivationTypeToStr(param_.activation_param.active_type);
     // MACs = 2.f * kw * kh * batchsize * out_c * out_h * out_w * in_c / group
     // GMACs = 1e-9f * MACs
     // GMACPS = 1e-6f * MACs / predict_ms
-    ch->macs = 2.f *
-               output_dims.production() * input_dims[1] / param_.groups;
-
+    ch->macs = 2.f * output_dims.production() * input_dims[1] / param_.groups;
   }
 #endif
 


### PR DESCRIPTION
解决了 sparse_conv2d 在profiler 工具中无法显示形状和remark的问题：
![image](https://user-images.githubusercontent.com/79566150/164126420-7b166610-054f-4e1d-89f9-4c76286a1bc7.png)
