### PR TITLE
Add an interface for obtaining OP shapes.

### DIFF
--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -182,7 +182,7 @@ class LITE_API Predictor {
     ClearTensorArray(program_desc_);
   }
 
-  std::map<std::string, std::vector<std::string>> Get_op_info(){
+  std::map<std::string, std::vector<std::string>> Get_op_info() {
     if (!program_generated_) {
       GenRuntimeProgram();
     }
@@ -196,7 +196,8 @@ class LITE_API Predictor {
     lite::TargetWrapperXPU::MallocL3Cache(query_shape);
 #endif
 
-    std::map<std::string, std::vector<std::string>> res = program_->Get_op_info();
+    std::map<std::string, std::vector<std::string>> res =
+        program_->Get_op_info();
 
 #ifdef LITE_WITH_XPU
     lite::TargetWrapperXPU::FreeL3Cache();

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -269,6 +269,13 @@ void CxxPaddleApiImpl::Run() {
   raw_predictor_->Run();
 }
 
+std::map<std::string, std::vector<std::string>> CxxPaddleApiImpl::Get_op_info() {
+#ifdef LITE_WITH_ARM
+  lite::DeviceInfo::Global().SetRunMode(mode_, threads_);
+#endif
+  return raw_predictor_->Get_op_info();
+}
+
 std::shared_ptr<lite_api::PaddlePredictor> CxxPaddleApiImpl::Clone() {
   std::lock_guard<std::mutex> lock(mutex_);
   auto predictor =

--- a/lite/api/cxx_api_impl.cc
+++ b/lite/api/cxx_api_impl.cc
@@ -269,7 +269,8 @@ void CxxPaddleApiImpl::Run() {
   raw_predictor_->Run();
 }
 
-std::map<std::string, std::vector<std::string>> CxxPaddleApiImpl::Get_op_info() {
+std::map<std::string, std::vector<std::string>>
+CxxPaddleApiImpl::Get_op_info() {
 #ifdef LITE_WITH_ARM
   lite::DeviceInfo::Global().SetRunMode(mode_, threads_);
 #endif

--- a/lite/api/python/pybind/pybind.cc
+++ b/lite/api/python/pybind/pybind.cc
@@ -390,6 +390,7 @@ void BindLiteCxxPredictor(py::module *m) {
       .def("get_input_by_name", &CxxPaddleApiImpl::GetInputByName)
       .def("get_output_by_name", &CxxPaddleApiImpl::GetOutputByName)
       .def("run", &CxxPaddleApiImpl::Run)
+      .def("get_op_info", &CxxPaddleApiImpl::Get_op_info)
       .def("get_version", &CxxPaddleApiImpl::GetVersion)
       .def("save_optimized_pb_model",
            [](CxxPaddleApiImpl &self, const std::string &output_dir) {

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -130,7 +130,13 @@ class OpLite : public Registry {
                     lite::Tensor **output_var);
 
   virtual ~OpLite() = default;
+  std::vector<const Tensor *> get_input_tensor_ptrs() {
+    return this->input_tensor_ptrs_cache_;
+  }
 
+  std::vector<Tensor *> get_output_tensor_ptrs() {
+    return this->output_tensor_ptrs_cache_; 
+  }
  protected:
   // Attach it with the runtime environment.
   virtual bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) = 0;

--- a/lite/core/op_lite.h
+++ b/lite/core/op_lite.h
@@ -135,8 +135,9 @@ class OpLite : public Registry {
   }
 
   std::vector<Tensor *> get_output_tensor_ptrs() {
-    return this->output_tensor_ptrs_cache_; 
+    return this->output_tensor_ptrs_cache_;
   }
+
  protected:
   // Attach it with the runtime environment.
   virtual bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) = 0;

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -500,12 +500,12 @@ std::map<std::string, std::vector<std::string>> RuntimeProgram::Get_op_info() {
   monitor.inferStart();
 #endif
 
-    int idx = -1;
+  int idx = -1;
 
-    std::map<std::string, std::vector<std::string>> res;  
-    auto& insts = instructions_[kRootBlockIdx];
-    for (auto& inst : insts) {
-      ++idx;
+  std::map<std::string, std::vector<std::string>> res;
+  auto& insts = instructions_[kRootBlockIdx];
+  for (auto& inst : insts) {
+    ++idx;
 #if !defined(LITE_WITH_FPGA) && !defined(LITE_WITH_METAL)
     if (inst.is_feed_fetch_op()) continue;
 #endif
@@ -513,12 +513,12 @@ std::map<std::string, std::vector<std::string>> RuntimeProgram::Get_op_info() {
     NVTXRangeAnnotation annotation = annotator.AnnotateBlock();
     nvtxStringHandle_t registered_name = register_layer_names_[idx];
     if (annotator.IsEnabled()) {
-    annotation.generate(registered_name, lite::Color::Runner);
+      annotation.generate(registered_name, lite::Color::Runner);
     }
 #endif
 #ifdef LITE_WITH_CUDA
     if (inst.need_sync()) {
-    inst.Sync();
+      inst.Sync();
     }
 #endif
 
@@ -530,9 +530,9 @@ std::map<std::string, std::vector<std::string>> RuntimeProgram::Get_op_info() {
     // delegate flush judgement to specify target , it is too heavy for Inst
     inst.Flush(idx);
 #endif
-      std::pair<std::string, std::vector<std::string>> op_info_shape;  
-      op_info_shape = inst.Get_op_info();
-      res.insert(op_info_shape);
+    std::pair<std::string, std::vector<std::string>> op_info_shape;
+    op_info_shape = inst.Get_op_info();
+    res.insert(op_info_shape);
 #ifdef LITE_WITH_FPGA
     monitor.postRun(inst);
 #endif
@@ -540,13 +540,13 @@ std::map<std::string, std::vector<std::string>> RuntimeProgram::Get_op_info() {
 #ifdef LITE_WITH_PRECISION_PROFILE
 #ifndef LITE_WITH_FPGA
     if (inst.op()->Type() != "while") {
-    precision_profiler_summary +=
-        inst_precision_profiler.GetInstPrecision(&inst);
+      precision_profiler_summary +=
+          inst_precision_profiler.GetInstPrecision(&inst);
     }
 #endif
 #endif  // LITE_WITH_PRECISION_PROFILE
-    }
-    return res;
+  }
+  return res;
 }
 
 void Program::Build(const std::shared_ptr<cpp::ProgramDesc>& program_desc) {
@@ -738,12 +738,11 @@ void Instruction::Run() {
 }
 
 std::pair<std::string, std::vector<std::string>> Instruction::Get_op_info() {
-
-  std::pair<std::string, std::vector<std::string>> res;  
+  std::pair<std::string, std::vector<std::string>> res;
 
   CHECK(op_) << "op null";
   CHECK(kernel_) << "kernel null";
-  
+
   if (first_epoch_) {
     first_epoch_ = false;
     CHECK(op_->CheckShape());
@@ -755,18 +754,18 @@ std::pair<std::string, std::vector<std::string>> Instruction::Get_op_info() {
 
   op_->InferShape();
 
-  const OpInfo *op_info_temp = op_->op_info();
+  const OpInfo* op_info_temp = op_->op_info();
   std::vector<std::string> inputs = op_info_temp->input_names();
   std::vector<std::string> outputs = op_info_temp->output_names();
-  
+
   std::string res_key = op_->Type() + "+" + outputs[0];
   std::vector<std::string> res_value;
-  for(auto it : op_->get_input_tensor_ptrs())
+  for (auto it : op_->get_input_tensor_ptrs())
     res_value.push_back(it->dims().repr());
-  for(auto it : op_->get_output_tensor_ptrs())
+  for (auto it : op_->get_output_tensor_ptrs())
     res_value.push_back(it->dims().repr());
   res = std::make_pair(res_key, res_value);
-  
+
   kernel_->Launch();
   has_run_ = true;
   return res;

--- a/lite/core/program.h
+++ b/lite/core/program.h
@@ -118,6 +118,7 @@ struct Instruction {
 
   // Run the instruction.
   void Run();
+  std::pair<std::string, std::vector<std::string>> Get_op_info();
 #ifdef LITE_WITH_METAL
   void SaveOutput();
 #endif
@@ -281,6 +282,7 @@ class LITE_API RuntimeProgram {
   }
 
   void Run();
+  std::map<std::string, std::vector<std::string>> Get_op_info();
 #ifdef LITE_WITH_METAL
   void SaveOutput();
 #endif


### PR DESCRIPTION
A python API is added to obtain the input and output shapes of each op in the model

场景：PaddleSlim的延时预估器功能通过获取模型opt优化后的graph信息，预估模型耗时。

需求：当导出预测模型是动态输入时，每个op具体的输入输出shape是不明确的。希望开发一个python api去获取准确的 op 信息，以支持延时预估器的功能，开放给用户使用。