### PR TITLE
Autoscan support adb ssh 

### DIFF
--- a/lite/tests/unittest_py/auto_scan_base.py
+++ b/lite/tests/unittest_py/auto_scan_base.py
@@ -99,6 +99,56 @@ parser.add_argument(
     default="",
     type=str,
     help="Set nnadapter mixed precision quantization config path")
+parser.add_argument(
+    "--username", default="", type=str, help="Set user name for remote login")
+parser.add_argument(
+    "--ip", default="", type=str, help="Set the IP address for remote login")
+parser.add_argument(
+    "--password",
+    default="",
+    type=str,
+    help="Set user name and password for remote login")
+parser.add_argument(
+    "--run_mode",
+    default='local',
+    choices=['local', 'ssh', 'adb'],
+    help="Set auto scan test run mode, default with local")
+parser.add_argument(
+    "--remote_work_dir",
+    default="",
+    type=str,
+    help="Set the working directory where the remote login is located")
+parser.add_argument(
+    "--adb_device_name",
+    default="",
+    type=str,
+    help="Set the adb device serial number")
+parser.add_argument(
+    "--target_os",
+    default="linux",
+    choices=['android', 'linux'],
+    help="Set the OS of the target machine")
+parser.add_argument(
+    "--target_arch",
+    default="armv8",
+    choices=['x86', 'armv7', 'armv8', 'armv7hf'],
+    help="Set the target arch of the target machine")
+parser.add_argument(
+    "--target_abi",
+    default="arm64",
+    choices=['arm64', 'armhf', 'amd64', 'arm64-v8a', 'armeabi-v7a'],
+    help="Set the target abi of the target machine")
+parser.add_argument(
+    "--host_android_ndk_path",
+    default="",
+    type=str,
+    help="Setting the android ndk path in host machine to build the autoscan cxx test demo"
+)
+parser.add_argument(
+    "--remote_env_variable",
+    default="",
+    type=str,
+    help="Setting environment variables on the target machine")
 args = parser.parse_args()
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -563,7 +613,8 @@ class AutoScanBaseTest(unittest.TestCase):
                     os.mkdir(self.cache_dir)
                 try:
                     result, opt_model_bytes = self.run_lite_config(
-                        model, params, feed_data, pred_config, args.server_ip)
+                        model, params, feed_data, pred_config, prog_config,
+                        args.server_ip)
                     results.append(result)
                     # add ignore methods
                     if self.passes is not None:  # pass check
@@ -663,6 +714,8 @@ class AutoScanBaseTest(unittest.TestCase):
 
     # judge if correct kernel is picked
     def assert_kernel_type(self, model_bytes, op_list, paddlelite_config):
+        if model_bytes == None:
+            return
         pg = paddle.static.deserialize_program(model_bytes)
         main_block = pg.desc.block(0)
         after_op_list = list()

--- a/lite/tests/unittest_py/auto_scan_test.py
+++ b/lite/tests/unittest_py/auto_scan_test.py
@@ -67,16 +67,73 @@ parser.add_argument(
     default="",
     type=str,
     help="Set nnadapter mixed precision quantization config path")
+parser.add_argument(
+    "--username", default="", type=str, help="Set user name for remote login")
+parser.add_argument(
+    "--ip", default="", type=str, help="Set the IP address for remote login")
+parser.add_argument(
+    "--password",
+    default="",
+    type=str,
+    help="Set user name and password for remote login")
+parser.add_argument(
+    "--run_mode",
+    default='local',
+    choices=['local', 'ssh', 'adb'],
+    help="Set auto scan test run mode, default with local")
+parser.add_argument(
+    "--remote_work_dir",
+    default="",
+    type=str,
+    help="Set the working directory where the remote login is located")
+parser.add_argument(
+    "--adb_device_name",
+    default="",
+    type=str,
+    help="Set the adb device serial number")
+parser.add_argument(
+    "--target_os",
+    default="linux",
+    choices=['android', 'linux'],
+    help="Set the OS of the target machine")
+parser.add_argument(
+    "--target_arch",
+    default="armv8",
+    choices=['x86', 'armv7', 'armv8', 'armv7hf'],
+    help="Set the ABI of the target machine")
+parser.add_argument(
+    "--target_abi",
+    default="arm64",
+    choices=['arm64', 'armhf', 'amd64', 'arm64-v8a', 'armeabi-v7a'],
+    help="Set the target abi of the target machine")
+parser.add_argument(
+    "--host_android_ndk_path",
+    default="",
+    type=str,
+    help="Setting the android ndk path in host machine to build the autoscan cxx test demo"
+)
+parser.add_argument(
+    "--remote_env_variable",
+    default="",
+    type=str,
+    help="Setting environment variables on the target machine")
 args = parser.parse_args()
 
-if (args.target == "ARM" and platform.system() == 'Darwin') or (
-        args.target == "OpenCL") or (
-            args.target == "Metal") or args.enforce_rpc == "on":
-    from auto_scan_test_rpc import AutoScanTest
-    from auto_scan_test_rpc import FusePassAutoScanTest
+if args.run_mode == "ssh":
+    from auto_scan_test_ssh import AutoScanTest
+    from auto_scan_test_ssh import FusePassAutoScanTest
+elif args.run_mode == "adb":
+    from auto_scan_test_adb import AutoScanTest
+    from auto_scan_test_adb import FusePassAutoScanTest
 else:
-    from auto_scan_test_no_rpc import AutoScanTest
-    from auto_scan_test_no_rpc import FusePassAutoScanTest
+    if (args.target == "ARM" and platform.system() == 'Darwin') or (
+            args.target == "OpenCL") or (
+                args.target == "Metal") or args.enforce_rpc == "on":
+        from auto_scan_test_rpc import AutoScanTest
+        from auto_scan_test_rpc import FusePassAutoScanTest
+    else:
+        from auto_scan_test_no_rpc import AutoScanTest
+        from auto_scan_test_no_rpc import FusePassAutoScanTest
 
 IgnoreReasons = IgnoreReasonsBase
 AutoScanTest = AutoScanTest

--- a/lite/tests/unittest_py/auto_scan_test_adb.py
+++ b/lite/tests/unittest_py/auto_scan_test_adb.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from rpc_service.cxx_service.auto_scan_test_rpc_cxx_base import AutoScanCxxBaseTest
+import numpy as np
+import logging
+import abc
+import enum
+import unittest
+import paddle
+import copy
+from typing import Optional, List, Callable, Dict, Any, Set
+import os
+import subprocess
+
+
+class ADBWrapper():
+    def __init__(self, adb_device_name):
+        self.adb_device_name = adb_device_name
+
+    def push(self, src_path, dst_path):
+        cmd = "adb -s {} push {} {}".format(self.adb_device_name, src_path,
+                                            dst_path)
+        p = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        logging.info(str(stdout, encoding='utf-8'))
+
+    def pull(self, src_path, dst_path):
+        cmd = "adb -s {} pull {} {}".format(self.adb_device_name, src_path,
+                                            dst_path)
+        p = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        logging.info(str(stdout, encoding='utf-8'))
+
+    def run_command(self, cmd):
+        cmd = "adb -s {} shell '{}'".format(self.adb_device_name, cmd)
+        p = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        logging.info(str(stdout, encoding='utf-8'))
+
+
+class AutoScanTest(AutoScanCxxBaseTest):
+    def __init__(self, *args, **kwargs):
+        super(AutoScanTest, self).__init__(*args, **kwargs)
+        self.adb_device_name = self.args.adb_device_name
+        self.adb_wrapper = ADBWrapper(self.adb_device_name)
+        self.init()
+
+    def check_params_valid(self):
+        assert (self.run_mode == "adb")
+        if self.adb_device_name == "":
+            raise ValueError(
+                "The adb_device_name is empty, please set the adb_device_name use --adb_device_name"
+            )
+
+        p = subprocess.Popen(
+            "adb devices",
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        if self.adb_device_name not in str(stdout, encoding='utf-8'):
+            raise ValueError(
+                "The adb_device_name {} is invalid, the list of all devices is listed below:\n {}".
+                format(
+                    self.adb_device_name, str(stdout, encoding='utf-8')))
+
+    def init(self):
+        logging.info("ADB process init start ... ")
+        super(AutoScanTest, self).init()
+        self.check_params_valid()
+        self.adb_wrapper.run_command(
+            cmd="rm -rf {}/autoscan_cxx_test_tools".format(
+                self.remote_work_dir))
+        logging.info(
+            "ADB wrapper upload autoscan cxx test demo from local to remote start ..."
+        )
+        self.adb_wrapper.push(
+            src_path=self.model_test_demo_dir, dst_path=self.remote_work_dir)
+        logging.info(
+            "ADB wrapper upload autoscan cxx test demo from local to remote success."
+        )
+        logging.info("ADB process init done.")
+
+    def run_cxx_test(self):
+        # 1. Upload model/data to target machine
+        test_info_src_dir = self.cache_dir
+        test_info_dst_dir = self.remote_work_dir + "/autoscan_cxx_test_tools/test"
+        self.adb_wrapper.run_command(
+            cmd="rm -rf {}/autoscan_cxx_test_tools/test".format(
+                self.remote_work_dir))
+        self.adb_wrapper.run_command(
+            cmd="mkdir -p {}/autoscan_cxx_test_tools/test".format(
+                self.remote_work_dir))
+        logging.info(
+            "ADB wrapper upload test model and data from local to remote start ..."
+        )
+        self.adb_wrapper.push(
+            src_path="{}/.".format(test_info_src_dir),
+            dst_path=test_info_dst_dir)
+        logging.info(
+            "ADB wrapper upload test model and data from local to remote done")
+        # 2. Run test demo
+        logging.info("Run autoscan cxx test in remote ...")
+        run_cmd = "cd {}/autoscan_cxx_test_tools; {} ./run.sh".format(
+            self.remote_work_dir, self.remote_environment_variable)
+        self.adb_wrapper.run_command(cmd=run_cmd)
+
+    def get_result(self, prog_config):
+        output_names = prog_config.outputs
+        test_info_dst_dir = self.remote_work_dir + "/autoscan_cxx_test_tools/test"
+        for output_name in output_names:
+            output_tensor_file = "{}/{}.bin".format(test_info_dst_dir,
+                                                    output_name)
+            self.adb_wrapper.pull(
+                src_path=output_tensor_file, dst_path=self.cache_dir)
+
+        output_model_info_file = "{}/output.json".format(test_info_dst_dir)
+        self.adb_wrapper.pull(
+            src_path=output_model_info_file, dst_path=self.cache_dir)
+
+        with open(self.cache_dir + "/output.json", "r") as f:
+            output_json = json.load(f)
+
+        result = {}
+        for output_name in output_names:
+            for elem in output_json['outputs']:
+                if elem['name'] == output_name:
+                    output_json_content = elem
+            output_shape = output_json_content['shape']
+            output_dtype = output_json_content['dtype']
+            output_file = "{}/{}.bin".format(self.cache_dir, output_name)
+            output_ = np.fromfile(
+                output_file, dtype=output_dtype).reshape(output_shape)
+            result[output_name] = output_
+
+        result_res = copy.deepcopy(result)
+        return result_res
+
+
+class FusePassAutoScanTest(AutoScanTest):
+    def run_and_statis(self,
+                       quant=False,
+                       max_examples=100,
+                       reproduce=None,
+                       min_success_num=25,
+                       passes=None):
+        assert passes is not None, "Parameter of passes must be defined in function run_and_statis."
+        super().run_and_statis(quant, max_examples, reproduce, min_success_num,
+                               passes)

--- a/lite/tests/unittest_py/auto_scan_test_no_rpc.py
+++ b/lite/tests/unittest_py/auto_scan_test_no_rpc.py
@@ -88,6 +88,7 @@ class AutoScanTest(AutoScanBaseTest):
                         params,
                         inputs,
                         pred_config,
+                        prog_config,
                         server_ip="localhost") -> Dict[str, np.ndarray]:
         # 1. store original model
         with open(self.cache_dir + "/model", "wb") as f:

--- a/lite/tests/unittest_py/auto_scan_test_rpc.py
+++ b/lite/tests/unittest_py/auto_scan_test_rpc.py
@@ -33,6 +33,7 @@ class AutoScanTest(AutoScanBaseTest):
                         params,
                         feed_data,
                         pred_config,
+                        prog_config,
                         server_ip="localhost") -> Dict[str, np.ndarray]:
         paddle_lite_path = os.path.abspath(__file__)
         paddlelite_source_path = re.findall(r"(.+?)Paddle-Lite",
@@ -43,7 +44,7 @@ class AutoScanTest(AutoScanBaseTest):
         conn = rpyc.connect(server_ip, port_id)
         conn._config['sync_request_timeout'] = 2400
         out, model = conn.root.run_lite_model(model, params, feed_data,
-                                              pred_config)
+                                              pred_config, prog_config)
         result_res = copy.deepcopy(out)
         return result_res, model
 

--- a/lite/tests/unittest_py/auto_scan_test_ssh.py
+++ b/lite/tests/unittest_py/auto_scan_test_ssh.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from rpc_service.cxx_service.auto_scan_test_rpc_cxx_base import AutoScanCxxBaseTest
+import numpy as np
+import logging
+import abc
+import enum
+import unittest
+import paddle
+import copy
+from typing import Optional, List, Callable, Dict, Any, Set
+import os
+import sys
+import paramiko
+from scp import SCPClient
+import traceback
+import subprocess
+
+
+class SshRemoteHost(object):
+    def __init__(self, hostname, username, password, port=""):
+        self.hostname_ = hostname
+        self.username_ = username
+        self.password_ = password
+        self.port_ = port
+        self.ssh_client_ = self.create_ssh_client()
+
+    def create_ssh_client(self):
+        '''
+            Note: Use paramiko creates the ssh client. 
+        '''
+        ssh_client = paramiko.SSHClient()
+        #自动添加策略，保存服务器的主机名和密钥信息
+        ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh_client.connect(
+            hostname=self.hostname_,
+            username=self.username_,
+            password=self.password_)
+        return ssh_client
+
+    def transfer_files(self,
+                       local_path,
+                       remote_path,
+                       upload=True,
+                       recursive=True):
+        '''
+            Note: Support file upload and download.
+        '''
+
+        def progress(filename, size, sent):
+            # Define progress callback that prints the current percentage completed for the filed
+            # print("INFO: scp {}'s progress: {:.2f}% ".format(filename, float(sent) / float(size) * 100))
+            pass
+
+        scp = SCPClient(
+            self.ssh_client_.get_transport(),
+            progress=progress,
+            socket_timeout=100.0)
+        try:
+            if upload:
+                scp.put(local_path, remote_path, recursive=recursive)
+            else:
+                scp.get(remote_path, local_path)
+        except Exception as e:
+            traceback.print_exc()
+            return False
+        finally:
+            scp.close()
+        return True
+
+    def __del__(self):
+        self.ssh_client_.close()
+
+    def run_command(self, cmd, bufsize=-1, timeout=None, environment=None):
+        stdin, stdout, stderr = self.ssh_client_.exec_command(
+            command=cmd,
+            bufsize=bufsize,
+            timeout=timeout,
+            environment=environment)
+        logging.info(str(stdout.read(), encoding='utf-8'))
+        return stdin, stdout, stderr
+
+
+class AutoScanTest(AutoScanCxxBaseTest):
+    def __init__(self, *args, **kwargs):
+        super(AutoScanTest, self).__init__(*args, **kwargs)
+        self.username = self.args.username
+        self.ip = self.args.ip
+        self.password = self.args.password
+        self.ssh_client_ = None
+        self.init()
+
+    def init(self):
+        logging.info("SSH process init start ... ")
+        super(AutoScanTest, self).init()
+        self.check_params_valid()
+        self.ssh_client_ = SshRemoteHost(self.ip, self.username, self.password)
+        self.ssh_client_.run_command(
+            cmd="rm -rf {}/autoscan_cxx_test_tools".format(
+                self.remote_work_dir))
+        logging.info(
+            "SSH client upload autoscan cxx test demo from local to remote start ..."
+        )
+        run_status = self.ssh_client_.transfer_files(
+            local_path=self.model_test_demo_dir,
+            remote_path=self.remote_work_dir,
+            upload=True)
+        if run_status == True:
+            logging.info(
+                "SSH client upload autoscan cxx test demo from local to remote succeed!"
+            )
+        else:
+            raise ValueError(
+                "SSH client upload autoscan cxx test demo from local to remote failed!"
+            )
+        logging.info("SSH process init done.")
+
+    def check_params_valid(self):
+        assert (self.run_mode == "ssh")
+        if self.ip == "":
+            raise ValueError(
+                "The remote IP address is empty, please set the IP address use --ip"
+            )
+        if self.username == "":
+            raise ValueError(
+                "The remote username is empty, please set the username use --username"
+            )
+        if self.password == "":
+            raise ValueError(
+                "The remote password is empty, please set the password use --password"
+            )
+
+    def run_cxx_test(self):
+        # 1. Upload model/data to target machine
+        test_info_src_dir = self.cache_dir
+        test_info_dst_dir = self.remote_work_dir + "/autoscan_cxx_test_tools/test"
+        self.ssh_client_.run_command(
+            cmd="rm -rf {}/autoscan_cxx_test_tools/test".format(
+                self.remote_work_dir))
+        self.ssh_client_.run_command(
+            cmd="mkdir -p {}/autoscan_cxx_test_tools/test".format(
+                self.remote_work_dir))
+        logging.info(
+            "SSH client upload test model and data from local to remote start ..."
+        )
+        for name in os.listdir(test_info_src_dir):
+            file_path = os.path.join(test_info_src_dir, name)
+            run_status = self.ssh_client_.transfer_files(
+                local_path=file_path,
+                remote_path=test_info_dst_dir,
+                upload=True,
+                recursive=False)
+            if run_status == True:
+                logging.info(
+                    "SSH client upload {} from {} to remote {} succeed!".
+                    format(name, file_path, test_info_dst_dir))
+            else:
+                raise ValueError(
+                    "SSH client upload {} from {} to remote {} failed!".format(
+                        name, file_path, test_info_dst_dir))
+        logging.info(
+            "SSH client upload test model and data from local to remote done")
+        # 2. Run test demo
+        logging.info("Run autoscan cxx test in remote ...")
+        run_cmd = "cd {}/autoscan_cxx_test_tools; {} ./run.sh".format(
+            self.remote_work_dir, self.remote_environment_variable)
+        self.ssh_client_.run_command(cmd=run_cmd)
+
+    def get_result(self, prog_config):
+        output_names = prog_config.outputs
+        test_info_dst_dir = self.remote_work_dir + "/autoscan_cxx_test_tools/test"
+        for output_name in output_names:
+            output_tensor_file = "{}/{}.bin".format(test_info_dst_dir,
+                                                    output_name)
+            run_status = self.ssh_client_.transfer_files(
+                local_path=self.cache_dir,
+                remote_path=output_tensor_file,
+                upload=False)
+            if run_status == True:
+                logging.info(
+                    "SSH client gets output tensor file {} success from remote!".
+                    format(output_tensor_file))
+            else:
+                raise ValueError(
+                    "SSH client gets output tensor file {} failed from remote!".
+                    format(output_tensor_file))
+
+        output_model_info_file = "{}/output.json".format(test_info_dst_dir)
+        run_status = self.ssh_client_.transfer_files(
+            local_path=self.cache_dir,
+            remote_path=output_model_info_file,
+            upload=False)
+        if run_status == True:
+            logging.info(
+                "SSH client gets output model json file {} success from remote!".
+                format(output_model_info_file))
+        else:
+            raise ValueError(
+                "SSH client gets output model json file {} failed from remote!".
+                format(output_model_info_file))
+
+        with open(self.cache_dir + "/output.json", "r") as f:
+            output_json = json.load(f)
+
+        result = {}
+        for output_name in output_names:
+            for elem in output_json['outputs']:
+                if elem['name'] == output_name:
+                    output_json_content = elem
+            output_shape = output_json_content['shape']
+            output_dtype = output_json_content['dtype']
+            output_file = "{}/{}.bin".format(self.cache_dir, output_name)
+            output_ = np.fromfile(
+                output_file, dtype=output_dtype).reshape(output_shape)
+            result[output_name] = output_
+        result_res = copy.deepcopy(result)
+        return result_res
+
+
+class FusePassAutoScanTest(AutoScanTest):
+    def run_and_statis(self,
+                       quant=False,
+                       max_examples=100,
+                       reproduce=None,
+                       min_success_num=25,
+                       passes=None):
+        assert passes is not None, "Parameter of passes must be defined in function run_and_statis."
+        super().run_and_statis(quant, max_examples, reproduce, min_success_num,
+                               passes)

--- a/lite/tests/unittest_py/rpc_service/cxx_service/auto_scan_test_rpc_cxx_base.py
+++ b/lite/tests/unittest_py/rpc_service/cxx_service/auto_scan_test_rpc_cxx_base.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from auto_scan_base import AutoScanBaseTest
+import numpy as np
+import logging
+import abc
+import enum
+import unittest
+import paddle
+import copy
+from typing import Optional, List, Callable, Dict, Any, Set
+import os
+import sys
+import paramiko
+from scp import SCPClient
+import traceback
+import subprocess
+
+
+class AutoScanCxxBaseTest(AutoScanBaseTest):
+    def __init__(self, *args, **kwargs):
+        super(AutoScanCxxBaseTest, self).__init__(*args, **kwargs)
+        self.remote_work_dir = self.args.remote_work_dir
+        self.run_mode = self.args.run_mode
+        self.target_os = self.args.target_os
+        self.target_arch = self.args.target_arch
+        self.target_abi = self.args.target_abi
+        self.remote_env_variable = self.args.remote_env_variable
+        self.host_android_ndk_path = self.args.host_android_ndk_path
+        self.model_test_demo_dir = os.path.abspath(os.path.dirname(
+            __file__)) + "/autoscan_cxx_test_tools"
+        self.remote_environment_variable = ""
+        self.check_base_param_valid()
+        self.download_cxx_test_demo()
+
+    def download_cxx_test_demo(self):
+        demo_url = "http://paddlelite-data.bj.bcebos.com/autoscan/autoscan_cxx_test_tools.tar.gz"
+        if not os.path.exists(self.model_test_demo_dir):
+            cmd = "curl {} -o -| tar -xz -C {} ".format(
+                demo_url, os.path.abspath(os.path.dirname(__file__)))
+            os.system(cmd)
+        if not os.path.exists(self.model_test_demo_dir):
+            raise ValueError(
+                "Download cxx test demo failed from url: {}!".format(demo_url))
+
+    @abc.abstractmethod
+    def check_params_valid(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def init(self):
+        # 1. Package paddlelite libs from build dir to test demo
+        self.package_paddlelite_libs_from_build_dir()
+        # 2. According to the target_os/target_abi build test demo
+        self.build_test_demo()
+        # 3. Init remote environment variable
+        env_list = self.remote_env_variable.split(";")
+        variable_list = []
+        for key_value in env_list:
+            if len(key_value) < 1:
+                continue
+            variable_list.append(key_value)
+        if len(variable_list) != 0:
+            if not variable_list[-1].endswith(";"):
+                variable_list[-1] = variable_list[-1] + ";"
+            self.remote_environment_variable = ";".join(variable_list)
+
+    def check_base_param_valid(self):
+        if self.remote_work_dir == "":
+            raise ValueError(
+                "The remote work dir is empty, please set the remote work dir use --remote_work_dir"
+            )
+        if self.target_os == "":
+            raise ValueError(
+                "The target os is empty, please set the target os use --target_os"
+            )
+        if self.target_arch == "":
+            raise ValueError(
+                "The target arch is empty, please set the target arch use --target_arch"
+            )
+        if self.target_abi == "":
+            raise ValueError(
+                "The target abi is empty, please set the target abi use --target_abi"
+            )
+        if self.target_os == "android":
+            if self.host_android_ndk_path == "":
+                raise ValueError(
+                    "If target_os is android, need set host_android_ndk_path use --host_android_ndk_path"
+                )
+            if self.target_abi not in ['arm64-v8a', 'armeabi-v7a']:
+                raise ValueError(
+                    "If target_os is android, need set target_abi use --target_abi, choices=['arm64-v8a','armeabi-v7a']"
+                )
+        elif self.target_os == "linux":
+            if self.target_abi not in ['arm64', 'armhf', 'amd64']:
+                raise ValueError(
+                    "If target_os is linux, need set target_abi use --target_abi, choices=['arm64','armhf','amd64']"
+                )
+        else:
+            raise ValueError(
+                "rpc cxx process not support the target os: {}, only support andorid or linux now".
+                format(self.target_os))
+
+    def build_test_demo(self):
+        cmd = "./build.sh {} {} {}".format(self.target_os, self.target_abi,
+                                           self.host_android_ndk_path)
+        try:
+            subprocess.check_call(
+                cmd, shell=True, cwd=self.model_test_demo_dir)
+        except subprocess.CalledProcessError as e:
+            logging.fatal("cmd:{}".format(e.cmd))
+            logging.fatal("output:{}".format(e.output))
+            logging.fatal("returncode:{}".format(e.returncode))
+            exit()
+
+    def package_paddlelite_libs_from_build_dir(self):
+        root_dir = "{}/../../../../..".format(
+            os.path.abspath(os.path.dirname(__file__)))
+        build_dir_prefix = "build.lite.{}.{}".format(self.target_os,
+                                                     self.target_arch)
+        build_dir = ""
+        for name in os.listdir(root_dir):
+            if name.startswith(build_dir_prefix):
+                build_dir = os.path.join(root_dir, name)
+                break
+        if build_dir == "":
+            raise ValueError(
+                "Cant't find build.lite.{}.{}.* in root dir: {}, please build first!".
+                format(self.target_os, self.target_arch, root_dir))
+
+        inference_lib_dir = ""
+        for dir_name in os.listdir(build_dir):
+            if dir_name.startswith("inference_lite_lib"):
+                inference_lib_dir = os.path.join(build_dir, dir_name)
+                break
+        if inference_lib_dir == "":
+            raise ValueError("Cant't find inference_lite_lib.* in {}".format(
+                build_dir))
+        cxx_include_path = "{}/cxx/include".format(inference_lib_dir)
+        cxx_lib_path = "{}/cxx/lib".format(inference_lib_dir)
+        demo_lib_path = "{}/libs/PaddleLite".format(self.model_test_demo_dir)
+        if os.path.exists(demo_lib_path):
+            os.system("rm -rf {}".format(demo_lib_path))
+        os.system("mkdir -p {}".format(demo_lib_path))
+        os.system("cp -r {} {}".format(cxx_include_path, demo_lib_path))
+        os.system("cp -r {} {}".format(cxx_lib_path, demo_lib_path))
+
+    @abc.abstractmethod
+    def run_cxx_test(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_result(self, prog_config):
+        raise NotImplementedError
+
+    def run_lite_config(self,
+                        model,
+                        params,
+                        inputs,
+                        pred_config,
+                        prog_config,
+                        server_ip="localhost") -> Dict[str, np.ndarray]:
+        with open(self.cache_dir + "/model", "wb") as f:
+            f.write(model)
+        with open(self.cache_dir + "/params", "wb") as f:
+            f.write(params)
+
+        with open(self.cache_dir + "/model_info.json", "w") as f:
+            model_info = {"inputs": []}
+            for idx, name in enumerate(inputs):
+                tensor_info = {
+                    "name": name,
+                    "shape": inputs[name]['data'].shape,
+                    "dtype": str(inputs[name]['data'].dtype)
+                }
+                if inputs[name]['lod'] is not None:
+                    tensor_info['lod'] = inputs[name]['lod']
+                model_info["inputs"].append(tensor_info)
+                inputs[name]['data'].tofile("{}/{}.bin".format(self.cache_dir,
+                                                               name))
+            model_info["configs"] = pred_config
+            model_info["model_file"] = "model"
+            model_info["param_file"] = "params"
+            model_info["source_dir"] = "test"
+            json.dump(model_info, f, indent=1)
+        # Run cxx test
+        self.run_cxx_test()
+
+        # Collect result from remote
+        result = self.get_result(prog_config)
+
+        return result, None

--- a/lite/tests/unittest_py/rpc_service/server.py
+++ b/lite/tests/unittest_py/rpc_service/server.py
@@ -80,7 +80,8 @@ def ParsePaddleLiteConfig(self, config):
 
 
 class RPCService(rpyc.Service):
-    def exposed_run_lite_model(self, model, params, inputs, config_str):
+    def exposed_run_lite_model(self, model, params, inputs, config_str,
+                               prog_config):
         '''
         Test a single case.
         '''


### PR DESCRIPTION
# 说明：
   + autoscan 新增支持 ssh 、adb 功能
   + ssh，adb 使用 c++ demo 远程执行
   + 无需使用 python 编译 Paddle Lite ，不依赖于 Paddle Lite 的 whl 包, 依赖于 cxx 编译出的预测库

+ ssh command:
  ```
    python3 test_conv2d_op.py     --target=ARM     --run_mode=ssh --ip=192.168.xx.xx --username=xxxx --password=xxxx     --target_os=linux --target_arch=armv8 --target_abi=arm64 --remote_work_dir=~/test 
  ```
+ adb command:
  ```
    python3 test_conv2d_op.py    --target=ARM --run_mode=adb --target_abi=arm64  --adb_device_name=xxxxxxxxx --remote_work_dir=~/test 
  ```