### PR TITLE
[PaddleSpeech] Add OPs, registrations and implement for PaddleSpeech model.

### DIFF
--- a/lite/backends/arm/math/reduce_sum.cc
+++ b/lite/backends/arm/math/reduce_sum.cc
@@ -423,6 +423,120 @@ void reduce_sum_n<int32_t>(const int32_t* src,
 }
 
 template <>
+void reduce_sum_n<int64_t>(const int64_t* src,
+                           int64_t* dst,
+                           int num_in,
+                           int channel_in,
+                           int height_in,
+                           int width_in) {
+  int chw_size = channel_in * height_in * width_in;
+  if (num_in == 1) {
+    memcpy(dst, src, sizeof(int64_t) * chw_size);
+  } else {
+    int cnt_n = num_in >> 2;
+    int remain_n = num_in & 3;
+    int cnt_chw = chw_size >> 2;
+    int cnt_rem = chw_size & 3;
+    int stride = chw_size << 2;
+    int stride_c = 0;
+    for (int c = 0; c < cnt_chw; c++) {
+      int64x2_t vsum0 = vdupq_n_s64(0);
+      int64x2_t vsum1 = vdupq_n_s64(0);
+      const int64_t* din_ptr0 = src + stride_c;
+      const int64_t* din_ptr1 = din_ptr0 + chw_size;
+      const int64_t* din_ptr2 = din_ptr1 + chw_size;
+      const int64_t* din_ptr3 = din_ptr2 + chw_size;
+      for (int n = 0; n < cnt_n; n++) {
+        int64x2_t va0 = vld1q_s64(din_ptr0);
+        int64x2_t vb0 = vld1q_s64(din_ptr1);
+        int64x2_t va1 = vld1q_s64(din_ptr0 + 2);
+        int64x2_t vb1 = vld1q_s64(din_ptr1 + 2);
+        int64x2_t vc0 = vld1q_s64(din_ptr2);
+        int64x2_t vd0 = vld1q_s64(din_ptr3);
+        int64x2_t vs00 = vaddq_s64(va0, vb0);
+        int64x2_t vc1 = vld1q_s64(din_ptr2 + 2);
+        int64x2_t vs10 = vaddq_s64(va1, vb1);
+        int64x2_t vd1 = vld1q_s64(din_ptr3 + 2);
+        int64x2_t vs01 = vaddq_s64(vc0, vd0);
+        vsum0 = vaddq_s64(vsum0, vs00);
+        int64x2_t vs11 = vaddq_s64(vc1, vd1);
+        vsum1 = vaddq_s64(vsum1, vs10);
+        din_ptr0 += stride;
+        din_ptr1 += stride;
+        vsum0 = vaddq_s64(vsum0, vs01);
+        din_ptr2 += stride;
+        din_ptr3 += stride;
+        vsum1 = vaddq_s64(vsum1, vs11);
+      }
+      for (int n = 0; n < remain_n; n++) {
+        int64x2_t va0 = vld1q_s64(din_ptr0);
+        int64x2_t va1 = vld1q_s64(din_ptr0 + 2);
+        vsum0 = vaddq_s64(vsum0, va0);
+        din_ptr0 += chw_size;
+        vsum1 = vaddq_s64(vsum1, va1);
+      }
+      vst1q_s64(dst, vsum0);
+      dst += 2;
+      stride_c += 4;
+      vst1q_s64(dst, vsum1);
+      dst += 2;
+    }
+    if (cnt_rem > 1) {
+      int64x2_t vsum0 = vdupq_n_s64(0);
+      const int64_t* din_ptr0 = src + stride_c;
+      const int64_t* din_ptr1 = din_ptr0 + chw_size;
+      const int64_t* din_ptr2 = din_ptr1 + chw_size;
+      const int64_t* din_ptr3 = din_ptr2 + chw_size;
+      for (int n = 0; n < cnt_n; n++) {
+        int64x2_t va0 = vld1q_s64(din_ptr0);
+        int64x2_t vb0 = vld1q_s64(din_ptr1);
+        int64x2_t vc0 = vld1q_s64(din_ptr2);
+        int64x2_t vd0 = vld1q_s64(din_ptr3);
+        int64x2_t vs00 = vaddq_s64(va0, vb0);
+        int64x2_t vs01 = vaddq_s64(vc0, vd0);
+        vsum0 = vaddq_s64(vsum0, vs00);
+        din_ptr0 += stride;
+        din_ptr1 += stride;
+        vsum0 = vaddq_s64(vsum0, vs01);
+        din_ptr2 += stride;
+        din_ptr3 += stride;
+      }
+      for (int n = 0; n < remain_n; n++) {
+        int64x2_t va0 = vld1q_s64(din_ptr0);
+        din_ptr0 += chw_size;
+        vsum0 = vaddq_s64(vsum0, va0);
+      }
+      stride_c += 2;
+      vst1q_s64(dst, vsum0);
+      dst += 2;
+      cnt_rem -= 2;
+    }
+    if (cnt_rem) {
+      const int64_t* din_ptr0 = src + stride_c;
+      const int64_t* din_ptr1 = din_ptr0 + chw_size;
+      const int64_t* din_ptr2 = din_ptr1 + chw_size;
+      const int64_t* din_ptr3 = din_ptr2 + chw_size;
+      int64_t sum = 0;
+      for (int n = 0; n < cnt_n; n++) {
+        int64_t tmp0 = din_ptr0[0] + din_ptr1[0];
+        int64_t tmp1 = din_ptr2[0] + din_ptr3[0];
+        din_ptr0 += stride;
+        din_ptr1 += stride;
+        sum += tmp0;
+        din_ptr2 += stride;
+        din_ptr3 += stride;
+        sum += tmp1;
+      }
+      for (int n = 0; n < remain_n; n++) {
+        sum += din_ptr0[0];
+        din_ptr0 += chw_size;
+      }
+      dst[0] = sum;
+    }
+  }
+}
+
+template <>
 void reduce_sum_w<int32_t>(const int32_t* src,
                            int32_t* dst,
                            int num_in,
@@ -600,6 +714,177 @@ void reduce_sum_w<int32_t>(const int32_t* src,
 }
 
 template <>
+void reduce_sum_w<int64_t>(const int64_t* src,
+                           int64_t* dst,
+                           int num_in,
+                           int channel_in,
+                           int height_in,
+                           int width_in) {
+  int nch_size = num_in * channel_in * height_in;
+  int cnt_w = width_in >> 2;
+  int cnt_n = nch_size >> 2;
+  int rem_w = width_in & 3;
+  int rem_n = nch_size & 3;
+  int stride = 0;
+  int stride_n = width_in << 2;
+  for (int n = 0; n < cnt_n; n++) {
+    const int64_t* din_ptr0 = src + stride;
+    const int64_t* din_ptr1 = din_ptr0 + width_in;
+    const int64_t* din_ptr2 = din_ptr1 + width_in;
+    const int64_t* din_ptr3 = din_ptr2 + width_in;
+    int64x2_t vsum[2] = {vdupq_n_s64(0), vdupq_n_s64(0)};
+    int tmp = rem_w;
+    for (int w = 0; w < cnt_w; w++) {
+      int64x2_t va0 = vld1q_s64(din_ptr0);
+      int64x2_t va1 = vld1q_s64(din_ptr0 + 2);
+      int64x2_t vb0 = vld1q_s64(din_ptr1);
+      int64x2_t vb1 = vld1q_s64(din_ptr1 + 2);
+      int64x2_t vc0 = vld1q_s64(din_ptr2);
+      int64x2_t vc1 = vld1q_s64(din_ptr2 + 2);
+      int64x2_t vs0 = vaddq_s64(va0, va1);
+      int64x2_t vd0 = vld1q_s64(din_ptr3);
+      int64x2_t vs1 = vaddq_s64(vb0, vb1);
+      int64x2_t vd1 = vld1q_s64(din_ptr3 + 2);
+      int64x2_t vs2 = vaddq_s64(vc0, vc1);
+      din_ptr0 += 4;
+      int64x2_t vs3 = vaddq_s64(vd0, vd1);
+      din_ptr1 += 4;
+      din_ptr2 += 4;
+#ifdef __aarch64__
+      int64x2_t vs00 = vpaddq_s64(vs0, vs1);
+      int64x2_t vs01 = vpaddq_s64(vs2, vs3);
+      din_ptr3 += 4;
+      vsum[0] = vaddq_s64(vs00, vsum[0]);
+      vsum[1] = vaddq_s64(vs01, vsum[1]);
+#else
+      int64x2_t vs[2];
+      vs[0][0] = vs0[0] + vs0[1];
+      vs[0][1] = vs1[0] + vs1[1];
+      vs[1][0] = vs2[0] + vs2[1];
+      vs[1][1] = vs3[0] + vs3[1];
+      din_ptr3 += 4;
+      vsum[0] = vaddq_s64(vs[0], vsum[0]);
+      vsum[1] = vaddq_s64(vs[1], vsum[1]);
+#endif
+    }
+    if (tmp > 1) {
+      int64x2_t va0 = vld1q_s64(din_ptr0);
+      int64x2_t vb0 = vld1q_s64(din_ptr1);
+      int64x2_t vc0 = vld1q_s64(din_ptr2);
+      int64x2_t vd0 = vld1q_s64(din_ptr3);
+      din_ptr0 += 2;
+      din_ptr1 += 2;
+#ifdef __aarch64__
+      int64x2_t vs00 = vpaddq_s64(va0, vb0);
+      int64x2_t vs01 = vpaddq_s64(vc0, vd0);
+      din_ptr2 += 2;
+      din_ptr3 += 2;
+      vsum[0] = vaddq_s64(vs00, vsum[0]);
+      vsum[1] = vaddq_s64(vs01, vsum[1]);
+#else
+      int64x2_t vs[2];
+      vs[0][0] = va0[0] + va0[1];
+      vs[0][1] = vb0[0] + vb0[1];
+      vs[1][0] = vc0[0] + vc0[1];
+      vs[1][1] = vd0[0] + vd0[1];
+      din_ptr2 += 2;
+      din_ptr3 += 2;
+      vsum[0] = vaddq_s64(vs[0], vsum[0]);
+      vsum[1] = vaddq_s64(vs[1], vsum[1]);
+#endif
+      tmp -= 2;
+    }
+    for (int w = 0; w < tmp; w++) {
+      vsum[0][0] += *din_ptr0++;
+      vsum[0][1] += *din_ptr1++;
+      vsum[1][0] += *din_ptr2++;
+      vsum[1][1] += *din_ptr3++;
+    }
+    stride += stride_n;
+    vst1q_s64(dst, vsum[0]);
+    dst += 2;
+    vst1q_s64(dst, vsum[1]);
+    dst += 2;
+  }
+  if (rem_n > 1) {
+    const int64_t* din_ptr0 = src + stride;
+    const int64_t* din_ptr1 = din_ptr0 + width_in;
+    int64x2_t vsum = vdupq_n_s64(0);
+    for (int w = 0; w < cnt_w; w++) {
+      int64x2_t va0 = vld1q_s64(din_ptr0);
+      din_ptr0 += 2;
+      int64x2_t vb0 = vld1q_s64(din_ptr1);
+      din_ptr1 += 2;
+      int64x2_t va1 = vld1q_s64(din_ptr0);
+      int64x2_t vb1 = vld1q_s64(din_ptr1);
+#ifdef __aarch64__
+      int64x2_t vs0 = vpaddq_s64(va0, va1);
+      din_ptr0 += 2;
+      int64x2_t vs1 = vpaddq_s64(vb0, vb1);
+      din_ptr1 += 2;
+      int64x2_t vs00 = vpaddq_s64(vs0, vs1);
+      vsum = vaddq_s64(vs00, vsum);
+#else
+      int64x2_t vs;
+      vs[0] = va0[0] + va0[1] + va1[0] + va1[1];
+      vs[1] = vb0[0] + vb0[1] + vb1[0] + vb1[1];
+      din_ptr0 += 2;
+      din_ptr1 += 2;
+      vsum = vaddq_s64(vs, vsum);
+#endif
+    }
+    int tmp = rem_w;
+    if (tmp > 1) {
+      int64x2_t va0 = vld1q_s64(din_ptr0);
+      int64x2_t vb0 = vld1q_s64(din_ptr1);
+      din_ptr0 += 2;
+      din_ptr1 += 2;
+      int64x2_t vs00;
+#ifdef __aarch64__
+      vs00 = vpaddq_s64(va0, vb0);
+#else
+      vs00[0] = va0[0] + va0[1];
+      vs00[1] = vb0[0] + vb0[1];
+#endif
+      tmp -= 2;
+      vsum[0] += vs00[0];
+      vsum[1] += vs00[1];
+    }
+    for (int w = 0; w < tmp; w++) {
+      vsum[0] += *din_ptr0++;
+      vsum[1] += *din_ptr1++;
+    }
+    stride += width_in;
+    *dst++ = vsum[0];
+    stride += width_in;
+    *dst++ = vsum[1];
+    rem_n -= 2;
+  }
+  for (int n = 0; n < rem_n; n++) {
+    const int64_t* din_ptr0 = src + stride;
+    int64x2_t vsum = vdupq_n_s64(0.f);
+    for (int w = 0; w < cnt_w; w++) {
+      int64x2_t va0 = vld1q_s64(din_ptr0);
+      int64x2_t va1 = vld1q_s64(din_ptr0 + 2);
+      int64x2_t vs0 = vaddq_s64(va0, va1);
+      din_ptr0 += 4;
+      vsum = vaddq_s64(vs0, vsum);
+    }
+    if (rem_w > 1) {
+      int64x2_t va0 = vld1q_s64(din_ptr0);
+      din_ptr0 += 2;
+      vsum = vaddq_s64(vsum, va0);
+      rem_w -= 2;
+    }
+    for (int w = 0; w < rem_w; w++) {
+      vsum[0] += *din_ptr0++;
+    }
+    vsum[0] += vsum[1];
+    *dst++ = vsum[0];
+  }
+}
+
+template <>
 void reduce_sum_all<int32_t>(const int32_t* src, int32_t* dst, int all_size) {
   int cnt_n = all_size >> 4;
   int rem_n = all_size & 15;
@@ -634,6 +919,41 @@ void reduce_sum_all<int32_t>(const int32_t* src, int32_t* dst, int all_size) {
     vsum[0] += *src++;
   }
   vsum[1] += vsum[3];
+  vsum[0] += vsum[1];
+  dst[0] = vsum[0];
+}
+
+template <>
+void reduce_sum_all<int64_t>(const int64_t* src, int64_t* dst, int all_size) {
+  int cnt_n = all_size >> 3;
+  int rem_n = all_size & 7;
+  int cnt_rem = rem_n >> 1;
+  int rem_rem = rem_n & 1;
+  int64x2_t vsum = vdupq_n_s64(0);
+  for (int n = 0; n < cnt_n; n++) {
+    int64x2_t va0 = vld1q_s64(src);
+    int64x2_t va1 = vld1q_s64(src + 2);
+    int64x2_t va2 = vld1q_s64(src + 4);
+    int64x2_t va3 = vld1q_s64(src + 6);
+    src += 8;
+    int64x2_t vs0 = vaddq_s64(va0, va1);
+    int64x2_t vs1 = vaddq_s64(va2, va3);
+#ifdef __aarch64__
+    int64x2_t vs = vpaddq_s64(vs0, vs1);
+    vsum = vaddq_s64(vsum, vs);
+#else
+    vsum[0] = vsum[0] + vs0[0] + vs0[1];
+    vsum[1] = vsum[1] + vs1[0] + vs1[1];
+#endif
+  }
+  for (int n = 0; n < cnt_rem; n++) {
+    int64x2_t va0 = vld1q_s64(src);
+    src += 2;
+    vsum = vaddq_s64(vsum, va0);
+  }
+  for (int n = 0; n < rem_rem; n++) {
+    vsum[0] += *src++;
+  }
   vsum[0] += vsum[1];
   dst[0] = vsum[0];
 }
@@ -722,6 +1042,12 @@ template void reduce_sum_c<int32_t>(const int32_t* src,
                                     int channel_in,
                                     int height_in,
                                     int width_in);
+template void reduce_sum_c<int64_t>(const int64_t* src,
+                                    int64_t* dst,
+                                    int num_in,
+                                    int channel_in,
+                                    int height_in,
+                                    int width_in);
 template void reduce_sum_h<float>(const float* src,
                                   float* dst,
                                   int num_in,
@@ -730,6 +1056,12 @@ template void reduce_sum_h<float>(const float* src,
                                   int width_in);
 template void reduce_sum_h<int32_t>(const int32_t* src,
                                     int32_t* dst,
+                                    int num_in,
+                                    int channel_in,
+                                    int height_in,
+                                    int width_in);
+template void reduce_sum_h<int64_t>(const int64_t* src,
+                                    int64_t* dst,
                                     int num_in,
                                     int channel_in,
                                     int height_in,
@@ -746,6 +1078,12 @@ template void reduce_sum_nc<int32_t>(const int32_t* src,
                                      int channel_in,
                                      int height_in,
                                      int width_in);
+template void reduce_sum_nc<int64_t>(const int64_t* src,
+                                     int64_t* dst,
+                                     int num_in,
+                                     int channel_in,
+                                     int height_in,
+                                     int width_in);
 template void reduce_sum_ch<float>(const float* src,
                                    float* dst,
                                    int num_in,
@@ -754,6 +1092,12 @@ template void reduce_sum_ch<float>(const float* src,
                                    int width_in);
 template void reduce_sum_ch<int32_t>(const int32_t* src,
                                      int32_t* dst,
+                                     int num_in,
+                                     int channel_in,
+                                     int height_in,
+                                     int width_in);
+template void reduce_sum_ch<int64_t>(const int64_t* src,
+                                     int64_t* dst,
                                      int num_in,
                                      int channel_in,
                                      int height_in,
@@ -770,6 +1114,13 @@ template void reduce_sum_hw<int32_t>(const int32_t* src,
                                      int channel_in,
                                      int height_in,
                                      int width_in);
+template void reduce_sum_hw<int64_t>(const int64_t* src,
+                                     int64_t* dst,
+                                     int num_in,
+                                     int channel_in,
+                                     int height_in,
+                                     int width_in);
+
 }  // namespace math
 }  // namespace arm
 }  // namespace lite

--- a/lite/core/optimizer/mir/memory_optimize_pass.cc
+++ b/lite/core/optimizer/mir/memory_optimize_pass.cc
@@ -74,6 +74,7 @@ void MemoryOptimizePass::CollectLifeCycleByDevice(
       "fetch",
       "cast",
       "expand",
+      "share_data",
   };
 
   auto insert_invalid_op_nodes_for_specific_target = [&](

--- a/lite/kernels/arm/reduce_max_compute.cc
+++ b/lite/kernels/arm/reduce_max_compute.cc
@@ -158,3 +158,8 @@ REGISTER_LITE_KERNEL(reduce_max, kARM, kFloat, kNCHW, int64_reduce_max, i64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
+using int32_reduce_max = paddle::lite::kernels::arm::ReduceMaxCompute<int32_t>;
+REGISTER_LITE_KERNEL(reduce_max, kARM, kFloat, kNCHW, int32_reduce_max, i32)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .Finalize();

--- a/lite/kernels/arm/reduce_sum_compute.cc
+++ b/lite/kernels/arm/reduce_sum_compute.cc
@@ -45,8 +45,9 @@ void ReduceSumCompute<T, Ptype>::Run() {
     if (x_vec.size() >= 5 && x_vec[0] == 1) {
       x_vec.erase(x_vec.begin());
       for (auto& val : dim) val--;
-    } else
+    } else {
       break;
+    }
   }
   auto x_dims = lite::DDim(x_vec);
 
@@ -116,6 +117,8 @@ using reduce_sum_arm_int32 =
     paddle::lite::kernels::arm::ReduceSumCompute<int, PRECISION(kFloat)>;
 using reduce_sum_arm_float =
     paddle::lite::kernels::arm::ReduceSumCompute<float, PRECISION(kFloat)>;
+using reduce_sum_arm_int64 =
+    paddle::lite::kernels::arm::ReduceSumCompute<int64_t, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
     reduce_sum, kARM, kFloat, kNCHW, reduce_sum_arm_int32, def_int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
@@ -125,4 +128,10 @@ REGISTER_LITE_KERNEL(
 REGISTER_LITE_KERNEL(reduce_sum, kARM, kFloat, kNCHW, reduce_sum_arm_float, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFloat))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    reduce_sum, kARM, kFloat, kNCHW, reduce_sum_arm_int64, def_int64)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();

--- a/lite/kernels/host/CMakeLists.txt
+++ b/lite/kernels/host/CMakeLists.txt
@@ -29,6 +29,9 @@ add_kernel(assign_value_compute_host Host basic SRCS assign_value_compute.cc)
 add_kernel(yolo_box_compute_host Host basic SRCS yolo_box_compute.cc)
 add_kernel(write_back_compute_host Host basic SRCS write_back_compute.cc)
 add_kernel(cast_compute_host Host basic SRCS cast_compute.cc)
+add_kernel(set_value Host basic SRCS set_value_compute.cc)
+add_kernel(share_data_compute_host Host basic SRCS share_data_compute.cc)
+add_kernel(round_compute_host Host basic SRCS round_compute.cc)
 
 # extra kernels
 add_kernel(reverse_compute_host Host extra SRCS reverse_compute.cc)

--- a/lite/kernels/host/elementwise_op_func.h
+++ b/lite/kernels/host/elementwise_op_func.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstring>
 #include <functional>
 #include <utility>
@@ -410,6 +411,7 @@ void BatchElementWiseArg<Elem_t, DimValue_t>::Update(
       }
       break;
     }
+
     default: {
       return;  // code should never goes to here
     }
@@ -525,6 +527,7 @@ void common_elmentwise_op_naive_cpu(
       }
       break;
     }
+    default: { return; }
   }
 }
 

--- a/lite/kernels/host/expand_v2_compute.cc
+++ b/lite/kernels/host/expand_v2_compute.cc
@@ -97,6 +97,27 @@ void ExpandV2Compute<T, PType>::Run() {
 }  // namespace lite
 }  // namespace paddle
 
+using expand_v2_bool =
+    paddle::lite::kernels::host::ExpandV2Compute<bool, PRECISION(kFloat)>;
+REGISTER_LITE_KERNEL(expand_v2, kHost, kFloat, kAny, expand_v2_bool, def_bool)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kBool),
+                                      DATALAYOUT(kAny))})
+    .BindInput("Shape",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kInt32),
+                                      DATALAYOUT(kAny))})
+    .BindInput("expand_shapes_tensor",
+               {LiteType::GetTensorTy(TARGET(kHost),
+                                      PRECISION(kInt32),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost),
+                                       PRECISION(kBool),
+                                       DATALAYOUT(kAny))})
+    .Finalize();
+
 using expand_v2_float =
     paddle::lite::kernels::host::ExpandV2Compute<float, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(expand_v2, kHost, kFloat, kAny, expand_v2_float, def)

--- a/lite/kernels/host/round_compute.cc
+++ b/lite/kernels/host/round_compute.cc
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/host/round_compute.h"
+#include "lite/kernels/host/elementwise_op_func.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <typename T>
+void RoundCompute<T>::Run() {
+  auto& param = Param<operators::RoundParam>();
+  const lite::Tensor* input = param.X;
+  lite::Tensor* output = param.Out;
+
+  output->Resize(input->dims());
+
+  auto out_num = output->dims().production();
+  for (int i = 0; i < out_num; ++i) {
+    output->mutable_data<T>()[i] = std::round(input->data<T>()[i]);
+  }
+
+  return;
+}
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(round,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::RoundCompute<float>,
+                     fp32)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFloat))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindPaddleOpVersion("round", 1)
+    .Finalize();

--- a/lite/kernels/host/round_compute.h
+++ b/lite/kernels/host/round_compute.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <typename T>
+class RoundCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
+ public:
+  using param_t = operators::RoundParam;
+  void Run() override;
+  virtual ~RoundCompute() = default;
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/host/set_value_compute.cc
+++ b/lite/kernels/host/set_value_compute.cc
@@ -1,0 +1,240 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/host/set_value_compute.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+template <typename D>
+void SetValueCompute<D>::Run() {
+  auto& param = *param_.get_mutable<param_t>();
+#define SET_VALUE_WITH_TENSOR(__starts__, __ends__, __steps__) \
+  if (param.ValueTensor != nullptr) {                          \
+    SetTensorValueKernel<D>(param.Input,                       \
+                            param.ValueTensor,                 \
+                            __starts__,                        \
+                            __ends__,                          \
+                            __steps__,                         \
+                            param.axes,                        \
+                            param.decrease_axes,               \
+                            param.none_axes,                   \
+                            param.Out);                        \
+    return;                                                    \
+  }
+
+#define SET_VALUE(__precision__, __starts__, __ends__, __steps__, __values__) \
+  if (!__values__.empty()) {                                                  \
+    SetValue<__precision__>(param.Input,                                      \
+                            __starts__,                                       \
+                            __ends__,                                         \
+                            __steps__,                                        \
+                            param.axes,                                       \
+                            param.decrease_axes,                              \
+                            param.none_axes,                                  \
+                            param.shape,                                      \
+                            __values__,                                       \
+                            param.Out);                                       \
+    return;                                                                   \
+  }
+
+  if (param.StartsTensorList.size() > 0) {
+    auto starts = GetDataFromTensorList(param.StartsTensorList);
+    if (param.EndsTensorList.size() > 0) {
+      auto ends = GetDataFromTensorList(param.EndsTensorList);
+      if (param.StepsTensorList.size() > 0) {
+        auto steps = GetDataFromTensorList(param.StepsTensorList);
+        SET_VALUE_WITH_TENSOR(starts, ends, steps)
+        SET_VALUE(float, starts, ends, steps, param.fp32_values)
+        SET_VALUE(double, starts, ends, steps, param.fp64_values)
+        SET_VALUE(int, starts, ends, steps, param.int32_values)
+        SET_VALUE(int64_t, starts, ends, steps, param.int64_values)
+        SET_VALUE(int, starts, ends, steps, param.bool_values)
+      } else {
+        SET_VALUE_WITH_TENSOR(starts, ends, param.steps)
+        SET_VALUE(float, starts, ends, param.steps, param.fp32_values)
+        SET_VALUE(double, starts, ends, param.steps, param.fp64_values)
+        SET_VALUE(int, starts, ends, param.steps, param.int32_values)
+        SET_VALUE(int64_t, starts, ends, param.steps, param.int64_values)
+        SET_VALUE(int, starts, ends, param.steps, param.bool_values)
+      }
+    } else {
+      if (param.StepsTensorList.size() > 0) {
+        auto steps = GetDataFromTensorList(param.StepsTensorList);
+        SET_VALUE_WITH_TENSOR(starts, param.ends, steps)
+        SET_VALUE(float, starts, param.ends, steps, param.fp32_values)
+        SET_VALUE(double, starts, param.ends, steps, param.fp64_values)
+        SET_VALUE(int, starts, param.ends, steps, param.int32_values)
+        SET_VALUE(int64_t, starts, param.ends, steps, param.int64_values)
+        SET_VALUE(int, starts, param.ends, steps, param.bool_values)
+      } else {
+        SET_VALUE_WITH_TENSOR(starts, param.ends, param.steps)
+        SET_VALUE(float, starts, param.ends, param.steps, param.fp32_values)
+        SET_VALUE(double, starts, param.ends, param.steps, param.fp64_values)
+        SET_VALUE(int, starts, param.ends, param.steps, param.int32_values)
+        SET_VALUE(int64_t, starts, param.ends, param.steps, param.int64_values)
+        SET_VALUE(int, starts, param.ends, param.steps, param.bool_values)
+      }
+    }
+  } else {
+    if (param.EndsTensorList.size() > 0) {
+      auto ends = GetDataFromTensorList(param.EndsTensorList);
+      if (param.StepsTensorList.size() > 0) {
+        auto steps = GetDataFromTensorList(param.StepsTensorList);
+        SET_VALUE_WITH_TENSOR(param.starts, ends, steps)
+        SET_VALUE(float, param.starts, ends, steps, param.fp32_values)
+        SET_VALUE(double, param.starts, ends, steps, param.fp64_values)
+        SET_VALUE(int, param.starts, ends, steps, param.int32_values)
+        SET_VALUE(int64_t, param.starts, ends, steps, param.int64_values)
+        SET_VALUE(int, param.starts, ends, steps, param.bool_values)
+      } else {
+        SET_VALUE_WITH_TENSOR(param.starts, ends, param.steps)
+        SET_VALUE(float, param.starts, ends, param.steps, param.fp32_values)
+        SET_VALUE(double, param.starts, ends, param.steps, param.fp64_values)
+        SET_VALUE(int, param.starts, ends, param.steps, param.int32_values)
+        SET_VALUE(int64_t, param.starts, ends, param.steps, param.int64_values)
+        SET_VALUE(int, param.starts, ends, param.steps, param.bool_values)
+      }
+    } else {
+      if (param.StepsTensorList.size() > 0) {
+        auto steps = GetDataFromTensorList(param.StepsTensorList);
+        SET_VALUE_WITH_TENSOR(param.starts, param.ends, steps)
+        SET_VALUE(float, param.starts, param.ends, steps, param.fp32_values)
+        SET_VALUE(double, param.starts, param.ends, steps, param.fp64_values)
+        SET_VALUE(int, param.starts, param.ends, steps, param.int32_values)
+        SET_VALUE(int64_t, param.starts, param.ends, steps, param.int64_values)
+        SET_VALUE(int, param.starts, param.ends, steps, param.bool_values)
+      } else {
+        SET_VALUE_WITH_TENSOR(param.starts, param.ends, param.steps)
+        SET_VALUE(
+            float, param.starts, param.ends, param.steps, param.fp32_values)
+        SET_VALUE(
+            double, param.starts, param.ends, param.steps, param.fp64_values)
+        SET_VALUE(
+            int, param.starts, param.ends, param.steps, param.int32_values)
+        SET_VALUE(
+            int64_t, param.starts, param.ends, param.steps, param.int64_values)
+        SET_VALUE(int, param.starts, param.ends, param.steps, param.bool_values)
+      }
+    }
+  }
+#undef SET_VALUE_WITH_TENSOR
+#undef SET_VALUE
+}
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+// float
+REGISTER_LITE_KERNEL(set_value,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::SetValueCompute<float>,
+                     fp32)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFloat))})
+    .BindInput("ValueTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StepsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFloat))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(set_value,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::SetValueCompute<int>,
+                     int32)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindInput("ValueTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StepsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(set_value,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::SetValueCompute<int64_t>,
+                     int64)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt64))})
+    .BindInput("ValueTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StepsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt64))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(set_value,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::SetValueCompute<int>,
+                     bool)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kBool))})
+    .BindInput("ValueTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StepsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kBool))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(set_value,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::SetValueCompute<double>,
+                     double)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFP64))})
+    .BindInput("ValueTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StepsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kFP64))})
+    .Finalize();

--- a/lite/kernels/host/set_value_compute.h
+++ b/lite/kernels/host/set_value_compute.h
@@ -253,6 +253,10 @@ class SetValueCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
     CheckAndUpdateSliceAttrs<int64_t>(in_dims, axes, &starts, &ends, &steps);
     auto slice_dims =
         GetSliceDims<int64_t>(in_dims, axes, starts, ends, &steps);
+    if (!slice_dims.production()) {
+      out->CopyDataFrom(*input);
+      return;
+    }
     auto decrease_slice_dims =
         GetDecreasedDims<int64_t>(slice_dims, decrease_axes);
     auto slice_dims_for_assign = decrease_slice_dims;

--- a/lite/kernels/host/set_value_compute.h
+++ b/lite/kernels/host/set_value_compute.h
@@ -1,0 +1,420 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <algorithm>
+#include <vector>
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+#include "lite/kernels/host/elementwise_op_func.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+// check whether the tensor with dimension of second can assign to the
+// tensor with dimension of first
+inline void CheckIsDimsMatch(const DDim& first, const DDim& second) {
+  int ignore_axis1 = 0, ignore_axis2 = 0;
+  for (; ignore_axis1 < first.size(); ++ignore_axis1) {
+    if (first[ignore_axis1] != 1) {
+      break;
+    }
+  }
+  for (; ignore_axis2 < second.size(); ++ignore_axis2) {
+    if (second[ignore_axis2] != 1) {
+      break;
+    }
+  }
+
+  if (second.size() == ignore_axis2) {
+    // second tensor has only one value
+    return;
+  }
+
+  if (first.size() - ignore_axis1 >= second.size() - ignore_axis2) {
+    int idx1 = first.size() - 1;
+    int idx2 = second.size() - 1;
+    bool is_match = true;
+    for (; idx2 >= ignore_axis2; idx2--) {
+      if (first[idx1--] != second[idx2] && second[idx2] != 1) {
+        is_match = false;
+        break;
+      }
+    }
+    if (is_match) {
+      return;
+    }
+  }
+  LOG(FATAL) << "The shape of tensor assigned value must match the shape of "
+                "target shape: "
+             << second << "but now shape is " << first << ".";
+}
+
+template <typename T = int64_t>
+void CheckAndUpdateSliceAttrs(const DDim in_dims,
+                              const std::vector<T>& axes,
+                              std::vector<T>* starts,
+                              std::vector<T>* ends,
+                              std::vector<int64_t>* steps = nullptr,
+                              std::vector<T>* infer_flags = nullptr) {
+  for (size_t i = 0; i < axes.size(); ++i) {
+    T axis = axes[i];
+    CHECK_LT(axis, in_dims.size()) << "The axis value should be less than "
+                                      "the rank of input, but received axes["
+                                   << i << "] = " << axis << "rank of input is "
+                                   << in_dims.size() << ".";
+
+    if (infer_flags != nullptr && (*infer_flags)[i] == -1) {
+      continue;
+    }
+
+    T dim_value = in_dims[axis];
+
+    if (dim_value > 0) {
+      T step = steps == nullptr ? 1 : (*steps)[i];
+      CHECK_NE(step, 0) << "Step should not be 0, but received step = " << step
+                        << ".";
+      T start = (*starts)[i] < 0 ? ((*starts)[i] + dim_value) : (*starts)[i];
+      start = std::max(start, static_cast<T>(0));
+
+      T end =
+          0 < step && (*ends)[i] < 0 ? ((*ends)[i] + dim_value) : (*ends)[i];
+      end = std::min(end, dim_value);
+
+      if (step > 0) {
+        start = std::min(start, dim_value);
+        end = std::max(end, static_cast<T>(0));
+        CHECK_GE(end, start)
+            << "When step > 0, end should be greater than start, but "
+               "received end = "
+            << end << ", start = " << start << ".";
+      } else {
+        start = std::min(start, dim_value - 1);
+        if (end < -1) {
+          end += dim_value;
+        }
+        end = std::max(end, static_cast<T>(-1));
+        CHECK_GE(start, end)
+            << "When step < 0, start should be greater than end, but "
+               "received end = "
+            << end << ", start = " << start << ".";
+      }
+
+      (*starts)[i] = start;
+      (*ends)[i] = end;
+    } else if (dim_value == 0) {
+      (*starts)[i] = 0;
+      (*ends)[i] = 0;
+    }
+  }
+}
+
+template <typename T = int64_t>
+DDim GetSliceDims(const DDim in_dims,
+                  const std::vector<T>& axes,
+                  const std::vector<T>& starts,
+                  const std::vector<T>& ends,
+                  std::vector<T>* steps = nullptr,
+                  std::vector<T>* infer_flags = nullptr) {
+  DDim slice_dims(in_dims);
+
+  for (size_t i = 0; i < axes.size(); ++i) {
+    T axis = axes[i];
+    if (infer_flags != nullptr && (*infer_flags)[i] == -1) {
+      slice_dims[axis] = -1;
+      continue;
+    }
+
+    if (in_dims[axis] == -1) {
+      continue;
+    }
+
+    T start = starts[i];
+    T end = ends[i];
+    T step = steps == nullptr ? 1 : (*steps)[i];
+
+    if (step > 0) {
+      slice_dims[axis] = (end - start + step - 1) / step;
+    } else {
+      slice_dims[axis] = (end - start + step + 1) / step;
+    }
+  }
+  return slice_dims;
+}
+
+template <typename T = int64_t>
+inline DDim GetDecreasedDims(const DDim slice_dims,
+                             const std::vector<T>& decrease_axes,
+                             std::vector<T>* infer_flags = nullptr) {
+  DDim decreased_dims(slice_dims);
+  std::vector<uint8_t> decrease_flag(slice_dims.size(), 0);
+  if (decrease_axes.size() > 0) {
+    for (size_t i = 0; i < decrease_axes.size(); ++i) {
+      T axis = decrease_axes[i];
+      decrease_flag[axis] = 1;
+      if (infer_flags && (*infer_flags)[i] != -1) {
+        CHECK_EQ(decreased_dims[axis], 1)
+            << "Decrease dim should be 1, but now received "
+            << decreased_dims[axis] << ".";
+      }
+    }
+
+    std::vector<T> new_shape;
+    for (int i = 0; i < decreased_dims.size(); ++i) {
+      if (decrease_flag[i] == 0) {
+        new_shape.push_back(decreased_dims[i]);
+      }
+    }
+
+    if (new_shape.size() == 0) {
+      new_shape.push_back(1);
+    }
+
+    decreased_dims = DDim(new_shape);
+  }
+  return decreased_dims;
+}
+
+static inline std::vector<int64_t> GetDataFromTensorList(
+    const std::vector<const lite::Tensor*>& tensor_list) {
+  // get tensor
+  std::vector<int64_t> vec_new_data;
+  for (size_t i = 0; i < tensor_list.size(); ++i) {
+    auto tensor = tensor_list[i];
+    CHECK_EQ(tensor->dims(), DDim({1})) << "shape of dim tensor should be [1]";
+    vec_new_data.push_back(static_cast<int64_t>(*tensor->data<int>()));
+  }
+  return vec_new_data;
+}
+
+template <typename T>
+void stride_slice_reverse_assign(T* input,
+                                 T* val,
+                                 std::vector<int64_t> in_dims,
+                                 std::vector<int64_t> val_dims,
+                                 std::vector<int64_t> starts_indices,
+                                 std::vector<int64_t> ends_indices,
+                                 std::vector<int64_t> strides_indices) {
+  size_t in_dims_size = in_dims.size();
+  std::vector<int> dst_step;
+  std::vector<int> src_step;
+  for (size_t i = 0; i < in_dims_size; ++i) {
+    dst_step.push_back(1);
+    src_step.push_back(1);
+  }
+  int val_num = val_dims[in_dims_size - 1];
+  for (int i = in_dims_size - 2; i >= 0; i--) {
+    dst_step[i] = val_dims[i + 1] * dst_step[i + 1];
+    src_step[i] = in_dims[i + 1] * src_step[i + 1];
+    val_num *= val_dims[i];
+  }
+
+  for (int dst_id = 0; dst_id < val_num; dst_id++) {
+    int src_id = 0;
+    int index_id = dst_id;
+    for (size_t j = 0; j < val_dims.size(); j++) {
+      int cur_id = index_id / dst_step[j];
+      index_id = index_id % dst_step[j];
+      src_id += (cur_id * strides_indices[j] + starts_indices[j]) * src_step[j];
+    }
+    input[src_id] = val[dst_id];
+  }
+}
+
+template <typename D>
+class SetValueCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
+ public:
+  using param_t = operators::SetValueParam;
+
+  template <typename T, size_t RANK>
+  void SetValueImpl(const lite::Tensor* input,
+                    const lite::Tensor* value,
+                    std::vector<int64_t>& starts,
+                    std::vector<int64_t>& ends,
+                    std::vector<int64_t>& steps,
+                    const std::vector<int64_t>& axes,
+                    const std::vector<int64_t>& decrease_axes,
+                    const std::vector<int64_t>& none_axes,
+                    lite::Tensor* out) {
+    auto in_dims = input->dims();
+    CheckAndUpdateSliceAttrs<int64_t>(in_dims, axes, &starts, &ends, &steps);
+    auto slice_dims =
+        GetSliceDims<int64_t>(in_dims, axes, starts, ends, &steps);
+    auto decrease_slice_dims =
+        GetDecreasedDims<int64_t>(slice_dims, decrease_axes);
+    auto slice_dims_for_assign = decrease_slice_dims;
+
+    if (!none_axes.empty()) {
+      std::vector<int64_t> slice_dims_with_none;
+
+      size_t none_axes_cur = 0, decrease_axes_cur = 0;
+      for (int i = 0; i < slice_dims.size(); ++i) {
+        while (none_axes_cur < none_axes.size() &&
+               none_axes[none_axes_cur] <= i) {
+          slice_dims_with_none.push_back(1);
+          none_axes_cur++;
+        }
+        if (decrease_axes_cur < decrease_axes.size() &&
+            decrease_axes[decrease_axes_cur] == i) {
+          decrease_axes_cur++;
+        } else {
+          slice_dims_with_none.push_back(slice_dims[i]);
+        }
+      }
+      while (none_axes_cur < none_axes.size()) {
+        slice_dims_with_none.push_back(1);
+        none_axes_cur++;
+      }
+      slice_dims_for_assign = DDim(slice_dims_with_none);
+    }
+
+    out->Resize(in_dims);
+    out->CopyDataFrom(*input);
+
+    lite::Tensor slice_tensor;
+    lite::Tensor pad_tensor;
+    slice_tensor.Resize(slice_dims);
+    slice_tensor.mutable_data<T>();
+    pad_tensor.Resize(in_dims);
+    pad_tensor.mutable_data<T>();
+
+    std::function<T(T, T)> SubFunc = naive_sub<T>;
+
+    // Step 1: Set the value of out at `_index` to zero
+    std::vector<int64_t> starts_indices;
+    std::vector<int64_t> ends_indices;
+    std::vector<int64_t> strides_indices;
+    for (size_t axis = 0; axis < in_dims.size(); axis++) {
+      starts_indices.push_back(0);
+      ends_indices.push_back(slice_dims[axis]);
+      strides_indices.push_back(1);
+    }
+    for (size_t axis = 0; axis < axes.size(); axis++) {
+      int axis_index = axes[axis];
+      starts_indices[axis_index] = starts[axis];
+      ends_indices[axis_index] = ends[axis];
+      strides_indices[axis_index] = steps[axis];
+    }
+    memset(slice_tensor.mutable_data<T>(), 0, slice_tensor.memory_size());
+    stride_slice_reverse_assign(out->mutable_data<T>(),
+                                slice_tensor.mutable_data<T>(),
+                                in_dims.data(),
+                                slice_dims.data(),
+                                starts_indices,
+                                ends_indices,
+                                strides_indices);
+
+    // Step 2: Set a tensor with the same shape as out tensor. And its data at
+    // '_index' is the same as value, and data out of '_index' to zero
+    slice_tensor.Resize(slice_dims_for_assign);
+    CheckIsDimsMatch(slice_dims_for_assign, value->dims());
+    // ElementwiseComputeEx can do broadcasting
+    auto batch_arg0 = lite::kernels::host::GenBatchElementWiseArg<T>(
+        &slice_tensor, value, &slice_tensor);
+    common_elmentwise_op_naive_cpu(batch_arg0, SubFunc);
+    slice_tensor.Resize(slice_dims);
+    // - Step 2.2 Pad slice tensor with 0
+    memset(pad_tensor.mutable_data<T>(), 0, pad_tensor.memory_size());
+
+    stride_slice_reverse_assign(pad_tensor.mutable_data<T>(),
+                                slice_tensor.mutable_data<T>(),
+                                in_dims.data(),
+                                slice_dims.data(),
+                                starts_indices,
+                                ends_indices,
+                                strides_indices);
+
+    // Step 3: Set out tensor with value
+    auto batch_arg1 =
+        lite::kernels::host::GenBatchElementWiseArg<T>(out, &pad_tensor, out);
+    common_elmentwise_op_naive_cpu(batch_arg1, SubFunc);
+  }
+
+  template <typename T>
+  void SetValue(const lite::Tensor* input,
+                std::vector<int64_t>& starts,
+                std::vector<int64_t>& ends,
+                std::vector<int64_t>& steps,
+                const std::vector<int64_t>& axes,
+                const std::vector<int64_t>& decrease_axes,
+                const std::vector<int64_t>& none_axes,
+                const std::vector<int64_t>& shape,
+                const std::vector<T>& values,
+                lite::Tensor* out) {
+    lite::Tensor value_tensor;
+    value_tensor.Resize(shape);
+    T* value_tensor_data = value_tensor.mutable_data<T>();
+    std::memcpy(static_cast<void*>(value_tensor_data),
+                static_cast<const void*>(values.data()),
+                sizeof(T) * values.size());
+    SetTensorValueKernel<T>(input,
+                            &value_tensor,
+                            starts,
+                            ends,
+                            steps,
+                            axes,
+                            decrease_axes,
+                            none_axes,
+                            out);
+  }
+
+  template <typename T>
+  void SetTensorValueKernel(const lite::Tensor* input,
+                            const lite::Tensor* value,
+                            std::vector<int64_t>& starts,
+                            std::vector<int64_t>& ends,
+                            std::vector<int64_t>& steps,
+                            const std::vector<int64_t>& axes,
+                            const std::vector<int64_t>& decrease_axes,
+                            const std::vector<int64_t>& none_axes,
+                            lite::Tensor* out) {
+    const int rank = input->dims().size();
+    switch (rank) {
+#define SET_VALUE_IMPL(rank)             \
+  case rank: {                           \
+    SetValueImpl<T, rank>(input,         \
+                          value,         \
+                          starts,        \
+                          ends,          \
+                          steps,         \
+                          axes,          \
+                          decrease_axes, \
+                          none_axes,     \
+                          out);          \
+    break;                               \
+  }
+      SET_VALUE_IMPL(1)
+      SET_VALUE_IMPL(2)
+      SET_VALUE_IMPL(3)
+      SET_VALUE_IMPL(4)
+      SET_VALUE_IMPL(5)
+      SET_VALUE_IMPL(6)
+      default:
+        LOG(FATAL) << "The rank of input should be less than 7, but received "
+                   << rank;
+        break;
+    }
+  }
+
+  void Run() override;
+
+  virtual ~SetValueCompute() = default;
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/host/share_data_compute.cc
+++ b/lite/kernels/host/share_data_compute.cc
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/host/share_data_compute.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+// template <typename T>
+void ShareDataCompute::Run() {
+  auto& param = Param<operators::ShareDataParam>();
+  const lite::Tensor* input = param.X;
+  lite::Tensor* output = param.Out;
+  output->ShareDataWith(*input);
+  return;
+}
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(share_data,
+                     kHost,
+                     kAny,
+                     kNCHW,
+                     paddle::lite::kernels::host::ShareDataCompute,
+                     def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindPaddleOpVersion("share_data", 1)
+    .Finalize();

--- a/lite/kernels/host/share_data_compute.h
+++ b/lite/kernels/host/share_data_compute.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "lite/core/kernel.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace host {
+
+class ShareDataCompute : public KernelLite<TARGET(kHost), PRECISION(kAny)> {
+ public:
+  using param_t = operators::ShareDataParam;
+  void Run() override;
+  virtual ~ShareDataCompute() = default;
+};
+
+}  // namespace host
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle

--- a/lite/kernels/x86/set_value_compute.h
+++ b/lite/kernels/x86/set_value_compute.h
@@ -58,8 +58,8 @@ inline void CheckIsDimsMatch(const DDim& first, const DDim& second) {
   }
 
   if (first.size() - ignore_axis1 >= second.size() - ignore_axis2) {
-    auto idx1 = first.size() - 1;
-    auto idx2 = second.size() - 1;
+    int idx1 = first.size() - 1;
+    int idx2 = second.size() - 1;
     bool is_match = true;
     for (; idx2 >= ignore_axis2; idx2--) {
       if (first[idx1--] != second[idx2] && second[idx2] != 1) {

--- a/lite/operators/CMakeLists.txt
+++ b/lite/operators/CMakeLists.txt
@@ -59,6 +59,8 @@ add_operator(write_back_op basic SRCS write_back_op.cc)
 add_operator(lod_array_length_op basic SRCS lod_array_length_op.cc)
 add_operator(unbind_op basic SRCS unbind_op.cc)
 add_operator(set_value basic SRCS set_value_op.cc)
+add_operator(share_data basic SRCS share_data_op.cc)
+add_operator(round basic SRCS round_op.cc)
 
 add_operator(pow_op extra SRCS pow_op.cc)
 add_operator(sign_op extra SRCS sign_op.cc)

--- a/lite/operators/op_params.h
+++ b/lite/operators/op_params.h
@@ -2320,6 +2320,16 @@ struct SetValueParam : ParamBase {
   std::vector<int64_t> shape{};
 };
 
+struct ShareDataParam : ParamBase {
+  const lite::Tensor* X{};
+  lite::Tensor* Out{};
+};
+
+struct RoundParam : ParamBase {
+  const lite::Tensor* X{};
+  lite::Tensor* Out{};
+};
+
 }  // namespace operators
 }  // namespace lite
 }  // namespace paddle

--- a/lite/operators/round_op.cc
+++ b/lite/operators/round_op.cc
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/round_op.h"
+
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+bool RoundOp::CheckShape() const {
+  CHECK(param_.X);
+  CHECK(param_.Out);
+  return true;
+}
+
+bool RoundOp::InferShapeImpl() const {
+  param_.Out->Resize(param_.X->dims());
+  return true;
+}
+
+bool RoundOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
+  // Input
+  auto input_name = opdesc.Input("X").front();
+  param_.X = GetTensor(scope, input_name);
+
+  // Out
+  auto out_name = opdesc.Output("Out").front();
+  param_.Out = GetMutableTensor(scope, out_name);
+  return true;
+}
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_OP(round, paddle::lite::operators::RoundOp);

--- a/lite/operators/round_op.h
+++ b/lite/operators/round_op.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+#include "lite/core/op_lite.h"
+#include "lite/core/scope.h"
+#include "lite/utils/all.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+class RoundOp : public OpLite {
+ public:
+  RoundOp() {}
+
+  explicit RoundOp(const std::string &op_type) : OpLite(op_type) {}
+
+  bool CheckShape() const override;
+
+  bool InferShapeImpl() const override;
+
+  bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+  std::string DebugString() const override { return "round"; }
+
+  bool InferType() override { return true; }
+
+ private:
+  mutable RoundParam param_;
+};
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle

--- a/lite/operators/set_value_op.cc
+++ b/lite/operators/set_value_op.cc
@@ -21,18 +21,23 @@ namespace lite {
 namespace operators {
 
 bool SetValueOp::CheckShape() const {
+  CHECK(param_.Input);
   CHECK(param_.Out);
   return true;
 }
 
-bool SetValueOp::InferShapeImpl() const { return true; }
+bool SetValueOp::InferShapeImpl() const {
+  param_.Out->Resize(param_.Input->dims());
+  return true;
+}
 
 bool SetValueOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
   // Input
   auto input_name = opdesc.Input("Input").front();
   param_.Input = GetTensor(scope, input_name);
+
   // ValueTensor
-  if (opdesc.HasInput("ValueTensor")) {
+  if (opdesc.HasInput("ValueTensor") && !opdesc.Input("ValueTensor").empty()) {
     auto value_tensor_name = opdesc.Input("ValueTensor").front();
     param_.ValueTensor = GetTensor(scope, value_tensor_name);
   }

--- a/lite/operators/share_data_op.cc
+++ b/lite/operators/share_data_op.cc
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/operators/share_data_op.h"
+
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+bool ShareDataOp::CheckShape() const {
+  CHECK(param_.X);
+  CHECK(param_.Out);
+  return true;
+}
+
+bool ShareDataOp::InferShapeImpl() const {
+  param_.Out->Resize(param_.X->dims());
+  return true;
+}
+
+bool ShareDataOp::AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) {
+  // Input
+  auto input_name = opdesc.Input("X").front();
+  param_.X = GetTensor(scope, input_name);
+
+  // Out
+  auto out_name = opdesc.Output("Out").front();
+  param_.Out = GetMutableTensor(scope, out_name);
+  return true;
+}
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_OP(share_data, paddle::lite::operators::ShareDataOp);

--- a/lite/operators/share_data_op.h
+++ b/lite/operators/share_data_op.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+#include "lite/core/op_lite.h"
+#include "lite/core/scope.h"
+#include "lite/utils/all.h"
+
+namespace paddle {
+namespace lite {
+namespace operators {
+
+class ShareDataOp : public OpLite {
+ public:
+  ShareDataOp() {}
+
+  explicit ShareDataOp(const std::string &op_type) : OpLite(op_type) {}
+
+  bool CheckShape() const override;
+
+  bool InferShapeImpl() const override;
+
+  bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+  std::string DebugString() const override { return "share_data"; }
+
+  bool InferType() override { return true; }
+
+ private:
+  mutable ShareDataParam param_;
+};
+
+}  // namespace operators
+}  // namespace lite
+}  // namespace paddle

--- a/lite/tests/unittest_py/op/test_round_op.py
+++ b/lite/tests/unittest_py/op/test_round_op.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('../')
+
+from auto_scan_test import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+from functools import partial
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+import numpy as np
+
+
+class TestSetValueOp(AutoScanTest):
+    def __init__(self, *args, **kwargs):
+        AutoScanTest.__init__(self, *args, **kwargs)
+        self.enable_testing_on_place(
+            TargetType.Host, [PrecisionType.FP32],
+            DataLayoutType.NCHW,
+            thread=[1, 4])
+
+    def is_program_valid(self,
+                         program_config: ProgramConfig,
+                         predictor_config: CxxConfig) -> bool:
+        return True
+
+    def sample_program_configs(self, draw):
+        in_shape = draw(
+            st.lists(
+                st.integers(
+                    min_value=1, max_value=10), min_size=1, max_size=4))
+        input_type = draw(st.sampled_from(["float32"]))
+        value_tensor_flag = draw(st.booleans())
+
+        def generate_input(*args, **kwargs):
+            if input_type == "float32":
+                return np.random.normal(1.0, 6.0, in_shape).astype(np.float32)
+
+        share_data_op = OpConfig(
+            type="round",
+            inputs={'X': ['input_data']},
+            outputs={"Out": ["output_data"]},
+            attrs={})
+
+        program_config = ProgramConfig(
+            ops=[share_data_op],
+            weights={},
+            inputs={"input_data": TensorConfig(shape=in_shape)},
+            outputs=["output_data"])
+
+        return program_config
+
+    def sample_predictor_configs(self):
+        return self.get_predictor_configs(), ["round"], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        self.run_and_statis(quant=False, max_examples=100)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[''])

--- a/lite/tests/unittest_py/op/test_set_value_op.py
+++ b/lite/tests/unittest_py/op/test_set_value_op.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('../')
+
+from auto_scan_test import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+from functools import partial
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+import numpy as np
+
+
+class TestSetValueOp(AutoScanTest):
+    def __init__(self, *args, **kwargs):
+        AutoScanTest.__init__(self, *args, **kwargs)
+        self.enable_testing_on_place(
+            TargetType.X86, [PrecisionType.FP32],
+            DataLayoutType.NCHW,
+            thread=[1, 4])
+        self.enable_testing_on_place(
+            TargetType.Host, [PrecisionType.FP32],
+            DataLayoutType.NCHW,
+            thread=[1, 4])
+
+    def is_program_valid(self,
+                         program_config: ProgramConfig,
+                         predictor_config: CxxConfig) -> bool:
+        target_type = predictor_config.target()
+        input_data_type = program_config.inputs["input_data"].dtype
+        # Check config
+        if target_type in [TargetType.X86]:
+            if predictor_config.precision(
+            ) == PrecisionType.FP32 and input_data_type != np.float32:
+                return False
+        return True
+
+    def sample_program_configs(self, draw):
+        in_shape = draw(
+            st.lists(
+                st.integers(
+                    min_value=1, max_value=10), min_size=1, max_size=1))
+
+        input_type = draw(st.sampled_from(["float32"]))
+        value_tensor_flag = draw(st.booleans())
+
+        def generate_input(*args, **kwargs):
+            if input_type == "float32":
+                return np.random.normal(1.0, 6.0, in_shape).astype(np.float32)
+
+        inputs_dict = {'Input': ['input_data']}
+        if value_tensor_flag:
+            inputs_dict['ValueTensor'] = ['value_data']
+        ops_config = OpConfig(
+            type="set_value",
+            inputs=inputs_dict,
+            outputs={"Out": ["output_data"]},
+            attrs={
+                'shape': in_shape,
+                'axes': [0],
+                'starts': [1],
+                'ends': [1],
+                'steps': [1],
+                'decrease_axes': [],
+                'none_axes': [],
+                'fp32_values': [1.0]
+            })
+
+        inputs_data_dict = {
+            "input_data": TensorConfig(data_gen=partial(generate_input))
+        }
+        if value_tensor_flag:
+            inputs_data_dict['value_data'] = TensorConfig(
+                data_gen=partial(generate_input))
+
+        program_config = ProgramConfig(
+            ops=[ops_config],
+            weights={},
+            inputs=inputs_data_dict,
+            outputs=["output_data"])
+
+        return program_config
+
+    def sample_predictor_configs(self):
+        return self.get_predictor_configs(), ["set_value"], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        self.run_and_statis(quant=False, max_examples=25)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[''])

--- a/lite/tests/unittest_py/op/test_share_data_op.py
+++ b/lite/tests/unittest_py/op/test_share_data_op.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+sys.path.append('../')
+
+from auto_scan_test import AutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig, CxxConfig, TargetType, PrecisionType, DataLayoutType, Place
+import unittest
+from functools import partial
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
+import numpy as np
+
+
+class TestSetValueOp(AutoScanTest):
+    def __init__(self, *args, **kwargs):
+        AutoScanTest.__init__(self, *args, **kwargs)
+        self.enable_testing_on_place(
+            TargetType.Host, [PrecisionType.FP32],
+            DataLayoutType.NCHW,
+            thread=[1, 4])
+
+    def is_program_valid(self,
+                         program_config: ProgramConfig,
+                         predictor_config: CxxConfig) -> bool:
+        return True
+
+    def sample_program_configs(self, draw):
+        in_shape = draw(
+            st.lists(
+                st.integers(
+                    min_value=1, max_value=10), min_size=1, max_size=4))
+        input_type = draw(st.sampled_from(["float32"]))
+        value_tensor_flag = draw(st.booleans())
+
+        def generate_input(*args, **kwargs):
+            if input_type == "float32":
+                return np.random.normal(1.0, 6.0, in_shape).astype(np.float32)
+
+        share_data_op = OpConfig(
+            type="share_data",
+            inputs={'X': ['input_data']},
+            outputs={"Out": ["output_data"]},
+            attrs={})
+
+        program_config = ProgramConfig(
+            ops=[share_data_op],
+            weights={},
+            inputs={"input_data": TensorConfig(shape=in_shape)},
+            outputs=["output_data"])
+
+        return program_config
+
+    def sample_predictor_configs(self):
+        return self.get_predictor_configs(), ["share_data"], (1e-5, 1e-5)
+
+    def add_ignore_pass_case(self):
+        pass
+
+    def test(self, *args, **kwargs):
+        self.run_and_statis(quant=False, max_examples=100)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[''])


### PR DESCRIPTION
1. [Host] Add OPs: set_value, share_data, round;  Add expand_v2 Bool registration .
2. [ARM] Add reduce_max INT32  registration;   Add reduce_sum OP INT64 registration and neon implement.
3. [X86] fix a bug in set_value OP.