### PR TITLE
[xpu] fix static kernel pass

### DIFF
--- a/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.cc
+++ b/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.cc
@@ -33,6 +33,8 @@ bool XPUKernelScoreCmp(const std::pair<float, std::unique_ptr<KernelBase>>& a,
 }
 
 void XPUStaticKernelPickPass::Apply(const std::unique_ptr<SSAGraph>& graph) {
+  Init();
+
   kernel_pick_factors_.ConsiderTarget();
   kernel_pick_factors_.ConsiderPrecision();
   kernel_pick_factors_.ConsiderDataLayout();

--- a/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
+++ b/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
@@ -42,7 +42,17 @@ namespace mir {
  */
 class XPUStaticKernelPickPass : public mir::StmtPass {
  public:
-  XPUStaticKernelPickPass() {
+  void Apply(const std::unique_ptr<SSAGraph>& graph) override;
+
+  const core::KernelPickFactor& kernel_pick_factors() const {
+    return kernel_pick_factors_;
+  }
+  core::KernelPickFactor* mutable_kernel_pick_factors() {
+    return &kernel_pick_factors_;
+  }
+
+ private:
+  void Init() {
 #ifdef LITE_WITH_XPU
     // get xpu device type
     int cur_dev_idx = 0;
@@ -72,16 +82,6 @@ class XPUStaticKernelPickPass : public mir::StmtPass {
 #endif
   }
 
-  void Apply(const std::unique_ptr<SSAGraph>& graph) override;
-
-  const core::KernelPickFactor& kernel_pick_factors() const {
-    return kernel_pick_factors_;
-  }
-  core::KernelPickFactor* mutable_kernel_pick_factors() {
-    return &kernel_pick_factors_;
-  }
-
- private:
   // Score the kernel.
   size_t KernelGrade(lite::mir::Node* node,
                      const lite::KernelBase& kernel,


### PR DESCRIPTION
- XPUStaticKernelPickPass 是 global static 变量， 所以构造初始化在 main() 函数之前，无法在构造函数中获得 config 设置进去的参数