### PR TITLE
[Pass] fix memory_optimize_pass for xshape

### DIFF
--- a/lite/core/optimizer/mir/memory_optimize_pass.cc
+++ b/lite/core/optimizer/mir/memory_optimize_pass.cc
@@ -143,12 +143,17 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
       }
       if (inplace) {
         for (auto& in_param_name : inplace_op_node->second.first) {
-          const auto& in_arg_names = op_info->Input(in_param_name);
-          invalid_var_names.insert(in_arg_names.begin(), in_arg_names.end());
+          if (op_info->HasInput(in_param_name)) {
+            const auto& in_arg_names = op_info->Input(in_param_name);
+            invalid_var_names.insert(in_arg_names.begin(), in_arg_names.end());
+          }
         }
         for (auto& out_param_name : inplace_op_node->second.second) {
-          const auto& out_arg_names = op_info->Output(out_param_name);
-          invalid_var_names.insert(out_arg_names.begin(), out_arg_names.end());
+          if (op_info->HasOutput(out_param_name)) {
+            const auto& out_arg_names = op_info->Output(out_param_name);
+            invalid_var_names.insert(out_arg_names.begin(),
+                                     out_arg_names.end());
+          }
         }
       }
     }


### PR DESCRIPTION
## PR Type
bug fix
## PR Describe
修复opmaker清理xshpae遗留的问题，使内存复用pass支持不存在xshape的case
