### PR TITLE
[Cherry-Pick][API] Add CopyFromCpu kHost kARM int64_t support (#9527)

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -188,11 +188,13 @@ void Tensor::CopyToCpu(T *data) const {
 }
 
 template void Tensor::CopyFromCpu<int, TargetType::kHost>(const int *);
+template void Tensor::CopyFromCpu<int64_t, TargetType::kHost>(const int64_t *);
 template void Tensor::CopyFromCpu<float, TargetType::kHost>(const float *);
 template void Tensor::CopyFromCpu<int8_t, TargetType::kHost>(const int8_t *);
 template void Tensor::CopyFromCpu<uint8_t, TargetType::kHost>(const uint8_t *);
 
 template void Tensor::CopyFromCpu<int, TargetType::kARM>(const int *);
+template void Tensor::CopyFromCpu<int64_t, TargetType::kARM>(const int64_t *);
 template void Tensor::CopyFromCpu<float, TargetType::kARM>(const float *);
 template void Tensor::CopyFromCpu<int8_t, TargetType::kARM>(const int8_t *);
 template void Tensor::CopyFromCpu<uint8_t, TargetType::kARM>(const uint8_t *);


### PR DESCRIPTION
See https://github.com/PaddlePaddle/Paddle-Lite/pull/9527
Issue https://github.com/PaddlePaddle/Paddle-Lite/issues/9528

Tensor::CopyFromCpu   没有int64_t类型的symbol问题，没有合并到release/v2.12