### PR TITLE
[Proto]Update core/framework.proto to keep same as PaddlePaddle

### DIFF
--- a/lite/core/framework.proto
+++ b/lite/core/framework.proto
@@ -35,6 +35,10 @@ enum AttrType {
   LONG = 9;
   BLOCKS = 10;
   LONGS = 11;
+  FLOAT64S = 12;
+  VAR = 13;
+  VARS = 14;
+  FLOAT64 = 15;
 }
 
 // OpDesc describes an instance of a C++ framework::OperatorBase
@@ -56,6 +60,10 @@ message OpDesc {
     optional int64 l = 13;
     repeated int32 blocks_idx = 14;
     repeated int64 longs = 15;
+    repeated double float64s = 16;
+    optional string var_name = 17;
+    repeated string vars_name = 18;
+    optional double float64 = 19;
   };
 
   message Var {
@@ -81,6 +89,8 @@ message OpProto {
     optional bool duplicable = 3 [ default = false ];
     optional bool intermediate = 4 [ default = false ];
     optional bool dispensable = 5 [ default = false ];
+    optional bool extra = 6 [ default = false ];
+    optional bool quant = 7 [ default = false ];
   }
 
   // AttrProto describes the C++ type Attribute.
@@ -92,6 +102,9 @@ message OpProto {
     // language binding has responsibility to fill that
     // attribute. End-User should not set that attribute.
     optional bool generated = 4 [ default = false ];
+    optional bool extra = 5 [ default = false ];
+    optional bool quant = 6 [ default = false ];
+    optional bool support_tensor = 7 [ default = false];
   }
 
   required string type = 1;
@@ -115,6 +128,9 @@ message VarType {
     SIZE_T = 19;
     UINT8 = 20;
     INT8 = 21;
+    BF16 = 22;
+    COMPLEX64 = 23;
+    COMPLEX128 = 24;
 
     // Other types that may need additional descriptions
     LOD_TENSOR = 7;
@@ -131,6 +147,13 @@ message VarType {
     // in operators like nccl_op
     RAW = 17;
     TUPLE = 18;
+
+    STRING = 25;
+    STRINGS = 26;
+    VOCAB = 27;
+    FEED_LIST = 28;
+    // The data type of phi::StringTensor
+    PSTRING = 29;
   }
 
   required Type type = 1;
@@ -159,15 +182,31 @@ message VarType {
 
   message Tuple { repeated Type element_type = 1; }
   optional Tuple tuple = 7;
+
+  optional TensorDesc string = 8;
+  optional TensorDesc strings = 9;
+  optional TensorDesc vocab = 10;
 }
 
 message VarDesc {
+
+  message Attr {
+    required string name = 1;
+    required AttrType type = 2;
+    optional int32 i = 3;
+    optional string s = 4;
+    repeated int32 ints = 5;
+  };
+
   required string name = 1;
   required VarType type = 2;
   optional bool persistable = 3 [ default = false ];
   // True if the variable is an input data and
   // have to check the feed data shape and dtype
   optional bool need_check_feed = 4 [ default = false ];
+  optional bool is_parameter = 5 [ default = false ];
+  optional bool stop_gradient = 6 [ default = false ];
+  repeated Attr attrs = 7;
 }
 
 message BlockDesc {

--- a/lite/core/framework.proto
+++ b/lite/core/framework.proto
@@ -104,7 +104,7 @@ message OpProto {
     optional bool generated = 4 [ default = false ];
     optional bool extra = 5 [ default = false ];
     optional bool quant = 6 [ default = false ];
-    optional bool support_tensor = 7 [ default = false];
+    optional bool support_tensor = 7 [ default = false ];
   }
 
   required string type = 1;


### PR DESCRIPTION
### What's New ?

Update core/framework.proto to keep same as PaddlePaddle

### Roadmap

- [x] Update core/framework.proto ([this PR]())
- [ ] Add Scalar, IntArrray structure ([PR9478](https://github.com/PaddlePaddle/Paddle-Lite/pull/9478))
- [ ] Adapt kernels attribute to Scalar, IntArray
- [ ] Adapt OpDesc and other core/xxx mechanism