### PR TITLE
Fix the bug of topological sorting of the main frame

### DIFF
--- a/lite/core/optimizer/mir/node.h
+++ b/lite/core/optimizer/mir/node.h
@@ -166,11 +166,15 @@ class Node {
   bool IsStmt() const { return role_ == Role::kStmt; }
   bool IsArg() const { return role_ == Role::kArg; }
 
+  void set_id(int id) { id_ = id; }
+  int get_id() { return id_; }
+
  private:
   // Either stmt_ or argument_ is used.
   std::unique_ptr<Stmt> stmt_;
   std::unique_ptr<Arg> arg_;
   Role role_{Role::kUnk};
+  int id_;
 };
 }  // namespace mir
 }  // namespace lite

--- a/lite/core/optimizer/mir/ssa_graph.h
+++ b/lite/core/optimizer/mir/ssa_graph.h
@@ -30,6 +30,17 @@ namespace paddle {
 namespace lite {
 namespace mir {
 
+struct NodeCompV2 {
+  bool operator()(mir::Node *const &node1, mir::Node *const &node2) const {
+    return node1 < node2;
+  }
+};
+struct NodeComp {
+  bool operator()(mir::Node *const &node1, mir::Node *const &node2) const {
+    return node1->get_id() < node2->get_id();
+  }
+};
+
 // An Graph for MIR. It is built from a list of Op and a scope.
 class GraphBase {};
 
@@ -80,6 +91,8 @@ class SSAGraph : GraphBase {
 
   int blockIdx() { return block_idx_; }
 
+  std::string dump();
+
  private:
   mir::Node *Argument(const std::string &name);
   // Check the bidirectional connection.
@@ -95,21 +108,26 @@ class SSAGraph : GraphBase {
   }
 
   // Build operator inlink edge table.
-  std::map<mir::Node *, std::set<mir::Node *>> BuildOperationAdjList();
+  std::map<mir::Node *, std::set<mir::Node *, NodeComp>, NodeComp>
+  BuildOperationAdjList();
 
   // Build node inlink edge table.
-  std::map<mir::Node *, std::set<mir::Node *>> BuildNodeAdjList();
+  std::map<mir::Node *, std::set<mir::Node *, NodeComp>, NodeComp>
+  BuildNodeAdjList();
 
-  void SortHelper(const std::map<mir::Node *, std::set<mir::Node *>> &adj_list,
-                  mir::Node *node,
-                  std::set<mir::Node *> *visited,
-                  std::vector<mir::Node *> *ret);
+  void SortHelper(
+      const std::map<mir::Node *, std::set<mir::Node *, NodeComp>, NodeComp>
+          &adj_list,
+      mir::Node *node,
+      std::set<mir::Node *, NodeComp> *visited,
+      std::vector<mir::Node *> *ret);
 
  private:
   std::list<mir::Node> node_storage_;
   std::map<std::string, mir::Node *> arguments_;
   std::vector<Place> valid_places_;
   int block_idx_ = kRootBlockIdx;
+  int num_node_created_ = 0;
 };
 
 // Remove the link between a -> b.

--- a/lite/core/program.h
+++ b/lite/core/program.h
@@ -87,6 +87,12 @@ struct Program {
     return var_type_map_;
   }
 
+  std::vector<std::string> getBlockOpsOrder(int block_idx) {
+    std::vector<std::string> ret;
+    for (auto& it : ops_[block_idx]) ret.push_back(it->op_info()->Type());
+    return ret;
+  }
+
  private:
   // Build from a program and scope.
   void Build(const std::shared_ptr<cpp::ProgramDesc>& program_desc);


### PR DESCRIPTION
简介：修复了lite主框架拓扑排序紊乱的问题。
背景：拓扑排序不稳定，多次推理时，发现执行算子顺序可能不相同。这会导致模型概率性跑通。也可能会导致light_api跑不过，cxx_api跑得过等之类的“奇怪问题”。

问题原因与解决方案：
topo排序函数中使用的辅助数据结构map或者set以指针为key时，默认元素按照指针大小排序，有不稳定因素
![image](https://user-images.githubusercontent.com/63448337/165692652-1170ef04-c752-42e9-b988-68a61397b2e6.png)
需要给map提供一个compare函数对象，使map结构稳定。
![image](https://user-images.githubusercontent.com/63448337/165693120-01f6b9de-a43e-4b0f-bf64-2cf69a43786d.png)
其中的 node 的 id值表述创建该node时，node的总个数。

该pr的修改：
mlir::node定义中，增加 id_ 字段。表示 ssagraph 创建该node时，node的总个数。由于 从 program --> SSAgraph(IR)，是按照program中的算子执行顺序逐个创建 op node 与 var node。因此 op node 的 id 值表示op node之间的相对执行顺序。

ssa_graph中的修改：修改 map 定义，保证map结构的稳定。

新增两个debug API：
program::getBlockOpsOrder(int block_idx); 获取program中保存的原始的算子执行顺序。
ssa_graph::dump(); 方便通过graph->dump()的调用方式，将 IR 结构dump下来（dot图形式），观察pass对IR的修改。

！注意
该pr中定义了两个 版本的比较对象，主要是进行CI测试，后续会删除。
<img width="565" alt="image" src="https://user-images.githubusercontent.com/63448337/165694465-601a252b-5963-4622-933c-1edf8bcda0e0.png">
V2版本相当于没有给 map 定义任何比较对象（默认以指针大小排序）。
在对比的pr测试中，该方式能够跑通当前所有CI的模型。
对比pr：https://github.com/PaddlePaddle/Paddle-Lite/pull/8965
其中：
<img width="551" alt="image" src="https://user-images.githubusercontent.com/63448337/165694925-3ff6c987-d311-46f8-b669-0190b727eec1.png">
与当前pr相反。

风险评估：
本pr的主要修改就是map中的排序方式，由于拓扑排序的改动可能会导致已有的模型跑不过。
但个人认为本pr风险较小，原因如下：
之前是以指针大小排序，而后创建的node对象，堆内存指针大小越来越大。这与node 的 id 值变化一致。保证了之前能跑过的模型顺利跑通。如果不能跑通，不会是本pr造成，而可能是其他隐藏问题。

