### PR TITLE
Fix the bug of topological sorting of the main frame

### DIFF
--- a/lite/core/optimizer/mir/fusion/fc_fuser.cc
+++ b/lite/core/optimizer/mir/fusion/fc_fuser.cc
@@ -135,6 +135,7 @@ void FcFuser::InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) {
   fc_op->Attach(op_desc, scope);
 
   auto* new_op_node = graph->GraphCreateInstructNode(fc_op, valid_places);
+  new_op_node->set_id(matched.at("mul")->get_id());
 
   IR_NODE_LINK_TO(matched.at("W"), new_op_node);
   IR_NODE_LINK_TO(matched.at("x"), new_op_node);

--- a/lite/core/optimizer/mir/node.h
+++ b/lite/core/optimizer/mir/node.h
@@ -166,11 +166,15 @@ class Node {
   bool IsStmt() const { return role_ == Role::kStmt; }
   bool IsArg() const { return role_ == Role::kArg; }
 
+  void set_id(int id) { id_ = id; }
+  int get_id() { return id_; }
+
  private:
   // Either stmt_ or argument_ is used.
   std::unique_ptr<Stmt> stmt_;
   std::unique_ptr<Arg> arg_;
   Role role_{Role::kUnk};
+  int id_;
 };
 }  // namespace mir
 }  // namespace lite

--- a/lite/core/optimizer/mir/ssa_graph.cc
+++ b/lite/core/optimizer/mir/ssa_graph.cc
@@ -18,6 +18,7 @@
 #include <memory>
 #include <set>
 #include <utility>
+#include "lite/core/optimizer/mir/dot.h"
 
 namespace paddle {
 namespace lite {
@@ -40,8 +41,9 @@ bool SSAGraph::CheckBidirectionalConnection() {
   return true;
 }
 
-std::map<mir::Node *, std::set<mir::Node *>> SSAGraph::BuildOperationAdjList() {
-  std::map<mir::Node *, std::set<mir::Node *>> adj_list;
+std::map<mir::Node *, std::set<mir::Node *>, NodeComp>
+SSAGraph::BuildOperationAdjList() {
+  std::map<mir::Node *, std::set<mir::Node *>, NodeComp> adj_list;
 
   for (auto &n : mutable_nodes()) {
     if (!n.IsStmt()) continue;
@@ -57,7 +59,7 @@ std::map<mir::Node *, std::set<mir::Node *>> SSAGraph::BuildOperationAdjList() {
     }
     std::stable_sort(
         nodes.begin(), nodes.end(), [](mir::Node *node1, mir::Node *node2) {
-          return node1 > node2;
+          return node1->get_id() < node2->get_id();
         });
     adj_list[&n].insert(std::make_move_iterator(nodes.begin()),
                         std::make_move_iterator(nodes.end()));
@@ -65,8 +67,9 @@ std::map<mir::Node *, std::set<mir::Node *>> SSAGraph::BuildOperationAdjList() {
   return adj_list;
 }
 
-std::map<mir::Node *, std::set<mir::Node *>> SSAGraph::BuildNodeAdjList() {
-  std::map<mir::Node *, std::set<mir::Node *>> adj_list;
+std::map<mir::Node *, std::set<mir::Node *>, NodeComp>
+SSAGraph::BuildNodeAdjList() {
+  std::map<mir::Node *, std::set<mir::Node *>, NodeComp> adj_list;
 
   for (auto &n : mutable_nodes()) {
     if (adj_list.find(&n) == adj_list.end()) {
@@ -78,7 +81,7 @@ std::map<mir::Node *, std::set<mir::Node *>> SSAGraph::BuildNodeAdjList() {
     }
     std::stable_sort(
         nodes.begin(), nodes.end(), [](mir::Node *node1, mir::Node *node2) {
-          return node1 > node2;
+          return node1->get_id() < node2->get_id();
         });
     adj_list[&n].insert(std::make_move_iterator(nodes.begin()),
                         std::make_move_iterator(nodes.end()));
@@ -87,7 +90,7 @@ std::map<mir::Node *, std::set<mir::Node *>> SSAGraph::BuildNodeAdjList() {
 }
 
 void SSAGraph::SortHelper(
-    const std::map<mir::Node *, std::set<mir::Node *>> &adj_list,
+    const std::map<mir::Node *, std::set<mir::Node *>, NodeComp> &adj_list,
     mir::Node *node,
     std::set<mir::Node *> *visited,
     std::vector<mir::Node *> *ret) {
@@ -167,9 +170,11 @@ void SSAGraph::Build(const Program &program,
 
   auto var_type_map = program.var_type_map();
   std::map<std::string, mir::Node *> arg_update_node_map;
+  int num_node_created = 0;
   for (auto &op : program.ops(block_idx)) {
     VLOG(3) << op->op_info()->Type();
     auto *op_node = GraphCreateInstructNode(op, valid_places);
+    op_node->set_id(num_node_created++);
     auto *op_info = op->op_info();
     const auto &op_type = op_info->Type();
     for (const auto &var_name : op_info->input_names()) {
@@ -179,6 +184,7 @@ void SSAGraph::Build(const Program &program,
       } else {
         node_storage_.emplace_back();
         arg_node = &node_storage_.back();
+        arg_node->set_id(num_node_created++);
         arg_node->AsArg(var_name, node_storage_.size() - 1);
         arg_update_node_map[var_name] = arg_node;
       }
@@ -202,6 +208,7 @@ void SSAGraph::Build(const Program &program,
     for (const auto &var_name : op->op_info()->output_names()) {
       node_storage_.emplace_back();
       auto *arg_node = &node_storage_.back();
+      arg_node->set_id(num_node_created++);
       arg_node->AsArg(var_name, node_storage_.size() - 1);
       arg_update_node_map[var_name] = arg_node;
       if (var_type_map.count(var_name) && !arg_node->arg()->type) {
@@ -333,6 +340,49 @@ Node *SSAGraph::NewInstructNode() {
   return &node_storage_.back();
 }
 
+std::string SSAGraph::dump() {
+  paddle::lite::mir::Dot dot;
+  using Attr = paddle::lite::mir::Dot::Attr;
+  const std::vector<Attr> op_attrs{Attr("style", "filled"),
+                                   Attr("fillcolor", "yellow")};
+  const std::vector<Attr> var_attrs{Attr("style", "filled"),
+                                    Attr("fillcolor", "gray"),
+                                    Attr("shape", "record")};
+  const std::vector<Attr> edge_attrs{};
+  for (auto &it : node_storage_) {
+    if (!it.IsArg()) continue;
+    if (it.arg()->is_weight) continue;
+    dot.AddNode(std::to_string(it.get_id()), var_attrs, it.arg()->name);
+  }
+  for (auto &it : node_storage_) {
+    if (!it.IsStmt()) continue;
+    const std::string op_type = it.stmt()->op_type();
+    dot.AddNode(std::to_string(it.get_id()), op_attrs, op_type);
+    if (op_type == "feed") {
+      for (auto out : it.outlinks)
+        dot.AddEdge(std::to_string(it.get_id()),
+                    std::to_string(out->get_id()),
+                    edge_attrs);
+    } else if (op_type == "fetch") {
+      for (auto in : it.inlinks)
+        dot.AddEdge(std::to_string(in->get_id()),
+                    std::to_string(it.get_id()),
+                    edge_attrs);
+    } else {
+      for (auto in : it.inlinks) {
+        if (in->arg()->is_weight) continue;
+        dot.AddEdge(std::to_string(in->get_id()),
+                    std::to_string(it.get_id()),
+                    edge_attrs);
+      }
+      for (auto out : it.outlinks)
+        dot.AddEdge(std::to_string(it.get_id()),
+                    std::to_string(out->get_id()),
+                    edge_attrs);
+    }
+  }
+  return dot.Build();
+}
 }  // namespace mir
 }  // namespace lite
 }  // namespace paddle

--- a/lite/core/optimizer/mir/ssa_graph.h
+++ b/lite/core/optimizer/mir/ssa_graph.h
@@ -30,6 +30,12 @@ namespace paddle {
 namespace lite {
 namespace mir {
 
+struct NodeComp {
+  bool operator()(mir::Node *const &node1, mir::Node *const &node2) const {
+    return node1->get_id() < node2->get_id();
+  }
+};
+
 // An Graph for MIR. It is built from a list of Op and a scope.
 class GraphBase {};
 
@@ -80,6 +86,8 @@ class SSAGraph : GraphBase {
 
   int blockIdx() { return block_idx_; }
 
+  std::string dump();
+
  private:
   mir::Node *Argument(const std::string &name);
   // Check the bidirectional connection.
@@ -95,15 +103,17 @@ class SSAGraph : GraphBase {
   }
 
   // Build operator inlink edge table.
-  std::map<mir::Node *, std::set<mir::Node *>> BuildOperationAdjList();
+  std::map<mir::Node *, std::set<mir::Node *>, NodeComp>
+  BuildOperationAdjList();
 
   // Build node inlink edge table.
-  std::map<mir::Node *, std::set<mir::Node *>> BuildNodeAdjList();
+  std::map<mir::Node *, std::set<mir::Node *>, NodeComp> BuildNodeAdjList();
 
-  void SortHelper(const std::map<mir::Node *, std::set<mir::Node *>> &adj_list,
-                  mir::Node *node,
-                  std::set<mir::Node *> *visited,
-                  std::vector<mir::Node *> *ret);
+  void SortHelper(
+      const std::map<mir::Node *, std::set<mir::Node *>, NodeComp> &adj_list,
+      mir::Node *node,
+      std::set<mir::Node *> *visited,
+      std::vector<mir::Node *> *ret);
 
  private:
   std::list<mir::Node> node_storage_;

--- a/lite/core/program.h
+++ b/lite/core/program.h
@@ -87,6 +87,12 @@ struct Program {
     return var_type_map_;
   }
 
+  std::vector<std::string> getBlockOpsOrder(int block_idx) {
+    std::vector<std::string> ret;
+    for (auto& it : ops_[block_idx]) ret.push_back(it->op_info()->Type());
+    return ret;
+  }
+
  private:
   // Build from a program and scope.
   void Build(const std::shared_ptr<cpp::ProgramDesc>& program_desc);


### PR DESCRIPTION
简介：当前pr修复了lite主框架拓扑排序的问题。

背景：
lite工作流程 program --> SSAgraph(IR) --> runtime_program。
从 program 建立的IR，逻辑上可能存在多种拓扑顺序，但只有与program中保存的算子执行顺序一致时，才是最为安全妥当的。

主要修改如下：
SSAGraph::BuildNodeAdjList()的修改，保证了上面背景中的要求。
SSAGraph node 中的修改，这里有一个重要的概念，node中新增 id_ 字段，保存node的相对执行顺序。可通过API get_id(), set_id() 读取和设置。

新增辅助debug的API： 
SSAGraph::dump() : 通过调用graph.dump() 直接把IR结构打印下来（dot图的形式），方便观察pass对IR结构的修改
graph::getBlockOpsOrder(int block_idx); 打印加载的program中保存的原始的算子执行顺序

### 注意：
当一些pass需要插入一个 op时：
如 fc fuse pass； mul + eleadd --> fc ，新创建的fc node， 其 id 值应设置为 mul 或者 eleadd 的 id 值，
<img width="522" alt="image" src="https://user-images.githubusercontent.com/63448337/165456106-7e4e5dfa-723d-4634-9c69-7b8b60f26998.png">

当前pr并未对相关的所有pass做类似的修改， 如插入 io copy算子。后续会陆续做出补充