### PR TITLE
[2.12] fix subgraph visualizer

### DIFF
--- a/lite/core/optimizer/mir/subgraph/subgraph_detector.cc
+++ b/lite/core/optimizer/mir/subgraph/subgraph_detector.cc
@@ -158,7 +158,7 @@ std::string SubgraphVisualizer::operator()() {
     } else {
       exists_ops[op_type]++;
     }
-    auto op_name = op_type + paddle::lite::to_string(exists_ops[op_type]);
+    auto op_name = op_type + "_" + paddle::lite::to_string(exists_ops[op_type]);
     std::string op_color = "white";
     if (subgraph_indices.count(node)) {
       auto subgraph_idx = subgraph_indices[node];


### PR DESCRIPTION
transpose 和 transpose2 都存在的情况下可能导致重名