### PR TITLE
[Op][Pass] Support Swin-Transformer model

### DIFF
--- a/lite/api/paddle_use_passes.h
+++ b/lite/api/paddle_use_passes.h
@@ -114,5 +114,6 @@ USE_MIR_PASS(p_norm_fill_constant_max_div_fuse_pass);
 USE_MIR_PASS(fill_constant_calc_offline_pass);
 USE_MIR_PASS(unsqueeze_calc_offline_pass);
 USE_MIR_PASS(scale_calc_offline_pass);
+USE_MIR_PASS(reshape_calc_offline_pass);
 USE_MIR_PASS(keepdims_convert_pass);
 USE_MIR_PASS(op_fusion_minimal_set_pass);

--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/slice.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/slice.h
@@ -28,6 +28,7 @@ static int slice(const T* input_data,
                  int32_t* axes,
                  int32_t* starts,
                  int32_t* ends,
+                 int32_t* steps,
                  T* output_data) {
   std::vector<int32_t> output_shape(input_shape);
   std::vector<int> real_starts(input_shape.size(), 0);
@@ -41,12 +42,14 @@ static int slice(const T* input_data,
     if (dim_value > 0) {
       int start = starts[i] < 0 ? (starts[i] + dim_value) : starts[i];
       int end = ends[i] < 0 ? (ends[i] + dim_value) : ends[i];
+      int step = std::abs(steps[i]);
       start = std::max(start, 0);
       end = std::max(end, 0);
       end = std::min(end, dim_value);
-      output_shape[axes[i]] = end - start;
+      output_shape[axes[i]] = (std::abs(end - start) + step - 1) / step;
       real_starts[axes[i]] = start;
       real_ends[axes[i]] = end;
+      real_step[axes[i]] = step;
     }
   }
   const int length = input_shape.size();
@@ -71,7 +74,7 @@ static int slice(const T* input_data,
     for (size_t j = 0; j < output_shape.size(); j++) {
       int cur_id = index_id / dst_step[j];
       index_id = index_id % dst_step[j];
-      src_id += (cur_id + real_starts[j]) * src_step[j];
+      src_id += (cur_id * real_step[j] + real_starts[j]) * src_step[j];
     }
     output_data[dst_id] = input_data[src_id];
   }

--- a/lite/backends/nnadapter/nnadapter/src/operation/slice.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/slice.cc
@@ -42,10 +42,11 @@ NNADAPTER_EXPORT int PrepareSlice(core::Operation* operation) {
       if (dim > 0) {
         int start = starts[i] < 0 ? (starts[i] + dim) : starts[i];
         int end = ends[i] < 0 ? (ends[i] + dim) : ends[i];
+        int step = std::abs(steps[i]);
         start = std::max(start, 0);
         end = std::max(end, 0);
         end = std::min(end, dim);
-        output_dimensions[axes[i]] = end - start;
+        output_dimensions[axes[i]] = (std::abs(end - start) + step - 1) / step;
       }
     }
   };
@@ -70,6 +71,7 @@ NNADAPTER_EXPORT int PrepareSlice(core::Operation* operation) {
         axes,
         starts,
         ends,
+        steps,
         dimension_type.data);
     for (uint32_t i = 0; i < dimension_type.dynamic_count; i++) {
       math::slice<int32_t>(
@@ -79,6 +81,7 @@ NNADAPTER_EXPORT int PrepareSlice(core::Operation* operation) {
           axes,
           starts,
           ends,
+          steps,
           dimension_type.dynamic_data[i]);
     }
     SetTemporaryShape(output_operand, dimension_type);

--- a/lite/core/optimizer/mir/elimination/reshape_calc_offline_pass.cc
+++ b/lite/core/optimizer/mir/elimination/reshape_calc_offline_pass.cc
@@ -1,0 +1,162 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/optimizer/mir/elimination/reshape_calc_offline_pass.h"
+#include <algorithm>
+#include <cmath>
+#include <list>
+#include <set>
+#include "lite/core/optimizer/mir/pattern_matcher.h"
+#include "lite/core/optimizer/mir/ssa_graph_utils.h"
+#include "lite/model_parser/cpp_desc.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+static bool CheckPositive(const DDim& dims) {
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (dims[i] <= 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::vector<int64_t> ValidateShape(const std::vector<int>& shape,
+                                   const DDim& input_dims) {
+  const int64_t input_size = input_dims.production();
+
+  // only one dimension can be set to -1, whose size will be automatically
+  // infered.
+  const int unk_dim_val = -1;
+  const int copy_dim_val = 0;
+
+  std::vector<int64_t> output_dims(shape.size());
+  int64_t capacity = 1;
+  int unk_dim_idx = -1;
+  for (size_t i = 0; i < shape.size(); ++i) {
+    if (shape[i] == unk_dim_val) {
+      CHECK_EQ(unk_dim_idx, -1)
+          << "Only one input dimension of Attr(shape) can be unknown.";
+      unk_dim_idx = i;
+    } else if (shape[i] == copy_dim_val) {
+      CHECK_LT(i, input_dims.size())
+          << "The index of dimension to copy from input shape must be less "
+             "than the size of input shape.";
+    } else {
+      CHECK_GT(shape[i], 0) << "Each input dimension of Attr(shape) must not "
+                               "be negtive except one unknown dimension.";
+    }
+
+    int64_t output_dim_i =
+        shape[i] ? static_cast<int64_t>(shape[i]) : input_dims[i];
+    output_dims[i] = output_dim_i;
+    capacity *= output_dim_i;
+  }
+
+  if (unk_dim_idx != -1) {
+    if (CheckPositive(input_dims)) {
+      // input_size < 0 and is un-determinate in compile time, skip the check,
+      // for example, input_dims = [-1, 8, 1, 1], shape = [-1, 3, 8],
+      // capacity = -24, input_size = -8, output_shape[0] = 0
+      // the following check will fail.
+      output_dims[unk_dim_idx] = -input_size / capacity;
+      CHECK_EQ(output_dims[unk_dim_idx] * capacity, -input_size)
+          << "Invalid shape is given.";
+    } else {
+      output_dims[unk_dim_idx] = -1;
+    }
+  } else {
+    CHECK_EQ(capacity, input_size) << "Invalid shape is given.";
+  }
+  return output_dims;
+}
+
+void ReshapeCalcOfflinePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
+  RemoveReshapePattern(graph);
+}
+
+void ReshapeCalcOfflinePass::RemoveReshapePattern(
+    const std::unique_ptr<SSAGraph>& graph) {
+  for (auto& node : graph->StmtTopologicalOrder()) {
+    if (node->AsStmt().op_type() != "reshape" &&
+        node->AsStmt().op_type() != "reshape2")
+      continue;
+    auto outlinks = node->outlinks;
+    bool has_extra_producers = false;
+    for (auto& out_link : outlinks) {
+      if (HasExtraProducers(
+              graph.get(), out_link->arg()->name, {"reshape", "reshape2"})) {
+        has_extra_producers = true;
+        break;
+      }
+    }
+    if (has_extra_producers) {
+      LOG(WARNING)
+          << "Unsupported for op output var containing multiple producers";
+      continue;
+    }
+
+    std::set<const Node*> nodes2rm_;
+    auto& reshape_instruct = node->AsStmt();
+    auto* scope = reshape_instruct.op()->scope();
+    auto op_desc = reshape_instruct.mutable_op_info();
+    // Get reshape's input tensor
+    auto input_var = scope->FindVar(op_desc->Input("X").front());
+    auto input_t = input_var->GetMutable<lite::Tensor>();
+    auto input_dims = input_t->dims();
+    if (!input_t->persistable()) {
+      LOG(WARNING) << "ReshapeCalcOfflinePass does not support input("
+                   << op_desc->Input("X").front()
+                   << ") that is not persistable";
+      continue;
+    }
+    // Get reshape's shape
+    if ((op_desc->HasInput("ShapeTensor") &&
+         !op_desc->Input("ShapeTensor").empty()) ||
+        (op_desc->HasInput("Shape") && !op_desc->Input("Shape").empty())) {
+      LOG(WARNING) << "Unsupported Shape or ShapeTensor input for "
+                      "reshape op.";
+      continue;
+    } else if (!op_desc->HasAttr("shape")) {
+      LOG(WARNING) << "shape(attr) must be set for ReshapeCalcOfflinePass.";
+      continue;
+    }
+    auto shape = op_desc->GetAttr<std::vector<int>>("shape");
+    // Get reshape's output tensor
+    auto out_var = scope->FindVar(op_desc->Output("Out").front());
+    auto out_t = out_var->GetMutable<lite::Tensor>();
+    auto output_shape = ValidateShape(shape, input_dims);
+    out_t->CopyDataFrom(*input_t);
+    out_t->Resize(DDim(output_shape));
+    // Offline calc reshape, only retain output tensor as persistable
+    // tensor
+    out_t->set_persistable(true);
+    auto reshape_outlinks = node->outlinks;
+    for (auto& reshape_out_link : reshape_outlinks) {
+      reshape_out_link->arg()->is_weight = true;
+    }
+    nodes2rm_.insert(node);
+    GraphSafeRemoveNodes(graph.get(), nodes2rm_);
+  }
+}
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_MIR_PASS(reshape_calc_offline_pass,
+                  paddle::lite::mir::ReshapeCalcOfflinePass)
+    .BindTargets({TARGET(kNNAdapter)});

--- a/lite/core/optimizer/mir/elimination/reshape_calc_offline_pass.cc
+++ b/lite/core/optimizer/mir/elimination/reshape_calc_offline_pass.cc
@@ -159,4 +159,4 @@ void ReshapeCalcOfflinePass::RemoveReshapePattern(
 
 REGISTER_MIR_PASS(reshape_calc_offline_pass,
                   paddle::lite::mir::ReshapeCalcOfflinePass)
-    .BindTargets({TARGET(kNNAdapter)});
+    .BindTargets({TARGET(kNNAdapter), TARGET(kXPU)});

--- a/lite/core/optimizer/mir/elimination/reshape_calc_offline_pass.h
+++ b/lite/core/optimizer/mir/elimination/reshape_calc_offline_pass.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+#include "lite/core/optimizer/mir/pass.h"
+#include "lite/core/optimizer/mir/pass_registry.h"
+#include "lite/core/tensor.h"
+#include "lite/core/types.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+class ReshapeCalcOfflinePass : public mir::StmtPass {
+ public:
+  void Apply(const std::unique_ptr<SSAGraph>& graph) override;
+  void RemoveReshapePattern(const std::unique_ptr<SSAGraph>& graph);
+};
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/optimizer/optimizer.cc
+++ b/lite/core/optimizer/optimizer.cc
@@ -144,6 +144,7 @@ std::unique_ptr<RuntimeProgram> RunDefaultOptimizer(
        "range_calc_offline_pass",
        "scale_calc_offline_pass",
        "unsqueeze_calc_offline_pass",
+       "reshape_calc_offline_pass",
        "ssd_boxes_calc_offline_pass",
        // A minimal set of op fusion pass.
        "op_fusion_minimal_set_pass",

--- a/lite/kernels/host/CMakeLists.txt
+++ b/lite/kernels/host/CMakeLists.txt
@@ -116,6 +116,7 @@ add_kernel(max_pool_with_index_compute Host extra SRCS max_pool_with_index_compu
 add_kernel(merge_lod_tensor_compute Host extra SRCS merge_lod_tensor_compute.cc)
 add_kernel(im2sequence_compute Host extra SRCS im2sequence_compute.cc)
 add_kernel(log_softmax_compute Host extra SRCS log_softmax_compute.cc)
+add_kernel(roll_compute Host extra SRCS roll_compute.cc)
 
 if(LITE_BUILD_EXTRA AND LITE_WITH_x86)
   lite_cc_test(test_where_index_compute_host SRCS where_index_compute.cc)

--- a/lite/kernels/host/roll_compute.cc
+++ b/lite/kernels/host/roll_compute.cc
@@ -1,0 +1,135 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/host/roll_compute.h"
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <typename T>
+inline void ShiftAlongDim(T* data,
+                          const DDim& input_dim,
+                          int64_t dim,
+                          int64_t shift) {
+  if (dim < 0) {
+    dim += input_dim.size();
+  }
+  if (input_dim[dim] == 0) {
+    return;
+  }
+  shift = shift % input_dim[dim];
+  if (shift < 0) {
+    shift += input_dim[dim];
+  }
+
+  auto outer_loops = 1;
+  for (auto i = 0; i < dim; i++) {
+    outer_loops *= input_dim[i];
+  }
+  auto slice_width = 1;
+  for (auto i = dim + 1; i < input_dim.size(); i++) {
+    slice_width *= input_dim[i];
+  }
+
+  VLOG(5) << "shift_along_dim_debug: input_dim: " << input_dim
+          << "; dim: " << dim << "; shift: " << shift
+          << "; outer_loops: " << outer_loops
+          << "; slice_width: " << slice_width;
+  if (shift == 0) {
+    return;
+  }
+
+  std::vector<T> head;
+  auto head_size = slice_width * (input_dim[dim] - shift);
+  head.resize(head_size);
+
+  for (auto i = 0; i < outer_loops; i++) {
+    for (auto j = 0; j < head_size; j++) {
+      head[j] = data[i * input_dim[dim] * slice_width + j];
+    }
+    for (auto j = input_dim[dim] - shift; j < input_dim[dim]; j++) {
+      auto dst_pos = j - input_dim[dim] + shift;
+      for (auto k = 0; k < slice_width; k++) {
+        data[(i * input_dim[dim] + dst_pos) * slice_width + k] =
+            data[(i * input_dim[dim] + j) * slice_width + k];
+      }
+    }
+    for (auto j = 0; j < head_size; j++) {
+      data[(i * input_dim[dim] + shift) * slice_width + j] = head[j];
+    }
+  }
+}
+
+void RollCompute::Run() {
+  auto& param = this->Param<operators::RollParam>();
+
+  const auto* x = param.X;
+  auto* out = param.Out;
+  std::vector<int64_t> axis = param.axis;
+  std::vector<int64_t> shifts;
+  if (param.ShiftsTensor != nullptr) {
+    auto shift_data = param.ShiftsTensor->template data<int64_t>();
+    for (int64_t i = 0; i < param.ShiftsTensor->numel(); i++) {
+      shifts.push_back(shift_data[i]);
+    }
+  } else {
+    shifts = param.shifts;
+  }
+
+  int nums = shifts.size();
+  DDim input_dim = x->dims();
+  int input_size = input_dim.size();
+  // axis = none, reshape to 1-D tensor
+  if (axis.size() == 0) {
+    axis.push_back(0l);
+    input_dim = DDim(std::vector<int64_t>({input_size}));
+  }
+
+  out->CopyDataFrom(*x);
+  auto* out_data = param.Out->mutable_data<float>();
+  for (size_t i = 0; i < nums; i++) {
+    int64_t input_size = input_dim.size();
+    CHECK_GE(axis[i], -input_size) << "axis[i]: " << axis[i]
+                                   << ", input_dim.size(): " << input_size;
+    CHECK_LT(axis[i], input_size) << "axis[i]: " << axis[i]
+                                  << ", input_dim.size(): " << input_size;
+    ShiftAlongDim(out_data, input_dim, axis[i], shifts[i]);
+  }
+}
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(
+    roll, kHost, kAny, kAny, paddle::lite::kernels::host::RollCompute, def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindInput("ShiftsTensor",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kInt64),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
+    .Finalize();

--- a/lite/kernels/host/roll_compute.cc
+++ b/lite/kernels/host/roll_compute.cc
@@ -47,10 +47,6 @@ inline void ShiftAlongDim(T* data,
     slice_width *= input_dim[i];
   }
 
-  VLOG(5) << "shift_along_dim_debug: input_dim: " << input_dim
-          << "; dim: " << dim << "; shift: " << shift
-          << "; outer_loops: " << outer_loops
-          << "; slice_width: " << slice_width;
   if (shift == 0) {
     return;
   }

--- a/lite/kernels/host/roll_compute.cc
+++ b/lite/kernels/host/roll_compute.cc
@@ -115,10 +115,10 @@ void RollCompute::Run() {
 }  // namespace paddle
 
 REGISTER_LITE_KERNEL(
-    roll, kHost, kAny, kAny, paddle::lite::kernels::host::RollCompute, def)
+    roll, kHost, kFloat, kAny, paddle::lite::kernels::host::RollCompute, def)
     .BindInput("X",
                {LiteType::GetTensorTy(TARGET(kHost),
-                                      PRECISION(kAny),
+                                      PRECISION(kFloat),
                                       DATALAYOUT(kAny))})
     .BindInput("ShiftsTensor",
                {LiteType::GetTensorTy(TARGET(kHost),
@@ -126,6 +126,6 @@ REGISTER_LITE_KERNEL(
                                       DATALAYOUT(kAny))})
     .BindOutput("Out",
                 {LiteType::GetTensorTy(TARGET(kHost),
-                                       PRECISION(kAny),
+                                       PRECISION(kFloat),
                                        DATALAYOUT(kAny))})
     .Finalize();

--- a/lite/kernels/host/roll_compute.h
+++ b/lite/kernels/host/roll_compute.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+class RollCompute
+    : public KernelLite<TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny)> {
+ public:
+  void Run() override;
+
+  virtual ~RollCompute() = default;
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/host/roll_compute.h
+++ b/lite/kernels/host/roll_compute.h
@@ -22,7 +22,7 @@ namespace kernels {
 namespace host {
 
 class RollCompute
-    : public KernelLite<TARGET(kHost), PRECISION(kAny), DATALAYOUT(kAny)> {
+    : public KernelLite<TARGET(kHost), PRECISION(kFloat), DATALAYOUT(kAny)> {
  public:
   void Run() override;
 

--- a/lite/operators/CMakeLists.txt
+++ b/lite/operators/CMakeLists.txt
@@ -164,6 +164,7 @@ add_operator(index_select_op extra SRCS index_select_op.cc)
 add_operator(gaussian_random_op extra SRCS gaussian_random_op.cc)
 add_operator(unfold_op extra SRCS unfold_op.cc)
 add_operator(log_softmax_op extra SRCS log_softmax_op.cc)
+add_operator(roll_op extra SRCS roll_op.cc)
 
 # for OCR specific
 add_operator(while_op extra SRCS while_op.cc)

--- a/lite/operators/index_select_op.cc
+++ b/lite/operators/index_select_op.cc
@@ -26,10 +26,6 @@ bool Index_selectOpLite::CheckShape() const {
   CHECK_OR_FALSE(param_.Out);
   CHECK_OR_FALSE(param_.dim >= static_cast<int>(-(param_.X)->dims().size()));
   CHECK_OR_FALSE(param_.dim < static_cast<int>((param_.X)->dims().size()));
-  for (auto val : param_.Index->dims().Vectorize()) {
-    CHECK_OR_FALSE(val >= 0);
-    CHECK_OR_FALSE(val < (param_.X)->dims()[param_.dim]);
-  }
   return true;
 }
 

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -2253,6 +2253,14 @@ struct GaussRandomParam : ParamBase {
   float gauss_std{0.f};
 };
 
+struct RollParam : ParamBase {
+  const lite::Tensor* X{};
+  const lite::Tensor* ShiftsTensor{};
+  lite::Tensor* Out{};
+  std::vector<int64_t> shifts{};
+  std::vector<int64_t> axis{};
+};
+
 }  // namespace operators
 }  // namespace lite
 }  // namespace paddle

--- a/lite/operators/roll_op.cc
+++ b/lite/operators/roll_op.cc
@@ -20,8 +20,8 @@ namespace lite {
 namespace operators {
 
 bool RollOp::CheckShape() const {
-  CHECK_OR_FALSE(param_.X);
-  CHECK_OR_FALSE(param_.Out);
+  CHECK(param_.X);
+  CHECK(param_.Out);
   return true;
 }
 

--- a/lite/operators/roll_op.cc
+++ b/lite/operators/roll_op.cc
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/roll_op.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+bool RollOp::CheckShape() const {
+  CHECK_OR_FALSE(param_.X);
+  CHECK_OR_FALSE(param_.Out);
+  return true;
+}
+
+bool RollOp::InferShapeImpl() const {
+  param_.Out->Resize(param_.X->dims());
+  return true;
+}
+
+bool RollOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
+  param_.X = scope->FindTensor(opdesc.Input("X").front());
+  param_.Out = scope->FindMutableTensor(opdesc.Output("Out").front());
+
+  if (opdesc.HasAttr("axis")) {
+    param_.axis = opdesc.GetAttr<std::vector<int64_t>>("axis");
+  }
+  if (opdesc.HasAttr("shifts")) {
+    param_.shifts = opdesc.GetAttr<std::vector<int64_t>>("shifts");
+  }
+
+  if (opdesc.HasInput("ShiftsTensor") &&
+      !opdesc.Input("ShiftsTensor").empty()) {
+    auto shifts_tensor_name = opdesc.Input("ShiftsTensor").front();
+    param_.ShiftsTensor =
+        GetMutableVar<lite::Tensor>(scope, shifts_tensor_name);
+  }
+
+  CHECK(param_.X) << "Input(X) of RollOp should not be null.";
+  CHECK(param_.Out) << "Output(Out) of RollOp should not be null.";
+
+  input_tensor_ptrs_cache_.push_back(param_.X);
+  output_tensor_ptrs_cache_.push_back(param_.Out);
+  return true;
+}
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_OP(roll, paddle::lite::operators::RollOp);

--- a/lite/operators/roll_op.h
+++ b/lite/operators/roll_op.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+#include "lite/core/op_lite.h"
+#include "lite/core/scope.h"
+#include "lite/utils/all.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+class RollOp : public OpLite {
+ public:
+  RollOp() {}
+  explicit RollOp(const std::string &op_type) : OpLite(op_type) {}
+
+  bool CheckShape() const override;
+
+  bool InferShapeImpl() const override;
+
+  bool InferShapeWithCache() const override { return true; }
+
+  bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+  std::string DebugString() const override { return "roll"; }
+
+  bool InferType() override {
+    param_.Out->set_precision(param_.X->precision());
+    return true;
+  }
+
+ protected:
+  mutable RollParam param_;
+};
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle

--- a/lite/tests/kernels/CMakeLists.txt
+++ b/lite/tests/kernels/CMakeLists.txt
@@ -129,6 +129,7 @@ if(LITE_BUILD_EXTRA)
     lite_cc_test(test_kernel_pow_compute SRCS pow_compute_test.cc)
     lite_cc_test(test_kernel_where_compute SRCS where_compute_test.cc)
     lite_cc_test(test_kernel_log_softmax_compute SRCS log_softmax_compute_test.cc)
+    lite_cc_test(test_kernel_roll_compute SRCS roll_compute_test.cc)
     # lite_cc_test(test_kernel_tensor_array_to_tensor_compute SRCS tensor_array_to_tensor_compute_test.cc)
     # TODO: fix tensor_array_to_tensor unittest
     

--- a/lite/tests/kernels/roll_compute_test.cc
+++ b/lite/tests/kernels/roll_compute_test.cc
@@ -1,0 +1,195 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "lite/api/paddle_use_kernels.h"
+#include "lite/api/paddle_use_ops.h"
+#include "lite/core/test/arena/framework.h"
+#include "lite/tests/utils/fill_data.h"
+
+namespace paddle {
+namespace lite {
+
+template <typename T>
+inline void ShiftAlongDim(T* data,
+                          const DDim& input_dim,
+                          int64_t dim,
+                          int64_t shift) {
+  if (dim < 0) {
+    dim += input_dim.size();
+  }
+  if (input_dim[dim] == 0) {
+    return;
+  }
+  shift = shift % input_dim[dim];
+  if (shift < 0) {
+    shift += input_dim[dim];
+  }
+
+  auto outer_loops = 1;
+  for (auto i = 0; i < dim; i++) {
+    outer_loops *= input_dim[i];
+  }
+  auto slice_width = 1;
+  for (auto i = dim + 1; i < input_dim.size(); i++) {
+    slice_width *= input_dim[i];
+  }
+
+  if (shift == 0) {
+    return;
+  }
+
+  std::vector<T> head;
+  auto head_size = slice_width * (input_dim[dim] - shift);
+  head.resize(head_size);
+
+  for (auto i = 0; i < outer_loops; i++) {
+    for (auto j = 0; j < head_size; j++) {
+      head[j] = data[i * input_dim[dim] * slice_width + j];
+    }
+    for (auto j = input_dim[dim] - shift; j < input_dim[dim]; j++) {
+      auto dst_pos = j - input_dim[dim] + shift;
+      for (auto k = 0; k < slice_width; k++) {
+        data[(i * input_dim[dim] + dst_pos) * slice_width + k] =
+            data[(i * input_dim[dim] + j) * slice_width + k];
+      }
+    }
+    for (auto j = 0; j < head_size; j++) {
+      data[(i * input_dim[dim] + shift) * slice_width + j] = head[j];
+    }
+  }
+}
+
+class RollComputeTester : public arena::TestCase {
+ protected:
+  // common attributes for this op.
+  std::string x_ = "X";
+  std::string out_ = "Out";
+  std::string shifts_tensor_;
+  DDim x_dims_{{1, 5, 6, 7}};
+  std::vector<int64_t> axis_;
+  std::vector<int64_t> shifts_;
+
+ public:
+  RollComputeTester(const Place& place,
+                    const std::string& alias,
+                    const DDim& x_dims,
+                    const std::vector<int64_t>& axis,
+                    const std::vector<int64_t>& shifts,
+                    const bool use_shifts_tensor = false)
+      : TestCase(place, alias), x_dims_(x_dims), axis_(axis), shifts_(shifts) {
+    if (use_shifts_tensor) {
+      shifts_tensor_ = "ShiftsTensor";
+    }
+  }
+
+  void RunBaseline(Scope* scope) override {
+    auto* x = scope->FindTensor(x_);
+    const auto* x_data = x->data<float>();
+    std::vector<int64_t> shifts;
+    if (!shifts_tensor_.empty()) {
+      auto* shift = scope->FindTensor(shifts_tensor_);
+      auto shift_data = shift->template data<int64_t>();
+      for (int64_t i = 0; i < shift->numel(); i++) {
+        shifts.push_back(shift_data[i]);
+      }
+    } else {
+      shifts = shifts_;
+    }
+    int nums = shifts.size();
+    DDim input_dim = x->dims();
+    int input_size = input_dim.size();
+    // axis = none, reshape to 1-D tensor
+    if (axis_.size() == 0) {
+      axis_.push_back(0l);
+      input_dim = DDim(std::vector<int64_t>({input_size}));
+    }
+    auto* out = scope->NewTensor(out_);
+    CHECK(out);
+    out->CopyDataFrom(*x);
+    auto* out_data = out->mutable_data<float>();
+    for (size_t i = 0; i < nums; i++) {
+      int64_t input_size = input_dim.size();
+      ShiftAlongDim(out_data, input_dim, axis_[i], shifts_[i]);
+    }
+  }
+
+  void PrepareOpDesc(cpp::OpDesc* op_desc) {
+    op_desc->SetType("roll");
+    op_desc->SetInput("X", {x_});
+    op_desc->SetOutput("Out", {out_});
+    op_desc->SetAttr("axis", axis_);
+    op_desc->SetAttr("shifts", shifts_);
+    if (!shifts_tensor_.empty()) {
+      op_desc->SetInput("ShiftsTensor", {shifts_tensor_});
+    }
+  }
+
+  void PrepareData() override {
+    std::vector<float> x_data(x_dims_.production());
+    fill_data_rand<float>(x_data.data(), -1, 1, x_data.size());
+    SetCommonTensor<float>(x_, x_dims_, x_data.data());
+    if (!shifts_tensor_.empty()) {
+      SetCommonTensor(shifts_tensor_,
+                      DDim({static_cast<int64_t>(axis_.size())}),
+                      axis_.data(),
+                      {},
+                      true);
+    }
+  }
+};
+
+void TestRoll(const Place& place, float abs_error) {
+  std::vector<std::vector<int64_t>> axes = {{
+                                                0,
+                                            },
+                                            {
+                                                2,
+                                            },
+                                            {1, 3}};
+  std::string alias{"def"};
+  for (std::vector<int64_t>& axis : axes) {
+    for (int n : {1, 3}) {
+      for (int c : {3, 6}) {
+        for (int h : {9, 18}) {
+          for (int w : {9, 18}) {
+            for (bool use_shifts_tensor : {false, true}) {
+              DDim dims{{n, c, h, w}};
+              std::unique_ptr<arena::TestCase> tester(new RollComputeTester(
+                  place, alias, dims, axis, axis, use_shifts_tensor));
+              arena::Arena arena(std::move(tester), place, abs_error);
+              arena.TestPrecision();
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(roll, precision) {
+  Place place;
+  float abs_error = 1e-5;
+#if defined(LITE_WITH_X86) || defined(LITE_WITH_ARM)
+  place = TARGET(kHost);
+#else
+  return;
+#endif
+
+  TestRoll(place, abs_error);
+}
+
+}  // namespace lite
+}  // namespace paddle

--- a/lite/tests/unittest_py/op/test_roll_op.py
+++ b/lite/tests/unittest_py/op/test_roll_op.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('../')
+
+from auto_scan_test import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+from functools import partial
+import random
+import numpy as np
+
+
+class TestRollOp(AutoScanTest):
+    def __init__(self, *args, **kwargs):
+        AutoScanTest.__init__(self, *args, **kwargs)
+
+        host_places = [
+            Place(TargetType.Host, PrecisionType.FP32, DataLayoutType.NCHW)
+        ]
+        self.enable_testing_on_place(places=host_places, thread=[1, 4])
+
+    def is_program_valid(self,
+                         program_config: ProgramConfig,
+                         predictor_config: CxxConfig) -> bool:
+        return True
+
+    def sample_program_configs(self, draw):
+        N = draw(st.integers(min_value=2, max_value=4))
+        C = draw(st.integers(min_value=2, max_value=64))
+        H = draw(st.integers(min_value=2, max_value=64))
+        W = draw(st.integers(min_value=2, max_value=64))
+        in_shape = draw(st.sampled_from([[N, C, H, W]]))
+        in_dtype = draw(st.sampled_from([np.float32]))
+        use_shifts_tensor = draw(st.sampled_from([True, False]))
+        shifts = draw(st.sampled_from([[0], [2], [1, 3], [1, 2, 3]]))
+        axis = draw(st.sampled_from([[0], [2], [1, 3], [1, 2, 3]]))
+        assume(len(shifts) == len(axis))
+
+        def generate_x_data():
+            return np.random.normal(0.0, 5.0, in_shape).astype(in_dtype)
+
+        def generate_shifts_tensor_data():
+            return np.array(shifts).astype(np.int64)
+
+        if (use_shifts_tensor):
+            roll_op = OpConfig(
+                type="roll",
+                inputs={"X": ["input_data"],
+                        "ShiftsTensor": ["shifts_data"]},
+                outputs={"Out": ["output_data"]},
+                attrs={"shifts": shifts,
+                       "axis": shifts})
+            program_config = ProgramConfig(
+                ops=[roll_op],
+                weights={},
+                inputs={
+                    "input_data":
+                    TensorConfig(data_gen=partial(generate_x_data)),
+                    "shifts_data":
+                    TensorConfig(data_gen=partial(generate_shifts_tensor_data))
+                },
+                outputs=["output_data"])
+        else:
+            roll_op = OpConfig(
+                type="roll",
+                inputs={"X": ["input_data"]},
+                outputs={"Out": ["output_data"]},
+                attrs={"shifts": shifts,
+                       "axis": shifts})
+            program_config = ProgramConfig(
+                ops=[roll_op],
+                weights={},
+                inputs={
+                    "input_data":
+                    TensorConfig(data_gen=partial(generate_x_data)),
+                },
+                outputs=["output_data"])
+
+        return program_config
+
+    def sample_predictor_configs(self):
+        return self.get_predictor_configs(), ["roll"], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        self.run_and_statis(quant=False, max_examples=200)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[''])


### PR DESCRIPTION
1、增加 roll op 的定义和 host 实现，以及c++和python的单测
2、增加 reshape/reshape2 op 的常量折叠 pass
3、删除 index_select op 错误的 check 代码
4、顺便修复 nnadapter 的 slice op shape 推导的 bug