### PR TITLE
[ARM]opt gemm_fp16, change micro kernel to 8*24 

### DIFF
--- a/lite/backends/arm/math/conv_block_utils.h
+++ b/lite/backends/arm/math/conv_block_utils.h
@@ -124,7 +124,7 @@ static bool conv_trans_weights_numc(const Dtype* din,
   memset(ptr_zero, 0, win_stride * sizeof(Dtype));
   for (; co < c_loop; ++co) {
     Dtype* dout_c = dout + co * wout_stride;
-    const Dtype* din_array[n];
+    const Dtype* din_array[n];  // n个channel的weights起始地址
     din_array[0] = din + co * wout_stride;
     for (int i = 1; i < n; i++) {
       din_array[i] = din_array[i - 1] + win_stride;

--- a/lite/backends/arm/math/fp16/common_preprocess.h
+++ b/lite/backends/arm/math/fp16/common_preprocess.h
@@ -52,25 +52,25 @@ typedef __fp16 float16_t;
       const dtype **inptr12, const dtype **inptr13, const dtype **inptr14, \
       const dtype **inptr15, int numa, int numb
 
-#define X_BLOCK_COMPUTE_FP16(llc_size, MBLOCK, NBLOCK, KBLOCK, beta)  \
-  /* MBLOCK * x (result) + MBLOCK * k (A) + x * k (B) = l2*/          \
-  int x_block =                                                       \
-      (llc_size - (MBLOCK * K)) / (sizeof(float16_t) * (K + MBLOCK)); \
-  x_block /= NBLOCK;                                                  \
-  x_block = (x_block == 0) ? 1 : x_block;                             \
-  x_block *= NBLOCK;                                                  \
-  int x_num = (N + (x_block - 1)) / x_block;                          \
-  x_block = (N + x_num - 1) / x_num;                                  \
-  x_block = (x_block + NBLOCK - 1) / NBLOCK;                          \
-  x_block *= NBLOCK;                                                  \
-  x_block = x_block < NBLOCK ? NBLOCK : x_block;                      \
-  int tail_pre = (K & (KBLOCK - 1));                                  \
-  int k_pre = ((K + KBLOCK - 1) / KBLOCK) - 1;                        \
-  bool flag_p_remain = false;                                         \
-  int remain = 0;                                                     \
-  if (tail_pre == 0) {                                                \
-    tail_pre = KBLOCK;                                                \
-  }                                                                   \
+#define X_BLOCK_COMPUTE_FP16(llc_size, MBLOCK, NBLOCK, KBLOCK, beta) \
+  /* MBLOCK * x (result) + MBLOCK * k (A) + k (B) * x = l2*/           \
+  int x_block =                                                        \
+      (llc_size / sizeof(float16_t) - (MBLOCK * K)) / (K + MBLOCK);  \
+  x_block /= NBLOCK;                                                   \
+  x_block = (x_block == 0) ? 1 : x_block;                              \
+  x_block *= NBLOCK;                                                   \
+  int x_num = (N + (x_block - 1)) / x_block;                           \
+  x_block = (N + x_num - 1) / x_num;                                   \
+  x_block = (x_block + NBLOCK - 1) / NBLOCK;                           \
+  x_block *= NBLOCK;                                                   \
+  x_block = x_block < NBLOCK ? NBLOCK : x_block;                       \
+  int tail_pre = (K & (KBLOCK - 1));                                   \
+  int k_pre = ((K + KBLOCK - 1) / KBLOCK) - 1;                         \
+  bool flag_p_remain = false;                                          \
+  int remain = 0;                                                      \
+  if (tail_pre == 0) {                                                 \
+    tail_pre = KBLOCK;                                                 \
+  }                                                                    \
   int has_beta = fabsf(beta) > 1e-8f ? 1 : 0;
 
 #define DIRECT_WORKSPACE_COMPUTE(                                              \

--- a/lite/backends/arm/math/fp16/conv_impl_fp16.cc
+++ b/lite/backends/arm/math/fp16/conv_impl_fp16.cc
@@ -287,9 +287,10 @@ void conv1x1s1_gemm_fp16(CONV_PARAM(float16_t)) {
   int channel_size_in = win * ih;
 
   const int group = param.groups;
-  const int m = oc / group;
-  const int n = oh * ow;
-  const int k = ic / group;
+  const int m =
+      oc / group;         //分组后，每组的卷积核数量减少，即输出特征图的通道数减少。
+  const int n = oh * ow;  // conv1*1，输出特征图的size和输入一致。
+  const int k = ic / group;  //分组后，每组的输入特征图通道数减少。
 
   bool flag_relu = param.fuse_relu;
   bool flag_bias = param.bias != nullptr;

--- a/lite/backends/arm/math/fp16/gemm_fp16.h
+++ b/lite/backends/arm/math/fp16/gemm_fp16.h
@@ -25,7 +25,7 @@ namespace arm {
 namespace math {
 namespace fp16 {
 typedef __fp16 float16_t;
-const int KBLOCK_FP16 = 4;
+const int KBLOCK_FP16 = 2;
 const int MBLOCK_FP16 = 8;
 #ifdef __aarch64__
 const int NBLOCK_FP16 = 24;

--- a/lite/backends/arm/math/fp16/gemm_fp16.h
+++ b/lite/backends/arm/math/fp16/gemm_fp16.h
@@ -25,10 +25,10 @@ namespace arm {
 namespace math {
 namespace fp16 {
 typedef __fp16 float16_t;
-const int KBLOCK_FP16 = 2;
+const int KBLOCK_FP16 = 4;
 const int MBLOCK_FP16 = 8;
 #ifdef __aarch64__
-const int NBLOCK_FP16 = 16;
+const int NBLOCK_FP16 = 24;
 #else
 const int NBLOCK_FP16 = 8;
 #endif  // __aarch64__

--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -795,8 +795,8 @@ bool DeviceInfo::SetCPUInfoByName() {
     little_core_ids_ = {0, 1, 2, 3};
     cluster_ids_ = {1, 1, 1, 1, 0, 0, 0, 0};
     SetArchInfo(2, kA77, kA55);
-    SetCacheInfo(0, 2, 192 * 1024, 256 * 1024);
-    SetCacheInfo(1, 2, 768 * 1024, 512 * 1024);
+    SetCacheInfo(0, 3, 64 * 1024, 192 * 1024, 256 * 1024);
+    SetCacheInfo(1, 3, 512 * 1024, 768 * 1024, 512 * 1024);
     SetCacheInfo(2, 1, 4 * 1024 * 1024);
     SetFP16Info(1, 1);
     SetDotInfo(2, 1, 1);
@@ -808,8 +808,8 @@ bool DeviceInfo::SetCPUInfoByName() {
     little_core_ids_ = {0, 1, 2, 3};
     cluster_ids_ = {1, 1, 1, 1, 0, 0, 0, 0};
     SetArchInfo(2, kA76, kA55);
-    SetCacheInfo(0, 2, 64 * 1024, 32 * 1024);
-    SetCacheInfo(1, 2, 256 * 1024, 128 * 1024);
+    SetCacheInfo(0, 3, 64 * 1024, 192 * 1024, 256 * 1024);
+    SetCacheInfo(1, 3, 512 * 1024, 768 * 1024, 512 * 1024);
     SetCacheInfo(2, 1, 2048 * 1024);
     SetFP16Info(1, 1);
     SetDotInfo(1, 1);

--- a/lite/kernels/arm/conv_gemmlike.cc
+++ b/lite/kernels/arm/conv_gemmlike.cc
@@ -286,7 +286,7 @@ void GemmLikeConv<PRECISION(kFP16), PRECISION(kFP16)>::Run() {
   auto dout = param.output->mutable_data<float16_t>();
 
   auto x_dims = param.x->dims();
-  auto w_dims = param.filter->dims();
+  // auto w_dims = param.filter->dims();
   auto o_dims = param.output->dims();
 
   int iw = x_dims[3];  // nchw
@@ -295,7 +295,7 @@ void GemmLikeConv<PRECISION(kFP16), PRECISION(kFP16)>::Run() {
   int bs = x_dims[0];
   int oh = o_dims[2];
   int ow = o_dims[3];
-  int oc = o_dims[1];
+  int oc = o_dims[1];  // oc == kn
   if (flag_1x1gemm_) {
     lite::arm::math::fp16::conv1x1s1_gemm_fp16(
         din, dout, bs, oc, oh, ow, ic, ih, iw, weights, bias, param, &ctx);

--- a/lite/tests/utils/naive_math_impl.h
+++ b/lite/tests/utils/naive_math_impl.h
@@ -290,6 +290,7 @@ static void basic_gemm(bool trans_a,
         }
         sum += av * bv;
       }
+      //type2 tmp = alpha * (sum + beta * c[i * ldc + j] + bias_data);
       type2 tmp = alpha * sum + beta * c[i * ldc + j] + bias_data;
       if (flag_act > 0) {
         if (flag_act == 1) {  // relu


### PR DESCRIPTION
### PR types
[Others]
### PR changes
[Backend]
### Describe
优化arm后端gemm_fp16实现，将micro_kernel大小从8*16扩大为8*24，最大效率利用寄存器数量，充分利用硬件的fmla计算单元，算子profile性能追平MNN。