### PR TITLE
[OpenCL] Fix cl_runtime.cc [-Werror=return-type]

### DIFF
--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -174,6 +174,7 @@ cl::Program& CLRuntime::GetProgram(const std::string& file_name,
     return *(programs_[program_key]);
   } else {
     LOG(FATAL) << "GetProgram failed, program_key: " << program_key;
+    return *(programs_[program_key]);
   }
 }
 


### PR DESCRIPTION
Fix cl_runtime.cc [-Werror=return-type] error.

/gitlab/paddle-lite/lite/backends/opencl/cl_runtime.cc:147:40: error: control reaches end of non-void function [-Werror=return-type]
  147 |   std::string build_option = options + " -cl-fast-relaxed-math -cl-mad-enable";
