### PR TITLE
[OpenCL]Opencl support image2d and buffer memory config

### DIFF
--- a/docs/demo_guides/opencl.md
+++ b/docs/demo_guides/opencl.md
@@ -544,6 +544,22 @@ OpenCL 的 fp16 特性是 OpenCL 标准的一个扩展，当前绝大部分移�
 - 函数声明[ paddle_api.h ](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/lite/api/paddle_api.h)
 - 使用示例[ mobilenetv1_light_api.cc](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc)
 
+### 设置 OpenCL 混合内存对象推理
+OpenCL大部分算子支持cl::Image2D数据排布，少部分算子支持cl::Buffer（正在持续扩充），出于以下背景原因考虑
+1. 不同的设备采用 cl::Image2D 和 cl::Buffer 性能优势不同。
+2. 设备本身对 cl::Image2D 的 CL_DEVICE_IMAGE2D_MAX_HEIGHT 和 CL_DEVICE_IMAGE2D_MAX_WIDTH 有限制，导致部分op尺寸过大时会报错：malloc image is out of max image size(w,h)。
+3. 部分op采用 cl::Buffer 内存对象会有很好的性能，比如reshape，transpose，keep_dims 为 false 的 argmax，reduce等。
+支持两种内存对象可配置，通过环境变量 `OPENCL_MEMORY_CONFIG_FILE` 设置『OpenCL 内存对象配置文件』，实现人为指定部分op使用cl::Buffer实现；
+
+```shell
+$ cd /data/local/tmp/opencl
+$ cat ./RES-paddle2-PPLIteSegSTDC1.txt
+arg_max:bilinear_interp_v2_6.tmp_0:argmax_0.tmp_0
+$ export OPENCL_MEMORY_CONFIG_FILE=./RES-paddle2-PPLIteSegSTDC1.txt
+$ ./benchmark_bin  --model_file=./RES-paddle2-PPLIteSegSTDC1/inference.pdmodel \
+    --param_file=./RES-paddle2-PPLIteSegSTDC1/ inference.pdiparams \
+    --input_shape=1,3,1024,1024 --backend=opencl --repeats=20 --warmup=2
+```
 
 ## 9. 常见问题
 

--- a/docs/demo_guides/opencl.md
+++ b/docs/demo_guides/opencl.md
@@ -545,23 +545,18 @@ OpenCL 的 fp16 特性是 OpenCL 标准的一个扩展，当前绝大部分移�
 - 使用示例[ mobilenetv1_light_api.cc](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc)
 
 ### 设置 OpenCL 混合内存对象推理
-OpenCL大部分算子支持cl::Image2D数据排布，少部分算子支持cl::Buffer（正在持续扩充），出于以下背景原因考虑
+OpenCL 大部分算子支持 cl::Image2D 数据排布，少部分算子支持 cl::Buffer（正在持续扩充），出于以下背景原因考虑
 1. 不同的设备采用 cl::Image2D 和 cl::Buffer 性能优势不同。
-2. 设备本身对 cl::Image2D 的 CL_DEVICE_IMAGE2D_MAX_HEIGHT 和 CL_DEVICE_IMAGE2D_MAX_WIDTH 有限制，导致部分op尺寸过大时会报错：malloc image is out of max image size(w,h)。
-3. 部分op采用 cl::Buffer 内存对象会有很好的性能，比如reshape，transpose，keep_dims 为 false 的 argmax，reduce等。
-支持两种内存对象可配置，通过环境变量 `OPENCL_MEMORY_CONFIG_FILE` 设置『OpenCL 内存对象配置文件』，实现人为指定部分op使用cl::Buffer实现；
+2. 设备本身对 cl::Image2D 的 CL_DEVICE_IMAGE2D_MAX_HEIGHT 和 CL_DEVICE_IMAGE2D_MAX_WIDTH 有限制，导致部分 op 尺寸过大时会报错：malloc image is out of max image size(w,h)。
+3. 部分 op 采用 cl::Buffer 内存对象会有很好的性能，比如 reshape，transpose，keep_dims 为 false 的 argmax，reduce 等。
+支持两种内存对象可配置，通过环境变量 `OPENCL_MEMORY_CONFIG_FILE` 设置『OpenCL 内存对象配置文件』，实现人为指定部分 op使用 cl::Buffer 实现；
 ### 设置 OpenCL 与 CPU 异构推理
-对于cl::Image2D和cl::Buffer均无法支持或者性能差的算子，可以人为指定部分op跑CPU的实现，可通过环境变量 `OPENCL_MEMORY_CONFIG_FILE` 设置『OpenCL 内存对象配置文件』实现。
-如下的例子，网络模型为ch_PP-OCRv3_rec_infer，其中reshape2 和 transpose2跑cl::Buffer实现，conv2d，depthwise_conv2d 和 pool2d跑CPU实现，剩余大部分op跑cl::Image2D实现。
+对于 cl::Image2D 和 cl::Buffer 均无法支持或者性能差的算子，可以人为指定部分 op 跑 CPU 的实现，可通过环境变量 `OPENCL_MEMORY_CONFIG_FILE` 设置『OpenCL 内存对象配置文件』实现。
+如下的例子使用 benchmark 工具，输入为 PaddlePaddle 的部署模型格式，网络模型为 ch_PP-OCRv3_rec_infer，其中 conv2d，depthwise_conv2d 和 pool2d 三个 op 指定为跑 CPU 实现，剩余 op 跑 OpenCL 后端默认实现(大部分为 cl::Image2D)。
 
 ```shell
 $ cd /data/local/tmp/opencl
 $ cat ./ch_PP-OCRv3_rec_infer_buffer.txt
-device:gpu buffer
-reshape2:linear_35.tmp_1:reshape2_5.tmp_0
-transpose2:reshape2_5.tmp_0:transpose_10.tmp_0
-reshape2:linear_39.tmp_1:reshape2_7.tmp_0
-transpose2:reshape2_7.tmp_0:transpose_13.tmp_0
 device:cpu
 conv2d:elementwise_mul_2:batch_norm_51.tmp_4
 depthwise_conv2d:batch_norm_51.tmp_4:batch_norm_52.tmp_4
@@ -570,6 +565,13 @@ $ export OPENCL_MEMORY_CONFIG_FILE=./ch_PP-OCRv3_rec_infer_buffer.txt
 $ ./benchmark_bin  --model_file=./ch_PP-OCRv3_rec_infer/inference.pdmodel \
     --param_file=./ch_PP-OCRv3_rec_infer/inference.pdiparams \
     --input_shape=1,3,48,320 --backend=opencl --repeats=20 --warmup=2
+```
+
+如下的例子为基于 OpenCL 与 CPU 异构推理将 PaddlePaddle 的部署模型格式转化为 Paddle Lite 支持的模型格式，网络模型和 OpenCL 内存对象配置文件同上, 使用 opt 工具方法如下:
+
+```shell
+export OPENCL_MEMORY_CONFIG_FILE=./ch_PP-OCRv3_rec_infer_buffer.txt
+./opt --model_file=./ch_PP-OCRv3_rec_infer/inference.pdmodel --param_file=./ch_PP-OCRv3_rec_infer/inference.pdiparams --optimize_out=./ch_PP-OCRv3_rec_infer/opt.nb --valid_targets=opencl
 ```
 
 ## 9. 常见问题

--- a/docs/demo_guides/opencl.md
+++ b/docs/demo_guides/opencl.md
@@ -551,7 +551,7 @@ OpenCL大部分算子支持cl::Image2D数据排布，少部分算子支持cl::Bu
 3. 部分op采用 cl::Buffer 内存对象会有很好的性能，比如reshape，transpose，keep_dims 为 false 的 argmax，reduce等。
 支持两种内存对象可配置，通过环境变量 `OPENCL_MEMORY_CONFIG_FILE` 设置『OpenCL 内存对象配置文件』，实现人为指定部分op使用cl::Buffer实现；
 ### 设置 OpenCL 与 CPU 异构推理
-对于cl::Image2D和cl::Buffer均无法支持或者性能差的算子，可以人为指定部分op跑cpu的实现，可通过环境变量 `OPENCL_MEMORY_CONFIG_FILE` 设置『OpenCL 内存对象配置文件』实现。
+对于cl::Image2D和cl::Buffer均无法支持或者性能差的算子，可以人为指定部分op跑CPU的实现，可通过环境变量 `OPENCL_MEMORY_CONFIG_FILE` 设置『OpenCL 内存对象配置文件』实现。
 如下的例子，网络模型为ch_PP-OCRv3_rec_infer，其中reshape2 和 transpose2跑cl::Buffer实现，conv2d，depthwise_conv2d 和 pool2d跑CPU实现，剩余大部分op跑cl::Image2D实现。
 
 ```shell
@@ -574,7 +574,7 @@ $ ./benchmark_bin  --model_file=./ch_PP-OCRv3_rec_infer/inference.pdmodel \
 
 ## 9. 常见问题
 
-1. OpenCL 计算过程中大多以 `cl::Image2D` 的数据排布进行计算，不同 gpu 支持的最大 `cl::Image2D` 的宽度和高度有限制，模型输入的数据格式是 buffer 形式的 `NCHW` 数据排布方式。要计算你的模型是否超出最大支持（大部分手机支持的 `cl::Image2D` 最大宽度和高度均为 16384），可以通过公式 `image_h = tensor_n * tensor_h, image_w=tensor_w * (tensor_c + 3) / 4` 计算当前层 `NCHW` 排布的 Tensor 所需的 `cl::Image2D` 的宽度和高度。如果某一层的 Tensor 维度大于如上限制，则会会在日志中输出超限提示。
+1. OpenCL 计算过程中大多以 `cl::Image2D` 的数据排布进行计算，不同 gpu 支持的最大 `cl::Image2D` 的宽度和高度有限制，模型输入的数据格式是 buffer 形式的 `NCHW` 数据排布方式。要计算你的模型是否超出最大支持（大部分手机支持的 `cl::Image2D` 最大宽度和高度均为 16384），可以通过公式 `image_h = tensor_n * tensor_h, image_w=tensor_w * (tensor_c + 3) / 4` 计算当前层 `NCHW` 排布的 Tensor 所需的 `cl::Image2D` 的宽度和高度。如果某一层的 Tensor 维度大于如上限制，则会在日志中输出超限提示。
 2. 当前版本的 Paddle Lite OpenCL 后端不支持量化模型作为输入；支持 fp32 精度的模型作为输入，在运行时会根据运行时精度配置 API `config.set_opencl_precision()` 来设定运行时精度（fp32 或 fp16）。
 3. 部署时需考虑不支持 OpenCL 的情况，可预先使用 API `bool ::IsOpenCLBackendValid()` 判断，对于不支持的情况加载 CPU 模型，详见[ ./lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc ](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc)。
 4. 对性能不满足需求的场景，可以考虑使用调优 API `config.set_opencl_tune(CL_TUNE_NORMAL)`，首次会有一定的初始化耗时，详见[ ./lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc ](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/lite/demo/cxx/mobile_light/mobilenetv1_light_api.cc)。

--- a/lite/api/paddle_use_passes.h
+++ b/lite/api/paddle_use_passes.h
@@ -17,6 +17,7 @@
 
 USE_MIR_PASS(demo);
 USE_MIR_PASS(static_kernel_pick_pass);
+USE_MIR_PASS(opencl_memory_object_config_pass);
 USE_MIR_PASS(lite_unsqueeze2_pad3d_squeeze2_fuse_pass);
 USE_MIR_PASS(op_transformation_pass);
 USE_MIR_PASS(variable_place_inference_pass);

--- a/lite/backends/opencl/cl_kernel/buffer/concat_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/buffer/concat_kernel.cl
@@ -39,7 +39,7 @@ __kernel void concat2(__global const CL_DTYPE* x_data0,
   } else if (index < axis_size) {
     for (int i = 0; i < pre_size; i++) {
       int offset_out = index * post_size + i * total;
-      int offset_in = index * post_size + i * total1;
+      int offset_in = (index - size) * post_size + i * total1;
       // memcpy(out_data + offset_out, x_data1 + offset_in, post_size);
       __global CL_DTYPE* dst = (__global CL_DTYPE*)(out_data + offset_out);
       __global CL_DTYPE* src = (__global CL_DTYPE*)(x_data1 + offset_in);

--- a/lite/backends/opencl/cl_kernel/buffer/precision_cast_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/buffer/precision_cast_kernel.cl
@@ -1,0 +1,55 @@
+/* Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cl_common.h>
+
+__kernel void fp32_fp16_buffer(__global const float* src,
+                               __global half* dst,
+                               __private const int count) {
+  const int idx = get_global_id(0) << 3;
+  if (idx > count) {
+    return;
+  }
+
+  if (count < 8) {
+    for (int i = 0; i < count; i++) {
+      dst[i] = convert_half(src[i]);
+    }
+  } else {
+    const int index = (idx + 8) > count ? (count - 8) : idx;
+    float8 src_v8 = vload8(0, src + index);
+    half8 out_v8 = convert_half8(src_v8);
+    vstore8(out_v8, 0, dst + index);
+  }
+}
+
+__kernel void fp16_fp32_buffer(__global const half* src,
+                               __global float* dst,
+                               __private const int count) {
+  const int idx = get_global_id(0) << 3;
+  if (idx > count) {
+    return;
+  }
+
+  if (count < 8) {
+    for (int i = 0; i < count; i++) {
+      dst[i] = convert_float(src[i]);
+    }
+  } else {
+    const int index = (idx + 8) > count ? (count - 8) : idx;
+    half8 src_v8 = vload8(0, src + index);
+    float8 out_v8 = convert_float8(src_v8);
+    vstore8(out_v8, 0, dst + index);
+  }
+}

--- a/lite/backends/opencl/cl_kernel/image/layout_kernel.cl
+++ b/lite/backends/opencl/cl_kernel/image/layout_kernel.cl
@@ -386,9 +386,37 @@ __kernel void image2d_folder_to_image2d_default(__read_only image2d_t input,
 // image2d_folder -> buffer
 ////////////////////////////////////////////////////////
 __kernel void image2d_folder_to_buffer(__read_only image2d_t input,
-                                       __global float* output,
+                                       __global CL_DTYPE* output,
                                        __private const int out_h,
                                        __private const int out_w) {
+  const int pos_x = get_global_id(0);
+  const int pos_y = get_global_id(1);
+
+  CL_DTYPE4 in =
+      READ_IMG_TYPE(CL_DTYPE_CHAR, input, SAMPLER, (int2)(pos_x, pos_y));
+
+  CL_DTYPE4 out = in;
+  int outpos_base = out_w * pos_y + pos_x * 4;
+
+  output[outpos_base] = out.x;
+  if (pos_x * 4 + 1 < out_w) {
+    output[outpos_base + 1] = out.y;
+  }
+  if (pos_x * 4 + 2 < out_w) {
+    output[outpos_base + 2] = out.z;
+  }
+  if (pos_x * 4 + 3 < out_w) {
+    output[outpos_base + 3] = out.w;
+  }
+}
+
+////////////////////////////////////////////////////////
+// image2d_folder -> buffer
+////////////////////////////////////////////////////////
+__kernel void image2d_folder_to_buffer_half2float(__read_only image2d_t input,
+                                                  __global float* output,
+                                                  __private const int out_h,
+                                                  __private const int out_w) {
   const int pos_x = get_global_id(0);
   const int pos_y = get_global_id(1);
 

--- a/lite/backends/opencl/cl_utility.h
+++ b/lite/backends/opencl/cl_utility.h
@@ -97,6 +97,11 @@ const char *opencl_error_to_str(cl_int error);
       ? (tensor_ins_p)->data<half_t, cl::Buffer>()                      \
       : (tensor_ins_p)->data<float, cl::Buffer>()
 
+#define MUTABLE_BUFFER_GPU(tensor_ins_p)                                  \
+  (CLRuntime::Global()->get_precision() == lite_api::CL_PRECISION_FP16)   \
+      ? (tensor_ins_p)->mutable_data<half_t, cl::Buffer>(TARGET(kOpenCL)) \
+      : (tensor_ins_p)->mutable_data<float, cl::Buffer>(TARGET(kOpenCL))
+
 template <typename T, typename Dim>
 inline void IOHW2OIHW(const T *src, T *dst, Dim O, Dim I, Dim H, Dim W) {
   for (Dim i = 0; i < I; i++) {

--- a/lite/core/optimizer/mir/memory_optimize_pass.cc
+++ b/lite/core/optimizer/mir/memory_optimize_pass.cc
@@ -43,6 +43,10 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
   auto has_x86_opencl = [&]() -> bool {
     bool has_x86{false};
     bool has_opencl{false};
+    auto path = GetStringFromEnv(OPENCL_MEMORY_CONFIG_FILE);
+    if (!path.empty()) {
+      return true;
+    }
     for (auto& op_node : graph->StmtTopologicalOrder()) {
       if (!op_node->IsStmt()) continue;
       TargetType op_target_type = op_node->AsStmt().place().target;

--- a/lite/core/optimizer/mir/opencl_memory_object_config_pass.cc
+++ b/lite/core/optimizer/mir/opencl_memory_object_config_pass.cc
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/optimizer/mir/opencl_memory_object_config_pass.h"
+#include <memory>
+#include "lite/core/optimizer/mir/pass_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace mir {
+
+void OpenCLMemoryObjectConfigPass::Apply(
+    const std::unique_ptr<SSAGraph> &graph) {
+  MemoryObjectConfig(graph.get());
+}
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_MIR_PASS(opencl_memory_object_config_pass,
+                  paddle::lite::mir::OpenCLMemoryObjectConfigPass)
+    .BindTargets({TARGET(kOpenCL)});

--- a/lite/core/optimizer/mir/opencl_memory_object_config_pass.cc
+++ b/lite/core/optimizer/mir/opencl_memory_object_config_pass.cc
@@ -338,7 +338,6 @@ void OpenCLMemoryObjectConfigPass::UpdateTargetToCPU(
   auto& inst = x->AsStmt();
   auto new_place = inst.place();
   new_place.layout = DATALAYOUT(kNCHW);
-  auto in = x->inlinks.front();
   const auto& op_type = inst.op_type();
 
   new_place.precision = PRECISION(kFloat);

--- a/lite/core/optimizer/mir/opencl_memory_object_config_pass.cc
+++ b/lite/core/optimizer/mir/opencl_memory_object_config_pass.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "lite/core/optimizer/mir/opencl_memory_object_config_pass.h"
+#include <list>
 #include <memory>
 #include "lite/core/optimizer/mir/pass_registry.h"
 
@@ -21,8 +22,443 @@ namespace lite {
 namespace mir {
 
 void OpenCLMemoryObjectConfigPass::Apply(
-    const std::unique_ptr<SSAGraph> &graph) {
+    const std::unique_ptr<SSAGraph>& graph) {
   MemoryObjectConfig(graph.get());
+  CorrectArgumentPlace(graph.get());
+}
+
+std::string OpenCLMemoryObjectConfigPass::ReadMemoryObjectConfigsFromEnv() {
+  std::string configs;
+  auto path = GetStringFromEnv(OPENCL_MEMORY_CONFIG_FILE);
+  if (!path.empty()) {
+    std::vector<char> buffer;
+    if (ReadFile(path, &buffer, false)) {
+      if (!buffer.empty()) {
+        configs.insert(configs.begin(), buffer.begin(), buffer.end());
+      }
+    } else {
+      LOG(WARNING) << "Missing the opencl memory configuration file " << path;
+    }
+  }
+  return configs;
+}
+
+std::set<Node*> OpenCLMemoryObjectConfigPass::GetNodesFromOpenCLOpConfig(
+    SSAGraph* graph, const std::string& ocl_op_configs) {
+  // Get the buffer nodes from the opencl memory configurations
+  std::set<Node*> buffer_nodes;
+  std::vector<std::string> lines = Split(ocl_op_configs, "\n");
+  for (const auto& line : lines) {
+    if (line.empty()) continue;
+    std::vector<std::string> node_info = Split(line, ":");
+    std::string op_type = node_info.at(0);
+    std::vector<std::string> in_vars_name;
+    if (node_info.size() > 1) {
+      in_vars_name = Split(node_info.at(1), ",");
+    }
+    std::vector<std::string> out_vars_name;
+    if (node_info.size() > 2) {
+      out_vars_name = Split(node_info.at(2), ",");
+    }
+
+    for (auto& node : graph->mutable_nodes()) {
+      if (node.IsArg()) continue;
+      auto stmt = node.stmt();
+      if (op_type != stmt->op_type()) continue;
+      auto in_nodes = node.inlinks;
+      auto out_nodes = node.outlinks;
+      if (in_vars_name.size() > in_nodes.size() ||
+          out_vars_name.size() > out_nodes.size()) {
+        continue;
+      }
+
+      bool matched = true;
+      for (auto in_var_name : in_vars_name) {
+        bool find_var = false;
+        for (auto* in_node : in_nodes) {
+          if (in_node->arg()->name == in_var_name) {
+            find_var = true;
+            break;
+          }
+        }
+        if (!find_var) {
+          matched = false;
+          break;
+        }
+      }
+
+      for (auto out_var_name : out_vars_name) {
+        bool find_var = false;
+        for (auto* out_node : out_nodes) {
+          if (out_node->arg()->name == out_var_name) {
+            find_var = true;
+            break;
+          }
+        }
+        if (!find_var) {
+          matched = false;
+          break;
+        }
+      }
+
+      if (matched) {
+        buffer_nodes.insert(&node);
+      }
+    }
+  }
+  return buffer_nodes;
+}
+
+void OpenCLMemoryObjectConfigPass::CorrectArgumentPlace(SSAGraph* graph) {
+  for (auto& x : graph->StmtTopologicalOrder()) {
+    auto& inst = x->AsStmt();
+    // deal with inputs
+    VLOG(4) << "checking op " << inst.op_info()->Repr();
+
+    std::string op_type = inst.op_type();
+    const auto op = inst.op();
+    const auto* op_info = inst.op_info();
+    auto* scope = op->scope();
+    bool change_image2d_to_buffer = false;
+    bool change_image2d_to_cpu = false;
+    // 1. op unsupport persistable
+    const std::vector<std::string> op_type_persistable{
+        "unsqueeze2", "slice", "reshape2"};
+    if (std::find(op_type_persistable.begin(),
+                  op_type_persistable.end(),
+                  op_type) != op_type_persistable.end()) {
+      for (auto& var_name : op_info->input_names()) {
+        auto* var = scope->FindVar(var_name);
+        CHECK(var) << "no variable called " << var_name << " found";
+        if (var->Get<Tensor>().persistable()) {
+          change_image2d_to_cpu = true;
+          break;
+        }
+      }
+    }
+
+    if (inst.place().layout == DATALAYOUT(kImageDefault) ||
+        inst.place().layout == DATALAYOUT(kImageFolder)) {
+      // 2. image2d unsupport dims.size() > 4
+      // 3. if input_shape_default_, according CL_DEVICE_IMAGE2D_MAX_WIDTH
+      // change target
+      auto device_info = CLRuntime::Global()->GetDeviceInfo();
+      int image2d_max_height_size = device_info["CL_DEVICE_IMAGE2D_MAX_HEIGHT"];
+      int image2d_max_width_size = device_info["CL_DEVICE_IMAGE2D_MAX_WIDTH"];
+      for (auto& var_name : op_info->output_names()) {
+        auto* var = scope->FindVar(var_name);
+        CHECK(var) << "no variable called " << var_name << " found";
+        const auto& tensor = var->Get<Tensor>();
+        const auto dims = tensor.dims();
+        if (dims.size() >= 5) {
+          change_image2d_to_cpu = true;
+          break;
+        }
+        if (input_shape_default_) {
+          auto max_dim =
+              *std::max_element(dims.data().begin(), dims.data().end());
+          if ((max_dim > image2d_max_width_size) ||
+              (dims.size() == 4 &&
+               dims[1] * dims[3] / 4 > image2d_max_width_size)) {
+            change_image2d_to_cpu = true;
+            break;
+          }
+        }
+      }
+      for (auto& var_name : op_info->input_names()) {
+        auto* var = scope->FindVar(var_name);
+        CHECK(var) << "no variable called " << var_name << " found";
+        const auto dims = var->Get<Tensor>().dims();
+        if (dims.size() >= 5) {
+          change_image2d_to_cpu = true;
+          break;
+        }
+        if (input_shape_default_) {
+          auto max_dim =
+              *std::max_element(dims.data().begin(), dims.data().end());
+          if ((max_dim > image2d_max_width_size) ||
+              (dims.size() == 4 &&
+               dims[1] * dims[3] / 4 > image2d_max_width_size)) {
+            change_image2d_to_cpu = true;
+            break;
+          }
+        }
+      }
+      // image2d unsupport
+      const std::vector<std::string> op_cases_unsupport_in_out_int{
+          "elementwise_floordiv",
+          "elementwise_add",
+          "elementwise_sub",
+          "elementwise_mul",
+          "elementwise_div",
+          "elementwise_pow",
+          "elementwise_mod",
+          "scale"};
+      if (std::find(op_cases_unsupport_in_out_int.begin(),
+                    op_cases_unsupport_in_out_int.end(),
+                    op_type) != op_cases_unsupport_in_out_int.end()) {
+        for (std::list<Node*>::iterator i = x->inlinks.begin();
+             i != x->inlinks.end();
+             ++i) {
+          if ((*i)->arg()->type) {
+            if ((*i)->arg()->type->precision() != PRECISION(kFP16) &&
+                (*i)->arg()->type->precision() != PRECISION(kFloat)) {
+              change_image2d_to_cpu = true;
+            }
+          }
+        }
+        for (std::list<Node*>::iterator i = x->outlinks.begin();
+             i != x->outlinks.end();
+             ++i) {
+          if ((*i)->arg()->type) {
+            if ((*i)->arg()->type->precision() != PRECISION(kFP16) &&
+                (*i)->arg()->type->precision() != PRECISION(kFloat)) {
+              change_image2d_to_cpu = true;
+            }
+          }
+        }
+      }
+
+      // 4. if reduce op keepdim=false change target
+      const std::vector<std::string> op_type_cases{"arg_max",
+                                                   "reduce_max",
+                                                   "reduce_min",
+                                                   "reduce_mean",
+                                                   "reduce_sum",
+                                                   "reduce_prob",
+                                                   "reduce_all",
+                                                   "reduce_any"};
+      if (std::find(op_type_cases.begin(), op_type_cases.end(), op_type) !=
+          op_type_cases.end()) {
+        auto op_teller = [&](const Node* node) -> bool {
+          const std::vector<std::string> attr_names{"keep_dim", "keepdims"};
+          auto* op_desc = const_cast<Node*>(node)->AsStmt().op_info();
+          for (auto attr_name : attr_names) {
+            if (op_desc->HasAttr(attr_name)) {
+              if (op_desc->GetAttr<bool>(attr_name)) {
+                return false;
+              }
+            }
+          }
+          return true;
+        };
+        change_image2d_to_cpu = change_image2d_to_cpu || op_teller(x);
+      }
+
+      // 5. split outlinks != 2 change target
+      if (op_type == "split" && x->outlinks.size() != 2)
+        change_image2d_to_cpu = true;
+
+      // 6. gather X.dims.size() == 2
+      if (op_type == "gather") {
+        auto get_argname = [&](
+            const std::string& node_name,
+            const std::map<std::string, std::vector<std::string>>& argname_map)
+            -> std::string {
+              for (auto& ele : argname_map) {
+                auto it =
+                    std::find(ele.second.begin(), ele.second.end(), node_name);
+                if (it != ele.second.end()) return ele.first;
+              }
+              return "";
+            };
+        for (std::list<Node*>::iterator i = x->inlinks.begin();
+             i != x->inlinks.end();
+             ++i) {
+          std::string in_name =
+              get_argname((*i)->AsArg().name, inst.op_info()->inputs());
+          if (in_name == "X") {
+            auto* var = scope->FindVar((*i)->arg()->name);
+            const auto& tensor = var->Get<Tensor>();
+            if (tensor.dims().size() != 2) change_image2d_to_cpu = true;
+          }
+        }
+      }
+    }
+    if (change_image2d_to_cpu) {
+      UpdateTargetToCPU(x, graph->valid_places());
+    } else if (change_image2d_to_buffer) {
+      UpdateLayoutToBuffer(x);
+    }
+  }
+}
+
+void OpenCLMemoryObjectConfigPass::UpdateLayoutToBuffer(Node* x) {
+  auto& inst = x->AsStmt();
+  auto new_place = inst.place();
+
+  new_place.target = TARGET(kOpenCL);
+  new_place.precision = PRECISION(kFP16);
+  new_place.layout = DATALAYOUT(kNCHW);
+
+  std::vector<Place> places;
+  places.push_back(new_place);
+  inst.ResetKernels(places);
+}
+
+bool OpenCLMemoryObjectConfigPass::PrecTypeCompatible(const PrecisionType& p1,
+                                                      const PrecisionType& p2) {
+  if (p1 == p2 || p2 == PRECISION(kAny)) {
+    return true;
+  } else if ((p1 == PRECISION(kFP16) || p1 == PRECISION(kFloat)) &&
+             (p2 == PRECISION(kFP16) || p2 == PRECISION(kFloat))) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void OpenCLMemoryObjectConfigPass::UpdateTargetToCPU(
+    Node* x, const std::vector<Place>& valid_places) {
+  std::vector<std::string> arm_host_ops{"gather",
+                                        "flatten2",
+                                        "reshape2",
+                                        "flatten",
+                                        "reshape",
+                                        "unsqueeze2",
+                                        "unsqueeze",
+                                        "squeeze2",
+                                        "squeeze",
+                                        "split"};
+  auto& inst = x->AsStmt();
+  auto new_place = inst.place();
+  new_place.layout = DATALAYOUT(kNCHW);
+  auto in = x->inlinks.front();
+  const auto& op_type = inst.op_type();
+
+  new_place.precision = PRECISION(kFloat);
+  // target
+  TargetType new_target = TARGET(kARM);
+  for (const auto& place : valid_places) {
+    if (place.target == TARGET(kARM)) {
+      new_target = place.target;
+      break;
+    } else if (place.target == TARGET(kX86)) {
+      new_target = place.target;
+      break;
+    }
+  }
+
+  if (new_target == TARGET(kARM)) {
+    if (op_type.find("elementwise") != std::string::npos) {
+      auto tmp_ptype = in->AsArg().type->precision();
+      new_place.precision = tmp_ptype;
+    }
+    if (std::find(arm_host_ops.begin(), arm_host_ops.end(), op_type) !=
+        arm_host_ops.end()) {
+      new_target = TARGET(kHost);
+    }
+  } else if (new_target == TARGET(kX86)) {
+    if (op_type.find("arg_max") != std::string::npos) {
+      new_target = TARGET(kHost);
+    }
+  }
+  new_place.target = new_target;
+  std::vector<Place> places;
+  places.push_back(new_place);
+  inst.ResetKernels(places);
+  // match input type
+  std::map<std::string, PrecisionType> in_types;
+  for (std::list<Node*>::iterator i = x->inlinks.begin(); i != x->inlinks.end();
+       ++i) {
+    if ((*i)->arg()->type)
+      in_types[(*i)->arg()->name] = (*i)->arg()->type->precision();
+  }
+  std::vector<std::string> in_names = inst.op_info()->input_names();
+  std::vector<std::pair<float, std::unique_ptr<KernelBase>>> scored;
+  bool type_match = false;
+  for (auto&& kernel : inst.kernels()) {
+    type_match = true;
+    VLOG(2) << "opencl current candidate kernel is: " << kernel->summary();
+    float score = 0;
+    for (size_t i = 0; i < in_names.size(); ++i) {
+      std::string tmp;
+      CHECK(inst.op_info()->GetInputArgname(in_names[i], &tmp));
+      if (!PrecTypeCompatible(in_types.at(in_names[i]),
+                              kernel->GetInputDeclType(tmp)->precision())) {
+        type_match = false;
+      } else {
+        score++;
+      }
+    }
+    scored.emplace_back(score, std::move(kernel));
+    if (type_match) break;
+  }
+  if (!type_match) LOG(WARNING) << "No kernel match all input precision";
+  std::stable_sort(scored.begin(), scored.end(), KernelScoreCmp);
+  inst.kernels().clear();
+  inst.kernels().emplace_back(std::move(scored.front().second));
+}
+
+void OpenCLMemoryObjectConfigPass::SeparateOclMemoryObject(
+    std::string* opencl_op_config,
+    std::string* cpu_op_config,
+    const std::string& ocl_memory_object_configs) {
+  std::string buffer_flag = "device:gpu buffer";
+  std::string cpu_flag = "device:cpu";
+  int buffer_flag_size = buffer_flag.size();
+  int cpu_flag_size = cpu_flag.size();
+  auto gpu_op_begin = ocl_memory_object_configs.find("device:gpu buffer");
+  auto cpu_op_begin = ocl_memory_object_configs.find("device:cpu");
+  auto config_file_end = ocl_memory_object_configs.rfind("\n");
+
+  if (gpu_op_begin != std::string::npos && cpu_op_begin == std::string::npos) {
+    opencl_op_config = ocl_memory_object_configs.substr(
+        gpu_op_begin + buffer_flag_size, config_file_end - buffer_flag_size);
+  } else if (gpu_op_begin == std::string::npos &&
+             cpu_op_begin != std::string::npos) {
+    cpu_op_config = ocl_memory_object_configs.substr(
+        cpu_op_begin + cpu_flag_size, config_file_end - cpu_flag_size);
+  } else if (gpu_op_begin != std::string::npos &&
+             cpu_op_begin != std::string::npos) {
+    if (cpu_op_begin > gpu_op_begin) {
+      opencl_op_config = ocl_memory_object_configs.substr(
+          gpu_op_begin + buffer_flag_size, cpu_op_begin - buffer_flag_size - 1);
+      cpu_op_config = ocl_memory_object_configs.substr(
+          cpu_op_begin + cpu_flag_size,
+          config_file_end - cpu_op_begin - cpu_flag_size);
+    } else {
+      cpu_op_config = ocl_memory_object_configs.substr(
+          cpu_op_begin + cpu_flag_size, gpu_op_begin - cpu_flag_size - 1);
+      opencl_op_config = ocl_memory_object_configs.substr(
+          gpu_op_begin + buffer_flag_size,
+          config_file_end - gpu_op_begin - buffer_flag_size);
+    }
+  }
+}
+
+void OpenCLMemoryObjectConfigPass::MemoryObjectConfig(SSAGraph* graph) {
+  auto ocl_memory_object_configs = ReadMemoryObjectConfigsFromEnv();
+  if (ocl_memory_object_configs.size() < 1) {
+    return;
+  }
+
+  if (ocl_memory_object_configs.find("input shape:default") !=
+      std::string::npos) {
+    input_shape_default_ = true;
+  }
+
+  std::string opencl_op_config = "";
+  std::string cpu_op_config = "";
+  SeparateOclMemoryObject(
+      &opencl_op_config, &cpu_op_config, ocl_memory_object_configs);
+
+  auto buffer_nodes = GetNodesFromOpenCLOpConfig(graph, opencl_op_config);
+  auto cpu_nodes = GetNodesFromOpenCLOpConfig(graph, cpu_op_config);
+
+  VLOG(4) << "opencl buffer nodes size:" << buffer_nodes.size();
+  VLOG(4) << "opencl cpu nodes size:" << cpu_nodes.size();
+  for (auto& x : graph->mutable_nodes()) {
+    auto in = x.inlinks.front();
+    if (!in) {
+      continue;
+    }
+    if (cpu_nodes.count(&x) != 0) {
+      UpdateTargetToCPU(&x, graph->valid_places());
+    } else if (buffer_nodes.count(&x) != 0) {
+      UpdateLayoutToBuffer(&x);
+    }
+  }
 }
 
 }  // namespace mir

--- a/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
+++ b/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
@@ -240,6 +240,9 @@ class OpenCLMemoryObjectConfigPass : public ProgramPass {
         }
         new_place.layout = DATALAYOUT(kNCHW);
 
+        if (op_type.find("gather") != std::string::npos) {
+          new_place.target = TARGET(kHost);
+        }
         std::vector<Place> places;
         places.push_back(new_place);
         inst.ResetKernels(places);

--- a/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
+++ b/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
@@ -235,7 +235,8 @@ class OpenCLMemoryObjectConfigPass : public ProgramPass {
         }
         new_place.target = new_target;
         new_place.precision = PRECISION(kFloat);
-        if (op_type.find("elementwise") != std::string::npos) {
+        if (op_type.find("elementwise") != std::string::npos &&
+            new_target == TARGET(kARM)) {
           new_place.precision = tmp_ptype;
         }
         new_place.layout = DATALAYOUT(kNCHW);
@@ -243,6 +244,12 @@ class OpenCLMemoryObjectConfigPass : public ProgramPass {
         if (op_type.find("gather") != std::string::npos) {
           new_place.target = TARGET(kHost);
         }
+
+        if (op_type.find("arg_max") != std::string::npos &&
+            new_target == TARGET(kX86)) {
+          new_place.target = TARGET(kHost);
+        }
+
         std::vector<Place> places;
         places.push_back(new_place);
         inst.ResetKernels(places);

--- a/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
+++ b/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
@@ -1,0 +1,142 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lite/core/optimizer/mir/pass.h"
+#include "lite/core/target_wrapper.h"
+#include "lite/utils/env.h"
+namespace paddle {
+namespace lite {
+namespace mir {
+
+class OpenCLMemoryObjectConfigPass : public ProgramPass {
+ public:
+  void Apply(const std::unique_ptr<SSAGraph> &graph) override;
+
+ private:
+  std::string ReadMemoryObjectConfigsFromEnv() {
+    std::string configs;
+    auto path = GetStringFromEnv(OPENCL_MEMORY_CONFIG_FILE);
+    if (!path.empty()) {
+      std::vector<char> buffer;
+      if (ReadFile(path, &buffer, false)) {
+        if (!buffer.empty()) {
+          configs.insert(configs.begin(), buffer.begin(), buffer.end());
+        }
+      } else {
+        LOG(WARNING) << "Missing the opencl memory configuration file " << path;
+      }
+    }
+    return configs;
+  }
+
+  std::set<Node *> GetBufferNodesFromOpenCLBufferConfig(
+      SSAGraph *graph, const std::string &ocl_buffer_configs) {
+    // Get the buffer nodes from the opencl memory configurations
+    std::set<Node *> buffer_nodes;
+    std::vector<std::string> lines = Split(ocl_buffer_configs, "\n");
+    for (const auto &line : lines) {
+      if (line.empty()) continue;
+      std::vector<std::string> node_info = Split(line, ":");
+      std::string op_type = node_info.at(0);
+      std::vector<std::string> in_vars_name;
+      if (node_info.size() > 1) {
+        in_vars_name = Split(node_info.at(1), ",");
+      }
+      std::vector<std::string> out_vars_name;
+      if (node_info.size() > 2) {
+        out_vars_name = Split(node_info.at(2), ",");
+      }
+
+      for (auto &node : graph->mutable_nodes()) {
+        if (node.IsArg()) continue;
+        auto stmt = node.stmt();
+        if (op_type != stmt->op_type()) continue;
+        auto in_nodes = node.inlinks;
+        auto out_nodes = node.outlinks;
+        if (in_vars_name.size() > in_nodes.size() ||
+            out_vars_name.size() > out_nodes.size()) {
+          continue;
+        }
+
+        bool matched = true;
+
+        for (auto in_var_name : in_vars_name) {
+          bool find_var = false;
+          for (auto *in_node : in_nodes) {
+            if (in_node->arg()->name == in_var_name) {
+              find_var = true;
+              break;
+            }
+          }
+          if (!find_var) {
+            matched = false;
+            break;
+          }
+        }
+
+        for (auto out_var_name : out_vars_name) {
+          bool find_var = false;
+          for (auto *out_node : out_nodes) {
+            if (out_node->arg()->name == out_var_name) {
+              find_var = true;
+              break;
+            }
+          }
+          if (!find_var) {
+            matched = false;
+            break;
+          }
+        }
+
+        if (matched) {
+          buffer_nodes.insert(&node);
+        }
+      }
+    }
+    return buffer_nodes;
+  }
+
+  void MemoryObjectConfig(SSAGraph *graph) {
+    auto ocl_memory_object_configs = ReadMemoryObjectConfigsFromEnv();
+    auto buffer_nodes =
+        GetBufferNodesFromOpenCLBufferConfig(graph, ocl_memory_object_configs);
+    VLOG(4) << "opencl buffer nodes size:" << buffer_nodes.size();
+    for (auto &x : graph->mutable_nodes()) {
+      if (buffer_nodes.count(&x) != 0) {
+        auto &inst = x.AsStmt();
+        auto new_place = inst.place();
+
+        new_place.target = TARGET(kOpenCL);
+        new_place.precision = PRECISION(kFP16);
+        new_place.layout = DATALAYOUT(kNCHW);
+
+        std::vector<Place> places;
+        places.push_back(new_place);
+        inst.ResetKernels(places);
+      }
+    }
+  }
+};
+
+}  // namespace mir
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
+++ b/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
@@ -32,243 +32,43 @@ class OpenCLMemoryObjectConfigPass : public ProgramPass {
   void Apply(const std::unique_ptr<SSAGraph> &graph) override;
 
  private:
-  std::string ReadMemoryObjectConfigsFromEnv() {
-    std::string configs;
-    auto path = GetStringFromEnv(OPENCL_MEMORY_CONFIG_FILE);
-    if (!path.empty()) {
-      std::vector<char> buffer;
-      if (ReadFile(path, &buffer, false)) {
-        if (!buffer.empty()) {
-          configs.insert(configs.begin(), buffer.begin(), buffer.end());
-        }
-      } else {
-        LOG(WARNING) << "Missing the opencl memory configuration file " << path;
-      }
-    }
-    return configs;
+  // Parse opencl memory object config file
+  std::string ReadMemoryObjectConfigsFromEnv();
+
+  // According config file to get node
+  std::set<Node *> GetNodesFromOpenCLOpConfig(
+      SSAGraph *graph, const std::string &ocl_op_configs);
+
+  // Update layout to DATALAYOUT(kNCHW)
+  void UpdateLayoutToBuffer(Node *x);
+
+  // Update layout to TARGET(kARM) or TARGET(kX86)
+  void UpdateTargetToCPU(Node *x, const std::vector<Place> &valid_places);
+
+  // Compatible for PrecisionType.
+  bool PrecTypeCompatible(const PrecisionType &p1, const PrecisionType &p2);
+
+  static bool KernelScoreCmp(
+      const std::pair<float, std::unique_ptr<KernelBase>> &a,
+      const std::pair<float, std::unique_ptr<KernelBase>> &b) {
+    return a.first > b.first;
   }
 
-  void UpdateTensor(mir::Node::Stmt &inst,  // NOLINT
-                    Node *in,
-                    Node *out,
-                    TargetType new_target = TargetType::kUnk) {
-    auto get_argname = [&](const std::string &node_name,
-                           const std::map<std::string, std::vector<std::string>>
-                               &argname_map) -> std::string {
-      for (auto &ele : argname_map) {
-        auto it = std::find(ele.second.begin(), ele.second.end(), node_name);
-        if (it != ele.second.end()) return ele.first;
-      }
-      return "";
-    };
+  // Separate OclMemoryObject to opencl_op_config and cpu_op_config
+  void SeparateOclMemoryObject(std::string *opencl_op_config,
+                               std::string *cpu_op_config,
+                               const std::string &ocl_memory_object_configs);
 
-    std::string arg_name =
-        get_argname(out->AsArg().name, inst.op_info()->outputs());
-    std::string in_name =
-        get_argname(in->AsArg().name, inst.op_info()->inputs());
+  // Check if the model's ops are opencl image2d supported. If you encounter
+  // unsupported
+  // ops, change target
+  void CorrectArgumentPlace(SSAGraph *graph);
 
-    auto type = inst.picked_kernel().GetInputDeclType(in_name);
-    auto tmp_ptype = in->AsArg().type->precision();
-    auto tmp_target = type->target();
-    auto tmp_layout = type->layout();
+  // According config file to select the correct kernels
+  void MemoryObjectConfig(SSAGraph *graph);
 
-    if (new_target == TargetType::kARM) {
-      tmp_target = TargetType::kARM;
-      tmp_ptype = PrecisionType::kFloat;
-      tmp_layout = DataLayoutType::kNCHW;
-    }
-
-    if (new_target == TargetType::kX86) {
-      tmp_target = TargetType::kX86;
-      tmp_ptype = PrecisionType::kFloat;
-      tmp_layout = DataLayoutType::kNCHW;
-    }
-
-    if (new_target == TargetType::kHost) {
-      tmp_target = TargetType::kHost;
-      tmp_ptype = PrecisionType::kFloat;
-      tmp_layout = DataLayoutType::kNCHW;
-    }
-
-    out->AsArg().type =
-        LiteType::GetTensorTy(tmp_target, tmp_ptype, tmp_layout);
-  }
-
-  std::set<Node *> GetBufferNodesFromOpenCLBufferConfig(
-      SSAGraph *graph, const std::string &ocl_buffer_configs) {
-    // Get the buffer nodes from the opencl memory configurations
-    std::set<Node *> buffer_nodes;
-    std::vector<std::string> lines = Split(ocl_buffer_configs, "\n");
-    for (const auto &line : lines) {
-      if (line.empty()) continue;
-      std::vector<std::string> node_info = Split(line, ":");
-      std::string op_type = node_info.at(0);
-      std::vector<std::string> in_vars_name;
-      if (node_info.size() > 1) {
-        in_vars_name = Split(node_info.at(1), ",");
-      }
-      std::vector<std::string> out_vars_name;
-      if (node_info.size() > 2) {
-        out_vars_name = Split(node_info.at(2), ",");
-      }
-
-      for (auto &node : graph->mutable_nodes()) {
-        if (node.IsArg()) continue;
-        auto stmt = node.stmt();
-        if (op_type != stmt->op_type()) continue;
-        auto in_nodes = node.inlinks;
-        auto out_nodes = node.outlinks;
-        if (in_vars_name.size() > in_nodes.size() ||
-            out_vars_name.size() > out_nodes.size()) {
-          continue;
-        }
-
-        bool matched = true;
-
-        for (auto in_var_name : in_vars_name) {
-          bool find_var = false;
-          for (auto *in_node : in_nodes) {
-            if (in_node->arg()->name == in_var_name) {
-              find_var = true;
-              break;
-            }
-          }
-          if (!find_var) {
-            matched = false;
-            break;
-          }
-        }
-
-        for (auto out_var_name : out_vars_name) {
-          bool find_var = false;
-          for (auto *out_node : out_nodes) {
-            if (out_node->arg()->name == out_var_name) {
-              find_var = true;
-              break;
-            }
-          }
-          if (!find_var) {
-            matched = false;
-            break;
-          }
-        }
-
-        if (matched) {
-          buffer_nodes.insert(&node);
-        }
-      }
-    }
-    return buffer_nodes;
-  }
-
-  void MemoryObjectConfig(SSAGraph *graph) {
-    auto ocl_memory_object_configs = ReadMemoryObjectConfigsFromEnv();
-
-    if (ocl_memory_object_configs.size() < 1) {
-      return;
-    }
-
-    std::string buffer_flag = "device:gpu buffer";
-    std::string cpu_flag = "device:cpu";
-    int buffer_flag_size = buffer_flag.size();
-    int cpu_flag_size = cpu_flag.size();
-    auto gpu_op_begin = ocl_memory_object_configs.find("device:gpu buffer");
-    auto cpu_op_begin = ocl_memory_object_configs.find("device:cpu");
-    auto config_file_end = ocl_memory_object_configs.rfind("\n");
-
-    std::string opencl_buffer_op_config;
-    std::string cpu_op_config;
-    if (gpu_op_begin != std::string::npos &&
-        cpu_op_begin == std::string::npos) {
-      opencl_buffer_op_config = ocl_memory_object_configs.substr(
-          gpu_op_begin + buffer_flag_size, config_file_end - buffer_flag_size);
-    } else if (gpu_op_begin == std::string::npos &&
-               cpu_op_begin != std::string::npos) {
-      cpu_op_config = ocl_memory_object_configs.substr(
-          cpu_op_begin + cpu_flag_size, config_file_end - cpu_flag_size);
-    } else if (gpu_op_begin != std::string::npos &&
-               cpu_op_begin != std::string::npos) {
-      if (cpu_op_begin > gpu_op_begin) {
-        opencl_buffer_op_config = ocl_memory_object_configs.substr(
-            gpu_op_begin + buffer_flag_size,
-            cpu_op_begin - buffer_flag_size - 1);
-        cpu_op_config = ocl_memory_object_configs.substr(
-            cpu_op_begin + cpu_flag_size,
-            config_file_end - cpu_op_begin - cpu_flag_size);
-      } else {
-        cpu_op_config = ocl_memory_object_configs.substr(
-            cpu_op_begin + cpu_flag_size, gpu_op_begin - cpu_flag_size - 1);
-        opencl_buffer_op_config = ocl_memory_object_configs.substr(
-            gpu_op_begin + buffer_flag_size,
-            config_file_end - gpu_op_begin - buffer_flag_size);
-      }
-    }
-
-    auto buffer_nodes =
-        GetBufferNodesFromOpenCLBufferConfig(graph, opencl_buffer_op_config);
-    auto cpu_nodes = GetBufferNodesFromOpenCLBufferConfig(graph, cpu_op_config);
-
-    VLOG(4) << "opencl buffer nodes size:" << buffer_nodes.size();
-    VLOG(4) << "opencl cpu nodes size:" << cpu_nodes.size();
-    for (auto &x : graph->mutable_nodes()) {
-      // slice reduce op unable to select the correct kernel temporarily
-      if (cpu_nodes.count(&x) != 0) {
-        auto &inst = x.AsStmt();
-        auto new_place = inst.place();
-        auto in = x.inlinks.front();
-        if (!in) {
-          continue;
-        }
-        auto out = x.outlinks.front();
-        const auto &op_type = inst.op_type();
-        auto tmp_ptype = in->AsArg().type->precision();
-        TargetType new_target = TARGET(kARM);
-        const auto &valid_places = graph->valid_places();
-        for (const auto &place : valid_places) {
-          if (place.target == TARGET(kARM)) {
-            new_target = place.target;
-            break;
-          } else if (place.target == TARGET(kX86)) {
-            new_target = place.target;
-            break;
-          }
-        }
-        new_place.target = new_target;
-        new_place.precision = PRECISION(kFloat);
-        if (op_type.find("elementwise") != std::string::npos &&
-            new_target == TARGET(kARM)) {
-          new_place.precision = tmp_ptype;
-        }
-        new_place.layout = DATALAYOUT(kNCHW);
-
-        if (op_type.find("gather") != std::string::npos) {
-          new_place.target = TARGET(kHost);
-        }
-
-        if (op_type.find("arg_max") != std::string::npos &&
-            new_target == TARGET(kX86)) {
-          new_place.target = TARGET(kHost);
-        }
-
-        std::vector<Place> places;
-        places.push_back(new_place);
-        inst.ResetKernels(places);
-
-        UpdateTensor(inst, in, out, new_target);
-      } else if (buffer_nodes.count(&x) != 0) {
-        auto &inst = x.AsStmt();
-        auto new_place = inst.place();
-
-        new_place.target = TARGET(kOpenCL);
-        new_place.precision = PRECISION(kFP16);
-        new_place.layout = DATALAYOUT(kNCHW);
-
-        std::vector<Place> places;
-        places.push_back(new_place);
-        inst.ResetKernels(places);
-      }
-    }
-  }
+ private:
+  bool input_shape_default_ = false;
 };
 
 }  // namespace mir

--- a/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
+++ b/lite/core/optimizer/mir/opencl_memory_object_config_pass.h
@@ -69,6 +69,7 @@ class OpenCLMemoryObjectConfigPass : public ProgramPass {
 
  private:
   bool input_shape_default_ = false;
+  int image2d_max_width_size_ = 65536;
 };
 
 }  // namespace mir

--- a/lite/core/optimizer/optimizer.cc
+++ b/lite/core/optimizer/optimizer.cc
@@ -220,7 +220,7 @@ std::unique_ptr<RuntimeProgram> RunDefaultOptimizer(
 #ifdef LITE_WITH_XPU
        "__xpu__static_kernel_pick_pass",  // xpu pick original kernel from graph
 #endif
-
+       "opencl_memory_object_config_pass",
        "remove_tf_redundant_ops_pass",
        "variable_place_inference_pass",  // inference arg/var's
        "control_flow_op_shared_inputs_and_outputs_place_sync_pass",

--- a/lite/core/optimizer/optimizer.cc
+++ b/lite/core/optimizer/optimizer.cc
@@ -194,7 +194,7 @@ std::unique_ptr<RuntimeProgram> RunDefaultOptimizer(
        "fill_range_fuse_pass",
        "identity_dropout_eliminate_pass",
        "sparse_conv_detect_pass",
-       "keepdims_convert_pass",
+       //  "keepdims_convert_pass",
        "__xpu__max_pooling_pad_zero_detect_fuse_pass",
        "__xpu__graph_dedup_pass",
        "__xpu__resnet_fuse_pass",

--- a/lite/core/profile/precision_profiler.h
+++ b/lite/core/profile/precision_profiler.h
@@ -425,46 +425,98 @@ class PrecisionProfiler {
           return;
         }
         case DATALAYOUT(kNCHW): {
-          auto* in_data_v =
-              use_fp16
-                  ? static_cast<void*>(calloc(in->numel(), sizeof(uint16_t)))
-                  : static_cast<void*>(calloc(in->numel(), sizeof(float)));
-          std::vector<float> real_out_v(in->numel());
-          TargetWrapperCL::MemcpySync(
-              in_data_v,
-              use_fp16 ? in->data<half_t, cl::Buffer>()
-                       : in->data<float, cl::Buffer>(),
-              in->numel() * (use_fp16 ? sizeof(uint16_t) : sizeof(float)),
-              IoDirection::DtoH);
-          VLOG(1) << name << ":" << in->numel();
-          if (use_fp16) {
-            HalfArray2FloatArray(static_cast<half_t*>(in_data_v),
-                                 real_out_v.data(),
-                                 in->numel());
-          } else {
-            memcpy(real_out_v.data(), in_data_v, in->numel() * sizeof(float));
+          switch (precision_type) {
+            case PRECISION(kInt64): {
+              std::vector<int64_t> in_data_v(in->numel(), 0);
+              TargetWrapperCL::MemcpySync(in_data_v.data(),
+                                          in->data<int64_t, cl::Buffer>(),
+                                          in->numel() * sizeof(int64_t),
+                                          IoDirection::DtoH);
+              *mean = compute_mean<int64_t>(in_data_v.data(), in->numel());
+              *std_dev = compute_standard_deviation<int64_t>(
+                  in_data_v.data(), in->numel(), true, *mean);
+              *ave_grow_rate = compute_average_grow_rate<int64_t>(
+                  in_data_v.data(), in->numel());
+              std::shared_ptr<lite::Tensor> real_out_t(new lite::Tensor);
+              real_out_t->Resize(in->dims());
+              int64_t* real_out_data = real_out_t->mutable_data<int64_t>();
+              memcpy(real_out_data,
+                     in_data_v.data(),
+                     in_data_v.size() * sizeof(int64_t));
+              if (write_result_to_file) {
+                write_tensorfile<int64_t>(real_out_t.get(), name, log_dir_);
+              }
+              return;
+            }
+            case PRECISION(kInt32): {
+              std::vector<int32_t> in_data_v(in->numel(), 0);
+              TargetWrapperCL::MemcpySync(in_data_v.data(),
+                                          in->data<int32_t, cl::Buffer>(),
+                                          in->numel() * sizeof(int32_t),
+                                          IoDirection::DtoH);
+              *mean = compute_mean<int32_t>(in_data_v.data(), in->numel());
+              *std_dev = compute_standard_deviation<int32_t>(
+                  in_data_v.data(), in->numel(), true, *mean);
+              *ave_grow_rate = compute_average_grow_rate<int32_t>(
+                  in_data_v.data(), in->numel());
+              std::shared_ptr<lite::Tensor> real_out_t(new lite::Tensor);
+              real_out_t->Resize(in->dims());
+              int32_t* real_out_data = real_out_t->mutable_data<int32_t>();
+              memcpy(real_out_data,
+                     in_data_v.data(),
+                     in_data_v.size() * sizeof(int32_t));
+              if (write_result_to_file) {
+                write_tensorfile<int32_t>(real_out_t.get(), name, log_dir_);
+              }
+              return;
+            }
+            default: {
+              auto* in_data_v =
+                  use_fp16
+                      ? static_cast<void*>(
+                            calloc(in->numel(), sizeof(uint16_t)))
+                      : static_cast<void*>(calloc(in->numel(), sizeof(float)));
+              std::vector<float> real_out_v(in->numel());
+              TargetWrapperCL::MemcpySync(
+                  in_data_v,
+                  use_fp16 ? in->data<half_t, cl::Buffer>()
+                           : in->data<float, cl::Buffer>(),
+                  in->numel() * (use_fp16 ? sizeof(uint16_t) : sizeof(float)),
+                  IoDirection::DtoH);
+              VLOG(1) << name << ":" << in->numel();
+              if (use_fp16) {
+                HalfArray2FloatArray(static_cast<half_t*>(in_data_v),
+                                     real_out_v.data(),
+                                     in->numel());
+              } else {
+                memcpy(
+                    real_out_v.data(), in_data_v, in->numel() * sizeof(float));
+              }
+              *mean = compute_mean<float>(real_out_v.data(), real_out_v.size());
+              *std_dev = compute_standard_deviation<float>(
+                  real_out_v.data(), in->numel(), true, *mean);
+              *ave_grow_rate = compute_average_grow_rate<float>(
+                  real_out_v.data(), real_out_v.size());
+              std::shared_ptr<lite::Tensor> real_out_t(new lite::Tensor);
+              real_out_t->Resize(in->dims());
+              float* real_out_data = real_out_t->mutable_data<float>();
+              memcpy(real_out_data,
+                     real_out_v.data(),
+                     real_out_v.size() * sizeof(float));
+              if (write_result_to_file) {
+                write_tensorfile<float>(real_out_t.get(), name, log_dir_);
+              }
+              return;
+            }
           }
-          *mean = compute_mean<float>(real_out_v.data(), real_out_v.size());
-          *std_dev = compute_standard_deviation<float>(
-              real_out_v.data(), in->numel(), true, *mean);
-          *ave_grow_rate = compute_average_grow_rate<float>(real_out_v.data(),
-                                                            real_out_v.size());
-          std::shared_ptr<lite::Tensor> real_out_t(new lite::Tensor);
-          real_out_t->Resize(in->dims());
-          float* real_out_data = real_out_t->mutable_data<float>();
-          memcpy(real_out_data,
-                 real_out_v.data(),
-                 real_out_v.size() * sizeof(float));
-          if (write_result_to_file) {
-            write_tensorfile<float>(real_out_t.get(), name, log_dir_);
-          }
-          return;
         }
         default:
           *mean = -222222222222;
           *std_dev = -22222222222;
           *ave_grow_rate = -22222222222;
-          LOG(ERROR) << unsupported_error_log;
+          LOG(INFO)
+              << "Unsupported data layout profile for kernel registered on " +
+                     DataLayoutToStr(layout_type);
           return;
       }
 #endif

--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -880,6 +880,16 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
+using elementwise_sub_int64_t =
+    paddle::lite::kernels::arm::ElementwiseSubCompute<int64_t,
+                                                      PRECISION(kInt64)>;
+REGISTER_LITE_KERNEL(
+    elementwise_sub, kARM, kInt64, kNCHW, elementwise_sub_int64_t, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+    .Finalize();
+
 #ifdef LITE_BUILD_EXTRA
 // float kernel has higher priority
 using elementwise_sub_int32_f =

--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -880,16 +880,6 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
-using elementwise_sub_int64_t =
-    paddle::lite::kernels::arm::ElementwiseSubCompute<int64_t,
-                                                      PRECISION(kInt64)>;
-REGISTER_LITE_KERNEL(
-    elementwise_sub, kARM, kInt64, kNCHW, elementwise_sub_int64_t, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .Finalize();
-
 #ifdef LITE_BUILD_EXTRA
 // float kernel has higher priority
 using elementwise_sub_int32_f =

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -164,8 +164,8 @@ lite_cc_test(test_max_image_opencl SRCS max_image_compute_test.cc
 add_kernel(activation_opencl_buffer OPENCL basic SRCS activation_buffer_compute.cc)
 #add_kernel(conv_opencl_buffer OPENCL basic SRCS conv_buffer_compute.cc)
 #add_kernel(depthwise_conv2d_opencl OPENCL basic SRCS depthwise_conv2d_buffer_compute.cc)
-#add_kernel(pool_opencl_buffer OPENCL basic SRCS pool_buffer_compute.cc)
-#add_kernel(concat_opencl_buffer OPENCL basic SRCS concat_buffer_compute.cc)
+add_kernel(pool_opencl_buffer OPENCL basic SRCS pool_buffer_compute.cc)
+add_kernel(concat_opencl_buffer OPENCL basic SRCS concat_buffer_compute.cc)
 add_kernel(fc_opencl_buffer OPENCL basic SRCS fc_buffer_compute.cc)
 # NOTE(ysh329): use fc as `mul`, and mul is not used.
 #add_kernel(mul_opencl_buffer OPENCL basic SRCS mul_buffer_compute.cc)

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -24,7 +24,7 @@ add_kernel(elementwise_opencl_image OPENCL basic SRCS elementwise_image_compute.
 
 add_kernel(pool_opencl_image OPENCL basic SRCS pool_image_compute.cc)
 add_kernel(activation_opencl_image OPENCL basic SRCS activation_image_compute.cc)
-# add_kernel(reshape_opencl_image OPENCL basic SRCS reshape_image_compute.cc)
+add_kernel(reshape_opencl_image OPENCL basic SRCS reshape_image_compute.cc)
 add_kernel(transpose_opencl_image OPENCL basic SRCS transpose_image_compute.cc)
 add_kernel(conv_opencl_image OPENCL basic SRCS conv_image_compute.cc)
 add_kernel(conv_transpose_opencl_image OPENCL basic SRCS conv_transpose_image_compute.cc)
@@ -88,9 +88,8 @@ lite_cc_test(test_depthwise_conv2d_transpose_image_opencl SRCS depthwise_conv2d_
 lite_cc_test(test_pool_image_opencl SRCS pool_image_compute_test.cc
              DEPS kernels core)
 
-# The buffer version can support more model shapes, but needs to evaluate the performance of the supported models
-# lite_cc_test(test_reshape_image_opencl SRCS reshape_image_compute_test.cc
-#              DEPS kernels core)
+lite_cc_test(test_reshape_image_opencl SRCS reshape_image_compute_test.cc
+             DEPS kernels core)
 
 lite_cc_test(test_transpose_image_opencl SRCS transpose_image_compute_test.cc
              DEPS kernels core)

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -82,8 +82,8 @@ lite_cc_test(test_conv_transpose_image_opencl SRCS conv_transpose_image_compute_
 lite_cc_test(test_depthwise_conv2d_transpose_image_opencl SRCS depthwise_conv2d_transpose_image_compute_test.cc
              DEPS kernels core)
 
-lite_cc_test(test_nearest_interp_image_opencl SRCS nearest_interp_image_compute_test.cc
-             DEPS kernels core)
+# lite_cc_test(test_nearest_interp_image_opencl SRCS nearest_interp_image_compute_test.cc
+#              DEPS kernels core)
 
 lite_cc_test(test_pool_image_opencl SRCS pool_image_compute_test.cc
              DEPS kernels core)
@@ -94,8 +94,8 @@ lite_cc_test(test_pool_image_opencl SRCS pool_image_compute_test.cc
 lite_cc_test(test_transpose_image_opencl SRCS transpose_image_compute_test.cc
              DEPS kernels core)
 
-lite_cc_test(test_concat_image_opencl SRCS concat_image_compute_test.cc
-             DEPS kernels core)
+# lite_cc_test(test_concat_image_opencl SRCS concat_image_compute_test.cc
+#              DEPS kernels core)
 
 #lite_cc_test(test_elementwise_mul_image_opencl SRCS elementwise_mul_image_compute_test.cc
 #             DEPS kernels core)
@@ -134,8 +134,8 @@ lite_cc_test(test_instance_norm_image_opencl SRCS instance_norm_image_compute_te
 lite_cc_test(test_dropout_image_opencl SRCS dropout_image_compute_test.cc
              DEPS kernels core)
 
-lite_cc_test(test_pad2d_image_opencl SRCS pad2d_image_compute_test.cc
-             DEPS kernels core)
+# lite_cc_test(test_pad2d_image_opencl SRCS pad2d_image_compute_test.cc
+#              DEPS kernels core)
 
 lite_cc_test(test_box_coder_image_opencl SRCS box_coder_image_compute_test.cc
              DEPS kernels core)

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -88,6 +88,7 @@ lite_cc_test(test_depthwise_conv2d_transpose_image_opencl SRCS depthwise_conv2d_
 lite_cc_test(test_pool_image_opencl SRCS pool_image_compute_test.cc
              DEPS kernels core)
 
+# The buffer version can support more model shapes, but needs to evaluate the performance of the supported models
 # lite_cc_test(test_reshape_image_opencl SRCS reshape_image_compute_test.cc
 #              DEPS kernels core)
 

--- a/lite/kernels/opencl/CMakeLists.txt
+++ b/lite/kernels/opencl/CMakeLists.txt
@@ -24,7 +24,7 @@ add_kernel(elementwise_opencl_image OPENCL basic SRCS elementwise_image_compute.
 
 add_kernel(pool_opencl_image OPENCL basic SRCS pool_image_compute.cc)
 add_kernel(activation_opencl_image OPENCL basic SRCS activation_image_compute.cc)
-add_kernel(reshape_opencl_image OPENCL basic SRCS reshape_image_compute.cc)
+# add_kernel(reshape_opencl_image OPENCL basic SRCS reshape_image_compute.cc)
 add_kernel(transpose_opencl_image OPENCL basic SRCS transpose_image_compute.cc)
 add_kernel(conv_opencl_image OPENCL basic SRCS conv_image_compute.cc)
 add_kernel(conv_transpose_opencl_image OPENCL basic SRCS conv_transpose_image_compute.cc)
@@ -88,8 +88,8 @@ lite_cc_test(test_nearest_interp_image_opencl SRCS nearest_interp_image_compute_
 lite_cc_test(test_pool_image_opencl SRCS pool_image_compute_test.cc
              DEPS kernels core)
 
-lite_cc_test(test_reshape_image_opencl SRCS reshape_image_compute_test.cc
-             DEPS kernels core)
+# lite_cc_test(test_reshape_image_opencl SRCS reshape_image_compute_test.cc
+#              DEPS kernels core)
 
 lite_cc_test(test_transpose_image_opencl SRCS transpose_image_compute_test.cc
              DEPS kernels core)

--- a/lite/kernels/opencl/concat_image_compute.cc
+++ b/lite/kernels/opencl/concat_image_compute.cc
@@ -101,7 +101,6 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       // note: do layout transform between image and buffer,
       // before and after concat(buffer impl.)
       kernel_func_name_ = "concat_mul_buffer";  // buffer/concat_kernel.cl
-      build_options_ = " -DCL_DTYPE_float";
       auto in_dims = inputs[0]->dims();
       for (int i = 0; i < axis_; i++) {
         pre_size_ *= in_dims[i];
@@ -355,8 +354,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
         img_to_buf_params[i].x = inputs[i];
         img_to_buf_params[i].y = &outputs_vec[i];
         outputs_vec[i].Resize(inputs_dims[i]);
-        outputs_buffer_pointers[i] =
-            outputs_vec[i].mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+        outputs_buffer_pointers[i] = MUTABLE_BUFFER_GPU(&outputs_vec[i]);
         img_to_buf_kernel_->SetParam(img_to_buf_params[i]);
 
         std::unique_ptr<KernelContext> img_to_buf_context(new KernelContext);
@@ -368,8 +366,7 @@ class ConcatComputeImage : public KernelLite<TARGET(kOpenCL),
       std::shared_ptr<lite::Tensor> concat_mul_buf_output_t(new lite::Tensor);
       concat_mul_buf_output_t->Resize(concat_param_->output->dims());
       auto conat_mul_buf_output_data =
-          concat_mul_buf_output_t->mutable_data<float, cl::Buffer>(
-              TARGET(kOpenCL));
+          MUTABLE_BUFFER_GPU(concat_mul_buf_output_t);
       operators::LayoutParam buf_to_img_param;
       buf_to_img_param.x = concat_mul_buf_output_t.get();
       buf_to_img_param.y = concat_param_->output;

--- a/lite/kernels/opencl/elementwise_image_compute.cc
+++ b/lite/kernels/opencl/elementwise_image_compute.cc
@@ -197,7 +197,7 @@ class ElementwiseImageCompute : public KernelLite<TARGET(kOpenCL),
     } else if (elementwise_compute_type == "elementwise_mod") {
       build_options_ += " -DOPERATOR(in,bias)=fmod(in,bias) ";
     } else if (elementwise_compute_type == "elementwise_floordiv") {
-      build_options_ += " -DOPERATOR(in,bias)=(int4)(in/bias) ";
+      build_options_ += " -DOPERATOR(in,bias)=trunc(in/bias) ";
     }
 
     if (ele_param_->fuse_scale) {

--- a/lite/kernels/opencl/elementwise_image_compute_test.cc
+++ b/lite/kernels/opencl/elementwise_image_compute_test.cc
@@ -756,6 +756,15 @@ void test_elementwise_broadcast_all_op() {
               "elementwise_mod",
               "",
               [](float l, float r) { return fmod(l, r); });
+          RunElementwiseBroadcast<float>(
+              TARGET(kOpenCL),
+              dim_size,
+              fuse_act,
+              precision_type,
+              "def",
+              "elementwise_floordiv",
+              "",
+              [](float l, float r) { return std::trunc(l / r); });
         }
       }
     }
@@ -781,6 +790,7 @@ USE_LITE_KERNEL(elementwise_max, kOpenCL, kFP16, kImageDefault, def);
 USE_LITE_KERNEL(elementwise_min, kOpenCL, kFP16, kImageDefault, def);
 USE_LITE_KERNEL(elementwise_pow, kOpenCL, kFP16, kImageDefault, def);
 USE_LITE_KERNEL(elementwise_mod, kOpenCL, kFP16, kImageDefault, def);
+USE_LITE_KERNEL(elementwise_floordiv, kOpenCL, kFP16, kImageDefault, def);
 USE_LITE_KERNEL(
     fusion_elementwise_add_activation, kOpenCL, kFP16, kImageDefault, def);
 USE_LITE_KERNEL(

--- a/lite/kernels/opencl/io_copy_buffer_compute.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute.cc
@@ -162,7 +162,6 @@ class IoCopykOpenCLToHostCompute
     auto& param = Param<operators::IoCopyParam>();
     CHECK(param.x->target() == TARGET(kOpenCL));
     auto mem_size = param.x->memory_size();
-    auto* data = param.y->mutable_data(TARGET(kHost), mem_size);
     const cl::Buffer* x_ptr;
     if (param.process_type == 1) {
       x_ptr = param.x->data<uint8_t, cl::Buffer>();
@@ -188,7 +187,7 @@ class IoCopykOpenCLToHostCompute
           CopyToHostSync(half_data.data(),
                          param.x->raw_data(),
                          param.x->dims().production() * sizeof(half_t));
-      float* data = param.y->mutable_data<float>(TARGET(kHost), mem_size);
+      auto* data = param.y->mutable_data<float>();
       for (size_t i = 0; i < param.x->dims().production(); ++i) {
         data[i] = Half2Float(half_data.data()[i]);
       }

--- a/lite/kernels/opencl/io_copy_buffer_compute.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute.cc
@@ -104,8 +104,7 @@ class IoCopyHostToOpenCLCompute
       for (size_t i = 0; i < param.x->dims().production(); ++i) {
         x_source_half[i] = Float2Half(param.x->data<float>()[i]);
       }
-      auto* data = param.y->mutable_data(
-          TARGET(kOpenCL), param.x->dims().production() * sizeof(half_t));
+      auto* data = param.y->mutable_data<half_t, cl::Buffer>(TARGET(kOpenCL));
       CHECK(data);
       CHECK(param.x->raw_data());
       h2d_duration_ =

--- a/lite/kernels/opencl/io_copy_buffer_compute.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lite/backends/opencl/cl_half.h"
+#include "lite/backends/opencl/cl_utility.h"
 #include "lite/backends/opencl/target_wrapper.h"
 #include "lite/core/kernel.h"
 #include "lite/core/op_registry.h"
+#include "lite/kernels/opencl/image_helper.h"
 #include "lite/utils/timer.h"
 
 #undef LITE_WITH_LOG
@@ -84,6 +87,14 @@ class IoCopyHostToOpenCLCompute
     ch->io_duration = h2d_duration_;
   }
 #endif
+  void PrepareForRun() override {
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
+    auto& context = ctx_->As<OpenCLContext>();
+    context.cl_context()->AddKernel(kernel_func_name_,
+                                    "buffer/precision_cast_kernel.cl",
+                                    build_options_,
+                                    time_stamp_);
+  }
 
   void Run() override {
     auto& param = Param<operators::IoCopyParam>();
@@ -100,17 +111,42 @@ class IoCopyHostToOpenCLCompute
     VLOG(2) << "param.y->dims():" << param.y->dims();
 #endif
     if (fp16_support_ && param.x->precision() == PRECISION(kFloat)) {
-      std::vector<half_t> x_source_half(param.x->dims().production());
-      for (size_t i = 0; i < param.x->dims().production(); ++i) {
-        x_source_half[i] = Float2Half(param.x->data<float>()[i]);
-      }
-      auto* data = param.y->mutable_data<half_t, cl::Buffer>(TARGET(kOpenCL));
-      CHECK(data);
+      std::unique_ptr<Tensor> precision_cast_t =
+          std::unique_ptr<Tensor>(new Tensor);
+      precision_cast_t->Resize(param.x->dims());
+      auto* data_fp32 =
+          precision_cast_t->mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
       CHECK(param.x->raw_data());
       h2d_duration_ =
-          CopyFromHostSync(data,
-                           x_source_half.data(),
-                           param.x->dims().production() * sizeof(half_t));
+          CopyFromHostSync(data_fp32, param.x->raw_data(), mem_size);
+
+      auto& context = ctx_->As<OpenCLContext>();
+      CHECK(context.cl_context() != nullptr);
+      STL::stringstream kernel_key;
+      kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
+      auto kernel = context.cl_context()->GetKernel(kernel_key.str());
+      size_t count = param.x->dims().production();
+
+      auto* y_data = MUTABLE_BUFFER_GPU(param.y);
+      int arg_idx = 0;
+      cl_int status;
+      status = kernel.setArg(arg_idx, *data_fp32);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, *y_data);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<int>(count));
+      CL_CHECK_FATAL(status);
+
+      auto global_work_size = cl::NDRange{(count + 7) / 8};
+
+      status = EnqueueNDRangeKernel(context,
+                                    kernel,
+                                    cl::NullRange,
+                                    global_work_size,
+                                    cl::NullRange,
+                                    nullptr,
+                                    event_);
+      CL_CHECK_FATAL(status);
     } else {
       auto* data = param.y->mutable_data(TARGET(kOpenCL), mem_size);
       CHECK(data);
@@ -141,6 +177,10 @@ class IoCopyHostToOpenCLCompute
 
   std::string doc() const override { return "Copy IO from HOST to OpenCL"; }
 
+ private:
+  std::string time_stamp_{GetTimeStamp()};
+  std::string kernel_func_name_{"fp32_fp16_buffer"};
+  std::string build_options_{""};
   float h2d_duration_{0};
 };
 
@@ -156,6 +196,14 @@ class IoCopykOpenCLToHostCompute
     ch->io_duration = d2h_duration_;
   }
 #endif
+  void PrepareForRun() override {
+    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
+    auto& context = ctx_->As<OpenCLContext>();
+    context.cl_context()->AddKernel(kernel_func_name_,
+                                    "buffer/precision_cast_kernel.cl",
+                                    build_options_,
+                                    time_stamp_);
+  }
 
   void Run() override {
     auto& param = Param<operators::IoCopyParam>();
@@ -187,15 +235,44 @@ class IoCopykOpenCLToHostCompute
 #endif
     if (fp16_support_ && param.x->precision() != PRECISION(kInt64) &&
         param.x->precision() != PRECISION(kInt32)) {
-      std::vector<half_t> half_data(param.x->dims().production());
+      mem_size = param.x->dims().production() * sizeof(float);
+      std::unique_ptr<Tensor> precision_cast_t =
+          std::unique_ptr<Tensor>(new Tensor);
+      precision_cast_t->Resize(param.x->dims());
+      auto* x_data = GET_DATA_GPU(param.x);
+      auto* y_data =
+          precision_cast_t->mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+
+      auto& context = ctx_->As<OpenCLContext>();
+      CHECK(context.cl_context() != nullptr);
+      STL::stringstream kernel_key;
+      kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
+      auto kernel = context.cl_context()->GetKernel(kernel_key.str());
+      size_t count = param.x->dims().production();
+
+      int arg_idx = 0;
+      cl_int status;
+      status = kernel.setArg(arg_idx, *x_data);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, *y_data);
+      CL_CHECK_FATAL(status);
+      status = kernel.setArg(++arg_idx, static_cast<int>(count));
+      CL_CHECK_FATAL(status);
+
+      auto global_work_size = cl::NDRange{(count + 7) / 8};
+
+      status = EnqueueNDRangeKernel(context,
+                                    kernel,
+                                    cl::NullRange,
+                                    global_work_size,
+                                    cl::NullRange,
+                                    nullptr,
+                                    event_);
+      CL_CHECK_FATAL(status);
+
+      auto* data = param.y->mutable_data(TARGET(kHost), mem_size);
       d2h_duration_ =
-          CopyToHostSync(half_data.data(),
-                         param.x->raw_data(),
-                         param.x->dims().production() * sizeof(half_t));
-      auto* data = param.y->mutable_data<float>();
-      for (size_t i = 0; i < param.x->dims().production(); ++i) {
-        data[i] = Half2Float(half_data.data()[i]);
-      }
+          CopyToHostSync(data, precision_cast_t->raw_data(), mem_size);
     } else {
       auto* data = param.y->mutable_data(TARGET(kHost), mem_size);
       d2h_duration_ = CopyToHostSync(data, param.x->raw_data(), mem_size);
@@ -204,6 +281,10 @@ class IoCopykOpenCLToHostCompute
 
   std::string doc() const override { return "Copy IO from OpenCL to HOST"; }
 
+ private:
+  std::string time_stamp_{GetTimeStamp()};
+  std::string kernel_func_name_{"fp16_fp32_buffer"};
+  std::string build_options_{""};
   float d2h_duration_{0};
 };
 

--- a/lite/kernels/opencl/io_copy_buffer_compute.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute.cc
@@ -88,12 +88,14 @@ class IoCopyHostToOpenCLCompute
   }
 #endif
   void PrepareForRun() override {
-    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
-    auto& context = ctx_->As<OpenCLContext>();
-    context.cl_context()->AddKernel(kernel_func_name_,
-                                    "buffer/precision_cast_kernel.cl",
-                                    build_options_,
-                                    time_stamp_);
+    if (fp16_support_) {
+      VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
+      auto& context = ctx_->As<OpenCLContext>();
+      context.cl_context()->AddKernel(kernel_func_name_,
+                                      "buffer/precision_cast_kernel.cl",
+                                      build_options_,
+                                      time_stamp_);
+    }
   }
 
   void Run() override {
@@ -197,12 +199,14 @@ class IoCopykOpenCLToHostCompute
   }
 #endif
   void PrepareForRun() override {
-    VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
-    auto& context = ctx_->As<OpenCLContext>();
-    context.cl_context()->AddKernel(kernel_func_name_,
-                                    "buffer/precision_cast_kernel.cl",
-                                    build_options_,
-                                    time_stamp_);
+    if (fp16_support_) {
+      VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
+      auto& context = ctx_->As<OpenCLContext>();
+      context.cl_context()->AddKernel(kernel_func_name_,
+                                      "buffer/precision_cast_kernel.cl",
+                                      build_options_,
+                                      time_stamp_);
+    }
   }
 
   void Run() override {

--- a/lite/kernels/opencl/io_copy_buffer_compute.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute.cc
@@ -165,6 +165,12 @@ class IoCopykOpenCLToHostCompute
     if (param.process_type == 1) {
       x_ptr = param.x->data<uint8_t, cl::Buffer>();
       param.y->set_precision(PRECISION(kUInt8));
+    } else if (param.x->precision() == PRECISION(kInt64)) {
+      x_ptr = param.x->data<int64_t, cl::Buffer>();
+      param.y->set_precision(PRECISION(kInt64));
+    } else if (param.x->precision() == PRECISION(kInt32)) {
+      x_ptr = param.x->data<int32_t, cl::Buffer>();
+      param.y->set_precision(PRECISION(kInt32));
     } else {
       x_ptr = param.x->data<float, cl::Buffer>();
       param.y->set_precision(PRECISION(kFloat));

--- a/lite/kernels/opencl/io_copy_buffer_compute_test.cc
+++ b/lite/kernels/opencl/io_copy_buffer_compute_test.cc
@@ -28,8 +28,11 @@ TEST(io_copy, compute) {
       "io_copy", TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kAny));
   ASSERT_FALSE(h2d_kernels.empty());
 
+  auto d2h_kernels = KernelRegistry::Global().Create(
+      "io_copy", TARGET(kOpenCL), PRECISION(kAny), DATALAYOUT(kAny));
+  ASSERT_FALSE(d2h_kernels.empty());
   auto h2d_kernel = std::move(h2d_kernels.front());
-  auto d2h_kernel = std::move(*std::next(h2d_kernels.begin(), 1));
+  auto d2h_kernel = std::move(*std::next(d2h_kernels.begin(), 1));
   LOG(INFO) << "get first kernel: " << h2d_kernel->doc();
   LOG(INFO) << "get second kernel: " << d2h_kernel->doc();
   lite::Tensor h_x, d_y, h_y;
@@ -69,7 +72,7 @@ TEST(io_copy, compute) {
   auto* h_y_data = h_y.data<float>();
 
   for (int i = 0; i < 3 * 9 * 28 * 28; i++) {
-    EXPECT_NEAR(h_x_data[i], h_y_data[i], 1e-6);
+    EXPECT_NEAR(h_x_data[i], h_y_data[i], 1e-1);
   }
 }
 

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -170,7 +170,7 @@ class LayoutComputeBufferChwToImageDefault
  private:
   std::string time_stamp_{GetTimeStamp()};
   std::string kernel_func_name_{"buffer_to_image2d"};
-  std::string build_options_{"-DCL_DTYPE_float"};
+  std::string build_options_{""};
 };
 
 // [ImageDefault] -> [NCHW]
@@ -209,7 +209,9 @@ class LayoutComputeImageDefaultToBufferChw
     if (param.process_type == 1) {
       y_data = param.y->mutable_data<uint8_t, cl::Buffer>(TARGET(kOpenCL));
     } else {
-      y_data = param.y->mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+      y_data = fp16_support_
+                   ? param.y->mutable_data<half_t, cl::Buffer>(TARGET(kOpenCL))
+                   : param.y->mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
     }
     auto* x_data = GET_DATA_GPU(param.x);
     auto x_dims = param.x->dims();
@@ -300,7 +302,7 @@ class LayoutComputeImageDefaultToBufferChw
  private:
   std::string time_stamp_{GetTimeStamp()};
   std::string kernel_func_name_{"image2d_to_buffer"};
-  std::string build_options_{"-DCL_DTYPE_float"};
+  std::string build_options_{""};
 };
 
 // [NCHW] -> [ImageDW]
@@ -414,7 +416,7 @@ class LayoutComputeBufferChwToImage2DNw
   std::string time_stamp_{GetTimeStamp()};
 
   std::string kernel_func_name_{"buffer_to_image2d_nw"};
-  std::string build_options_{"-DCL_DTYPE_float "};
+  std::string build_options_{""};
 };
 
 // [ImageDefault] -> [ImageFolder]
@@ -653,9 +655,10 @@ class LayoutComputeImageFolderToBufferChw
       CLImageConverterFolder folder_converter;
       x_image_shape = folder_converter.InitImageDimInfoWith(x_dims);
     }
-
-    const cl::Buffer* y_data =
-        param.y->mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+    auto* y_data =
+        fp16_support_
+            ? param.y->mutable_data<half_t, cl::Buffer>(TARGET(kOpenCL))
+            : param.y->mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
     auto* x_data = GET_DATA_GPU(param.x);
 
     // out info
@@ -748,7 +751,7 @@ class LayoutComputeImageFolderToBufferChw
  private:
   std::string time_stamp_{GetTimeStamp()};
   std::string kernel_func_name_{"image2d_folder_to_buffer"};
-  std::string build_options_{"-DCL_DTYPE_float "};
+  std::string build_options_{""};
 };
 
 // [NCHW] -> [ImageFolder]
@@ -876,7 +879,7 @@ class LayoutComputeBufferChwToImageFolder
  private:
   std::string time_stamp_{GetTimeStamp()};
   std::string kernel_func_name_{"buffer_to_image2d_folder"};
-  std::string build_options_{"-DCL_DTYPE_float "};
+  std::string build_options_{""};
   cl::NDRange gws_;
 };
 

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -45,9 +45,6 @@ class LayoutComputeBufferChwToImageDefault
     if (param.process_type == 1) {
       kernel_func_name_ = "buffer_to_image2d_with_pre255";
     }
-    if (!fp16_support_) {
-      build_options_ += " -DCL_DTYPE_FLOAT_FORCE";
-    }
     VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     auto& context = ctx_->As<OpenCLContext>();
     context.cl_context()->AddKernel(kernel_func_name_,
@@ -183,9 +180,6 @@ class LayoutComputeImageDefaultToBufferChw
     auto& param = Param<param_t>();
     if (param.process_type == 1) {
       kernel_func_name_ = "image2d_to_buffer_with_post255";
-    }
-    if (!fp16_support_) {
-      build_options_ += " -DCL_DTYPE_FLOAT_FORCE";
     }
     VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     auto& context = ctx_->As<OpenCLContext>();
@@ -623,9 +617,6 @@ class LayoutComputeImageFolderToBufferChw
     if (x_dims.size() > 2) {
       kernel_func_name_ = "image2d_to_buffer";
     }
-    if (!fp16_support_) {
-      build_options_ += " -DCL_DTYPE_FLOAT_FORCE";
-    }
     VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     auto& context = ctx_->As<OpenCLContext>();
     context.cl_context()->AddKernel(kernel_func_name_,
@@ -767,9 +758,6 @@ class LayoutComputeBufferChwToImageFolder
     auto x_dims = param.x->dims();
     if (x_dims.size() > 2) {
       kernel_func_name_ = "buffer_to_image2d";
-    }
-    if (!fp16_support_) {
-      build_options_ += " -DCL_DTYPE_FLOAT_FORCE";
     }
     VLOG(1) << "kernel_func_name_:" << kernel_func_name_;
     auto& context = ctx_->As<OpenCLContext>();

--- a/lite/kernels/opencl/layout_image_compute.cc
+++ b/lite/kernels/opencl/layout_image_compute.cc
@@ -1035,4 +1035,21 @@ REGISTER_LITE_KERNEL(
                                        DATALAYOUT(kNCHW))})
     .Finalize();
 
+// [ImageFolder] -> [NCHW]
+REGISTER_LITE_KERNEL(
+    layout,
+    kOpenCL,
+    kAny,
+    kNCHW,
+    paddle::lite::kernels::opencl::LayoutComputeImageFolderToBufferChw,
+    ImageFolder_to_Any)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kImageFolder))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
+    .Finalize();
 #define LITE_WITH_LOG

--- a/lite/kernels/opencl/layout_image_compute_test.cc
+++ b/lite/kernels/opencl/layout_image_compute_test.cc
@@ -83,7 +83,7 @@ TEST(layout_ImageDefault, compute) {
           auto* y_data = y.mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
           auto image_shape =
               paddle::lite::kernels::opencl::InitImageDimInfoWith(x_dim);
-          auto* y_image_data = y_image.mutable_data<half_t, cl::Image2D>(
+          auto* y_image_data = y_image.mutable_data<float, cl::Image2D>(
               image_shape["width"], image_shape["height"]);
           auto* mapped_x = static_cast<float*>(TargetWrapperCL::Map(
               x_data, 0, sizeof(float) * x_dim.production()));
@@ -97,6 +97,8 @@ TEST(layout_ImageDefault, compute) {
           LOG(INFO) << "set context and kernel args";
           std::unique_ptr<KernelContext> context(new KernelContext);
           context->As<OpenCLContext>().InitOnce();
+          CLRuntime::Global()->set_precision(
+              paddle::lite_api::CLPrecisionType::CL_PRECISION_FP32);
 
           buf_to_img_kernel->SetParam(BufferToImageParam);
           std::unique_ptr<KernelContext> buf_to_img_context(new KernelContext);
@@ -186,8 +188,7 @@ TEST(layout_ImageFolder, compute) {
   const int w = randint(1, 9);
   std::vector<std::vector<int64_t>> dims{{w}, {h, w}, {c, h, w}, {n, c, h, w}};
   for (const auto precision_type :
-       {lite_api::CLPrecisionType::CL_PRECISION_FP32,
-        lite_api::CLPrecisionType::CL_PRECISION_FP16}) {
+       {lite_api::CLPrecisionType::CL_PRECISION_FP32}) {
     for (auto dim : dims) {
       // set context and kernel args
       LOG(INFO) << "set context and kernel args";
@@ -346,7 +347,7 @@ TEST(layout_ImageDefault_With_Pre_Post, compute) {
           auto* y_data = y.mutable_data<uint8_t, cl::Buffer>(TARGET(kOpenCL));
           auto image_shape =
               paddle::lite::kernels::opencl::InitImageDimInfoWith(x_dim);
-          auto* y_image_data = y_image.mutable_data<half_t, cl::Image2D>(
+          auto* y_image_data = y_image.mutable_data<float, cl::Image2D>(
               image_shape["width"], image_shape["height"]);
           auto* mapped_x = static_cast<uint8_t*>(TargetWrapperCL::Map(
               x_data, 0, sizeof(uint8_t) * x_dim.production()));

--- a/lite/kernels/opencl/pool_buffer_compute.cc
+++ b/lite/kernels/opencl/pool_buffer_compute.cc
@@ -31,11 +31,11 @@ namespace kernels {
 namespace opencl {
 
 class PoolCompute
-    : public KernelLite<TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNCHW)> {
+    : public KernelLite<TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kNCHW)> {
  public:
   using param_t = operators::PoolParam;
 
-  std::string doc() const override { return "Pool using cl::Buffer, kFloat"; }
+  std::string doc() const override { return "Pool using cl::Buffer, kFP16"; }
 
   void PrepareForRun() override {
     const auto& param = *param_.get_mutable<param_t>();
@@ -71,9 +71,9 @@ class PoolCompute
     }
     auto& context = ctx_->As<OpenCLContext>();
     CHECK(context.cl_context() != nullptr);
-    auto* input_buf = param.x->data<float, cl::Buffer>();
-    auto* output_buf =
-        param.output->mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
+    auto* input_buf = GET_BUFFER_GPU(param.x);
+    auto* output_buf = MUTABLE_BUFFER_GPU(param.output);
+    std::cout << "222222~~~" << std::endl;
     STL::stringstream kernel_key;
     kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
     auto kernel = context.cl_context()->GetKernel(kernel_key.str());
@@ -130,7 +130,7 @@ class PoolCompute
 
  private:
   std::string kernel_func_name_{"pool_"};
-  std::string build_options_{"-DCL_DTYPE_float"};
+  std::string build_options_{""};
   std::string time_stamp_{GetTimeStamp()};
 };
 
@@ -141,7 +141,7 @@ class PoolCompute
 
 REGISTER_LITE_KERNEL(pool2d,
                      kOpenCL,
-                     kFloat,
+                     kFP16,
                      kNCHW,
                      paddle::lite::kernels::opencl::PoolCompute,
                      def)

--- a/lite/kernels/opencl/pool_buffer_compute.cc
+++ b/lite/kernels/opencl/pool_buffer_compute.cc
@@ -73,7 +73,6 @@ class PoolCompute
     CHECK(context.cl_context() != nullptr);
     auto* input_buf = GET_BUFFER_GPU(param.x);
     auto* output_buf = MUTABLE_BUFFER_GPU(param.output);
-    std::cout << "222222~~~" << std::endl;
     STL::stringstream kernel_key;
     kernel_key << kernel_func_name_ << build_options_ << time_stamp_;
     auto kernel = context.cl_context()->GetKernel(kernel_key.str());

--- a/lite/kernels/opencl/pow_buffer_compute.cc
+++ b/lite/kernels/opencl/pow_buffer_compute.cc
@@ -83,7 +83,7 @@ class PowComputeBuffer
       last_x_dims_ = x_dims;
       first_epoch_for_reinit_ = false;
       size_t count = x_dims.production();
-      global_work_size_ = cl::NDRange{count};
+      global_work_size_ = cl::NDRange{(count + 7) / 8};
     }
   }
 

--- a/lite/kernels/opencl/reshape_buffer_compute.cc
+++ b/lite/kernels/opencl/reshape_buffer_compute.cc
@@ -32,8 +32,8 @@ namespace lite {
 namespace kernels {
 namespace opencl {
 
-class ReshapeComputeFloatBuffer
-    : public KernelLite<TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNCHW)> {
+class ReshapeComputekFP16Buffer
+    : public KernelLite<TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kNCHW)> {
  public:
   using param_t = operators::ReshapeParam;
 
@@ -71,9 +71,9 @@ class ReshapeComputeFloatBuffer
 
 REGISTER_LITE_KERNEL(reshape,
                      kOpenCL,
-                     kFloat,
+                     kFP16,
                      kNCHW,
-                     paddle::lite::kernels::opencl::ReshapeComputeFloatBuffer,
+                     paddle::lite::kernels::opencl::ReshapeComputekFP16Buffer,
                      def)
     .BindInput("X",
                {LiteType::GetTensorTy(TARGET(kOpenCL),
@@ -91,9 +91,9 @@ REGISTER_LITE_KERNEL(reshape,
 
 REGISTER_LITE_KERNEL(reshape2,
                      kOpenCL,
-                     kFloat,
+                     kFP16,
                      kNCHW,
-                     paddle::lite::kernels::opencl::ReshapeComputeFloatBuffer,
+                     paddle::lite::kernels::opencl::ReshapeComputekFP16Buffer,
                      def)
     .BindInput("X",
                {LiteType::GetTensorTy(TARGET(kOpenCL),

--- a/lite/kernels/opencl/reshape_buffer_compute.cc
+++ b/lite/kernels/opencl/reshape_buffer_compute.cc
@@ -111,4 +111,42 @@ REGISTER_LITE_KERNEL(reshape2,
                                        DATALAYOUT(kNCHW))})
     .Finalize();
 
+REGISTER_LITE_KERNEL(flatten,
+                     kOpenCL,
+                     kFP16,
+                     kNCHW,
+                     paddle::lite::kernels::opencl::ReshapeComputekFP16Buffer,
+                     def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kNCHW))})
+    .BindInput("Shape",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kNCHW))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(flatten2,
+                     kOpenCL,
+                     kFP16,
+                     kNCHW,
+                     paddle::lite::kernels::opencl::ReshapeComputekFP16Buffer,
+                     def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kNCHW))})
+    .BindInput("Shape",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindOutput("XShape",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kOpenCL),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kNCHW))})
+    .Finalize();
+
 #define LITE_WITH_LOG

--- a/lite/kernels/opencl/scale_buffer_compute.cc
+++ b/lite/kernels/opencl/scale_buffer_compute.cc
@@ -59,7 +59,7 @@ class ScaleComputeBuffer
       first_epoch_for_reinit_ = false;
 
       size_t count = x_dims.production();
-      global_work_size_ = cl::NDRange{count};
+      global_work_size_ = cl::NDRange{(count + 7) / 8};
     }
   }
 

--- a/lite/kernels/opencl/squeeze_unsqueeze_buffer_compute.cc
+++ b/lite/kernels/opencl/squeeze_unsqueeze_buffer_compute.cc
@@ -52,20 +52,16 @@ class SqueezeUnsqueezeCompute
       kernel_inplace = kernel_param->inplace;
     }
 
-    auto* x_data = x->data<float, cl::Buffer>();
     if (kernel_inplace) {
       auto out_dims = out->dims();
       out->ShareDataWith(*x);
       out->Resize(out_dims);
     } else {
-      auto* out_data = out->mutable_data<float, cl::Buffer>(TARGET(kOpenCL));
-      d2d_duration_ =
-          CopyFromDeviceToDeviceSync(out_data, x_data, out->memory_size());
+      auto out_dims = out->dims();
+      out->CopyDataFrom(*x);
+      out->Resize(out_dims);
     }
 #ifdef LITE_WITH_LOG
-    size_t buffer_size;
-    x_data->getInfo(CL_MEM_SIZE, &buffer_size);
-    VLOG(4) << "out of squeeze, opencl buffer size: " << buffer_size;
     VLOG(4) << "squeeze out dims: " << out->dims();
     VLOG(4) << "out->memory_size():" << out->memory_size();
 #endif

--- a/lite/tests/kernels/concat_compute_test.cc
+++ b/lite/tests/kernels/concat_compute_test.cc
@@ -169,9 +169,25 @@ TEST(Concat, precision) {
   place = TARGET(kXPU);
   use_axis_tensor = std::vector<bool>{false};
 #elif defined(LITE_WITH_OPENCL)
+  // opencl buffer op_test
   place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kNCHW));
   abs_error = 1e-2;  // Using fp16 in OPENCL
-  use_axis_tensor = std::vector<bool>{false};
+  for (int axis : axes) {
+    std::unique_ptr<arena::TestCase> tester(
+        new ConcateComputeTester(place, "def", axis, false));
+    arena::Arena arena(std::move(tester), place, abs_error);
+    arena.TestPrecision();
+  }
+
+  // opencl image2d op_test
+  place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault));
+  for (int axis : axes) {
+    std::unique_ptr<arena::TestCase> tester(
+        new ConcateComputeTester(place, "ImageDefault", axis, false));
+    arena::Arena arena(std::move(tester), place, abs_error);
+    arena.TestPrecision();
+  }
+  return;
 #elif defined(LITE_WITH_ARM)
   place = TARGET(kARM);
 #elif defined(LITE_WITH_X86)
@@ -193,17 +209,6 @@ TEST(Concat, precision) {
       arena.TestPrecision();
     }
   }
-
-#if defined(LITE_WITH_OPENCL)
-  place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault));
-  abs_error = 1e-2;
-  for (int axis : axes) {
-    std::unique_ptr<arena::TestCase> tester(
-        new ConcateComputeTester(place, "ImageDefault", axis, false));
-    arena::Arena arena(std::move(tester), place, abs_error);
-    arena.TestPrecision();
-  }
-#endif
 }
 
 }  // namespace lite

--- a/lite/tests/kernels/concat_compute_test.cc
+++ b/lite/tests/kernels/concat_compute_test.cc
@@ -168,6 +168,10 @@ TEST(Concat, precision) {
 #elif defined(LITE_WITH_XPU)
   place = TARGET(kXPU);
   use_axis_tensor = std::vector<bool>{false};
+#elif defined(LITE_WITH_OPENCL)
+  place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kNCHW));
+  abs_error = 1e-2;  // Using fp16 in OPENCL
+  use_axis_tensor = std::vector<bool>{false};
 #elif defined(LITE_WITH_ARM)
   place = TARGET(kARM);
 #elif defined(LITE_WITH_X86)

--- a/lite/tests/kernels/concat_compute_test.cc
+++ b/lite/tests/kernels/concat_compute_test.cc
@@ -193,6 +193,17 @@ TEST(Concat, precision) {
       arena.TestPrecision();
     }
   }
+
+#if defined(LITE_WITH_OPENCL)
+  place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault));
+  abs_error = 1e-2;
+  for (int axis : axes) {
+    std::unique_ptr<arena::TestCase> tester(
+        new ConcateComputeTester(place, "ImageDefault", axis, false));
+    arena::Arena arena(std::move(tester), place, abs_error);
+    arena.TestPrecision();
+  }
+#endif
 }
 
 }  // namespace lite

--- a/lite/tests/kernels/interp_compute_test.cc
+++ b/lite/tests/kernels/interp_compute_test.cc
@@ -345,6 +345,15 @@ void TestInterpOuthw(Place place, float abs_error = 2e-5) {
                                              out_w,
                                              false,
                                              0));
+#elif defined(LITE_WITH_OPENCL)
+          std::unique_ptr<arena::TestCase> tester(
+              new NearestInterpComputeTester(place,
+                                             "ImageDefault",
+                                             DDim(x_dims),
+                                             interp_method,
+                                             -1.f,
+                                             out_h,
+                                             out_w));
 #else
           std::unique_ptr<arena::TestCase> tester(
               new NearestInterpComputeTester(place,
@@ -378,6 +387,9 @@ void TestInterpScale(Place place, float abs_error = 2e-5) {
                                            -1,
                                            false,
                                            0));
+#elif defined(LITE_WITH_OPENCL)
+        std::unique_ptr<arena::TestCase> tester(new NearestInterpComputeTester(
+            place, "ImageDefault", DDim(x_dims), interp_method, scale));
 #else
         std::unique_ptr<arena::TestCase> tester(new NearestInterpComputeTester(
             place, "def", DDim(x_dims), interp_method, scale));
@@ -392,9 +404,13 @@ void TestInterpScale(Place place, float abs_error = 2e-5) {
 void TestInterpSizetensor(Place place, float abs_error = 2e-5) {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (auto interp_method : std::vector<std::string>{"nearest", "bilinear"}) {
+      std::string alias = "def";
+#if defined(LITE_WITH_OPENCL)
+      alias = "ImageDefault";
+#endif
       std::unique_ptr<arena::TestCase> tester(
           new NearestInterpComputeTester(place,
-                                         "def",
+                                         alias,
                                          DDim(x_dims),
                                          interp_method,
                                          -1.f,
@@ -414,9 +430,13 @@ void TestInterpSizetensor(Place place, float abs_error = 2e-5) {
 void TestInterpInputScale(Place place, float abs_error = 2e-5) {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (auto interp_method : std::vector<std::string>{"nearest", "bilinear"}) {
+      std::string alias = "def";
+#if defined(LITE_WITH_OPENCL)
+      alias = "ImageDefault";
+#endif
       std::unique_ptr<arena::TestCase> tester(
           new NearestInterpComputeTester(place,
-                                         "def",
+                                         alias,
                                          DDim(x_dims),
                                          interp_method,
                                          0.7,
@@ -436,9 +456,13 @@ void TestInterpInputScale(Place place, float abs_error = 2e-5) {
 void TestInterpOutsize(Place place, float abs_error = 2e-5) {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (auto interp_method : std::vector<std::string>{"nearest", "bilinear"}) {
+      std::string alias = "def";
+#if defined(LITE_WITH_OPENCL)
+      alias = "ImageDefault";
+#endif
       std::unique_ptr<arena::TestCase> tester(
           new NearestInterpComputeTester(place,
-                                         "def",
+                                         alias,
                                          DDim(x_dims),
                                          interp_method,
                                          -1,
@@ -458,8 +482,12 @@ void TestInterpOutsize(Place place, float abs_error = 2e-5) {
 void TestInterpAlignCorners(Place place, float abs_error = 2e-5) {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (bool align_corners : {true, false}) {
+      std::string alias = "def";
+#if defined(LITE_WITH_OPENCL)
+      alias = "ImageDefault";
+#endif
       std::unique_ptr<arena::TestCase> tester(new NearestInterpComputeTester(
-          place, "def", DDim(x_dims), "nearest", -1, 4, 4, align_corners));
+          place, alias, DDim(x_dims), "nearest", -1, 4, 4, align_corners));
       arena::Arena arena(std::move(tester), place, abs_error);
       arena.TestPrecision();
     }
@@ -477,9 +505,13 @@ void TestInterpAlignMode(Place place, float abs_error = 2e-5) {
 #if defined(LITE_WITH_NNADAPTER) && defined(NNADAPTER_WITH_HUAWEI_ASCEND_NPU)
         if (align_mode == 0 && align_corners) continue;
 #endif
+        std::string alias = "def";
+#if defined(LITE_WITH_OPENCL)
+        alias = "ImageDefault";
+#endif
         std::unique_ptr<arena::TestCase> tester(
             new NearestInterpComputeTester(place,
-                                           "def",
+                                           alias,
                                            DDim(x_dims),
                                            "bilinear",
                                            -1.,
@@ -583,6 +615,16 @@ TEST(Interp, precision) {
 #else
   return;
 #endif
+#elif defined(LITE_WITH_OPENCL)
+  place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault));
+  abs_error = 5e-2;
+  TestInterpOuthw(place, abs_error);
+  TestInterpScale(place, abs_error);
+  TestInterpInputScale(place, abs_error);
+  TestInterpOutsize(place, abs_error);
+  TestInterpAlignCorners(place, abs_error);
+  TestInterpAlignMode(place, abs_error);
+  return;
 #elif defined(LITE_WITH_ARM)
   place = TARGET(kARM);
 #ifdef ENABLE_ARM_FP16

--- a/lite/tests/kernels/interp_compute_test.cc
+++ b/lite/tests/kernels/interp_compute_test.cc
@@ -329,7 +329,9 @@ class NearestInterpComputeTester : public arena::TestCase {
   }
 };
 
-void TestInterpOuthw(Place place, float abs_error = 2e-5) {
+void TestInterpOuthw(Place place,
+                     float abs_error = 2e-5,
+                     std::string alias = "def") {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (auto interp_method : std::vector<std::string>{"nearest", "bilinear"}) {
       for (int out_h : {6, 8, 12}) {
@@ -345,19 +347,10 @@ void TestInterpOuthw(Place place, float abs_error = 2e-5) {
                                              out_w,
                                              false,
                                              0));
-#elif defined(LITE_WITH_OPENCL)
-          std::unique_ptr<arena::TestCase> tester(
-              new NearestInterpComputeTester(place,
-                                             "ImageDefault",
-                                             DDim(x_dims),
-                                             interp_method,
-                                             -1.f,
-                                             out_h,
-                                             out_w));
 #else
           std::unique_ptr<arena::TestCase> tester(
               new NearestInterpComputeTester(place,
-                                             "def",
+                                             alias,
                                              DDim(x_dims),
                                              interp_method,
                                              -1.f,
@@ -372,7 +365,9 @@ void TestInterpOuthw(Place place, float abs_error = 2e-5) {
   }
 }
 
-void TestInterpScale(Place place, float abs_error = 2e-5) {
+void TestInterpScale(Place place,
+                     float abs_error = 2e-5,
+                     std::string alias = "def") {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (auto interp_method : std::vector<std::string>{"nearest", "bilinear"}) {
       for (float scale : {0.3f, 1.f, 1.7f}) {
@@ -387,12 +382,9 @@ void TestInterpScale(Place place, float abs_error = 2e-5) {
                                            -1,
                                            false,
                                            0));
-#elif defined(LITE_WITH_OPENCL)
-        std::unique_ptr<arena::TestCase> tester(new NearestInterpComputeTester(
-            place, "ImageDefault", DDim(x_dims), interp_method, scale));
 #else
         std::unique_ptr<arena::TestCase> tester(new NearestInterpComputeTester(
-            place, "def", DDim(x_dims), interp_method, scale));
+            place, alias, DDim(x_dims), interp_method, scale));
 #endif
         arena::Arena arena(std::move(tester), place, abs_error);
         arena.TestPrecision();
@@ -401,13 +393,11 @@ void TestInterpScale(Place place, float abs_error = 2e-5) {
   }
 }
 
-void TestInterpSizetensor(Place place, float abs_error = 2e-5) {
+void TestInterpSizetensor(Place place,
+                          float abs_error = 2e-5,
+                          std::string alias = "def") {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (auto interp_method : std::vector<std::string>{"nearest", "bilinear"}) {
-      std::string alias = "def";
-#if defined(LITE_WITH_OPENCL)
-      alias = "ImageDefault";
-#endif
       std::unique_ptr<arena::TestCase> tester(
           new NearestInterpComputeTester(place,
                                          alias,
@@ -427,13 +417,11 @@ void TestInterpSizetensor(Place place, float abs_error = 2e-5) {
   }
 }
 
-void TestInterpInputScale(Place place, float abs_error = 2e-5) {
+void TestInterpInputScale(Place place,
+                          float abs_error = 2e-5,
+                          std::string alias = "def") {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (auto interp_method : std::vector<std::string>{"nearest", "bilinear"}) {
-      std::string alias = "def";
-#if defined(LITE_WITH_OPENCL)
-      alias = "ImageDefault";
-#endif
       std::unique_ptr<arena::TestCase> tester(
           new NearestInterpComputeTester(place,
                                          alias,
@@ -453,13 +441,11 @@ void TestInterpInputScale(Place place, float abs_error = 2e-5) {
   }
 }
 
-void TestInterpOutsize(Place place, float abs_error = 2e-5) {
+void TestInterpOutsize(Place place,
+                       float abs_error = 2e-5,
+                       std::string alias = "def") {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (auto interp_method : std::vector<std::string>{"nearest", "bilinear"}) {
-      std::string alias = "def";
-#if defined(LITE_WITH_OPENCL)
-      alias = "ImageDefault";
-#endif
       std::unique_ptr<arena::TestCase> tester(
           new NearestInterpComputeTester(place,
                                          alias,
@@ -479,13 +465,11 @@ void TestInterpOutsize(Place place, float abs_error = 2e-5) {
   }
 }
 
-void TestInterpAlignCorners(Place place, float abs_error = 2e-5) {
+void TestInterpAlignCorners(Place place,
+                            float abs_error = 2e-5,
+                            std::string alias = "def") {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (bool align_corners : {true, false}) {
-      std::string alias = "def";
-#if defined(LITE_WITH_OPENCL)
-      alias = "ImageDefault";
-#endif
       std::unique_ptr<arena::TestCase> tester(new NearestInterpComputeTester(
           place, alias, DDim(x_dims), "nearest", -1, 4, 4, align_corners));
       arena::Arena arena(std::move(tester), place, abs_error);
@@ -494,7 +478,9 @@ void TestInterpAlignCorners(Place place, float abs_error = 2e-5) {
   }
 }
 
-void TestInterpAlignMode(Place place, float abs_error = 2e-5) {
+void TestInterpAlignMode(Place place,
+                         float abs_error = 2e-5,
+                         std::string alias = "def") {
   for (auto x_dims : std::vector<std::vector<int64_t>>{{3, 4, 8, 9}}) {
     for (bool align_corners : {true, false}) {
       for (int align_mode : {0, 1}) {
@@ -504,10 +490,6 @@ void TestInterpAlignMode(Place place, float abs_error = 2e-5) {
         }
 #if defined(LITE_WITH_NNADAPTER) && defined(NNADAPTER_WITH_HUAWEI_ASCEND_NPU)
         if (align_mode == 0 && align_corners) continue;
-#endif
-        std::string alias = "def";
-#if defined(LITE_WITH_OPENCL)
-        alias = "ImageDefault";
 #endif
         std::unique_ptr<arena::TestCase> tester(
             new NearestInterpComputeTester(place,
@@ -618,12 +600,12 @@ TEST(Interp, precision) {
 #elif defined(LITE_WITH_OPENCL)
   place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault));
   abs_error = 5e-2;
-  TestInterpOuthw(place, abs_error);
-  TestInterpScale(place, abs_error);
-  TestInterpInputScale(place, abs_error);
-  TestInterpOutsize(place, abs_error);
-  TestInterpAlignCorners(place, abs_error);
-  TestInterpAlignMode(place, abs_error);
+  TestInterpOuthw(place, abs_error, "ImageDefault");
+  TestInterpScale(place, abs_error, "ImageDefault");
+  TestInterpInputScale(place, abs_error, "ImageDefault");
+  TestInterpOutsize(place, abs_error, "ImageDefault");
+  TestInterpAlignCorners(place, abs_error, "ImageDefault");
+  TestInterpAlignMode(place, abs_error, "ImageDefault");
   return;
 #elif defined(LITE_WITH_ARM)
   place = TARGET(kARM);

--- a/lite/tests/kernels/pad2d_compute_test.cc
+++ b/lite/tests/kernels/pad2d_compute_test.cc
@@ -154,7 +154,7 @@ void TestPad2d(const Place& place,
                std::string data_format,
                float abs_error = 2e-5) {
   std::unique_ptr<arena::TestCase> tester(new Pad2dComputeTester<T>(
-      place, "def", pad_mode, paddings, pad_value, data_format));
+      place, alias, pad_mode, paddings, pad_value, data_format));
   arena::Arena arena(std::move(tester), place, abs_error);
   arena.TestPrecision();
 }
@@ -187,6 +187,9 @@ TEST(Pad2d, precision) {
   place = TARGET(kXPU);
   pad_mode_list = {"constant",
                    "reflect"};  // XPU support constant and reflect now
+#elif defined(LITE_WITH_OPENCL)
+  place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kImageDefault));
+  abs_error = 1e-2;
 #elif defined(LITE_WITH_ARM)
   place = TARGET(kARM);
 #elif defined(LITE_WITH_X86)
@@ -215,6 +218,15 @@ TEST(Pad2d, precision) {
               VLOG(5) << "pad param: " << pad_mode << " " << pad_value << " "
                       << paddings[0] << " " << paddings[1] << " " << paddings[2]
                       << " " << paddings[3];
+#if defined(LITE_WITH_OPENCL)
+              TestPad2d(place,
+                        "ImageDefault",
+                        pad_mode,
+                        paddings,
+                        pad_value,
+                        data_format,
+                        abs_error);
+#else
               TestPad2d(place,
                         "def",
                         pad_mode,
@@ -222,6 +234,7 @@ TEST(Pad2d, precision) {
                         pad_value,
                         data_format,
                         abs_error);
+#endif
             }
           }
         }

--- a/lite/tests/kernels/pool_compute_test.cc
+++ b/lite/tests/kernels/pool_compute_test.cc
@@ -315,7 +315,8 @@ void TestPoolPaddings(Place place, float abs_error = 2e-5) {
   for (auto pooling_type : {"max", "avg"}) {
     TestPoolHelper(
         place, abs_error, {2, 3, 6, 7}, pooling_type, {1, 1}, {0, 0}, {2, 2});
-#if !defined(LITE_WITH_XPU) && !defined(NNADAPTER_WITH_HUAWEI_ASCEND_NPU)
+#if !defined(LITE_WITH_XPU) && !defined(NNADAPTER_WITH_HUAWEI_ASCEND_NPU) && \
+    !defined(LITE_WITH_OPENCL)
     TestPoolHelper(
         place, abs_error, {2, 3, 6, 7}, pooling_type, {1, 1}, {1, 1}, {2, 2});
     TestPoolHelper(place,
@@ -353,7 +354,8 @@ void TestPoolKsize(Place place, float abs_error = 2e-5) {
                      {1, 1},
                      {0, 0},
                      {ksize, ksize});
-#if !defined(LITE_WITH_XPU) && !defined(NNADAPTER_WITH_HUAWEI_ASCEND_NPU)
+#if !defined(LITE_WITH_XPU) && !defined(NNADAPTER_WITH_HUAWEI_ASCEND_NPU) && \
+    !defined(LITE_WITH_OPENCL)
       TestPoolHelper(place,
                      abs_error,
                      {2, 3, 6, 7},
@@ -398,10 +400,12 @@ TEST(Pool, precision) {
 #else
   return;
 #endif
+#elif defined(LITE_WITH_OPENCL)
+  place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kNCHW));
+  abs_error = 1e-2;  // Using fp16 in OPENCL
 #else
   return;
 #endif
-
   TestPoolGlobal(place, abs_error);
   TestPoolAlgorithm(place, abs_error);
   TestPoolStrides(place, abs_error);

--- a/lite/tests/kernels/reshape_compute_test.cc
+++ b/lite/tests/kernels/reshape_compute_test.cc
@@ -217,7 +217,7 @@ TEST(Reshape, precision) {
   return;
 #endif
 #elif defined(LITE_WITH_OPENCL)
-  place = Place(TARGET(kOpenCL), PRECISION(kFloat), DATALAYOUT(kNCHW));
+  place = Place(TARGET(kOpenCL), PRECISION(kFP16), DATALAYOUT(kNCHW));
   abs_error = 1e-2;  // Using fp16 in OPENCL
 #elif defined(LITE_WITH_ARM) || defined(LITE_WITH_X86)
   place = TARGET(kHost);

--- a/lite/utils/env.h
+++ b/lite/utils/env.h
@@ -39,6 +39,16 @@
 // target device model online during the execution phase.
 #define SUBGRAPH_ONLINE_MODE "SUBGRAPH_ONLINE_MODE"
 
+// The environment variables for the opencl memory config settings
+// Specify the path of configuration file for the opencl buffer memory config,
+// an
+// example is shown as below:
+// op_type:in_var_name_0,in_var_name1:out_var_name_0,out_var_name1
+// op_type::out_var_name_0
+// op_type:in_var_name_0
+// op_type
+#define OPENCL_MEMORY_CONFIG_FILE "OPENCL_MEMORY_CONFIG_FILE"
+
 // Due to various reasons (such as bugs from PaddleSlim), some ops in the model
 // lack quantization parameters. Optionally, the missing quantization parameters
 // can be completed by the following rules.


### PR DESCRIPTION
【问题】
1. 不同的设备采用 cl::Image2D 和 cl::Buffer 性能优势不同。
2. 设备本身对 cl::Image2D 的 CL_DEVICE_IMAGE2D_MAX_HEIGHT 和 CL_DEVICE_IMAGE2D_MAX_WIDTH 有限制，导致部分op尺寸过大时会报错：malloc image is out of max image size(w,h)。
3. 部分op采用 cl::Buffer 内存对象会有很好的性能，比如reshape，transpose，keep_dims 为 false 的 argmax，reduce等。

【解决方法】
通过 pass，通过环境变量 `OPENCL_MEMORY_CONFIG_FILE` 设置『OpenCL 内存对象配置文件』，然后根据配置文件中的node，修改 op 的 kernel place.layout 属性为kNCHW，或者修改op的kernel 的 place.target 为arm/x86。

另外，由于此前只支持cl::Buffer为fp32精度，所以在layout转换的时候是固定为cl::Image2D(fp16或fp32精度) -> cl::Buffer(fp32精度)，目前cl::Buffer需要支持fp32和fp16精度，现在把精度转换移至iocopy过程中。

【效果】
验证了 mobilenetv1全网络image2d，fp32精度和fp16均运行正常
验证了网络模型ch_PP-OCRv3_rec_infer，其中reshape2 和 transpose2跑cl::Buffer实现，conv2d，depthwise_conv2d 和 pool2d跑CPU实现，剩余大部分op跑cl::Image2D实现。（该网络之前运行报错，op的输出dims超出了CL_DEVICE_IMAGE2D_MAX_HEIGHT），该网络的配置文件如下
<img width="525" alt="image" src="https://user-images.githubusercontent.com/89541335/195573273-c4ac63e3-c6da-41ed-862f-6f4f7b566204.png">

