### PR TITLE
[ARM]Fix interp bug when input_width is 1 with aligned

### DIFF
--- a/lite/backends/arm/math/fp16/interpolate_fp16.cc
+++ b/lite/backends/arm/math/fp16/interpolate_fp16.cc
@@ -142,8 +142,15 @@ void bilinear_interp(const float16_t* src,
   int sx = 0;
   int sy = 0;
   if (with_align) {
-    scale_x = static_cast<float>(w_in - 1) / (w_out - 1);
-    scale_y = static_cast<float>(h_in - 1) / (h_out - 1);
+    if (w_out - 1 > 0 && w_in - 1 > 0)
+      scale_x = static_cast<float>(w_in - 1) / (w_out - 1);
+    else
+      scale_x = 1.f;
+    if (h_out - 1 > 0 && h_in - 1 > 0)
+      scale_y = static_cast<float>(h_in - 1) / (h_out - 1);
+    else
+      scale_y = 1.f;
+
     // calculate x axis coordinate
     for (int dx = 0; dx < w_out; dx++) {
       fx = dx * scale_x;

--- a/lite/backends/arm/math/interpolate.cc
+++ b/lite/backends/arm/math/interpolate.cc
@@ -65,8 +65,15 @@ void bilinear_interp(const float* src,
   int sy = 0;
   int loop_cnt_idx = w_out;
   if (with_align) {
-    scale_x = static_cast<float>(w_in - 1) / (w_out - 1);
-    scale_y = static_cast<float>(h_in - 1) / (h_out - 1);
+    if (w_out - 1 > 0 && w_in - 1 > 0)
+      scale_x = static_cast<float>(w_in - 1) / (w_out - 1);
+    else
+      scale_x = 1.f;
+    if (h_out - 1 > 0 && h_in - 1 > 0)
+      scale_y = static_cast<float>(h_in - 1) / (h_out - 1);
+    else
+      scale_y = 1.f;
+
     // calculate x axis coordinate
     for (int dx = 0; dx < w_out; dx++) {
       fx = dx * scale_x;


### PR DESCRIPTION
## PR types
[Bug Fix]

## PR changes
[ OPs]

## Describe
修复arm fp16 interp后端，当输入宽高为1时，计算scale时没有检测分母是否为0