### PR TITLE
[ARM] fix sharing zero point between quant_linear and dequant_linear op

### DIFF
--- a/lite/core/optimizer/mir/fusion/quant_dequant_fuse_pass.cc
+++ b/lite/core/optimizer/mir/fusion/quant_dequant_fuse_pass.cc
@@ -71,8 +71,11 @@ void QuantDequantFusePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
 
   // process new quant op pass: quantize_linear and dequantize_linear
   // pass1: input+quantize_linear+dequantize_linear --> input
-  fusion::QuantDequantLinearOpFuser quant_dequant_linear_fuser;
-  quant_dequant_linear_fuser(graph.get());
+  for (auto share_zero_point : {true, false}) {
+    fusion::QuantDequantLinearOpFuser quant_dequant_linear_fuser(
+        share_zero_point);
+    quant_dequant_linear_fuser(graph.get());
+  }
   // pass2: weight+dequantize_linear --> weight
   fusion::DequantLinearOpFuser dequantize_linear_fuser;
   dequantize_linear_fuser(graph.get());

--- a/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
+++ b/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
@@ -742,15 +742,8 @@ void QuantDequantLinearOpFuser::InsertNewNode(SSAGraph* graph,
     op_info->SetAttr<int>("bit_length", bit_length);
     std::string op_type = op_info->Type();
 #ifndef LITE_WITH_FPGA
-    std::vector<std::string> quant_op_types_tmp = {"conv2d",
-                                                   "depthwise_conv2d",
-                                                   "depthwise_conv2d_transpose",
-                                                   "mul",
-                                                   "matmul",
-                                                   "matmul_v2"};
-    if (std::find(quant_op_types_tmp.begin(),
-                  quant_op_types_tmp.end(),
-                  op_type) != quant_op_types_tmp.end()) {
+    if (std::find(quant_op_types_.begin(), quant_op_types_.end(), op_type) !=
+        quant_op_types_.end()) {
       op_info->SetAttr("enable_int8", true);
     }
 #endif

--- a/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.h
+++ b/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.h
@@ -140,7 +140,9 @@ class DynamicQuantOpFuser : public FuseBase {
 */
 class QuantDequantLinearOpFuser : public FuseBase {
  public:
-  QuantDequantLinearOpFuser() {}
+  explicit QuantDequantLinearOpFuser(const bool shared_zero_point) {
+    shared_zero_point_ = shared_zero_point;
+  }
   void BuildPattern() override;
   void InsertNewNode(SSAGraph* graph, const key2nodes_t& matched) override;
 
@@ -152,6 +154,7 @@ class QuantDequantLinearOpFuser : public FuseBase {
                                               "mul",
                                               "matmul",
                                               "matmul_v2"};
+  bool shared_zero_point_{};
 };
 
 /* The pattern like "dequantize_linear_op + quantized_op "


### PR DESCRIPTION
## PR Type
add pass pattern
## PR Describe
<img width="670" alt="image" src="https://user-images.githubusercontent.com/54735487/197702264-3da990d8-5aba-4b03-9779-aac8ae47d258.png">

在pass中增加 共享zero point的pattern