### PR TITLE
[OpenCL] Fix opencl precision fp16 set bug

### DIFF
--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -201,6 +201,11 @@ struct PrecisionTypeTrait {
 
 _ForEachPrecisionType(DefinePrecisionTypeTrait);
 
+#ifdef LITE_WITH_OPENCL
+typedef uint16_t half_t;
+_ForEachPrecisionTypeHelper(DefinePrecisionTypeTrait, half_t, kFP16);
+#endif
+
 #ifdef ENABLE_ARM_FP16
 typedef __fp16 float16_t;
 _ForEachPrecisionTypeHelper(DefinePrecisionTypeTrait, float16_t, kFP16);

--- a/lite/api/tools/opt_base.cc
+++ b/lite/api/tools/opt_base.cc
@@ -129,6 +129,8 @@ void OptBase::SetValidPlaces(const std::string& valid_places) {
       valid_places_.emplace_back(
           Place{TARGET(kOpenCL), PRECISION(kInt32), DATALAYOUT(kNCHW)});
       valid_places_.emplace_back(
+          Place{TARGET(kOpenCL), PRECISION(kInt64), DATALAYOUT(kNCHW)});
+      valid_places_.emplace_back(
           TARGET(kARM));  // enable kARM CPU kernel when no opencl kernel
     } else if (target_repr == "metal") {
       valid_places_.emplace_back(Place{

--- a/lite/core/optimizer/mir/opencl_memory_object_config_pass.cc
+++ b/lite/core/optimizer/mir/opencl_memory_object_config_pass.cc
@@ -221,32 +221,13 @@ void OpenCLMemoryObjectConfigPass::CorrectArgumentPlace(SSAGraph* graph) {
           }
         }
       }
-      // image2d unsupport
-      const std::vector<std::string> op_cases_unsupport_in_out_int{
-          "elementwise_floordiv",
-          "elementwise_add",
-          "elementwise_sub",
-          "elementwise_mul",
-          "elementwise_div",
-          "elementwise_pow",
-          "elementwise_mod",
-          "scale"};
-      if (std::find(op_cases_unsupport_in_out_int.begin(),
-                    op_cases_unsupport_in_out_int.end(),
-                    op_type) != op_cases_unsupport_in_out_int.end()) {
-        for (std::list<Node*>::iterator i = x->inlinks.begin();
-             i != x->inlinks.end();
-             ++i) {
-          if ((*i)->arg()->type) {
-            if ((*i)->arg()->type->precision() != PRECISION(kFP16) &&
-                (*i)->arg()->type->precision() != PRECISION(kFloat)) {
-              change_image2d_to_cpu = true;
-            }
-          }
-        }
-        for (std::list<Node*>::iterator i = x->outlinks.begin();
-             i != x->outlinks.end();
-             ++i) {
+      // 4. image2d only support input fp32/fp16
+      for (std::list<Node*>::iterator i = x->inlinks.begin();
+           i != x->inlinks.end();
+           ++i) {
+        std::string in_name =
+            get_argname((*i)->arg()->name, inst.op_info()->inputs());
+        if (in_name == "X") {
           if ((*i)->arg()->type) {
             if ((*i)->arg()->type->precision() != PRECISION(kFP16) &&
                 (*i)->arg()->type->precision() != PRECISION(kFloat)) {
@@ -256,7 +237,7 @@ void OpenCLMemoryObjectConfigPass::CorrectArgumentPlace(SSAGraph* graph) {
         }
       }
 
-      // 4. if reduce op keepdim=false change target
+      // 5. if reduce op keepdim=false change target
       const std::vector<std::string> op_type_cases{"arg_max",
                                                    "reduce_max",
                                                    "reduce_min",
@@ -282,11 +263,11 @@ void OpenCLMemoryObjectConfigPass::CorrectArgumentPlace(SSAGraph* graph) {
         change_image2d_to_cpu = change_image2d_to_cpu || op_teller(x);
       }
 
-      // 5. split outlinks != 2 change target
+      // 6. split outlinks != 2 change target
       if (op_type == "split" && x->outlinks.size() != 2)
         change_image2d_to_cpu = true;
 
-      // 6. gather X.dims.size() == 2
+      // 7. gather X.dims.size() == 2
       if (op_type == "gather") {
         for (std::list<Node*>::iterator i = x->inlinks.begin();
              i != x->inlinks.end();
@@ -301,7 +282,7 @@ void OpenCLMemoryObjectConfigPass::CorrectArgumentPlace(SSAGraph* graph) {
         }
       }
 
-      // 7. reshape transpose change target
+      // 8. reshape transpose change target
       if ((op_type == "reshape" || op_type == "reshape2") &&
           input_shape_default_) {
         change_image2d_to_buffer = true;

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -605,18 +605,6 @@ void RuntimeProgram::Run() {
 #ifdef LITE_WITH_OPENCL
     // delegate flush judgement to specify target , it is too heavy for Inst
     inst.Flush(idx);
-#if defined(LITE_WITH_PROFILE) || defined(LITE_WITH_PRECISION_PROFILE)
-    VLOG(4) << "kernel name " << idx << " " << inst.kernel()->name();
-    const auto* op_info = inst.op()->op_info();
-    auto var_in_names = op_info->input_names();
-    for (int i = 0; i < var_in_names.size(); i++) {
-      VLOG(4) << "input var_in_names: " << var_in_names[i];
-    }
-    auto var_out_names = op_info->output_names();
-    for (int i = 0; i < var_out_names.size(); i++) {
-      VLOG(4) << "output var_out_names: " << var_out_names[i];
-    }
-#endif
 #endif
 
     inst.Run();


### PR DESCRIPTION
原本是判断image2d的算子实现elementwise_xx和scale的输入输出精度是否不是float或者fp16，现在改为任意image2d的算子输入“X”的输入精度是否不是float或者fp16，因为发现有更多的op输入可能为int