### PR TITLE
[BUG_FIX]Fix compilation bugs

### DIFF
--- a/lite/api/CMakeLists.txt
+++ b/lite/api/CMakeLists.txt
@@ -11,7 +11,11 @@ execute_process(
     ${LITE_BUILD_TAILOR}
     ${LITE_BUILD_EXTRA}
     ${LITE_WITH_ARM82_FP16}
-    RESULT_VARIABLE result)
+    RESULT_VARIABLE result
+    ERROR_VARIABLE error)
+if(NOT "${error}" STREQUAL "")
+    message(FATAL_ERROR ${error})
+endif()
 # A trick to generate the paddle_use_ops.h
 execute_process(
     COMMAND python ${CMAKE_SOURCE_DIR}/lite/tools/cmake_tools/parse_op_registry.py
@@ -20,7 +24,11 @@ execute_process(
     "${LITE_OPTMODEL_DIR}/.tailored_ops_list"
     ${LITE_BUILD_TAILOR}
     ${LITE_BUILD_EXTRA}
-    RESULT_VARIABLE result)
+    RESULT_VARIABLE result
+    ERROR_VARIABLE error)
+if(NOT "${error}" STREQUAL "")
+    message(FATAL_ERROR ${error})
+endif()
 #----------------------------------------------- NOT CHANGE ---------------------------------------
 
 set(LIGHT_API_SRC  light_api.cc paddle_api.cc light_api_impl.cc paddle_place.cc)

--- a/lite/kernels/CMakeLists.txt
+++ b/lite/kernels/CMakeLists.txt
@@ -112,7 +112,11 @@ execute_process(
     ${CMAKE_BINARY_DIR}/all_kernel_faked.h
     ${CMAKE_BINARY_DIR}/all_kernel_faked.cc
     ${CMAKE_BINARY_DIR}/kernel_src_map.h
-    RESULT_VARIABLE result)
+    RESULT_VARIABLE result
+    ERROR_VARIABLE error)
+if(NOT "${error}" STREQUAL "")
+  message(FATAL_ERROR ${error})
+endif()
 
 file(GLOB all_kernel_faked_src ${CMAKE_BINARY_DIR}/all_kernel_faked_dir/*.cc)
 lite_cc_library(kernels SRCS ${KERNELS_SRC} ${all_kernel_faked_src} DEPS ${lite_kernel_deps})
@@ -129,5 +133,9 @@ execute_process(
     ${ops_src_list}
     ${CMAKE_BINARY_DIR}/supported_kernel_op_info.h
     ${LITE_BUILD_EXTRA}
-    RESULT_VARIABLE result)
+    RESULT_VARIABLE result
+    ERROR_VARIABLE error)
+if(NOT "${error}" STREQUAL "")
+    message(FATAL_ERROR ${error})
+endif()
 #--------------------------------------------------------------------------------------------------

--- a/lite/tools/cmake_tools/create_fake_kernel_registry.py
+++ b/lite/tools/cmake_tools/create_fake_kernel_registry.py
@@ -100,76 +100,144 @@ def parse_fake_kernels_from_path(list_path):
     with open(list_path) as f:
         paths = set([path for path in f])
         for path in paths:
-            with open(path.strip()) as g:
-                c = g.read()
-                kernel_parser = RegisterLiteKernelParser(c)
-                kernel_parser.parse("ON", "ON")
-                for k in kernel_parser.kernels:
-                    out_src_lines = ['#include "all_kernel_faked.h"', ]
-                    out_src_lines.append("")
-                    kernel_name = "{op_type}_{target}_{precision}_{data_layout}_{alias}_class".format(
-                        op_type=k.op_type,
-                        target=k.target,
-                        precision=k.precision,
-                        data_layout=k.data_layout,
-                        alias=k.alias)
+            if (sys.version[0] == '3'):
+                with open(path.strip(), encoding='utf-8') as g:
+                    c = g.read()
+                    kernel_parser = RegisterLiteKernelParser(c)
+                    kernel_parser.parse("ON", "ON")
+                    for k in kernel_parser.kernels:
+                        out_src_lines = ['#include "all_kernel_faked.h"', ]
+                        out_src_lines.append("")
+                        kernel_name = "{op_type}_{target}_{precision}_{data_layout}_{alias}_class".format(
+                            op_type=k.op_type,
+                            target=k.target,
+                            precision=k.precision,
+                            data_layout=k.data_layout,
+                            alias=k.alias)
 
-                    kernel_define = fake_kernel % (kernel_name, k.target,
-                                                   k.precision, k.data_layout,
-                                                   kernel_name)
+                        kernel_define = fake_kernel % (
+                            kernel_name, k.target, k.precision, k.data_layout,
+                            kernel_name)
 
-                    out_lines.append(kernel_define)
-                    out_lines.append("")
-                    out_hdr_lines.append(kernel_define)
-                    out_hdr_lines.append("")
+                        out_lines.append(kernel_define)
+                        out_lines.append("")
+                        out_hdr_lines.append(kernel_define)
+                        out_hdr_lines.append("")
 
-                    key = "REGISTER_LITE_KERNEL(%s, %s, %s, %s, %s, %s)" % (
-                        k.op_type, k.target, k.precision, k.data_layout,
-                        '::paddle::lite::' + kernel_name, k.alias)
-                    out_lines.append(key)
-                    out_src_lines.append(key)
+                        key = "REGISTER_LITE_KERNEL(%s, %s, %s, %s, %s, %s)" % (
+                            k.op_type, k.target, k.precision, k.data_layout,
+                            '::paddle::lite::' + kernel_name, k.alias)
+                        out_lines.append(key)
+                        out_src_lines.append(key)
 
-                    for input in k.inputs:
-                        io = '    .BindInput("%s", {%s})' % (input.name,
-                                                             input.type)
-                        out_lines.append(io)
-                        out_src_lines.append(io)
-                    for output in k.outputs:
-                        io = '    .BindOutput("%s", {%s})' % (output.name,
-                                                              output.type)
-                        out_lines.append(io)
-                        out_src_lines.append(io)
-                    for op_versions in k.op_versions:
-                        io = '    .BindPaddleOpVersion("%s", %s)' % (
-                            op_versions.name, op_versions.version)
-                        out_lines.append(io)
-                        out_src_lines.append(io)
-                    out_lines.append("    .Finalize();")
-                    out_lines.append("")
-                    out_src_lines.append("    .Finalize();")
-                    out_src_lines.append("")
-                    with open(
-                            os.path.join(src_dest_path, '%s.cc' %
-                                         (kernel_name)), 'w') as file:
-                        file.write('\n'.join(out_src_lines))
+                        for input in k.inputs:
+                            io = '    .BindInput("%s", {%s})' % (input.name,
+                                                                 input.type)
+                            out_lines.append(io)
+                            out_src_lines.append(io)
+                        for output in k.outputs:
+                            io = '    .BindOutput("%s", {%s})' % (output.name,
+                                                                  output.type)
+                            out_lines.append(io)
+                            out_src_lines.append(io)
+                        for op_versions in k.op_versions:
+                            io = '    .BindPaddleOpVersion("%s", %s)' % (
+                                op_versions.name, op_versions.version)
+                            out_lines.append(io)
+                            out_src_lines.append(io)
+                        out_lines.append("    .Finalize();")
+                        out_lines.append("")
+                        out_src_lines.append("    .Finalize();")
+                        out_src_lines.append("")
+                        with open(
+                                os.path.join(src_dest_path, '%s.cc' %
+                                             (kernel_name)), 'w') as file:
+                            file.write('\n'.join(out_src_lines))
+            else:
+                with open(path.strip()) as g:
+                    c = g.read()
+                    kernel_parser = RegisterLiteKernelParser(c)
+                    kernel_parser.parse("ON", "ON")
+                    for k in kernel_parser.kernels:
+                        out_src_lines = ['#include "all_kernel_faked.h"', ]
+                        out_src_lines.append("")
+                        kernel_name = "{op_type}_{target}_{precision}_{data_layout}_{alias}_class".format(
+                            op_type=k.op_type,
+                            target=k.target,
+                            precision=k.precision,
+                            data_layout=k.data_layout,
+                            alias=k.alias)
+
+                        kernel_define = fake_kernel % (
+                            kernel_name, k.target, k.precision, k.data_layout,
+                            kernel_name)
+
+                        out_lines.append(kernel_define)
+                        out_lines.append("")
+                        out_hdr_lines.append(kernel_define)
+                        out_hdr_lines.append("")
+
+                        key = "REGISTER_LITE_KERNEL(%s, %s, %s, %s, %s, %s)" % (
+                            k.op_type, k.target, k.precision, k.data_layout,
+                            '::paddle::lite::' + kernel_name, k.alias)
+                        out_lines.append(key)
+                        out_src_lines.append(key)
+
+                        for input in k.inputs:
+                            io = '    .BindInput("%s", {%s})' % (input.name,
+                                                                 input.type)
+                            out_lines.append(io)
+                            out_src_lines.append(io)
+                        for output in k.outputs:
+                            io = '    .BindOutput("%s", {%s})' % (output.name,
+                                                                  output.type)
+                            out_lines.append(io)
+                            out_src_lines.append(io)
+                        for op_versions in k.op_versions:
+                            io = '    .BindPaddleOpVersion("%s", %s)' % (
+                                op_versions.name, op_versions.version)
+                            out_lines.append(io)
+                            out_src_lines.append(io)
+                        out_lines.append("    .Finalize();")
+                        out_lines.append("")
+                        out_src_lines.append("    .Finalize();")
+                        out_src_lines.append("")
+                        with open(
+                                os.path.join(src_dest_path, '%s.cc' %
+                                             (kernel_name)), 'w') as file:
+                            file.write('\n'.join(out_src_lines))
 
 
 def parse_sppported_kernels_from_path(list_path):
     with open(list_path) as f:
         paths = set([path for path in f])
         for path in paths:
-            with open(path.strip()) as g:
-                c = g.read()
-                kernel_parser = RegisterLiteKernelParser(c)
-                kernel_parser.parse("ON", "ON")
+            if (sys.version[0] == '3'):
+                with open(path.strip(), encoding='utf-8') as g:
+                    c = g.read()
+                    kernel_parser = RegisterLiteKernelParser(c)
+                    kernel_parser.parse("ON", "ON")
 
-                for k in kernel_parser.kernels:
-                    index = path.rindex('/')
-                    filename = path[index + 1:]
-                    map_element = '  {"%s,%s,%s,%s,%s", "%s"},' % (
-                        k.op_type, k.target, k.precision, k.data_layout,
-                        k.alias, filename.strip())
-                    kernel_src_map_lines.append(map_element)
+                    for k in kernel_parser.kernels:
+                        index = path.rindex('/')
+                        filename = path[index + 1:]
+                        map_element = '  {"%s,%s,%s,%s,%s", "%s"},' % (
+                            k.op_type, k.target, k.precision, k.data_layout,
+                            k.alias, filename.strip())
+                        kernel_src_map_lines.append(map_element)
+            else:
+                with open(path.strip()) as g:
+                    c = g.read()
+                    kernel_parser = RegisterLiteKernelParser(c)
+                    kernel_parser.parse("ON", "ON")
+
+                    for k in kernel_parser.kernels:
+                        index = path.rindex('/')
+                        filename = path[index + 1:]
+                        map_element = '  {"%s,%s,%s,%s,%s", "%s"},' % (
+                            k.op_type, k.target, k.precision, k.data_layout,
+                            k.alias, filename.strip())
+                        kernel_src_map_lines.append(map_element)
 
 
 parse_fake_kernels_from_path(faked_kernels_list_path)

--- a/lite/tools/cmake_tools/parse_kernel_registry.py
+++ b/lite/tools/cmake_tools/parse_kernel_registry.py
@@ -66,27 +66,50 @@ with open(kernels_list_path) as f:
 with open(faked_kernels_list_path) as f:
     paths = set([path for path in f])
     for path in paths:
-        with open(path.strip()) as g:
-            c = g.read()
-            kernel_parser = RegisterLiteKernelParser(c)
-            kernel_parser.parse(with_extra, "ON")
+        if (sys.version[0] == '3'):
+            with open(path.strip(), encoding='utf-8') as g:
+                c = g.read()
+                kernel_parser = RegisterLiteKernelParser(c)
+                kernel_parser.parse(with_extra, "ON")
 
-            for k in kernel_parser.kernels:
-                kernel = "%s,%s,%s,%s,%s" % (
-                    k.op_type,
-                    k.target,
-                    k.precision,
-                    k.data_layout,
-                    k.alias, )
-                if tailored == "ON":
-                    if kernel not in minlines: continue
-                key = "USE_LITE_KERNEL(%s, %s, %s, %s, %s);" % (
-                    k.op_type,
-                    k.target,
-                    k.precision,
-                    k.data_layout,
-                    k.alias, )
-                out_lines.append(key)
+                for k in kernel_parser.kernels:
+                    kernel = "%s,%s,%s,%s,%s" % (
+                        k.op_type,
+                        k.target,
+                        k.precision,
+                        k.data_layout,
+                        k.alias, )
+                    if tailored == "ON":
+                        if kernel not in minlines: continue
+                    key = "USE_LITE_KERNEL(%s, %s, %s, %s, %s);" % (
+                        k.op_type,
+                        k.target,
+                        k.precision,
+                        k.data_layout,
+                        k.alias, )
+                    out_lines.append(key)
+        else:
+            with open(path.strip()) as g:
+                c = g.read()
+                kernel_parser = RegisterLiteKernelParser(c)
+                kernel_parser.parse(with_extra, "ON")
+
+                for k in kernel_parser.kernels:
+                    kernel = "%s,%s,%s,%s,%s" % (
+                        k.op_type,
+                        k.target,
+                        k.precision,
+                        k.data_layout,
+                        k.alias, )
+                    if tailored == "ON":
+                        if kernel not in minlines: continue
+                    key = "USE_LITE_KERNEL(%s, %s, %s, %s, %s);" % (
+                        k.op_type,
+                        k.target,
+                        k.precision,
+                        k.data_layout,
+                        k.alias, )
+                    out_lines.append(key)
 
 with open(dest_path, 'w') as f:
     logging.info("write kernel list to %s" % dest_path)

--- a/lite/tools/cmake_tools/record_supported_kernel_op.py
+++ b/lite/tools/cmake_tools/record_supported_kernel_op.py
@@ -102,14 +102,24 @@ with open(kernels_list_path) as f:
 with open(faked_kernels_list_path) as f:
     paths = set([path for path in f])
     for path in paths:
-        with open(path.strip()) as g:
-            c = g.read()
-            kernel_parser = RegisterLiteKernelParser(c)
-            kernel_parser.parse("ON", "ON")
-            for k in kernel_parser.kernels:
-                if hasattr(TargetType, k.target):
-                    index = getattr(TargetType, k.target)
-                    valid_ops[index].append(k.op_type)
+        if (sys.version[0] == '3'):
+            with open(path.strip(), encoding='utf-8') as g:
+                c = g.read()
+                kernel_parser = RegisterLiteKernelParser(c)
+                kernel_parser.parse("ON", "ON")
+                for k in kernel_parser.kernels:
+                    if hasattr(TargetType, k.target):
+                        index = getattr(TargetType, k.target)
+                        valid_ops[index].append(k.op_type)
+        else:
+            with open(path.strip()) as g:
+                c = g.read()
+                kernel_parser = RegisterLiteKernelParser(c)
+                kernel_parser.parse("ON", "ON")
+                for k in kernel_parser.kernels:
+                    if hasattr(TargetType, k.target):
+                        index = getattr(TargetType, k.target)
+                        valid_ops[index].append(k.op_type)
 
 # clear the repeated ops
 for target in valid_targets:


### PR DESCRIPTION
cmake config过程中需要运行几个python脚本来生成一些文件， 如果python 链接到2.7版本，则可以正常生成，如果python链接到了3.5 3.6等，则无法正常生成，该pr做出修改：
1、如果没有正确生成，则在cmake config过程中报错并终止，不用等到编译过程中报错。
<img width="347" alt="image" src="https://user-images.githubusercontent.com/63448337/163715038-d6ad0b34-9837-48f1-9dce-6e07880cfaa7.png">

2、修改脚本，是python2 python3都可以使cmake过程正常。