### PR TITLE
[OpenCL] Remove force "opencl off" when building with x86 benchmark.

### DIFF
--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -117,14 +117,6 @@ function set_benchmark_options {
   WITH_EXTRA=ON
   WITH_EXCEPTION=ON
   WITH_NNADAPTER=ON
-  if [ "${ARCH}" == "x86" ]; then
-    # Turn off opencl. Additional third party library need to be installed on
-    # Linux. Otherwise opencl is not supported on Linux. See link for more info:
-    # https://software.intel.com/content/www/us/en/develop/articles/opencl-drivers.html
-    WITH_OPENCL=OFF
-  else
-    WITH_OPENCL=ON
-  fi
   if [ ${WITH_PROFILE} == "ON" ] || [ ${WITH_PRECISION_PROFILE} == "ON" ]; then
     WITH_LOG=ON
   else


### PR DESCRIPTION
在opencl, x86环境中，benckmark对intel opencl driver并没有特殊依赖，运行时用户需要保证系统中有可用的opencl driver，但是不影响build。

test=develop