### PR TITLE
[Core] Update program desc from the runtime program only once

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -76,7 +76,6 @@ void Predictor::SaveModel(const std::string &dir,
   if (!program_) {
     GenRuntimeProgram();
   }
-  program_->SaveRuntimProgramIntoProgramDesc(program_desc_);
   switch (model_type) {
     case lite_api::LiteModelType::kProtobuf:
       SaveModelPb(dir, *program_->exec_scope(), *program_desc_.get(), true);
@@ -396,6 +395,9 @@ void Predictor::Build(const std::shared_ptr<cpp::ProgramDesc> &program_desc,
   // Verify if the ops version of current runtime program is
   // the same with that in models.
   CheckPaddleOpVersions(program_desc);
+
+  // Update the runtime program to program_desc only once
+  program_->SaveRuntimProgramIntoProgramDesc(program_desc_);
 }
 
 void Predictor::GenRuntimeProgram() {

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -113,7 +113,6 @@ class LITE_API Predictor {
     if (!program_generated_) {
       GenRuntimeProgram();
     }
-    program_->SaveRuntimProgramIntoProgramDesc(program_desc_);
     // step 2. Create a predictor friom current program_desc_ and
     // runtime_program.
     auto predictor =
@@ -138,7 +137,6 @@ class LITE_API Predictor {
     if (!program_generated_) {
       GenRuntimeProgram();
     }
-    program_->SaveRuntimProgramIntoProgramDesc(program_desc_);
     // step 2. Create a predictor friom current program_desc_ and
     // runtime_program.
     auto predictor = std::make_shared<Predictor>(


### PR DESCRIPTION
program_->SaveRuntimProgramIntoProgramDesc(program_desc_);  理论上只应该在 predictor->build 完成之后更新一次。