### PR TITLE
[Cherry-pick][Arm] add dequantize_log op, lookup_table_v2 supports int32_t ids and int8_t weights 

### DIFF
--- a/lite/kernels/arm/CMakeLists.txt
+++ b/lite/kernels/arm/CMakeLists.txt
@@ -75,7 +75,7 @@ add_kernel(scatter_compute_arm ARM extra SRCS scatter_compute.cc)
 add_kernel(sequence_expand_as_compute_arm ARM extra SRCS sequence_expand_as_compute.cc)
 add_kernel(matmul_v2_compute ARM extra SRCS matmul_v2_compute.cc)
 add_kernel(sum_compute ARM extra SRCS sum_compute.cc)
-
+add_kernel(dequantize_log_compute ARM extra SRCS dequantize_log_compute.cc)
 
 # for OCR specific
 add_kernel(gru_unit_compute_arm ARM extra SRCS gru_unit_compute.cc)

--- a/lite/kernels/arm/dequantize_log_compute.cc
+++ b/lite/kernels/arm/dequantize_log_compute.cc
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/arm/dequantize_log_compute.h"
+#include <set>
+#include <string>
+#include <vector>
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace arm {
+
+template <typename T>
+void DequantizeLogCompute<T>::Run() {
+  auto& param = Param<operators::QuantizeLogParam>();
+  auto x = param.X;
+  auto dict = param.Dict;
+  auto output = param.Out;
+  const float* dict_data = dict->template data<float>();
+  const T* input_data = x->template data<T>();
+  float* output_data = output->template mutable_data<float>();
+  int ind = x->numel();
+  for (size_t i = 0; i < (unsigned)ind; i++) {
+    if (input_data[i] < 0) {
+      output_data[i] = -dict_data[input_data[i] + 128];
+    } else {
+      output_data[i] = dict_data[input_data[i]];
+    }
+  }
+}
+
+}  // namespace arm
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(dequantize_log,
+                     kARM,
+                     kInt8,
+                     kNCHW,
+                     paddle::lite::kernels::arm::DequantizeLogCompute<int8_t>,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
+    .BindInput("Dict", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .BindPaddleOpVersion("dequantize_log", 1)
+    .Finalize();

--- a/lite/kernels/arm/dequantize_log_compute.h
+++ b/lite/kernels/arm/dequantize_log_compute.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <stdint.h>
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace arm {
+
+template <typename T>
+class DequantizeLogCompute : public KernelLite<TARGET(kARM), PRECISION(kInt8)> {
+ public:
+  void Run() override;
+
+  virtual ~DequantizeLogCompute() = default;
+
+ private:
+};
+
+}  // namespace arm
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/arm/lookup_table_compute.cc
+++ b/lite/kernels/arm/lookup_table_compute.cc
@@ -91,6 +91,8 @@ using LookupTableInt8Int64 =
     paddle::lite::kernels::arm::LookupTableCompute<int8_t, int64_t>;
 using LookupTableFloatInt32 =
     paddle::lite::kernels::arm::LookupTableCompute<float, int32_t>;
+using LookupTableInt8Int32 =
+    paddle::lite::kernels::arm::LookupTableCompute<int8_t, int32_t>;
 
 REGISTER_LITE_KERNEL(
     lookup_table, kARM, kAny, kNCHW, LookupTableFloatInt64, def)
@@ -111,6 +113,14 @@ REGISTER_LITE_KERNEL(
     lookup_table_v2, kARM, kAny, kNCHW, LookupTableInt8Int64, int8_int64)
     .BindInput("W", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
     .BindInput("Ids", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
+    .BindPaddleOpVersion("lookup_table_v2", 1)
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    lookup_table_v2, kARM, kAny, kNCHW, LookupTableInt8Int32, int8_int32)
+    .BindInput("W", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
+    .BindInput("Ids", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
     .BindPaddleOpVersion("lookup_table_v2", 1)
     .Finalize();

--- a/lite/kernels/arm/lookup_table_compute.cc
+++ b/lite/kernels/arm/lookup_table_compute.cc
@@ -70,10 +70,10 @@ void LookupTableCompute<T_W, T_IDS>::Run() {
         memcpy(dout + i * row_width, table_data, row_width * sizeof(float));
       }
 #else
-      auto table_data = w->template data<float>();
+      auto table_data = w->template data<T_W>();
       memcpy(dout + i * row_width,
              table_data + ids_int * row_width,
-             row_width * sizeof(float));
+             row_width * sizeof(T_W));
 #endif
     }
   }
@@ -87,6 +87,8 @@ void LookupTableCompute<T_W, T_IDS>::Run() {
 
 using LookupTableFloatInt64 =
     paddle::lite::kernels::arm::LookupTableCompute<float, int64_t>;
+using LookupTableInt8Int64 =
+    paddle::lite::kernels::arm::LookupTableCompute<int8_t, int64_t>;
 using LookupTableFloatInt32 =
     paddle::lite::kernels::arm::LookupTableCompute<float, int32_t>;
 
@@ -102,6 +104,14 @@ REGISTER_LITE_KERNEL(
     .BindInput("W", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Ids", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindPaddleOpVersion("lookup_table_v2", 1)
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    lookup_table_v2, kARM, kAny, kNCHW, LookupTableInt8Int64, int8_int64)
+    .BindInput("W", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
+    .BindInput("Ids", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt8))})
     .BindPaddleOpVersion("lookup_table_v2", 1)
     .Finalize();
 

--- a/lite/operators/CMakeLists.txt
+++ b/lite/operators/CMakeLists.txt
@@ -109,6 +109,7 @@ add_operator(fake_channel_wise_quantize_dequantize_abs_max_op extra SRCS fake_ch
 add_operator(fake_channel_wise_dequantize_max_abs_op extra SRCS fake_channel_wise_dequantize_max_abs.cc)
 add_operator(quantize_linear_op extra SRCS quantize_linear_op.cc)
 add_operator(dequantize_linear_op extra SRCS dequantize_linear_op.cc)
+add_operator(dequantize_log_op extra SRCS dequantize_log_op.cc)
 add_operator(split_lod_tensor_op_lite extra SRCS split_lod_tensor_op.cc)
 add_operator(merge_lod_tensor_op_lite extra SRCS merge_lod_tensor_op.cc)
 add_operator(sequence_reshape_op_lite extra SRCS sequence_reshape_op.cc)

--- a/lite/operators/dequantize_log_op.cc
+++ b/lite/operators/dequantize_log_op.cc
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/dequantize_log_op.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+bool DequantizeLogOpLite::CheckShape() const {
+  CHECK_OR_FALSE(param_.X);
+  CHECK_OR_FALSE(param_.Out);
+  return true;
+}
+
+bool DequantizeLogOpLite::InferShape() {
+  lite::DDim x_dims = param_.X->dims();
+  param_.Out->Resize(x_dims);
+
+  return true;
+}
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_OP(dequantize_log, paddle::lite::operators::DequantizeLogOpLite);

--- a/lite/operators/dequantize_log_op.h
+++ b/lite/operators/dequantize_log_op.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "lite/core/kernel.h"
+#include "lite/core/op_lite.h"
+#include "lite/core/scope.h"
+#include "lite/core/tensor.h"
+#include "lite/operators/op_params.h"
+#include "lite/utils/all.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+class DequantizeLogOpLite : public OpLite {
+ public:
+  DequantizeLogOpLite() {}
+
+  explicit DequantizeLogOpLite(const std::string &type) : OpLite(type) {}
+
+  bool CheckShape() const override;
+
+  bool InferShape() override;
+  bool AttachImpl(const cpp::OpDesc &op_desc, lite::Scope *scope) override {
+    auto x = op_desc.Input("X").front();
+    auto dict = op_desc.Input("Dict").front();
+    auto out = op_desc.Output("Out").front();
+
+    param_.X = scope->FindVar(x)->GetMutable<lite::Tensor>();
+    param_.Dict = scope->FindVar(dict)->GetMutable<lite::Tensor>();
+    param_.Out = scope->FindVar(out)->GetMutable<lite::Tensor>();
+    return true;
+  }
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+
+  std::string DebugString() const override { return "dequantize_log"; }
+
+ private:
+  mutable QuantizeLogParam param_;
+};
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -667,6 +667,12 @@ struct QuantizeLinearParam : ParamBase {
   int bit_length;
 };
 
+struct QuantizeLogParam : ParamBase {
+  const lite::Tensor* X{};
+  const lite::Tensor* Dict{};
+  lite::Tensor* Out{};
+};
+
 /// ----------------------- sgd operators ----------------------
 struct SGDParam : ParamBase {
   int dtype{static_cast<int>(VarDescAPI::VarDataType::FP32)};


### PR DESCRIPTION
refer to https://github.com/PaddlePaddle/Paddle-Lite/pull/9669 , https://github.com/PaddlePaddle/Paddle-Lite/pull/9678