### PR TITLE
[Op] fix split bug when sections having -1

### DIFF
--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -44,14 +44,14 @@ bool SplitOp::InferShapeImpl() const {
     axis += in_dims.size();
   }
   // update sections
-  int infer_num = 0;
+  int infer_num = std::count(sections.begin(), sections.end(), -1);
+  CHECK_LT(infer_num, 2);
   for (int i = 0; i < sections.size(); i++) {
     if (sections[i] == -1) {
       sections[i] =
           in_dims[axis] - std::accumulate(sections.begin(), sections.end(), 1);
     }
   }
-  CHECK_LT(infer_num, 2);
   // update sections end
 
   const int outs_number = outs.size();

--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -45,19 +45,13 @@ bool SplitOp::InferShapeImpl() const {
   }
   // update sections
   int infer_num = 0;
-  int infer_index = -1;
-  int other_sum = 0;
-  for (int i = 0; i < sections.size(); i++)
-  {
-    if (sections[i] == -1) 
-    {
-      infer_num += 1;
-      infer_index = i;
+  for (int i = 0; i < sections.size(); i++) {
+    if (sections[i] == -1) {
+      sections[i] = in_dims[axis] -
+                    std::accumulate(sections.begin(), sections.end(), 0) - 1;
     }
-    else other_sum += sections[i];
   }
   CHECK_LT(infer_num, 2);
-  sections[infer_index] = in_dims[axis] - other_sum;
   // update sections end
 
   const int outs_number = outs.size();

--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -21,7 +21,6 @@ namespace operators {
 
 bool SplitOp::CheckShape() const {
   CHECK_OR_FALSE(param_.x);
-  CHECK_GT_OR_FALSE(param_.output.size(), 1UL);
   auto x_dims = param_.x->dims();
   auto x_rank = x_dims.size();
   CHECK_GE(param_.axis, -static_cast<int>(x_rank));
@@ -33,7 +32,7 @@ bool SplitOp::InferShapeImpl() const {
   const auto &outs = param_.output;
   auto in_dims = param_.x->dims();
   int num = param_.num;
-  const auto &sections = param_.sections;
+  auto &sections = param_.sections;
 
   int axis = 0;
   if (param_.axis_tensor != nullptr) {
@@ -44,6 +43,22 @@ bool SplitOp::InferShapeImpl() const {
   if (axis < 0) {
     axis += in_dims.size();
   }
+  // update sections
+  int infer_num = 0;
+  int infer_index = -1;
+  int other_sum = 0;
+  for (int i = 0; i < sections.size(); i++)
+  {
+    if (sections[i] == -1) 
+    {
+      infer_num += 1;
+      infer_index = i;
+    }
+    else other_sum += sections[i];
+  }
+  CHECK_LT(infer_num, 2);
+  sections[infer_index] = in_dims[axis] - other_sum;
+  // update sections end
 
   const int outs_number = outs.size();
   std::vector<lite::DDim> outs_dims;

--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -47,8 +47,8 @@ bool SplitOp::InferShapeImpl() const {
   int infer_num = 0;
   for (int i = 0; i < sections.size(); i++) {
     if (sections[i] == -1) {
-      sections[i] = in_dims[axis] -
-                    std::accumulate(sections.begin(), sections.end(), 0) - 1;
+      sections[i] =
+          in_dims[axis] - std::accumulate(sections.begin(), sections.end(), 1);
     }
   }
   CHECK_LT(infer_num, 2);


### PR DESCRIPTION
cascade_rcnn_r50_fpn_1x_coco模型运行时出错。
定位为split Op的问题，当属性sections含-1时需要自行推断更新sections