### PR TITLE
add CopyFromCpu kHost kARM int64_t support

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -223,11 +223,13 @@ void Tensor::CopyToCpu(T *data) const {
 }
 
 template void Tensor::CopyFromCpu<int, TargetType::kHost>(const int *);
+template void Tensor::CopyFromCpu<int64_t, TargetType::kHost>(const int64_t *);
 template void Tensor::CopyFromCpu<float, TargetType::kHost>(const float *);
 template void Tensor::CopyFromCpu<int8_t, TargetType::kHost>(const int8_t *);
 template void Tensor::CopyFromCpu<uint8_t, TargetType::kHost>(const uint8_t *);
 
 template void Tensor::CopyFromCpu<int, TargetType::kARM>(const int *);
+template void Tensor::CopyFromCpu<int64_t, TargetType::kARM>(const int64_t *);
 template void Tensor::CopyFromCpu<float, TargetType::kARM>(const float *);
 template void Tensor::CopyFromCpu<int8_t, TargetType::kARM>(const int8_t *);
 template void Tensor::CopyFromCpu<uint8_t, TargetType::kARM>(const uint8_t *);


### PR DESCRIPTION
When input int64_t data, kHost and kARM will happen unreference error.
```
 undefined reference to `void paddle::lite_api::Tensor::CopyFromCpu<long, (paddle::lite_api::TargetType)1>(long const*)'
```

paddle::lite_api::Tensor
input_tensor->CopyFromCpu(input.data());  缺少int64_t的模板定义。

BUG ISSUE:  
https://github.com/PaddlePaddle/Paddle-Lite/issues/9528