### PR TITLE
add common conv depthwise optimization

### DIFF
--- a/lite/backends/arm/math/fp16/conv3x3s2_depthwise_fp16.cc
+++ b/lite/backends/arm/math/fp16/conv3x3s2_depthwise_fp16.cc
@@ -1011,7 +1011,9 @@ void conv_depthwise_3x3s2p1_bias_noact_common_fp16_fp16(
                              bias_val,
                              bias_val};
 #endif
-      INIT_PTR_3x3_S2_FP16(din_ch_ptr, w_in) for (int i = 0; i < h_in; i += 4) {
+      INIT_PTR_3x3_S2_FP16(din_ch_ptr, w_in) for (int i = 0, j = 0;
+                                                  i < h_in, j < h_out;
+                                                  i += 4, j += 2) {
         ASSIGN_PTR_3x3_S2_FP16(w_out) TOP_BOTTOM_BORDER_3x3_S2P1_FP16(
             w_in, h_in, h_out) int cnt = cnt_col;
         uint16_t* val_mask = vmask;
@@ -1115,7 +1117,9 @@ void conv_depthwise_3x3s2p1_bias_relu_common_fp16_fp16(float16_t* dout,
                              bias_val,
                              bias_val};
 #endif
-      INIT_PTR_3x3_S2_FP16(din_ch_ptr, w_in) for (int i = 0; i < h_in; i += 4) {
+      INIT_PTR_3x3_S2_FP16(din_ch_ptr, w_in) for (int i = 0, j = 0;
+                                                  i < h_in, j < h_out;
+                                                  i += 4, j += 2) {
         ASSIGN_PTR_3x3_S2_FP16(w_out) TOP_BOTTOM_BORDER_3x3_S2P1_FP16(
             w_in, h_in, h_out) int cnt = cnt_col;
         uint16_t* val_mask = vmask;
@@ -1235,7 +1239,9 @@ void conv_depthwise_3x3s2p1_bias_relu6_common_fp16_fp16(
                              bias_val,
                              bias_val};
 #endif
-      INIT_PTR_3x3_S2_FP16(din_ch_ptr, w_in) for (int i = 0; i < h_in; i += 4) {
+      INIT_PTR_3x3_S2_FP16(din_ch_ptr, w_in) for (int i = 0, j = 0;
+                                                  i < h_in, j < h_out;
+                                                  i += 4, j += 2) {
         ASSIGN_PTR_3x3_S2_FP16(w_out) TOP_BOTTOM_BORDER_3x3_S2P1_FP16(
             w_in, h_in, h_out) int cnt = cnt_col;
         uint16_t* val_mask = vmask;
@@ -1355,7 +1361,9 @@ void conv_depthwise_3x3s2p1_bias_leaky_relu_common_fp16_fp16(
                              bias_val,
                              bias_val};
 #endif
-      INIT_PTR_3x3_S2_FP16(din_ch_ptr, w_in) for (int i = 0; i < h_in; i += 4) {
+      INIT_PTR_3x3_S2_FP16(din_ch_ptr, w_in) for (int i = 0, j = 0;
+                                                  i < h_in, j < h_out;
+                                                  i += 4, j += 2) {
         ASSIGN_PTR_3x3_S2_FP16(w_out) TOP_BOTTOM_BORDER_3x3_S2P1_FP16(
             w_in, h_in, h_out) int cnt = cnt_col;
         uint16_t* val_mask = vmask;

--- a/lite/backends/arm/math/fp16/conv3x3s2_depthwise_fp16.cc
+++ b/lite/backends/arm/math/fp16/conv3x3s2_depthwise_fp16.cc
@@ -82,7 +82,7 @@ namespace fp16 {
 #define LEFT_RESULT_FP16_S2                             \
   "st1    {v16.8h}, [%[ptr_out0]], #16              \n" \
   "st1    {v17.8h}, [%[ptr_out1]], #16              \n" \
-  "cmp    %w[cnt], #8                               \n" \
+  "cmp    %w[cnt], #1                               \n" \
   "blt    1f                                        \n"
 
 #define LEFT_RESULT_FP16_S2_RELU                        \
@@ -90,7 +90,7 @@ namespace fp16 {
   "fmax   v17.8h,  v17.8h, %[vzero].8h              \n" \
   "st1    {v16.8h}, [%[ptr_out0]], #16              \n" \
   "st1    {v17.8h}, [%[ptr_out1]], #16              \n" \
-  "cmp    %w[cnt], #8                               \n" \
+  "cmp    %w[cnt], #1                               \n" \
   "blt    1f                                        \n"
 
 #define LEFT_RESULT_FP16_S2_RELU6                       \
@@ -101,7 +101,7 @@ namespace fp16 {
   "fmin   v17.8h,  v17.8h, v21.8h                   \n" \
   "st1    {v16.8h}, [%[ptr_out0]], #16              \n" \
   "st1    {v17.8h}, [%[ptr_out1]], #16              \n" \
-  "cmp    %w[cnt], #8                               \n" \
+  "cmp    %w[cnt], #1                               \n" \
   "blt    1f                                        \n"
 
 #define LEFT_RESULT_FP16_S2_LEAKY_RELU                  \
@@ -114,7 +114,7 @@ namespace fp16 {
   "bif    v17.16b, v15.16b, v14.16b                 \n" \
   "st1    {v16.8h}, [%[ptr_out0]], #16              \n" \
   "st1    {v17.8h}, [%[ptr_out1]], #16              \n" \
-  "cmp    %w[cnt], #8                               \n" \
+  "cmp    %w[cnt], #1                               \n" \
   "blt    1f                                        \n"
 
 #define MID_COMPUTE_FP16_S2                             \
@@ -158,12 +158,12 @@ namespace fp16 {
   "ld2    {v8.8h, v9.8h}, [%[din_ptr4]], #32        \n" \
   "fadd   v17.8h, v17.8h, v13.8h                    \n" \
   "fadd   v17.8h, v17.8h, v14.8h                    \n" \
-  "subs   %w[cnt], %w[cnt], #8                      \n"
+  "subs   %w[cnt], %w[cnt], #1                      \n"
 
 #define MID_RESULT_FP16_S2                              \
   "st1    {v16.8h}, [%[ptr_out0]], #16              \n" \
   "st1    {v17.8h}, [%[ptr_out1]], #16              \n" \
-  "cmp    %w[cnt], #8                               \n" \
+  "cmp    %w[cnt], #1                               \n" \
   "bge    2b                                        \n"
 
 #define MID_RESULT_FP16_S2_RELU                         \
@@ -171,7 +171,7 @@ namespace fp16 {
   "fmax   v17.8h,  v17.8h, %[vzero].8h              \n" \
   "st1    {v16.8h}, [%[ptr_out0]], #16              \n" \
   "st1    {v17.8h}, [%[ptr_out1]], #16              \n" \
-  "cmp    %w[cnt], #8                               \n" \
+  "cmp    %w[cnt], #1                               \n" \
   "bge    2b                                        \n"
 
 #define MID_RESULT_FP16_S2_RELU6                        \
@@ -182,7 +182,7 @@ namespace fp16 {
   "fmin   v17.8h,  v17.8h, v21.8h                   \n" \
   "st1    {v16.8h}, [%[ptr_out0]], #16              \n" \
   "st1    {v17.8h}, [%[ptr_out1]], #16              \n" \
-  "cmp    %w[cnt], #8                               \n" \
+  "cmp    %w[cnt], #1                               \n" \
   "bge    2b                                        \n"
 
 #define MID_RESULT_FP16_S2_LEAKY_RELU                   \
@@ -195,77 +195,77 @@ namespace fp16 {
   "bif    v17.16b, v15.16b, v14.16b                 \n" \
   "st1    {v16.8h}, [%[ptr_out0]], #16              \n" \
   "st1    {v17.8h}, [%[ptr_out1]], #16              \n" \
-  "cmp    %w[cnt], #8                               \n" \
+  "cmp    %w[cnt], #1                               \n" \
   "bge    2b                                        \n"
 
-#define RIGHT_COMPUTE_FP16_S2                                 \
-  "1:                                                     \n" \
-  "cmp    %w[cnt], #1                                  \n"    \
-  "blt    4f                                              \n" \
-  "3:                                                     \n" \
-  "ld1    {v16.8h}, [%[bias_val]]                         \n" \
-  "ld1    {v17.8h}, [%[bias_val]]                         \n" \
-  "ldr    q18, [%[vmask]]                                 \n" \
-  "ldr    q19, [%[vmask], #0x10]                          \n" \
-  "ldr    q20, [%[vmask], #0x20]                          \n" \
-  "sub    %[din_ptr0], %[din_ptr0], %[right_pad_num]      \n" \
-  "sub    %[din_ptr1], %[din_ptr1], %[right_pad_num]      \n" \
-  "sub    %[din_ptr2], %[din_ptr2], %[right_pad_num]      \n" \
-  "sub    %[din_ptr3], %[din_ptr3], %[right_pad_num]      \n" \
-  "sub    %[din_ptr4], %[din_ptr4], %[right_pad_num]      \n" \
-  "sub    %[ptr_out0], %[ptr_out0], %[right_st_num]       \n" \
-  "sub    %[ptr_out1], %[ptr_out1], %[right_st_num]       \n" \
-  "ld2    {v0.8h, v1.8h}, [%[din_ptr0]]                   \n" \
-  "ld2    {v2.8h, v3.8h}, [%[din_ptr1]]                   \n" \
-  "ld2    {v4.8h, v5.8h}, [%[din_ptr2]]                   \n" \
-  "ld2    {v6.8h, v7.8h}, [%[din_ptr3]]                   \n" \
-  "ld2    {v8.8h, v9.8h}, [%[din_ptr4]]                   \n" \
-  "bif    v0.16b, %[vzero].16b, v18.16b                   \n" \
-  "bif    v1.16b, %[vzero].16b, v19.16b                   \n" \
-  "bif    v2.16b, %[vzero].16b, v18.16b                   \n" \
-  "bif    v3.16b, %[vzero].16b, v19.16b                   \n" \
-  "bif    v4.16b, %[vzero].16b, v18.16b                   \n" \
-  "bif    v5.16b, %[vzero].16b, v19.16b                   \n" \
-  "add    %[din_ptr0], %[din_ptr0], #4                    \n" \
-  "add    %[din_ptr1], %[din_ptr1], #4                    \n" \
-  "add    %[din_ptr2], %[din_ptr2], #4                    \n" \
-  "add    %[din_ptr3], %[din_ptr3], #4                    \n" \
-  "add    %[din_ptr4], %[din_ptr4], #4                    \n" \
-  "ld2    {v10.8h, v11.8h}, [%[din_ptr0]]                 \n" \
-  "bif    v10.16b, %[vzero].16b, v20.16b                  \n" \
-  "bif    v6.16b, %[vzero].16b, v18.16b                   \n" \
-  "bif    v7.16b, %[vzero].16b, v19.16b                   \n" \
-  "fmul   v21.8h, v0.8h, %[wr00].8h                       \n" \
-  "fmul   v12.8h, v1.8h, %[wr01].8h                       \n" \
-  "fmla   v16.8h, v10.8h, %[wr02].8h                      \n" \
-  "ld2    {v10.8h, v11.8h}, [%[din_ptr1]]                 \n" \
-  "bif    v10.16b, %[vzero].16b, v20.16b                  \n" \
-  "bif    v8.16b, %[vzero].16b, v18.16b                   \n" \
-  "bif    v9.16b, %[vzero].16b, v19.16b                   \n" \
-  "fmla   v21.8h, v2.8h, %[wr10].8h                       \n" \
-  "fmla   v12.8h, v3.8h, %[wr11].8h                       \n" \
-  "fmla   v16.8h, v10.8h, %[wr12].8h                      \n" \
-  "ld2    {v10.8h, v11.8h}, [%[din_ptr2]]                 \n" \
-  "bif    v10.16b, %[vzero].16b, v20.16b                  \n" \
-  "fmul   v13.8h, v4.8h, %[wr00].8h                       \n" \
-  "fmla   v21.8h, v4.8h, %[wr20].8h                       \n" \
-  "fmul   v14.8h, v5.8h, %[wr01].8h                       \n" \
-  "fmla   v12.8h, v5.8h, %[wr21].8h                       \n" \
-  "fmla   v17.8h, v10.8h, %[wr02].8h                      \n" \
-  "fmla   v16.8h, v10.8h, %[wr22].8h                      \n" \
-  "ld2    {v10.8h, v11.8h}, [%[din_ptr3]]                 \n" \
-  "bif    v10.16b, %[vzero].16b, v20.16b                  \n" \
-  "fmla   v13.8h, v6.8h, %[wr10].8h                       \n" \
-  "fmla   v14.8h, v7.8h, %[wr11].8h                       \n" \
-  "fmla   v17.8h, v10.8h, %[wr12].8h                      \n" \
-  "ld2    {v10.8h, v11.8h}, [%[din_ptr4]]                 \n" \
-  "bif    v10.16b, %[vzero].16b, v20.16b                  \n" \
-  "fadd   v16.8h, v16.8h, v21.8h                          \n" \
-  "fadd   v16.8h, v16.8h, v12.8h                          \n" \
-  "fmla   v13.8h, v8.8h, %[wr20].8h                       \n" \
-  "fmla   v14.8h, v9.8h, %[wr21].8h                       \n" \
-  "fmla   v17.8h, v10.8h, %[wr22].8h                      \n" \
-  "fadd   v17.8h, v17.8h, v13.8h                          \n" \
+#define RIGHT_COMPUTE_FP16_S2                                        \
+  "1:                                                     \n"        \
+  "cmp    %w[right_st_num], #16                                  \n" \
+  "beq    4f                                              \n"        \
+  "3:                                                     \n"        \
+  "ld1    {v16.8h}, [%[bias_val]]                         \n"        \
+  "ld1    {v17.8h}, [%[bias_val]]                         \n"        \
+  "ldr    q18, [%[vmask]]                                 \n"        \
+  "ldr    q19, [%[vmask], #0x10]                          \n"        \
+  "ldr    q20, [%[vmask], #0x20]                          \n"        \
+  "sub    %[din_ptr0], %[din_ptr0], %[right_pad_num]      \n"        \
+  "sub    %[din_ptr1], %[din_ptr1], %[right_pad_num]      \n"        \
+  "sub    %[din_ptr2], %[din_ptr2], %[right_pad_num]      \n"        \
+  "sub    %[din_ptr3], %[din_ptr3], %[right_pad_num]      \n"        \
+  "sub    %[din_ptr4], %[din_ptr4], %[right_pad_num]      \n"        \
+  "sub    %[ptr_out0], %[ptr_out0], %[right_st_num]       \n"        \
+  "sub    %[ptr_out1], %[ptr_out1], %[right_st_num]       \n"        \
+  "ld2    {v0.8h, v1.8h}, [%[din_ptr0]]                   \n"        \
+  "ld2    {v2.8h, v3.8h}, [%[din_ptr1]]                   \n"        \
+  "ld2    {v4.8h, v5.8h}, [%[din_ptr2]]                   \n"        \
+  "ld2    {v6.8h, v7.8h}, [%[din_ptr3]]                   \n"        \
+  "ld2    {v8.8h, v9.8h}, [%[din_ptr4]]                   \n"        \
+  "bif    v0.16b, %[vzero].16b, v18.16b                   \n"        \
+  "bif    v1.16b, %[vzero].16b, v19.16b                   \n"        \
+  "bif    v2.16b, %[vzero].16b, v18.16b                   \n"        \
+  "bif    v3.16b, %[vzero].16b, v19.16b                   \n"        \
+  "bif    v4.16b, %[vzero].16b, v18.16b                   \n"        \
+  "bif    v5.16b, %[vzero].16b, v19.16b                   \n"        \
+  "add    %[din_ptr0], %[din_ptr0], #4                    \n"        \
+  "add    %[din_ptr1], %[din_ptr1], #4                    \n"        \
+  "add    %[din_ptr2], %[din_ptr2], #4                    \n"        \
+  "add    %[din_ptr3], %[din_ptr3], #4                    \n"        \
+  "add    %[din_ptr4], %[din_ptr4], #4                    \n"        \
+  "ld2    {v10.8h, v11.8h}, [%[din_ptr0]]                 \n"        \
+  "bif    v10.16b, %[vzero].16b, v20.16b                  \n"        \
+  "bif    v6.16b, %[vzero].16b, v18.16b                   \n"        \
+  "bif    v7.16b, %[vzero].16b, v19.16b                   \n"        \
+  "fmul   v21.8h, v0.8h, %[wr00].8h                       \n"        \
+  "fmul   v12.8h, v1.8h, %[wr01].8h                       \n"        \
+  "fmla   v16.8h, v10.8h, %[wr02].8h                      \n"        \
+  "ld2    {v10.8h, v11.8h}, [%[din_ptr1]]                 \n"        \
+  "bif    v10.16b, %[vzero].16b, v20.16b                  \n"        \
+  "bif    v8.16b, %[vzero].16b, v18.16b                   \n"        \
+  "bif    v9.16b, %[vzero].16b, v19.16b                   \n"        \
+  "fmla   v21.8h, v2.8h, %[wr10].8h                       \n"        \
+  "fmla   v12.8h, v3.8h, %[wr11].8h                       \n"        \
+  "fmla   v16.8h, v10.8h, %[wr12].8h                      \n"        \
+  "ld2    {v10.8h, v11.8h}, [%[din_ptr2]]                 \n"        \
+  "bif    v10.16b, %[vzero].16b, v20.16b                  \n"        \
+  "fmul   v13.8h, v4.8h, %[wr00].8h                       \n"        \
+  "fmla   v21.8h, v4.8h, %[wr20].8h                       \n"        \
+  "fmul   v14.8h, v5.8h, %[wr01].8h                       \n"        \
+  "fmla   v12.8h, v5.8h, %[wr21].8h                       \n"        \
+  "fmla   v17.8h, v10.8h, %[wr02].8h                      \n"        \
+  "fmla   v16.8h, v10.8h, %[wr22].8h                      \n"        \
+  "ld2    {v10.8h, v11.8h}, [%[din_ptr3]]                 \n"        \
+  "bif    v10.16b, %[vzero].16b, v20.16b                  \n"        \
+  "fmla   v13.8h, v6.8h, %[wr10].8h                       \n"        \
+  "fmla   v14.8h, v7.8h, %[wr11].8h                       \n"        \
+  "fmla   v17.8h, v10.8h, %[wr12].8h                      \n"        \
+  "ld2    {v10.8h, v11.8h}, [%[din_ptr4]]                 \n"        \
+  "bif    v10.16b, %[vzero].16b, v20.16b                  \n"        \
+  "fadd   v16.8h, v16.8h, v21.8h                          \n"        \
+  "fadd   v16.8h, v16.8h, v12.8h                          \n"        \
+  "fmla   v13.8h, v8.8h, %[wr20].8h                       \n"        \
+  "fmla   v14.8h, v9.8h, %[wr21].8h                       \n"        \
+  "fmla   v17.8h, v10.8h, %[wr22].8h                      \n"        \
+  "fadd   v17.8h, v17.8h, v13.8h                          \n"        \
   "fadd   v17.8h, v17.8h, v14.8h                          \n"
 
 #define RIGHT_RESULT_FP16_S2_RELU                       \
@@ -1017,7 +1017,6 @@ void conv_depthwise_3x3s2p1_bias_noact_common_fp16_fp16(
         uint16_t* val_mask = vmask;
 // clang-format off
 #ifdef __aarch64__
-        cnt = cnt_col * 8 + cnt_remain;
         asm volatile(
           INIT_FP16_S2 LEFT_COMPUTE_FP16_S2 LEFT_RESULT_FP16_S2
           MID_COMPUTE_FP16_S2 MID_RESULT_FP16_S2
@@ -1122,7 +1121,6 @@ void conv_depthwise_3x3s2p1_bias_relu_common_fp16_fp16(float16_t* dout,
         uint16_t* val_mask = vmask;
 // clang-format off
 #ifdef __aarch64__
-        cnt = cnt_col * 8 + cnt_remain;
         asm volatile(
           INIT_FP16_S2 LEFT_COMPUTE_FP16_S2 LEFT_RESULT_FP16_S2_RELU
           MID_COMPUTE_FP16_S2 MID_RESULT_FP16_S2_RELU
@@ -1243,7 +1241,6 @@ void conv_depthwise_3x3s2p1_bias_relu6_common_fp16_fp16(
         uint16_t* val_mask = vmask;
 // clang-format off
 #ifdef __aarch64__
-        cnt = cnt_col * 8 + cnt_remain;
         asm volatile(
           INIT_FP16_S2 LEFT_COMPUTE_FP16_S2 LEFT_RESULT_FP16_S2_RELU6
           MID_COMPUTE_FP16_S2 MID_RESULT_FP16_S2_RELU6
@@ -1364,7 +1361,6 @@ void conv_depthwise_3x3s2p1_bias_leaky_relu_common_fp16_fp16(
         uint16_t* val_mask = vmask;
 // clang-format off
 #ifdef __aarch64__
-        cnt = cnt_col * 8 + cnt_remain;
         asm volatile(
           INIT_FP16_S2 LEFT_COMPUTE_FP16_S2 LEFT_RESULT_FP16_S2_LEAKY_RELU
           MID_COMPUTE_FP16_S2 MID_RESULT_FP16_S2_LEAKY_RELU
@@ -1487,7 +1483,6 @@ void conv_depthwise_3x3s2p0_bias_noact_common_fp16_fp16(
         uint16_t* val_mask = vmask;
 // clang-format off
 #ifdef __aarch64__
-        cnt = cnt_col * 8 + cnt_remain;
         asm volatile(
           INIT_FP16_S2
           MID_COMPUTE_FP16_S2 MID_RESULT_FP16_S2
@@ -1606,7 +1601,6 @@ void conv_depthwise_3x3s2p0_bias_relu_common_fp16_fp16(float16_t* dout,
         uint16_t* val_mask = vmask;
 // clang-format off
 #ifdef __aarch64__
-        cnt = cnt_col * 8 + cnt_remain;
         asm volatile(
           INIT_FP16_S2
           MID_COMPUTE_FP16_S2 MID_RESULT_FP16_S2_RELU
@@ -1725,7 +1719,6 @@ void conv_depthwise_3x3s2p0_bias_relu6_common_fp16_fp16(
         uint16_t* val_mask = vmask;
 // clang-format off
 #ifdef __aarch64__
-        cnt = cnt_col * 8 + cnt_remain;
         asm volatile(
           INIT_FP16_S2
           MID_COMPUTE_FP16_S2 MID_RESULT_FP16_S2_RELU6
@@ -1844,7 +1837,6 @@ void conv_depthwise_3x3s2p0_bias_leaky_relu_common_fp16_fp16(
         uint16_t* val_mask = vmask;
 // clang-format off
 #ifdef __aarch64__
-        cnt = cnt_col * 8 + cnt_remain;
         asm volatile(
           INIT_FP16_S2
           MID_COMPUTE_FP16_S2 MID_RESULT_FP16_S2_LEAKY_RELU

--- a/lite/backends/arm/math/fp16/conv_depthwise_common_fp16.cc
+++ b/lite/backends/arm/math/fp16/conv_depthwise_common_fp16.cc
@@ -34,19 +34,19 @@ namespace fp16 {
   "mov x7, %[weight]\n"
 
 #define LOOP               \
-  "Loop:\n"                \
+  "Loop_%=:\n"             \
   "mov x9, %[pre_din]\n"   \
   "mov x10, %[pre_dout]\n" \
   "mov x6, %[ow]\n"
 
 #define COMPUTE16                                        \
-  "L16:\n"                                               \
+  "L16_%=:\n"                                            \
   "cmp x6, #16\n"                                        \
-  "blt L8\n"                                             \
+  "blt L8_%=\n"                                          \
   "mov x3, #16\n" /*x3 = sw * 8(c) * 16(w)*/             \
   "mul x3, %[src_w_setup], x3\n"                         \
                                                          \
-  "L16Loop:\n"                                           \
+  "L16Loop_%=:\n"                                        \
   "mov x8, %[pre_din]\n"                                 \
   "mov v16.8h, %[vbias].8h\n"                            \
   "mov v17.8h, %[vbias].8h\n"                            \
@@ -67,9 +67,9 @@ namespace fp16 {
                                                          \
   /*kh*/                                                 \
   "mov x1, %[kh]\n"                                      \
-  "L16LoopH:\n"                                          \
+  "L16LoopH_%=:\n"                                       \
   "mov x2, %[kw]\n" /*kw*/                               \
-  "L16LoopW:\n"                                          \
+  "L16LoopW_%=:\n"                                       \
   "ld1 {v7.8h}, [%[weight]], #16\n"                      \
   "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
   "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
@@ -106,10 +106,10 @@ namespace fp16 {
   "sub %[pre_din], %[pre_din], x3\n"                     \
   "add %[pre_din], %[pre_din], %[dilateX_step]\n" /*kw*/ \
   "subs x2, x2, #1\n"                                    \
-  "bne L16LoopW\n" /*kh*/                                \
+  "bne L16LoopW_%=\n" /*kh*/                             \
   "add %[pre_din], %[pre_din], x5\n"                     \
   "subs x1, x1, #1\n"                                    \
-  "bne L16LoopH\n"                                       \
+  "bne L16LoopH_%=\n"                                    \
   "mov %[weight], x7\n"                                  \
   "sub x6, x6, #16\n"                                    \
   "add %[pre_din], x8, x3\n"
@@ -120,16 +120,16 @@ namespace fp16 {
   "st1 {v24.8h, v25.8h, v26.8h, v27.8h}, [%[pre_dout]], #64\n" \
   "st1 {v28.8h, v29.8h, v30.8h, v31.8h}, [%[pre_dout]], #64\n" \
   "cmp x6, #16\n"                                              \
-  "bge L16Loop\n"
+  "bge L16Loop_%=\n"
 
 #define COMPUTE8                                         \
-  "L8:"                                                  \
+  "L8_%=:"                                               \
   "cmp x6, #8\n"                                         \
-  "blt L4\n"                                             \
+  "blt L4_%=\n"                                          \
   "mov x3, #8\n" /*x3 = sw * 8(c) * 8(w)*/               \
   "mul x3, %[src_w_setup], x3\n"                         \
                                                          \
-  "L8Loop:\n"                                            \
+  "L8Loop_%=:\n"                                         \
   "mov x8, %[pre_din]\n"                                 \
   "mov v16.8h, %[vbias].8h\n"                            \
   "mov v17.8h, %[vbias].8h\n"                            \
@@ -142,9 +142,9 @@ namespace fp16 {
                                                          \
   /*kh*/                                                 \
   "mov x1, %[kh]\n"                                      \
-  "L8LoopH:\n"                                           \
+  "L8LoopH_%=:\n"                                        \
   "mov x2, %[kw]\n" /*kw*/                               \
-  "L8LoopW:\n"                                           \
+  "L8LoopW_%=:\n"                                        \
   "ld1 {v7.8h}, [%[weight]], #16\n"                      \
   "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
   "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
@@ -165,10 +165,10 @@ namespace fp16 {
   "sub %[pre_din], %[pre_din], x3\n"                     \
   "add %[pre_din], %[pre_din], %[dilateX_step]\n" /*kw*/ \
   "subs x2, x2, #1\n"                                    \
-  "bne L8LoopW\n"                                        \
+  "bne L8LoopW_%=\n"                                     \
   "add %[pre_din], %[pre_din], x5\n" /*kh*/              \
   "subs x1, x1, #1\n"                                    \
-  "bne L8LoopH\n"                                        \
+  "bne L8LoopH_%=\n"                                     \
   "mov %[weight], x7\n"                                  \
   "sub x6, x6, #8\n"                                     \
   "add %[pre_din], x8, x3\n"
@@ -178,22 +178,22 @@ namespace fp16 {
   "st1 {v20.8h, v21.8h, v22.8h, v23.8h}, [%[pre_dout]], #64\n"
 
 #define COMPUTE4                                         \
-  "L4:\n"                                                \
+  "L4_%=:\n"                                             \
   "cmp x6, #4\n"                                         \
-  "blt L1\n"                                             \
+  "blt L1_%=\n"                                          \
   "mov x3, #4\n" /*x3 = sw * 8(c) * 4(w)*/               \
   "mul x3, %[src_w_setup], x3\n"                         \
                                                          \
-  "L4Loop:\n"                                            \
+  "L4Loop_%=:\n"                                         \
   "mov x8, %[pre_din]\n"                                 \
   "mov v16.8h, %[vbias].8h\n"                            \
   "mov v17.8h, %[vbias].8h\n"                            \
   "mov v18.8h, %[vbias].8h\n"                            \
   "mov v19.8h, %[vbias].8h\n" /*kh*/                     \
   "mov x1, %[kh]\n"                                      \
-  "L4LoopH:\n" /*kw*/                                    \
+  "L4LoopH_%=:\n" /*kw*/                                 \
   "mov x2, %[kw]\n"                                      \
-  "L4LoopW:\n"                                           \
+  "L4LoopW_%=:\n"                                        \
   "ld1 {v7.8h}, [%[weight]], #16\n"                      \
   "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
   "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
@@ -206,10 +206,10 @@ namespace fp16 {
   "sub %[pre_din], %[pre_din], x3\n"                     \
   "add %[pre_din], %[pre_din], %[dilateX_step]\n" /*kw*/ \
   "subs x2, x2, #1\n"                                    \
-  "bne L4LoopW\n"                                        \
+  "bne L4LoopW_%=\n"                                     \
   "add %[pre_din], %[pre_din], x5\n" /*kh*/              \
   "subs x1, x1, #1\n"                                    \
-  "bne L4LoopH\n"                                        \
+  "bne L4LoopH_%=\n"                                     \
   "mov %[weight], x7\n"                                  \
   "sub x6, x6, #4\n"                                     \
   "add %[pre_din], x8, x3\n"
@@ -217,24 +217,24 @@ namespace fp16 {
 #define STORE4 "st1 {v16.8h, v17.8h, v18.8h, v19.8h}, [%[pre_dout]], #64\n"
 
 #define COMPUTE1                                 \
-  "L1:\n"                                        \
+  "L1_%=:\n"                                     \
   "cmp x6, #1\n"                                 \
-  "blt END\n"                                    \
-  "L1Loop:\n"                                    \
+  "blt 0f\n"                                     \
+  "L1Loop_%=:\n"                                 \
   "mov x8, %[pre_din]\n"                         \
   "mov v16.8h, %[vbias].8h\n" /*kh*/             \
   "mov x1, %[kh]\n"                              \
-  "L1LoopH:\n"                                   \
+  "L1LoopH_%=:\n"                                \
   "mov x2, %[kw]\n" /*kw*/                       \
-  "L1LoopW:\n"                                   \
+  "L1LoopW_%=:\n"                                \
   "ld1 {v7.8h}, [%[weight]], #16\n"              \
   "ld1 {v0.8h}, [%[pre_din]], %[dilateX_step]\n" \
   "fmla v16.8h, v7.8h, v0.8h\n" /*kw*/           \
   "subs x2, x2, #1\n"                            \
-  "bne L1LoopW\n" /*kh*/                         \
+  "bne L1LoopW_%=\n" /*kh*/                      \
   "add %[pre_din], %[pre_din], x5\n"             \
   "subs x1, x1, #1\n"                            \
-  "bne L1LoopH\n"                                \
+  "bne L1LoopH_%=\n"                             \
   "mov %[weight], x7\n"                          \
   "sub x6, x6, #1\n"                             \
   "add %[pre_din], x8, %[src_w_setup]\n"
@@ -242,14 +242,14 @@ namespace fp16 {
 #define STORE1                         \
   "st1 {v16.8h}, [%[pre_dout]], #16\n" \
   "cmp x6, #1\n"                       \
-  "bge L1Loop\n"
+  "bge L1Loop_%=\n"
 
 #define END                             \
-  "END:\n"                              \
+  "0:\n"                                \
   "add %[pre_din], x9, %[srcHStep]\n"   \
   "add %[pre_dout], x10, %[dstHStep]\n" \
   "subs %[oh], %[oh], #1 \n"            \
-  "bne Loop\n"
+  "bne Loop_%=\n"
 #else
 #define INIT                      \
   /*r10 = kw * dw * 8(c)*/        \
@@ -260,18 +260,18 @@ namespace fp16 {
   "vmov.i32 d8[0], %[weight]\n"
 
 #define LOOP                      \
-  "Loop:\n"                       \
+  "Loop_%=:\n"                    \
   "ldr r9, [%[param_ptr], #12]\n" \
   "push {%[oh], %[ow], %[pre_din]}\n"
 
 #define COMPUTE8                                 \
-  "L8:"                                          \
+  "L8_%=:"                                       \
   "cmp %[ow], #8\n"                              \
-  "blt L4\n"                                     \
+  "blt L4_%=\n"                                  \
   "mov %[oh], #8\n"                              \
   "mul %[oh], %[src_w_setup], %[oh]\n"           \
                                                  \
-  "L8Loop:\n"                                    \
+  "L8Loop_%=:\n"                                 \
   "vmov.i32 d8[1], %[pre_din]\n"                 \
   "vmov q8,  %[vbias]\n"                         \
   "vmov q9,  %[vbias]\n"                         \
@@ -284,9 +284,9 @@ namespace fp16 {
                                                  \
   /*kh*/                                         \
   "mov r11, %[kh]\n"                             \
-  "L8LoopH:\n"                                   \
+  "L8LoopH_%=:\n"                                \
   "mov r10, %[kw]\n" /*kw*/                      \
-  "L8LoopW:\n"                                   \
+  "L8LoopW_%=:\n"                                \
   "vld1.16 {q3}, [%[weight]]!\n"                 \
   "vld1.16 {q0}, [%[pre_din]], %[src_w_setup]\n" \
   "vmla.f16 q8,  q0, q3\n"                       \
@@ -307,10 +307,10 @@ namespace fp16 {
   "sub %[pre_din], %[pre_din], %[oh]\n"          \
   "add %[pre_din], %[pre_din], r9\n" /*kw*/      \
   "subs r10, r10, #1\n"                          \
-  "bne L8LoopW\n"                                \
+  "bne L8LoopW_%=\n"                             \
   "add %[pre_din], %[pre_din], r12\n" /*kh*/     \
   "subs r11, r11, #1\n"                          \
-  "bne L8LoopH\n"                                \
+  "bne L8LoopH_%=\n"                             \
   "vmov.i32 %[weight], d8[0]\n"                  \
   "sub %[ow], %[ow], #8\n"                       \
   "vmov.i32  %[pre_din], d8[1]\n"                \
@@ -322,25 +322,25 @@ namespace fp16 {
   "vst1.16  {d24-d27}, [%[pre_dout]]!\n" \
   "vst1.16  {d28-d31}, [%[pre_dout]]!\n" \
   "cmp %[ow], #8\n"                      \
-  "bge L8Loop\n"
+  "bge L8Loop_%=\n"
 
 #define COMPUTE4                                 \
-  "L4:\n"                                        \
+  "L4_%=:\n"                                     \
   "cmp %[ow], #4\n"                              \
-  "blt L1\n"                                     \
+  "blt L1_%=\n"                                  \
   "mov %[oh], #4\n"                              \
   "mul %[oh], %[src_w_setup], %[oh]\n"           \
                                                  \
-  "L4Loop:\n"                                    \
+  "L4Loop_%=:\n"                                 \
   "vmov.i32 d8[1], %[pre_din]\n"                 \
   "vmov q8,  %[vbias]\n"                         \
   "vmov q9,  %[vbias]\n"                         \
   "vmov q10, %[vbias]\n"                         \
   "vmov q11, %[vbias]\n" /*kh*/                  \
   "mov r11, %[kh]\n"                             \
-  "L4LoopH:\n" /*kw*/                            \
+  "L4LoopH_%=:\n" /*kw*/                         \
   "mov r10, %[kw]\n"                             \
-  "L4LoopW:\n"                                   \
+  "L4LoopW_%=:\n"                                \
   "vld1.16 {q3}, [%[weight]]!\n"                 \
   "vld1.16 {q0}, [%[pre_din]], %[src_w_setup]\n" \
   "vmla.f16 q8,  q0, q3\n"                       \
@@ -353,10 +353,10 @@ namespace fp16 {
   "sub %[pre_din], %[pre_din], %[oh]\n"          \
   "add %[pre_din], %[pre_din], r9\n" /*kw*/      \
   "subs r10, r10, #1\n"                          \
-  "bne L4LoopW\n"                                \
+  "bne L4LoopW_%=\n"                             \
   "add %[pre_din], %[pre_din], r12\n" /*kh*/     \
   "subs r11, r11, #1\n"                          \
-  "bne L4LoopH\n"                                \
+  "bne L4LoopH_%=\n"                             \
   "vmov.i32 %[weight], d8[0]\n"                  \
   "sub %[ow], %[ow], #4\n"                       \
   "vmov.i32 %[pre_din], d8[1]\n"                 \
@@ -367,24 +367,24 @@ namespace fp16 {
   "vst1.16  {d20-d23}, [%[pre_dout]]!\n"
 
 #define COMPUTE1                      \
-  "L1:\n"                             \
+  "L1_%=:\n"                          \
   "cmp %[ow], #1\n"                   \
-  "blt END\n"                         \
-  "L1Loop:\n"                         \
+  "blt 0f\n"                          \
+  "L1Loop_%=:\n"                      \
   "vmov.i32 d8[1], %[pre_din]\n"      \
   "vmov q8,  %[vbias]\n" /*kh*/       \
   "mov r11, %[kh]\n"                  \
-  "L1LoopH:\n"                        \
+  "L1LoopH_%=:\n"                     \
   "mov r10, %[kw]\n" /*kw*/           \
-  "L1LoopW:\n"                        \
+  "L1LoopW_%=:\n"                     \
   "vld1.16 {q3}, [%[weight]]!\n"      \
   "vld1.16 {q0}, [%[pre_din]], r9\n"  \
   "vmla.f16 q8, q0, q3\n" /*kw*/      \
   "subs r10, r10, #1\n"               \
-  "bne L1LoopW\n" /*kh*/              \
+  "bne L1LoopW_%=\n" /*kh*/           \
   "add %[pre_din], %[pre_din], r12\n" \
   "subs r11, r11, #1\n"               \
-  "bne L1LoopH\n"                     \
+  "bne L1LoopH_%=\n"                  \
   "vmov.i32 %[weight], d8[0]\n"       \
   "sub %[ow], %[ow], #1\n"            \
   "vmov.i32 %[pre_din], d8[1]\n"      \
@@ -393,15 +393,15 @@ namespace fp16 {
 #define STORE1                           \
   "vst1.16  {d16-d17}, [%[pre_dout]]!\n" \
   "cmp %[ow], #1\n"                      \
-  "bge L1Loop\n"
+  "bge L1Loop_%=\n"
 
 #define END                          \
-  "END:\n"                           \
+  "0:\n"                             \
   "pop {%[oh], %[ow], %[pre_din]}\n" \
   "ldr r9, [%[param_ptr], #0]\n"     \
   "add %[pre_din], %[pre_din], r9\n" \
   "subs %[oh], %[oh], #1 \n"         \
-  "bne Loop\n"
+  "bne Loop_%=\n"
 #endif
 /*
 *The following function conv_depthwise_common_line is

--- a/lite/backends/arm/math/fp16/conv_depthwise_common_fp16.cc
+++ b/lite/backends/arm/math/fp16/conv_depthwise_common_fp16.cc
@@ -1,0 +1,593 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/backends/arm/math/fp16/conv_depthwise_common_fp16.h"
+#include "lite/backends/arm/math/fp16/common_preprocess.h"
+#include "lite/backends/arm/math/fp16/conv_block_utils_fp16.h"
+#include "lite/core/context.h"
+#include "lite/core/parallel_defines.h"
+#ifdef ARM_WITH_OMP
+#include <omp.h>
+#endif
+
+namespace paddle {
+namespace lite {
+namespace arm {
+namespace math {
+namespace fp16 {
+#ifdef __aarch64__
+#define INIT                         \
+  /*x4 = kw * dw * 8(c)*/            \
+  "mul x4, %[kw], %[dilateX_step]\n" \
+  "sub x5, %[dilateY_step], x4\n"    \
+  "mov x7, %[weight]\n"
+
+#define LOOP               \
+  "Loop:\n"                \
+  "mov x9, %[pre_din]\n"   \
+  "mov x10, %[pre_dout]\n" \
+  "mov x6, %[ow]\n"
+
+#define COMPUTE16                                        \
+  "L16:\n"                                               \
+  "cmp x6, #16\n"                                        \
+  "blt L8\n"                                             \
+  "mov x3, #16\n" /*x3 = sw * 8(c) * 16(w)*/             \
+  "mul x3, %[src_w_setup], x3\n"                         \
+                                                         \
+  "L16Loop:\n"                                           \
+  "mov x8, %[pre_din]\n"                                 \
+  "mov v16.8h, %[vbias].8h\n"                            \
+  "mov v17.8h, %[vbias].8h\n"                            \
+  "mov v18.8h, %[vbias].8h\n"                            \
+  "mov v19.8h, %[vbias].8h\n"                            \
+  "mov v20.8h, %[vbias].8h\n"                            \
+  "mov v21.8h, %[vbias].8h\n"                            \
+  "mov v22.8h, %[vbias].8h\n"                            \
+  "mov v23.8h, %[vbias].8h\n"                            \
+  "mov v24.8h, %[vbias].8h\n"                            \
+  "mov v25.8h, %[vbias].8h\n"                            \
+  "mov v26.8h, %[vbias].8h\n"                            \
+  "mov v27.8h, %[vbias].8h\n"                            \
+  "mov v28.8h, %[vbias].8h\n"                            \
+  "mov v29.8h, %[vbias].8h\n"                            \
+  "mov v30.8h, %[vbias].8h\n"                            \
+  "mov v31.8h, %[vbias].8h\n"                            \
+                                                         \
+  /*kh*/                                                 \
+  "mov x1, %[kh]\n"                                      \
+  "L16LoopH:\n"                                          \
+  "mov x2, %[kw]\n" /*kw*/                               \
+  "L16LoopW:\n"                                          \
+  "ld1 {v7.8h}, [%[weight]], #16\n"                      \
+  "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v16.8h, v7.8h, v0.8h\n"                          \
+  "fmla v17.8h, v7.8h, v1.8h\n"                          \
+  "ld1 {v2.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v3.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v18.8h, v7.8h, v2.8h\n"                          \
+  "fmla v19.8h, v7.8h, v3.8h\n"                          \
+  "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v20.8h, v7.8h, v0.8h\n"                          \
+  "fmla v21.8h, v7.8h, v1.8h\n"                          \
+  "ld1 {v2.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v3.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v22.8h, v7.8h, v2.8h\n"                          \
+  "fmla v23.8h, v7.8h, v3.8h\n"                          \
+  "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v24.8h, v7.8h, v0.8h\n"                          \
+  "fmla v25.8h, v7.8h, v1.8h\n"                          \
+  "ld1 {v2.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v3.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v26.8h, v7.8h, v2.8h\n"                          \
+  "fmla v27.8h, v7.8h, v3.8h\n"                          \
+  "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v28.8h, v7.8h, v0.8h\n"                          \
+  "fmla v29.8h, v7.8h, v1.8h\n"                          \
+  "ld1 {v2.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v3.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v30.8h, v7.8h, v2.8h\n"                          \
+  "fmla v31.8h, v7.8h, v3.8h\n"                          \
+  "sub %[pre_din], %[pre_din], x3\n"                     \
+  "add %[pre_din], %[pre_din], %[dilateX_step]\n" /*kw*/ \
+  "subs x2, x2, #1\n"                                    \
+  "bne L16LoopW\n" /*kh*/                                \
+  "add %[pre_din], %[pre_din], x5\n"                     \
+  "subs x1, x1, #1\n"                                    \
+  "bne L16LoopH\n"                                       \
+  "mov %[weight], x7\n"                                  \
+  "sub x6, x6, #16\n"                                    \
+  "add %[pre_din], x8, x3\n"
+
+#define STORE16                                                \
+  "st1 {v16.8h, v17.8h, v18.8h, v19.8h}, [%[pre_dout]], #64\n" \
+  "st1 {v20.8h, v21.8h, v22.8h, v23.8h}, [%[pre_dout]], #64\n" \
+  "st1 {v24.8h, v25.8h, v26.8h, v27.8h}, [%[pre_dout]], #64\n" \
+  "st1 {v28.8h, v29.8h, v30.8h, v31.8h}, [%[pre_dout]], #64\n" \
+  "cmp x6, #16\n"                                              \
+  "bge L16Loop\n"
+
+#define COMPUTE8                                         \
+  "L8:"                                                  \
+  "cmp x6, #8\n"                                         \
+  "blt L4\n"                                             \
+  "mov x3, #8\n" /*x3 = sw * 8(c) * 8(w)*/               \
+  "mul x3, %[src_w_setup], x3\n"                         \
+                                                         \
+  "L8Loop:\n"                                            \
+  "mov x8, %[pre_din]\n"                                 \
+  "mov v16.8h, %[vbias].8h\n"                            \
+  "mov v17.8h, %[vbias].8h\n"                            \
+  "mov v18.8h, %[vbias].8h\n"                            \
+  "mov v19.8h, %[vbias].8h\n"                            \
+  "mov v20.8h, %[vbias].8h\n"                            \
+  "mov v21.8h, %[vbias].8h\n"                            \
+  "mov v22.8h, %[vbias].8h\n"                            \
+  "mov v23.8h, %[vbias].8h\n"                            \
+                                                         \
+  /*kh*/                                                 \
+  "mov x1, %[kh]\n"                                      \
+  "L8LoopH:\n"                                           \
+  "mov x2, %[kw]\n" /*kw*/                               \
+  "L8LoopW:\n"                                           \
+  "ld1 {v7.8h}, [%[weight]], #16\n"                      \
+  "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v16.8h, v7.8h, v0.8h\n"                          \
+  "fmla v17.8h, v7.8h, v1.8h\n"                          \
+  "ld1 {v2.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v3.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v18.8h, v7.8h, v2.8h\n"                          \
+  "fmla v19.8h, v7.8h, v3.8h\n"                          \
+  "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v20.8h, v7.8h, v0.8h\n"                          \
+  "fmla v21.8h, v7.8h, v1.8h\n"                          \
+  "ld1 {v2.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v3.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v22.8h, v7.8h, v2.8h\n"                          \
+  "fmla v23.8h, v7.8h, v3.8h\n"                          \
+  "sub %[pre_din], %[pre_din], x3\n"                     \
+  "add %[pre_din], %[pre_din], %[dilateX_step]\n" /*kw*/ \
+  "subs x2, x2, #1\n"                                    \
+  "bne L8LoopW\n"                                        \
+  "add %[pre_din], %[pre_din], x5\n" /*kh*/              \
+  "subs x1, x1, #1\n"                                    \
+  "bne L8LoopH\n"                                        \
+  "mov %[weight], x7\n"                                  \
+  "sub x6, x6, #8\n"                                     \
+  "add %[pre_din], x8, x3\n"
+
+#define STORE8                                                 \
+  "st1 {v16.8h, v17.8h, v18.8h, v19.8h}, [%[pre_dout]], #64\n" \
+  "st1 {v20.8h, v21.8h, v22.8h, v23.8h}, [%[pre_dout]], #64\n"
+
+#define COMPUTE4                                         \
+  "L4:\n"                                                \
+  "cmp x6, #4\n"                                         \
+  "blt L1\n"                                             \
+  "mov x3, #4\n" /*x3 = sw * 8(c) * 4(w)*/               \
+  "mul x3, %[src_w_setup], x3\n"                         \
+                                                         \
+  "L4Loop:\n"                                            \
+  "mov x8, %[pre_din]\n"                                 \
+  "mov v16.8h, %[vbias].8h\n"                            \
+  "mov v17.8h, %[vbias].8h\n"                            \
+  "mov v18.8h, %[vbias].8h\n"                            \
+  "mov v19.8h, %[vbias].8h\n" /*kh*/                     \
+  "mov x1, %[kh]\n"                                      \
+  "L4LoopH:\n" /*kw*/                                    \
+  "mov x2, %[kw]\n"                                      \
+  "L4LoopW:\n"                                           \
+  "ld1 {v7.8h}, [%[weight]], #16\n"                      \
+  "ld1 {v0.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v1.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v16.8h, v7.8h, v0.8h\n"                          \
+  "fmla v17.8h, v7.8h, v1.8h\n"                          \
+  "ld1 {v2.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "ld1 {v3.8h}, [%[pre_din]], %[src_w_setup]\n"          \
+  "fmla v18.8h, v7.8h, v2.8h\n"                          \
+  "fmla v19.8h, v7.8h, v3.8h\n"                          \
+  "sub %[pre_din], %[pre_din], x3\n"                     \
+  "add %[pre_din], %[pre_din], %[dilateX_step]\n" /*kw*/ \
+  "subs x2, x2, #1\n"                                    \
+  "bne L4LoopW\n"                                        \
+  "add %[pre_din], %[pre_din], x5\n" /*kh*/              \
+  "subs x1, x1, #1\n"                                    \
+  "bne L4LoopH\n"                                        \
+  "mov %[weight], x7\n"                                  \
+  "sub x6, x6, #4\n"                                     \
+  "add %[pre_din], x8, x3\n"
+
+#define STORE4 "st1 {v16.8h, v17.8h, v18.8h, v19.8h}, [%[pre_dout]], #64\n"
+
+#define COMPUTE1                                 \
+  "L1:\n"                                        \
+  "cmp x6, #1\n"                                 \
+  "blt END\n"                                    \
+  "L1Loop:\n"                                    \
+  "mov x8, %[pre_din]\n"                         \
+  "mov v16.8h, %[vbias].8h\n" /*kh*/             \
+  "mov x1, %[kh]\n"                              \
+  "L1LoopH:\n"                                   \
+  "mov x2, %[kw]\n" /*kw*/                       \
+  "L1LoopW:\n"                                   \
+  "ld1 {v7.8h}, [%[weight]], #16\n"              \
+  "ld1 {v0.8h}, [%[pre_din]], %[dilateX_step]\n" \
+  "fmla v16.8h, v7.8h, v0.8h\n" /*kw*/           \
+  "subs x2, x2, #1\n"                            \
+  "bne L1LoopW\n" /*kh*/                         \
+  "add %[pre_din], %[pre_din], x5\n"             \
+  "subs x1, x1, #1\n"                            \
+  "bne L1LoopH\n"                                \
+  "mov %[weight], x7\n"                          \
+  "sub x6, x6, #1\n"                             \
+  "add %[pre_din], x8, %[src_w_setup]\n"
+
+#define STORE1                         \
+  "st1 {v16.8h}, [%[pre_dout]], #16\n" \
+  "cmp x6, #1\n"                       \
+  "bge L1Loop\n"
+
+#define END                             \
+  "END:\n"                              \
+  "add %[pre_din], x9, %[srcHStep]\n"   \
+  "add %[pre_dout], x10, %[dstHStep]\n" \
+  "subs %[oh], %[oh], #1 \n"            \
+  "bne Loop\n"
+#else
+#define INIT                      \
+  /*r10 = kw * dw * 8(c)*/        \
+  "ldr r9, [%[param_ptr], #12]\n" \
+  "mul r10, %[kw], r9\n"          \
+  "ldr r9, [%[param_ptr], #8]\n"  \
+  "sub r12, r9, r10\n"            \
+  "vmov.i32 d8[0], %[weight]\n"
+
+#define LOOP                      \
+  "Loop:\n"                       \
+  "ldr r9, [%[param_ptr], #12]\n" \
+  "push {%[oh], %[ow], %[pre_din]}\n"
+
+#define COMPUTE8                                 \
+  "L8:"                                          \
+  "cmp %[ow], #8\n"                              \
+  "blt L4\n"                                     \
+  "mov %[oh], #8\n"                              \
+  "mul %[oh], %[src_w_setup], %[oh]\n"           \
+                                                 \
+  "L8Loop:\n"                                    \
+  "vmov.i32 d8[1], %[pre_din]\n"                 \
+  "vmov q8,  %[vbias]\n"                         \
+  "vmov q9,  %[vbias]\n"                         \
+  "vmov q10, %[vbias]\n"                         \
+  "vmov q11, %[vbias]\n"                         \
+  "vmov q12, %[vbias]\n"                         \
+  "vmov q13, %[vbias]\n"                         \
+  "vmov q14, %[vbias]\n"                         \
+  "vmov q15, %[vbias]\n"                         \
+                                                 \
+  /*kh*/                                         \
+  "mov r11, %[kh]\n"                             \
+  "L8LoopH:\n"                                   \
+  "mov r10, %[kw]\n" /*kw*/                      \
+  "L8LoopW:\n"                                   \
+  "vld1.16 {q3}, [%[weight]]!\n"                 \
+  "vld1.16 {q0}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q8,  q0, q3\n"                       \
+  "vld1.16 {q1}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q9,  q1, q3\n"                       \
+  "vld1.16 {q0}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q10, q0, q3\n"                       \
+  "vld1.16 {q1}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q11, q1, q3\n"                       \
+  "vld1.16 {q0}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q12, q0, q3\n"                       \
+  "vld1.16 {q1}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q13, q1, q3\n"                       \
+  "vld1.16 {q0}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q14, q0, q3\n"                       \
+  "vld1.16 {q1}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q15, q1, q3\n"                       \
+  "sub %[pre_din], %[pre_din], %[oh]\n"          \
+  "add %[pre_din], %[pre_din], r9\n" /*kw*/      \
+  "subs r10, r10, #1\n"                          \
+  "bne L8LoopW\n"                                \
+  "add %[pre_din], %[pre_din], r12\n" /*kh*/     \
+  "subs r11, r11, #1\n"                          \
+  "bne L8LoopH\n"                                \
+  "vmov.i32 %[weight], d8[0]\n"                  \
+  "sub %[ow], %[ow], #8\n"                       \
+  "vmov.i32  %[pre_din], d8[1]\n"                \
+  "add %[pre_din], %[pre_din], %[oh]\n"
+
+#define STORE8                           \
+  "vst1.16  {d16-d19}, [%[pre_dout]]!\n" \
+  "vst1.16  {d20-d23}, [%[pre_dout]]!\n" \
+  "vst1.16  {d24-d27}, [%[pre_dout]]!\n" \
+  "vst1.16  {d28-d31}, [%[pre_dout]]!\n" \
+  "cmp %[ow], #8\n"                      \
+  "bge L8Loop\n"
+
+#define COMPUTE4                                 \
+  "L4:\n"                                        \
+  "cmp %[ow], #4\n"                              \
+  "blt L1\n"                                     \
+  "mov %[oh], #4\n"                              \
+  "mul %[oh], %[src_w_setup], %[oh]\n"           \
+                                                 \
+  "L4Loop:\n"                                    \
+  "vmov.i32 d8[1], %[pre_din]\n"                 \
+  "vmov q8,  %[vbias]\n"                         \
+  "vmov q9,  %[vbias]\n"                         \
+  "vmov q10, %[vbias]\n"                         \
+  "vmov q11, %[vbias]\n" /*kh*/                  \
+  "mov r11, %[kh]\n"                             \
+  "L4LoopH:\n" /*kw*/                            \
+  "mov r10, %[kw]\n"                             \
+  "L4LoopW:\n"                                   \
+  "vld1.16 {q3}, [%[weight]]!\n"                 \
+  "vld1.16 {q0}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q8,  q0, q3\n"                       \
+  "vld1.16 {q1}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q9,  q1, q3\n"                       \
+  "vld1.16 {q0}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q10, q0, q3\n"                       \
+  "vld1.16 {q1}, [%[pre_din]], %[src_w_setup]\n" \
+  "vmla.f16 q11, q1, q3\n"                       \
+  "sub %[pre_din], %[pre_din], %[oh]\n"          \
+  "add %[pre_din], %[pre_din], r9\n" /*kw*/      \
+  "subs r10, r10, #1\n"                          \
+  "bne L4LoopW\n"                                \
+  "add %[pre_din], %[pre_din], r12\n" /*kh*/     \
+  "subs r11, r11, #1\n"                          \
+  "bne L4LoopH\n"                                \
+  "vmov.i32 %[weight], d8[0]\n"                  \
+  "sub %[ow], %[ow], #4\n"                       \
+  "vmov.i32 %[pre_din], d8[1]\n"                 \
+  "add %[pre_din], %[pre_din], %[oh]\n"
+
+#define STORE4                           \
+  "vst1.16  {d16-d19}, [%[pre_dout]]!\n" \
+  "vst1.16  {d20-d23}, [%[pre_dout]]!\n"
+
+#define COMPUTE1                      \
+  "L1:\n"                             \
+  "cmp %[ow], #1\n"                   \
+  "blt END\n"                         \
+  "L1Loop:\n"                         \
+  "vmov.i32 d8[1], %[pre_din]\n"      \
+  "vmov q8,  %[vbias]\n" /*kh*/       \
+  "mov r11, %[kh]\n"                  \
+  "L1LoopH:\n"                        \
+  "mov r10, %[kw]\n" /*kw*/           \
+  "L1LoopW:\n"                        \
+  "vld1.16 {q3}, [%[weight]]!\n"      \
+  "vld1.16 {q0}, [%[pre_din]], r9\n"  \
+  "vmla.f16 q8, q0, q3\n" /*kw*/      \
+  "subs r10, r10, #1\n"               \
+  "bne L1LoopW\n" /*kh*/              \
+  "add %[pre_din], %[pre_din], r12\n" \
+  "subs r11, r11, #1\n"               \
+  "bne L1LoopH\n"                     \
+  "vmov.i32 %[weight], d8[0]\n"       \
+  "sub %[ow], %[ow], #1\n"            \
+  "vmov.i32 %[pre_din], d8[1]\n"      \
+  "add %[pre_din], %[pre_din], %[src_w_setup]\n"
+
+#define STORE1                           \
+  "vst1.16  {d16-d17}, [%[pre_dout]]!\n" \
+  "cmp %[ow], #1\n"                      \
+  "bge L1Loop\n"
+
+#define END                          \
+  "END:\n"                           \
+  "pop {%[oh], %[ow], %[pre_din]}\n" \
+  "ldr r9, [%[param_ptr], #0]\n"     \
+  "add %[pre_din], %[pre_din], r9\n" \
+  "subs %[oh], %[oh], #1 \n"         \
+  "bne Loop\n"
+#endif
+/*
+*The following function conv_depthwise_common_line is
+*base on
+*MNN[https://github.com/alibaba/MNN]
+*
+*Copyright © 2018, Alibaba Group Holding Limited
+*/
+void conv_depthwise_common_line(const float16_t* i_data,
+                                float16_t* o_data,
+                                int ic,
+                                int ih,
+                                int iw,
+                                int bs,
+                                int oc,
+                                int oh,
+                                int ow,
+                                int kh,
+                                int kw,
+                                std::vector<int> strides,
+                                std::vector<int> dilations,
+                                std::vector<int> paddings,
+                                const float16_t* weights,
+                                const float16_t* bias,
+                                const operators::ConvParam& param,
+                                ARMContext* ctx) {
+  int sh = strides[0];
+  int sw = strides[1];
+  int dh = dilations[0];
+  int dw = dilations[1];
+  int pad_top = paddings[0];
+  int pad_bottom = paddings[1];
+  int pad_left = paddings[2];
+  int pad_right = paddings[3];
+  int threads = ctx->threads();
+  const int out_c_block = 8;
+
+  const int prein_size =
+      (iw + pad_left + pad_right) * (ih + pad_top + pad_bottom) * out_c_block;
+  const int preout_size = ow * oh * out_c_block;
+  auto workspace_size =
+      threads * (prein_size + preout_size) + (iw + pad_left + pad_right);
+  ctx->ExtendWorkspace(sizeof(float16_t) * workspace_size);
+
+  bool flag_bias = param.bias != nullptr;
+  auto act_param = param.activation_param;
+
+  /// get workspace
+  auto ptr_zero = ctx->workspace_data<float16_t>();
+  memset(ptr_zero, 0, sizeof(float16_t) * (iw + pad_left + pad_right));
+  float16_t* ptr_write = ptr_zero + (iw + pad_left + pad_right);
+  float16_t* ptr_out =
+      ptr_zero + (iw + pad_left + pad_right) + threads * prein_size;
+
+  int size_in_channel = iw * ih;
+  int size_out_channel = ow * oh;
+
+  int ws = -pad_left;
+  int we = iw + pad_right;
+  int hs = -pad_top;
+  int he = ih + pad_bottom;
+
+  uint src_w_setup = sw * out_c_block * 2;
+  uint srcHStep = (iw + pad_left + pad_right) * out_c_block * sh * 2;
+  uint dstHStep = ow * out_c_block * 2;
+  uint dilateY_step = (iw + pad_left + pad_right) * out_c_block * dh * 2;
+  uint dilateX_step = dw * out_c_block * 2;
+  uint compute_param[4] = {srcHStep, dstHStep, dilateY_step, dilateX_step};
+  auto param_ptr = compute_param;
+
+  auto act_type = act_param.active_type;
+  float16_t alpha = 0.f;
+  int flag_act = 0x00;  // relu: 1, relu6: 2, leakey: 3 hardswish:4
+  float16_t offset = 0.f;
+  float16_t threshold = 6.f;
+
+  if (act_param.has_active) {
+    act_acquire(act_type, flag_act, alpha, offset, threshold, act_param);
+  }
+
+  for (int n = 0; n < bs; ++n) {
+    const float16_t* din_batch = i_data + n * ic * size_in_channel;
+    float16_t* dout_batch = o_data + n * oc * size_out_channel;
+    LITE_PARALLEL_COMMON_BEGIN(c, tid, oc, 0, out_c_block) {
+      auto oh_bak = oh;
+#ifdef LITE_USE_THREAD_POOL
+      float16_t* pre_din = ptr_write + tid * prein_size;
+      float16_t* pre_dout = ptr_out + tid * preout_size;
+#elif ARM_WITH_OMP
+      float16_t* pre_din = ptr_write + omp_get_thread_num() * prein_size;
+      float16_t* pre_dout = ptr_out + omp_get_thread_num() * preout_size;
+#else
+      float16_t* pre_din = ptr_write;
+      float16_t* pre_dout = ptr_out;
+#endif
+      float16_t* out_back = pre_dout;
+      prepack_input_nxwc8_fp16_dw(
+          din_batch, pre_din, c, hs, he, ws, we, ic, iw, ih, ptr_zero);
+      const float16_t* weight_c = weights + c * kw * kh;  // kernel_w * kernel_h
+      float16_t bias_local[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+      float16x8_t vbias = vdupq_n_f16(0.f);
+      if (flag_bias) {
+        if (c + out_c_block < oc) {
+          vbias = vld1q_f16(&bias[c]);
+        } else {
+          for (int k = 0; k < 8 && c + k < oc; k++) {
+            bias_local[k] = bias[c + k];
+          }
+          vbias = vld1q_f16(bias_local);
+        }
+      }
+#ifdef __aarch64__
+      asm volatile(INIT LOOP COMPUTE16 STORE16 COMPUTE8 STORE8 COMPUTE4 STORE4 COMPUTE1 STORE1 END
+                          :[pre_dout] "+r"(pre_dout),\
+                           [pre_din] "+r"(pre_din),\
+                           [weight] "+r"(weight_c),\
+                           [oh] "+r"(oh_bak)                      
+                          :[ow] "r"(ow),\
+                           [src_w_setup] "r"(src_w_setup),\
+                           [kh] "r"(kh),\
+                           [kw] "r"(kw),\
+                           [dilateY_step] "r"(dilateY_step),\
+                           [dilateX_step] "r"(dilateX_step),\                                                                               
+                           [srcHStep] "r"(srcHStep),\
+                           [dstHStep] "r"(dstHStep),\
+                           [vbias] "w"(vbias)
+                          :"cc", "memory", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10",
+                           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v16",\
+                           "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26",\
+                           "v27", "v28", "v29", "v30", "v31"\
+                          );
+#else
+      asm volatile(INIT LOOP COMPUTE8 STORE8 COMPUTE4 STORE4 COMPUTE1 STORE1 END
+                   : [pre_dout] "+r"(pre_dout),
+                     [pre_din] "+r"(pre_din),
+                     [weight] "+r"(weight_c),
+                     [oh] "+r"(oh_bak)
+                   : [ow] "r"(ow),
+                     [src_w_setup] "r"(src_w_setup),
+                     [kh] "r"(kh),
+                     [kw] "r"(kw),
+                     [param_ptr] "r"(param_ptr),
+                     [vbias] "w"(vbias)
+                   : "cc",
+                     "memory",
+                     "r9",
+                     "r10",
+                     "r11",
+                     "r12",
+                     "q0",
+                     "q1",
+                     "q3",
+                     "q4",
+                     "q8",
+                     "q9",
+                     "q10",
+                     "q11",
+                     "q12",
+                     "q13",
+                     "q14",
+                     "q15");
+#endif
+      write_to_oc8_fp16(out_back,
+                        dout_batch,
+                        c,
+                        c + out_c_block,
+                        0,
+                        oh,
+                        0,
+                        ow,
+                        oc,
+                        oh,
+                        ow,
+                        flag_act,
+                        alpha,
+                        nullptr,
+                        false,
+                        offset,
+                        threshold);
+    }
+    LITE_PARALLEL_COMMON_END()
+  }
+}
+
+}  // namespace fp16
+}  // namespace math
+}  // namespace arm
+}  // namespace lite
+}  // namespace paddle

--- a/lite/backends/arm/math/fp16/conv_depthwise_common_fp16.h
+++ b/lite/backends/arm/math/fp16/conv_depthwise_common_fp16.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LITE_BACKENDS_ARM_MATH_FP16_CONV_DEPTHWISE_COMMON_FP16_H_
+#define LITE_BACKENDS_ARM_MATH_FP16_CONV_DEPTHWISE_COMMON_FP16_H_
+
+#include <vector>
+#include "lite/backends/arm/math/fp16/common_preprocess.h"
+#include "lite/backends/arm/math/fp16/conv_block_utils_fp16.h"
+#include "lite/core/context.h"
+#include "lite/core/parallel_defines.h"
+#ifdef ARM_WITH_OMP
+#include <omp.h>
+#endif
+
+namespace paddle {
+namespace lite {
+namespace arm {
+namespace math {
+namespace fp16 {
+void conv_depthwise_common_line(const float16_t* i_data,
+                                float16_t* o_data,
+                                int ic,
+                                int ih,
+                                int iw,
+                                int bs,
+                                int oc,
+                                int oh,
+                                int ow,
+                                int kh,
+                                int kw,
+                                std::vector<int> strides,
+                                std::vector<int> dilations,
+                                std::vector<int> paddings,
+                                const float16_t* weights,
+                                const float16_t* bias,
+                                const operators::ConvParam& param,
+                                ARMContext* ctx);
+
+}  // namespace fp16
+}  // namespace math
+}  // namespace arm
+}  // namespace lite
+}  // namespace paddle
+
+#endif  // LITE_BACKENDS_ARM_MATH_FP16_CONV_DEPTHWISE_COMMON_FP16_H_

--- a/lite/backends/arm/math/fp16/conv_impl_fp16.h
+++ b/lite/backends/arm/math/fp16/conv_impl_fp16.h
@@ -67,6 +67,10 @@ void conv_depthwise_5x5s1_fp16(CONV_PARAM(float16_t));
 
 void conv_depthwise_5x5s2_fp16(CONV_PARAM(float16_t));
 
+void conv_depthwise_common(const float16_t *w_data,
+                           const operators::ConvParam &param,
+                           ARMContext *ctx);
+
 void weight_trans_c8_4x4_fp16(
     float16_t *dest, const float16_t *src, int ic, int oc, void *workspace);
 
@@ -93,6 +97,7 @@ void col2im(const Dtype *data_col,
             const int dilation_h,
             const int dilation_w,
             Dtype *data_im);
+
 }  // namespace fp16
 }  // namespace math
 }  // namespace arm

--- a/lite/kernels/arm/CMakeLists.txt
+++ b/lite/kernels/arm/CMakeLists.txt
@@ -15,6 +15,7 @@ message(STATUS "compile with lite ARM kernels")
 # 1. basic kernels for basic models
 # for conv op
 add_kernel(conv_depthwise ARM basic SRCS conv_depthwise.cc)
+add_kernel(conv_depthwise_common ARM basic SRCS conv_depthwise_common.cc)
 add_kernel(conv_direct ARM basic SRCS conv_direct.cc)
 add_kernel(conv_gemmlike ARM basic SRCS conv_gemmlike.cc)
 add_kernel(conv_winograd ARM basic SRCS conv_winograd.cc)

--- a/lite/kernels/arm/conv_depthwise_common.cc
+++ b/lite/kernels/arm/conv_depthwise_common.cc
@@ -1,0 +1,97 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/arm/conv_depthwise_common.h"
+#include "lite/backends/arm/math/conv_block_utils.h"
+#include "lite/backends/arm/math/conv_impl.h"
+#ifdef ENABLE_ARM_FP16
+#include "lite/backends/arm/math/fp16/conv_impl_fp16.h"
+#endif
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace arm {
+
+template <>
+void DepthwiseConvCommon<PRECISION(kFloat),
+                         PRECISION(kFloat)>::ReInitWhenNeeded() {}
+
+template <>
+void DepthwiseConvCommon<PRECISION(kFloat),
+                         PRECISION(kFloat)>::PrepareForRun() {}
+
+template <>
+void DepthwiseConvCommon<PRECISION(kInt8),
+                         PRECISION(kFloat)>::ReInitWhenNeeded() {}
+
+template <>
+void DepthwiseConvCommon<PRECISION(kInt8), PRECISION(kFloat)>::PrepareForRun() {
+}
+
+template <>
+void DepthwiseConvCommon<PRECISION(kInt8),
+                         PRECISION(kInt8)>::ReInitWhenNeeded() {}
+
+template <>
+void DepthwiseConvCommon<PRECISION(kInt8), PRECISION(kInt8)>::PrepareForRun() {}
+
+template <>
+void DepthwiseConvCommon<PRECISION(kFloat), PRECISION(kFloat)>::Run() {}
+
+template <>
+void DepthwiseConvCommon<PRECISION(kInt8), PRECISION(kFloat)>::Run() {}
+
+template <>
+void DepthwiseConvCommon<PRECISION(kInt8), PRECISION(kInt8)>::Run() {}
+
+#ifdef ENABLE_ARM_FP16
+template <>
+void DepthwiseConvCommon<PRECISION(kFP16),
+                         PRECISION(kFP16)>::ReInitWhenNeeded() {}
+
+template <>
+void DepthwiseConvCommon<PRECISION(kFP16), PRECISION(kFP16)>::PrepareForRun() {
+  auto& param = this->Param<param_t>();
+  CHECK(this->ctx_);
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  auto w_dims = param.filter->dims();
+  auto kh = w_dims[2];
+  auto kw = w_dims[3];
+  auto oc = w_dims[0];
+  constexpr int cblock = 8;
+  auto cround = ROUNDUP(oc, cblock);
+  weights_.Resize({cround, 1, kh, kw});
+  auto w_data = weights_.mutable_data<float16_t>();
+  auto w_data_in = param.filter->data<float16_t>();
+  lite::arm::math::conv_trans_weights_numc(
+      w_data_in, w_data, oc, 1, cblock, kh * kw);
+  KERNEL_FUNC_NAME("conv_depthwise_common_fp16")
+}
+PROFILE_INFO(kFP16, kFP16)
+
+template <>
+void DepthwiseConvCommon<PRECISION(kFP16), PRECISION(kFP16)>::Run() {
+  auto& param = this->Param<param_t>();
+  CHECK(this->ctx_);
+  auto& ctx = this->ctx_->template As<ARMContext>();
+  lite::arm::math::fp16::conv_depthwise_common(
+      weights_.data<float16_t>(), param, &ctx);
+}
+
+#endif
+}  // namespace arm
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/arm/conv_depthwise_common.h
+++ b/lite/kernels/arm/conv_depthwise_common.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cmath>
+#include <string>
+#include <vector>
+#include "lite/backends/arm/math/conv_impl.h"
+#include "lite/core/context.h"
+#include "lite/core/kernel.h"
+#include "lite/core/target_wrapper.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace arm {
+
+template <PrecisionType Ptype, PrecisionType Otype>
+class DepthwiseConvCommon : public KernelLite<TARGET(kARM), Ptype> {
+ public:
+  DepthwiseConvCommon() = default;
+  ~DepthwiseConvCommon() {}
+  virtual void PrepareForRun();
+  virtual void ReInitWhenNeeded();
+  virtual void Run();
+
+#ifdef LITE_WITH_PROFILE
+  virtual void SetProfileRuntimeKernelInfo(
+      paddle::lite::profile::OpCharacter* ch) {
+    ch->kernel_func_name = kernel_func_name_;
+  }
+
+  std::string kernel_func_name_{"NotImplForConvDWCommon"};
+#define PROFILE_INFO(dtype1, dtype2)                                        \
+  template <>                                                               \
+  void DepthwiseConvCommon<PRECISION(dtype1), PRECISION(dtype2)>::          \
+      SetProfileRuntimeKernelInfo(paddle::lite::profile::OpCharacter* ch) { \
+    ch->kernel_func_name = kernel_func_name_;                               \
+  }
+
+#define KERNEL_FUNC_NAME(kernel_func_name) kernel_func_name_ = kernel_func_name;
+
+#else
+#define PROFILE_INFO(dtype1, dtype2)
+#define KERNEL_FUNC_NAME(kernel_func_name)
+#endif
+
+ private:
+  using param_t = operators::ConvParam;
+  Tensor weights_;
+  Tensor bias_;
+  std::vector<float> w_scale_;
+};
+
+}  // namespace arm
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/tests/math/conv_fp16_compute_test.cc
+++ b/lite/tests/math/conv_fp16_compute_test.cc
@@ -299,6 +299,54 @@ void test_conv_fp16(const std::vector<DDim>& input_dims,
                     const float leakey_relu_scale) {}
 #endif  // LITE_WITH_ARM
 
+#if 1  /// common dw
+TEST(TestConvCommonDwFp16, test_conv_common_depthwise) {
+  if (FLAGS_basic_test) {
+    for (auto& stride0 : {3}) {
+      for (auto& stride1 : {2, 1}) {
+        for (auto& dia0 : {2}) {
+          for (auto& dia1 : {1, 2}) {
+            for (auto& pad : {0}) {
+              for (auto& pad1 : {1, 2}) {
+                for (auto& flag_bias : {false, true}) {
+                  for (auto& flag_act : {0, 1, 2, 4}) {
+                    for (auto& c : {1, 5, 12, 32, 35, 46}) {
+                      for (auto kh : {2, 3}) {
+                        for (auto kw : {2, 3}) {
+                          std::vector<DDim> dims;
+                          for (auto& batch : {2}) {
+                            for (auto& h : {8, 15, 25, 36, 46, 74, 108}) {
+                              dims.push_back(DDim({batch, c, h, h}));
+                            }
+                          }
+                          DDim weights_dim({c, 1, kh, kw});
+                          const float leakey_relu_scale = 1.0f;
+                          test_conv_fp16(dims,
+                                         weights_dim,
+                                         c,
+                                         {stride0, stride1},
+                                         {pad, pad1, pad1, pad1},
+                                         {dia0, dia1},
+                                         flag_bias,
+                                         flag_act,
+                                         {FLAGS_threads},
+                                         {FLAGS_power_mode},
+                                         leakey_relu_scale);
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+#endif  /// common dw
+
 #if 1  /// 3x3dw
 TEST(TestConv3x3DwFp16, test_conv3x3_depthwise) {
   if (FLAGS_basic_test) {


### PR DESCRIPTION
### PR types
Performance optimization
### PR changes
Others
### Describe
此pr目的是优化stride不相等，dilation不为1，kernel size 不为 3x3 5x5等特殊depthwise conv，之前的做法是转换成矩阵乘计算，有多少group就调用多少次img2col，效率低下。本pr的优化采用直接计算的方式，性能比矩阵乘有显著提升，部分性能数据如下：

conv | old | new | rate
------------ | ------------ | ------------- | -------------
input:1×32×128×128; weight:32×1×3×3 stride 2,1 | 2.88 | 0.51 | 82%
input:1×64×128×128; weight:64×1×3×3 stride 2,1 | 5.55  |1  | 82%
input:1×32×256×256; weight:32×1×3×3 stride 2,1 | 28.79 | 3.35 | 88%
input:1×64×256×256; weight:64×1×3×3 stride 2,1 |  56.45 | 7.78 |  86%
