### PR TITLE
get_cpu_arch protect vector out of range on some device, test=develop

### DIFF
--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -281,8 +281,13 @@ void get_cpu_arch(std::vector<ARMArch>* archs, const int cpu_num) {
         default:
           LOG(ERROR) << "Unknow cpu arch: " << arch_id;
       }
-      archs->at(cpu_idx) = arch_type;
-      cpu_idx++;
+      // may cause out of range exception from vector.
+      if(cpu_idx < cpu_num) {
+        archs->at(cpu_idx) = arch_type;
+        cpu_idx++;
+      }else{
+        LOG(ERROR) << "cpu_idx: " << cpu_idx << " is out of range: " << cpu_num;
+      }
     }
   }
   fclose(fp);

--- a/lite/tools/build_macos.sh
+++ b/lite/tools/build_macos.sh
@@ -38,7 +38,7 @@ workspace=$PWD/$(dirname $0)/../../
 OPTMODEL_DIR=""
 IOS_DEPLOYMENT_TARGET=11.0
 # num of threads used during compiling..
-readonly NUM_PROC=${LITE_BUILD_THREADS:-4}
+readonly NUM_PROC=16
 #####################################################################################################
 
 
@@ -424,6 +424,11 @@ function main {
                 ;;
             --with_benchmark=*)
                 WITH_BENCHMARK="${i#*=}"
+                shift
+                ;;
+
+            --with_testing=*)
+                WITH_TESTING="${i#*=}"
                 shift
                 ;;
             --with_lto=*)


### PR DESCRIPTION
1.  protect vector out of range on some device in device info: get_cpu_arch.