### PR TITLE
fix gcc fatal warning error about extra, pessimizing-move

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -138,6 +138,7 @@ set(COMMON_FLAGS
     -Wno-error=int-in-bool-context # Warning in Eigen gcc 7.2
     -Wimplicit-fallthrough=0 # Warning in tinyformat.h
     -Wno-error=maybe-uninitialized # Warning in boost gcc 7.2
+    -Wno-error=unused-variable # Warning unused variable 
 )
 
 if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR EMSCRIPTEN)

--- a/lite/backends/opencl/cl_context.cc
+++ b/lite/backends/opencl/cl_context.cc
@@ -229,7 +229,7 @@ CLContext::GenerateLocalWorkSizes(cl::NDRange gws, size_t max_ws) {
 }
 std::set<cl::NDRange, CLContext::CompareByRange>
 CLContext::DefaultLocalWorkSize(const cl::NDRange &gws,
-                                register size_t max_ws,
+                                size_t max_ws,
                                 size_t tune_type /*=0*/,
                                 const int &divisor /*=2*/,
                                 const bool &reverse /*=false*/,

--- a/lite/backends/opencl/cl_context.h
+++ b/lite/backends/opencl/cl_context.h
@@ -75,7 +75,7 @@ class CLContext {
 
   std::set<cl::NDRange, CompareByRange> DefaultLocalWorkSize(
       const cl::NDRange &global_work_size,
-      register size_t max_work_size,
+      size_t max_work_size,
       size_t tune_type = 0,
       const int &divitor = 2,
       const bool &tune_reverse = false,

--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -342,7 +342,7 @@ std::unique_ptr<cl::Program> CLRuntime::CreateProgramFromSource(
   VLOG(4) << "Program source size: " << content.size();
 #endif
   CL_CHECK_FATAL_SOLID(status_);
-  return std::move(prog);
+  return prog;
 }
 
 bool CLRuntime::BuildProgram(cl::Program* program, const std::string& options) {
@@ -519,7 +519,7 @@ std::unique_ptr<cl::UserEvent> CLRuntime::CreateEvent(
   auto event =
       std::unique_ptr<cl::UserEvent>(new cl::UserEvent(context, &status_));
   CL_CHECK_FATAL_SOLID(status_);
-  return std::move(event);
+  return event;
 }
 
 bool CLRuntime::InitializePlatform() {

--- a/third-party/opencl/include/CL/cl2.hpp
+++ b/third-party/opencl/include/CL/cl2.hpp
@@ -1697,7 +1697,7 @@ public:
 
     cl_type& operator ()() { return object_; }
 
-    const cl_type get() const { return object_; }
+    cl_type get() const { return object_; }
 
     cl_type get() { return object_; }
 
@@ -1826,7 +1826,7 @@ public:
 
     cl_type& operator ()() { return object_; }
 
-    const cl_type get() const { return object_; }
+    cl_type get() const { return object_; }
 
     cl_type get() { return object_; }
 


### PR DESCRIPTION
Fix Multiple compile warning fatal error about opencl.
## Fix std::move error.  纠正move错误
```
/home/wjl/github/Paddle-Lite/lite/backends/opencl/cl_runtime.cc: In member function ‘std::unique_ptr<cl::Program> paddle::lite::CLRuntime::CreateProgramFromSource(const cl::Context&, std::string)’:
/home/wjl/github/Paddle-Lite/lite/backends/opencl/cl_runtime.cc:345:19: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
  345 |   return std::move(prog);
      |          ~~~~~~~~~^~~~~~

```
T foo() { T res; return std::move(res); } 是错误写法。应该直接return res


## 访问了引用变量的变量不能使用register寄存器变量。
```
/home/wjl/github/Paddle-Lite/lite/backends/opencl/cl_context.cc: In member function ‘std::set<cl::NDRange, paddle::lite::CLContext::CompareByRange> paddle::lite::CLContext::DefaultLocalWorkSize(const cl::NDRange&, size_t, size_t, const int&, const bool&, const size_t&)’:
/home/wjl/github/Paddle-Lite/lite/backends/opencl/cl_context.cc:242:65: error: address requested for ‘max_ws’, which is declared ‘register’ [-Werror=extra]
  242 |                                                               : max_ws;
```

-Wno-error=unused-variable 禁用一堆未使用的变量错误


## const cl_type get() const  错误写法
应该是cl_type get() const
参考 https://github.com/KhronosGroup/OpenCL-CLHPP/blob/main/include/CL/opencl.hpp