### PR TITLE
[Benchmark Tool] Update benchmark_bin functions

### DIFF
--- a/lite/api/tools/benchmark/benchmark.cc
+++ b/lite/api/tools/benchmark/benchmark.cc
@@ -133,29 +133,26 @@ void Run(const std::string& model_file,
 #endif
   perf_data.set_init_time(timer.Stop());
 
+  // Get input types
+  auto input_types = lite::Split(FLAGS_input_data_type, ":");
+
   // Set inputs
   if (FLAGS_validation_set.empty()) {
+    auto paths = lite::Split(FLAGS_input_data_path, ":");
     for (size_t i = 0; i < input_shapes.size(); i++) {
       auto input_tensor = predictor->GetInput(i);
-      input_tensor->Resize(input_shapes[i]);
-      // NOTE: Change input data type to other type as you need.
-      auto input_data = input_tensor->mutable_data<float>();
-      auto input_num = lite::ShapeProduction(input_shapes[i]);
+      std::string path;
+
       if (FLAGS_input_data_path.empty()) {
-        for (auto j = 0; j < input_num; j++) {
-          input_data[j] = 1.f;
-        }
+        path = "";
       } else {
-        auto paths = lite::Split(FLAGS_input_data_path, ":");
-        std::ifstream fs(paths[i]);
-        if (!fs.is_open()) {
-          std::cerr << "Open input image " << paths[i] << " error."
-                    << std::endl;
-        }
-        for (int k = 0; k < input_num; k++) {
-          fs >> input_data[k];
-        }
-        fs.close();
+        path = paths[i];
+      }
+
+      if ((i < input_types.size()) && (input_types[i] == "int64")) {
+        setInputValue<int64_t>(input_tensor, input_shapes[i], path);
+      } else { //default input_type float32
+        setInputValue<float>(input_tensor, input_shapes[i], path);
       }
     }
   } else {
@@ -223,6 +220,7 @@ void Run(const std::string& model_file,
   std::stringstream out_ss;
   out_ss << "output tensor num: " << output_tensor_num;
 
+
   for (size_t tidx = 0; tidx < output_tensor_num; ++tidx) {
     std::unique_ptr<const Tensor> output_tensor = predictor->GetOutput(tidx);
     out_ss << "\n--- output tensor " << tidx << " ---\n";
@@ -247,6 +245,22 @@ void Run(const std::string& model_file,
                << "]:" << output_tensor->data<float>()[i] << std::endl;
       }
     }
+
+    //TODO: Only support float for now, add more types if needed.
+    if (!FLAGS_output_data_path.empty()) {
+      std::stringstream out_data;
+      auto output_path = lite::Split(FLAGS_output_data_path, ":");
+      if (output_path.size() <= tidx) {
+        std::cerr << "Fail to write output tensor to file, tensor_output_path not matching output tensor number. "
+                  << std::endl;
+      } else {
+        for (int i = 0; i < ele_num; ++i) {
+            out_data << output_tensor->data<float>()[i] << std::endl;
+        }
+        StoreOutputTensor(out_data, output_path[tidx]);
+      }
+    }
+
   }
 
   // Save benchmark info

--- a/lite/api/tools/benchmark/benchmark.h
+++ b/lite/api/tools/benchmark/benchmark.h
@@ -144,6 +144,16 @@ void StoreBenchmarkResult(const std::string res) {
   }
 }
 
+void StoreOutputTensor(const std::stringstream &data, std::string path) {
+    std::ofstream fs(path);
+    if (!fs.is_open()) {
+      std::cerr << "Fail to open output data file: " << FLAGS_result_path
+                << std::endl;
+    }
+    fs << data.rdbuf();
+    fs.close();
+}
+
 bool CheckFlagsValid() {
   bool ret = true;
   bool is_opt_model =
@@ -412,6 +422,32 @@ const std::string OutputOptModel(const std::string& opt_model_file) {
   StoreBenchmarkResult(ss.str());
   return saved_opt_model_file;
 }
+
+template<typename T>
+void setInputValue(const std::unique_ptr<paddle::lite_api::Tensor> &input_tensor,
+                   std::vector<int64_t> tensor_shape, std::string input_path)
+{
+  input_tensor->Resize(tensor_shape);
+  auto input_data = input_tensor->mutable_data<T>();
+  auto input_num = lite::ShapeProduction(tensor_shape);
+
+  if (input_path.empty()) {
+    for (auto i = 0; i < input_num; i++) {
+        input_data[i] = T(1);
+    }
+  } else {
+    std::ifstream fs(input_path);
+    if (!fs.is_open()) {
+      std::cerr << "Open input image " << input_path << " error."
+                << std::endl;
+    }
+    for (auto i = 0; i < input_num; i++) {
+        fs >> input_data[i];
+    }
+    fs.close();
+  }
+}
+
 
 }  // namespace lite_api
 }  // namespace paddle

--- a/lite/api/tools/benchmark/utils/flags.cc
+++ b/lite/api/tools/benchmark/utils/flags.cc
@@ -24,6 +24,8 @@ DEFINE_string(model_file, "", model_file_msg);
 DEFINE_string(param_file, "", param_file_msg);
 DEFINE_string(input_shape, "", input_shape_msg);
 DEFINE_string(input_data_path, "", input_data_path_msg);
+DEFINE_string(input_data_type, "", input_data_type_msg);
+DEFINE_string(output_data_path, "", output_data_path_msg);
 DEFINE_string(validation_set, "", validation_set_msg);
 DEFINE_bool(show_output_elem, false, show_output_elem_msg);
 

--- a/lite/api/tools/benchmark/utils/flags.h
+++ b/lite/api/tools/benchmark/utils/flags.h
@@ -43,6 +43,19 @@ static const char input_data_path_msg[] =
     "such as /path/to/in.txt for only one input, "
     "/path/to/in0.txt:/path/to/in1.txt for two inputs."
     "The input of model will be 1.0 if this option in not set.";
+static const char input_data_type_msg[] =
+    "Set input types according to the model, "
+    "separated by colon, "
+    "available types: float32, int64. "
+    "Default to float32, if not available."
+    "such as float32 for only one input, "
+    "float32:int64 for two inputs.";
+static const char output_data_path_msg[] =
+    "Set the path(s) of model output, "
+    "separated by comma and colon, "
+    "such as /path/to/out.txt for only one input, "
+    "/path/to/out0.txt:/path/to/out1.txt for two inputs."
+    "The output of model will not be saved to file.";
 static const char validation_set_msg[] =
     "Use validation images and lables as inputs. Only supports a minival "
     "dataset of ILSVRC_2012 as inputs."
@@ -118,7 +131,9 @@ DECLARE_string(uncombined_model_dir);
 DECLARE_string(model_file);
 DECLARE_string(param_file);
 DECLARE_string(input_shape);
+DECLARE_string(input_data_type);
 DECLARE_string(input_data_path);
+DECLARE_string(output_data_path);
 DECLARE_string(validation_set);
 DECLARE_bool(show_output_elem);
 


### PR DESCRIPTION
Update benchmark_bin functions:
1. Add flag input_data_type to handle different data types: in64, float32.

static const char input_data_type_msg[] =
    "Set input types according to the model, "
     "separated by colon, "
     "available types: float32, int64. "
     "Default to float32, if not available."
     "such as float32 for only one input, "
     "float32:int64 for two inputs.";

2. Add flag output_data_path to save model output(s) to file(s).

 static const char output_data_path_msg[] =
     "Set the path(s) of model output, "
     "separated by comma and colon, "
     "such as /path/to/out.txt for only one input, "
     "/path/to/out0.txt:/path/to/out1.txt for two inputs."
     "The output of model will not be saved to file.";


