### PR TITLE
[ARM] fuse im2col and packB for 3x3s1p1d1 sdot

### DIFF
--- a/lite/backends/arm/math/conv_impl.cc
+++ b/lite/backends/arm/math/conv_impl.cc
@@ -936,52 +936,26 @@ static void padding_zero(const int8_t* data_in,
   }
 }
 
-#define transfer4x12(line1, line2, line3, line4, data_out)        \
-  line_1_2 = vtrnq_s8(line1, line2);                              \
-  line_3_4 = vtrnq_s8(line3, line4);                              \
-  out0 = vtrnq_s16(vreinterpretq_s16_s8(line_1_2.val[0]),         \
-                   vreinterpretq_s16_s8(line_3_4.val[0]));        \
-  out1 = vtrnq_s16(vreinterpretq_s16_s8(line_1_2.val[1]),         \
-                   vreinterpretq_s16_s8(line_3_4.val[1]));        \
-  line_1_2_int32 = vtrnq_s32(vreinterpretq_s32_s16(out0.val[0]),  \
-                             vreinterpretq_s32_s16(out1.val[0])); \
-  line_3_4_int32 = vtrnq_s32(vreinterpretq_s32_s16(out0.val[1]),  \
-                             vreinterpretq_s32_s16(out1.val[1])); \
-  vst1q_s32(reinterpret_cast<int*>(data_out),                     \
-            vcombine_s32(vget_low_s32(line_1_2_int32.val[0]),     \
-                         vget_low_s32(line_3_4_int32.val[0])));   \
-  vst1q_s32(reinterpret_cast<int*>(data_out + 16),                \
-            vcombine_s32(vget_low_s32(line_1_2_int32.val[1]),     \
-                         vget_low_s32(line_3_4_int32.val[1])));   \
-  vst1q_s32(reinterpret_cast<int*>(data_out + 32),                \
-            vcombine_s32(vget_high_s32(line_1_2_int32.val[0]),    \
-                         vget_high_s32(line_3_4_int32.val[0])));
-
-#define transfer4x8(line1, line2, line3, line4, data_out)                \
-  line_1_2 = vtrn_s8(line1, line2);                                      \
-  line_3_4 = vtrn_s8(line3, line4);                                      \
-  out0 = vtrn_s16(vreinterpret_s16_s8(line_1_2.val[0]),                  \
-                  vreinterpret_s16_s8(line_3_4.val[0]));                 \
-  out1 = vtrn_s16(vreinterpret_s16_s8(line_1_2.val[1]),                  \
-                  vreinterpret_s16_s8(line_3_4.val[1]));                 \
-  line_1_2_int32 = vtrn_s32(vreinterpret_s32_s16(out0.val[0]),           \
-                            vreinterpret_s32_s16(out1.val[0]));          \
-  line_3_4_int32 = vtrn_s32(vreinterpret_s32_s16(out0.val[1]),           \
-                            vreinterpret_s32_s16(out1.val[1]));          \
-  vst1q_s32(reinterpret_cast<int*>(data_out),                            \
-            vcombine_s32(line_1_2_int32.val[0], line_3_4_int32.val[0])); \
-  vst1q_s32(reinterpret_cast<int*>(data_out + 16),                       \
-            vcombine_s32(line_1_2_int32.val[1], line_3_4_int32.val[1]));
-
-#define transfer4x4(line1, line2, line3, line4, data_out) \
-  cnt = 0;                                                \
-  for (int i = 0; i < 4; i++) {                           \
-    res[cnt++] = line1[i];                                \
-    res[cnt++] = line2[i];                                \
-    res[cnt++] = line3[i];                                \
-    res[cnt++] = line4[i];                                \
-  }                                                       \
-  vst1q_s8(data_out, res);
+#define transfer4x12(line1, line2, line3, line4, data_out)            \
+  line_1_2_q = vtrnq_s8(line1, line2);                                \
+  line_3_4_q = vtrnq_s8(line3, line4);                                \
+  out0_8 = vtrnq_s16(vreinterpretq_s16_s8(line_1_2_q.val[0]),         \
+                     vreinterpretq_s16_s8(line_3_4_q.val[0]));        \
+  out1_8 = vtrnq_s16(vreinterpretq_s16_s8(line_1_2_q.val[1]),         \
+                     vreinterpretq_s16_s8(line_3_4_q.val[1]));        \
+  line_1_2_int32_4 = vtrnq_s32(vreinterpretq_s32_s16(out0_8.val[0]),  \
+                               vreinterpretq_s32_s16(out1_8.val[0])); \
+  line_3_4_int32_4 = vtrnq_s32(vreinterpretq_s32_s16(out0_8.val[1]),  \
+                               vreinterpretq_s32_s16(out1_8.val[1])); \
+  vst1q_s32(reinterpret_cast<int*>(data_out),                         \
+            vcombine_s32(vget_low_s32(line_1_2_int32_4.val[0]),       \
+                         vget_low_s32(line_3_4_int32_4.val[0])));     \
+  vst1q_s32(reinterpret_cast<int*>(data_out + 16),                    \
+            vcombine_s32(vget_low_s32(line_1_2_int32_4.val[1]),       \
+                         vget_low_s32(line_3_4_int32_4.val[1])));     \
+  vst1q_s32(reinterpret_cast<int*>(data_out + 32),                    \
+            vcombine_s32(vget_high_s32(line_1_2_int32_4.val[0]),      \
+                         vget_high_s32(line_3_4_int32_4.val[0])));
 
 #define LOAD_36x12_K3(vec_k0, vec_k1, vec_k2, data_input) \
   vec_k0 = vld1q_s8((data_input));                        \
@@ -1006,6 +980,22 @@ static void padding_zero(const int8_t* data_in,
   vec_k2 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx5), vec_tmp, 4), \
                        vext_s8(vec_tmp, vec_zero_h, 4));
 
+#define transfer4x8(line1, line2, line3, line4, data_out)                \
+  line_1_2 = vtrn_s8(line1, line2);                                      \
+  line_3_4 = vtrn_s8(line3, line4);                                      \
+  out0 = vtrn_s16(vreinterpret_s16_s8(line_1_2.val[0]),                  \
+                  vreinterpret_s16_s8(line_3_4.val[0]));                 \
+  out1 = vtrn_s16(vreinterpret_s16_s8(line_1_2.val[1]),                  \
+                  vreinterpret_s16_s8(line_3_4.val[1]));                 \
+  line_1_2_int32 = vtrn_s32(vreinterpret_s32_s16(out0.val[0]),           \
+                            vreinterpret_s32_s16(out1.val[0]));          \
+  line_3_4_int32 = vtrn_s32(vreinterpret_s32_s16(out0.val[1]),           \
+                            vreinterpret_s32_s16(out1.val[1]));          \
+  vst1q_s32(reinterpret_cast<int*>(data_out),                            \
+            vcombine_s32(line_1_2_int32.val[0], line_3_4_int32.val[0])); \
+  vst1q_s32(reinterpret_cast<int*>(data_out + 16),                       \
+            vcombine_s32(line_1_2_int32.val[1], line_3_4_int32.val[1]));
+
 #define LOAD_36x8_K3(vec_k0, vec_k1, vec_k2, data_input) \
   vec_k0 = vld1_s8((data_input));                        \
   vec_h = vld1_s8((data_input) + 8);                     \
@@ -1018,6 +1008,16 @@ static void padding_zero(const int8_t* data_in,
   vec_k0 = vext_s8(vtbl1_s8(vec_h, vec_idx3), vec_tmp, 2);  \
   vec_k1 = vext_s8(vtbl1_s8(vec_h, vec_idx4), vec_tmp, 3);  \
   vec_k2 = vext_s8(vtbl1_s8(vec_h, vec_idx5), vec_tmp, 4);
+
+#define transfer4x4(line1, line2, line3, line4, data_out) \
+  cnt = 0;                                                \
+  for (int i = 0; i < 4; i++) {                           \
+    res[cnt++] = line1[i];                                \
+    res[cnt++] = line2[i];                                \
+    res[cnt++] = line3[i];                                \
+    res[cnt++] = line4[i];                                \
+  }                                                       \
+  vst1q_s8(data_out, res);
 
 #define LOAD_36x4                     \
   out_k00 = data_input;               \
@@ -1047,6 +1047,12 @@ void im2col_packb_3x3s1p1(const int8_t* data_im,
   const int hin = height + 2;
   const int padding_size = win * hin;
   const int output_w = width;
+  int cnt = 0;
+  int cur_ow, cur_oh, input_idx;
+  int8_t* data_input;
+  int8_t* data_output;
+  int8_t *out_k00, *out_k01, *out_k02, *out_k10, *out_k11, *out_k12, *out_k20,
+      *out_k21, *out_k22;
   int8x16_t vec_zero = vdupq_n_s8(0);
   int8x8_t vec_zero_h = vdup_n_s8(0);
   int8x8_t vec_idx = {2, 3, 4, 5, 2, 3, 4, 5};  // for vtbl1
@@ -1055,297 +1061,18 @@ void im2col_packb_3x3s1p1(const int8_t* data_im,
   int8x8_t vec_idx3 = {0, 0, 0, 1, 2, 3, 6, 7};
   int8x8_t vec_idx4 = {0, 0, 0, 1, 2, 3, 4, 7};
   int8x8_t vec_idx5 = {0, 0, 0, 0, 2, 3, 4, 5};
-
-  auto loop_func_36x12 = [&](int8_t* data_im_block,
-                             int loop_row,
-                             int loop_col,
-                             int8_t* data_out_block) {
-    auto cur_ow = loop_col % output_w;
-    auto cur_oh = loop_col / output_w;
-    int input_idx = cur_oh * win + cur_ow;
-    int8_t* data_input = data_im_block;
-    int8_t* data_output = data_out_block;
-    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, vec_k11, vec_k12, vec_k20,
-        vec_k21, vec_k22;
-    int8x8_t vec_tmp, vec_h;
-    int8x16x2_t line_1_2, line_3_4;
-    int16x8x2_t out0, out1;
-    int32x4x2_t line_1_2_int32, line_3_4_int32;
-
-    // for ow % 8 == 0, (ow*oh)%12 must be 4/8/12
-    if (cur_ow + 11 <
-        output_w) {  // overread 2bytes(16(neon) - 12(block) - 2(pad))
-      // OC1
-      data_input = data_im_block + input_idx;
-      LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
-      LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k00, vec_k01, vec_k02, vec_k10, data_output);
-      data_output += 48;
-      LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k11, vec_k12, vec_k20, vec_k21, data_output);
-      data_output += 48;
-      // OC2
-      data_input = data_im_block + input_idx + padding_size;
-      LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
-      LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k22, vec_k00, vec_k01, vec_k02, data_output);
-      data_output += 48;
-      LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k10, vec_k11, vec_k12, vec_k20, data_output);
-      data_output += 48;
-      // OC3
-      data_input = data_im_block + input_idx + padding_size * 2;
-      LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
-      LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k21, vec_k22, vec_k00, vec_k01, data_output);
-      data_output += 48;
-      LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k02, vec_k10, vec_k11, vec_k12, data_output);
-      data_output += 48;
-      // OC4
-      data_input = data_im_block + input_idx + padding_size * 3;
-      LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k20, vec_k21, vec_k22, vec_k00, data_output);
-      data_output += 48;
-      LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k01, vec_k02, vec_k10, vec_k11, data_output);
-      data_output += 48;
-      LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k12, vec_k20, vec_k21, vec_k22, data_output);
-      data_output += 48;
-    } else if (cur_ow + 7 <
-               output_w) {  // current line fetch 8 and next line fetch 4
-      // OC1
-      data_input = data_im_block + input_idx;
-      LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
-      LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k00, vec_k01, vec_k02, vec_k10, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k11, vec_k12, vec_k20, vec_k21, data_output);
-      data_output += 48;
-      // OC2
-      data_input = data_im_block + input_idx + padding_size;
-      LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k22, vec_k00, vec_k01, vec_k02, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
-      LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k10, vec_k11, vec_k12, vec_k20, data_output);
-      data_output += 48;
-      // OC3
-      data_input = data_im_block + input_idx + 2 * padding_size;
-      LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k21, vec_k22, vec_k00, vec_k01, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k02, vec_k10, vec_k11, vec_k12, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      // OC4
-      data_input = data_im_block + input_idx + 3 * padding_size;
-      LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k20, vec_k21, vec_k22, vec_k00, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k01, vec_k02, vec_k10, vec_k11, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k12, vec_k20, vec_k21, vec_k22, data_output);
-      data_output += 48;
-    } else {  // 4, current line fetch 4 and next line fetch 8
-      // OC1
-      data_input = data_im_block + input_idx;
-      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
-      LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k00, vec_k01, vec_k02, vec_k10, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
-      transfer4x12(vec_k11, vec_k12, vec_k20, vec_k21, data_output);
-      data_output += 48;
-      // OC2
-      data_input = data_im_block + input_idx + padding_size;
-      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k22, vec_k00, vec_k01, vec_k02, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
-      LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
-      transfer4x12(vec_k10, vec_k11, vec_k12, vec_k20, data_output);
-      data_output += 48;
-      // OC3
-      data_input = data_im_block + input_idx + 2 * padding_size;
-      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k21, vec_k22, vec_k00, vec_k01, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k02, vec_k10, vec_k11, vec_k12, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
-      // OC4
-      data_input = data_im_block + input_idx + 3 * padding_size;
-      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k20, vec_k21, vec_k22, vec_k00, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k01, vec_k02, vec_k10, vec_k11, data_output);
-      data_output += 48;
-      LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
-      transfer4x12(vec_k12, vec_k20, vec_k21, vec_k22, data_output);
-      data_output += 48;
-    }
-  };
-
-  auto loop_func_36x8 = [&](int8_t* data_im_block,
-                            int loop_row,
-                            int loop_col,
-                            int8_t* data_out_block) {
-    auto cur_ow = loop_col % output_w;
-    auto cur_oh = loop_col / output_w;
-    int input_idx = cur_oh * win + cur_ow;
-    auto data_output = data_out_block;
-    auto data_input = data_im_block;
-    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, vec_k11, vec_k12, vec_k20,
-        vec_k21, vec_k22;
-    int8x8_t vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h,
-        vec_k20_h, vec_k21_h, vec_k22_h;
-    int8x8_t vec_h, vec_tmp;
-    int8x8x2_t line_1_2, line_3_4;
-    int16x4x2_t out0, out1;
-    int32x2x2_t line_1_2_int32, line_3_4_int32;
-
-    if (cur_ow + 7 < output_w) {
-      // OC1
-      data_input = data_im_block + input_idx;
-      LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
-      transfer4x8(vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, data_output);
-      data_output += 32;
-      LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, data_output);
-      data_output += 32;
-      // OC2
-      data_input = data_im_block + input_idx + padding_size;
-      LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      transfer4x8(vec_k22_h, vec_k00_h, vec_k01_h, vec_k02_h, data_output);
-      data_output += 32;
-      LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
-      LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k10_h, vec_k11_h, vec_k12_h, vec_k20_h, data_output);
-      data_output += 32;
-      // OC3
-      data_input = data_im_block + input_idx + 2 * padding_size;
-      LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      transfer4x8(vec_k21_h, vec_k22_h, vec_k00_h, vec_k01_h, data_output);
-      data_output += 32;
-      LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
-      LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h, data_output);
-      data_output += 32;
-      // OC4
-      data_input = data_im_block + input_idx + 3 * padding_size;
-      LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      transfer4x8(vec_k20_h, vec_k21_h, vec_k22_h, vec_k00_h, data_output);
-      data_output += 32;
-      LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
-      LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, data_output);
-      data_output += 32;
-      transfer4x8(vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h, data_output);
-      data_output += 32;
-    } else {
-      // OC1
-      data_input = data_im_block + input_idx;
-      LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
-      transfer4x8(vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, data_output);
-      data_output += 32;
-      LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, data_output);
-      data_output += 32;
-      // OC2
-      data_input = data_im_block + input_idx + padding_size;
-      LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      transfer4x8(vec_k22_h, vec_k00_h, vec_k01_h, vec_k02_h, data_output);
-      data_output += 32;
-      LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
-      LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k10_h, vec_k11_h, vec_k12_h, vec_k20_h, data_output);
-      data_output += 32;
-      // OC3
-      data_input = data_im_block + input_idx + padding_size * 2;
-      LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      transfer4x8(vec_k21_h, vec_k22_h, vec_k00_h, vec_k01_h, data_output);
-      data_output += 32;
-      LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
-      LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h, data_output);
-      data_output += 32;
-      // OC4
-      data_input = data_im_block + input_idx + padding_size * 3;
-      LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      transfer4x8(vec_k20_h, vec_k21_h, vec_k22_h, vec_k00_h, data_output);
-      data_output += 32;
-      LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
-      transfer4x8(vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, data_output);
-      data_output += 32;
-      LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h, data_output);
-      data_output += 32;
-    }
-  };
-
-  auto loop_func_36x4 = [&](int8_t* data_im_block,
-                            int loop_row,
-                            int loop_col,
-                            int8_t* data_out_block) {
-    auto cur_ow = loop_col % output_w;
-    auto cur_oh = loop_col / output_w;
-    int input_idx = cur_oh * win + cur_ow;
-    auto data_input = data_im_block;
-    auto data_output = data_out_block;
-    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, vec_k11, vec_k12, vec_k20,
-        vec_k21, vec_k22;
-    int8x8_t vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h,
-        vec_k20_h, vec_k21_h, vec_k22_h;
-    int8x8_t vec_h, vec_tmp, vec_tmp1;
-    int8_t *out_k00, *out_k01, *out_k02, *out_k10, *out_k11, *out_k12, *out_k20,
-        *out_k21, *out_k22;
-    int8x16_t res;
-    int cnt = 0;
-
-    if (cur_ow + 3 < output_w) {
-      // OC1
-      data_input = data_im_block + input_idx;
-      LOAD_36x4;
-      transfer4x4(out_k00, out_k01, out_k02, out_k10, data_output);
-      data_output += 16;
-      transfer4x4(out_k11, out_k12, out_k20, out_k21, data_output);
-      data_output += 16;
-      // OC2
-      data_input = data_im_block + input_idx + padding_size;
-      LOAD_36x4;
-      transfer4x4(out_k22, out_k00, out_k01, out_k02, data_output);
-      data_output += 16;
-      transfer4x4(out_k10, out_k11, out_k12, out_k20, data_output);
-      data_output += 16;
-      // OC3
-      data_input = data_im_block + input_idx + 2 * padding_size;
-      LOAD_36x4;
-      transfer4x4(out_k21, out_k22, out_k00, out_k01, data_output);
-      data_output += 16;
-      transfer4x4(out_k02, out_k10, out_k11, out_k12, data_output);
-      data_output += 16;
-      // OC4
-      data_input = data_im_block + input_idx + 3 * padding_size;
-      LOAD_36x4;
-      transfer4x4(out_k20, out_k21, out_k22, out_k00, data_output);
-      data_output += 16;
-      transfer4x4(out_k01, out_k02, out_k10, out_k11, data_output);
-      data_output += 16;
-      transfer4x4(out_k12, out_k20, out_k21, out_k22, data_output);
-      data_output += 16;
-    }
-  };
+  int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, vec_k11, vec_k12, vec_k20,
+      vec_k21, vec_k22;
+  int8x16x2_t line_1_2_q, line_3_4_q;
+  int16x8x2_t out0_8, out1_8;
+  int32x4x2_t line_1_2_int32_4, line_3_4_int32_4;
+  int8x8_t vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h,
+      vec_k20_h, vec_k21_h, vec_k22_h;
+  int8x8x2_t line_1_2, line_3_4;
+  int16x4x2_t out0, out1;
+  int32x2x2_t line_1_2_int32, line_3_4_int32;
+  int8x8_t vec_h, vec_tmp, vec_tmp1;
+  int8x16_t res;
 
   // 4c x 3 x 3, only support c%4==0
   for (int loop_row = 0; loop_row + 35 < looph; loop_row += 36) {
@@ -1356,20 +1083,264 @@ void im2col_packb_3x3s1p1(const int8_t* data_im,
                    width,
                    height,
                    workspace + c * padding_size);
-    auto data_im_pad = workspace;
-
-    int loop_col = 0;  // only support ow % 8 == 0, tail must be 12/8/4
+    auto data_im_block = workspace;
+    int loop_col = 0;  // only support ow % 8 == 0,
+                       // tail must be 12/8/4
     for (; loop_col + 11 < loopw; loop_col += 12) {
-      auto data_col_12_block = data_col + loop_col * looph + 12 * loop_row;
-      loop_func_36x12(data_im_pad, loop_row, loop_col, data_col_12_block);
+      auto data_out_block = data_col + loop_col * looph + 12 * loop_row;
+      cur_ow = loop_col % output_w;
+      cur_oh = loop_col / output_w;
+      input_idx = cur_oh * win + cur_ow;
+      data_input = data_im_block;
+      data_output = data_out_block;
+      if (cur_ow + 11 < output_w) {  // overread 2bytes(16(neon) -
+                                     // 12(block) - 2(pad))
+        // OC1
+        data_input = data_im_block + input_idx;
+        LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
+        LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k00, vec_k01, vec_k02, vec_k10, data_output);
+        data_output += 48;
+        LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+        transfer4x12(vec_k11, vec_k12, vec_k20, vec_k21, data_output);
+        data_output += 48;
+        // OC2
+        data_input = data_im_block + input_idx + padding_size;
+        LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
+        LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k22, vec_k00, vec_k01, vec_k02, data_output);
+        data_output += 48;
+        LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+        transfer4x12(vec_k10, vec_k11, vec_k12, vec_k20, data_output);
+        data_output += 48;
+        // OC3
+        data_input = data_im_block + input_idx + padding_size * 2;
+        LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
+        LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k21, vec_k22, vec_k00, vec_k01, data_output);
+        data_output += 48;
+        LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+        transfer4x12(vec_k02, vec_k10, vec_k11, vec_k12, data_output);
+        data_output += 48;
+        // OC4
+        data_input = data_im_block + input_idx + padding_size * 3;
+        LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
+        transfer4x12(vec_k20, vec_k21, vec_k22, vec_k00, data_output);
+        data_output += 48;
+        LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k01, vec_k02, vec_k10, vec_k11, data_output);
+        data_output += 48;
+        LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+        transfer4x12(vec_k12, vec_k20, vec_k21, vec_k22, data_output);
+        data_output += 48;
+      } else if (cur_ow + 7 < output_w) {  // current line fetch 8
+                                           // and next line fetch 4
+        // OC1
+        data_input = data_im_block + input_idx;
+        LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
+        LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k00, vec_k01, vec_k02, vec_k10, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+        transfer4x12(vec_k11, vec_k12, vec_k20, vec_k21, data_output);
+        data_output += 48;
+        // OC2
+        data_input = data_im_block + input_idx + padding_size;
+        LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
+        transfer4x12(vec_k22, vec_k00, vec_k01, vec_k02, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
+        LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+        transfer4x12(vec_k10, vec_k11, vec_k12, vec_k20, data_output);
+        data_output += 48;
+        // OC3
+        data_input = data_im_block + input_idx + 2 * padding_size;
+        LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
+        transfer4x12(vec_k21, vec_k22, vec_k00, vec_k01, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k02, vec_k10, vec_k11, vec_k12, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+        // OC4
+        data_input = data_im_block + input_idx + 3 * padding_size;
+        LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
+        transfer4x12(vec_k20, vec_k21, vec_k22, vec_k00, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k01, vec_k02, vec_k10, vec_k11, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+        transfer4x12(vec_k12, vec_k20, vec_k21, vec_k22, data_output);
+        data_output += 48;
+      } else {  // 4, current line fetch 4 and next
+                // line fetch 8
+        // OC1
+        data_input = data_im_block + input_idx;
+        LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
+        LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k00, vec_k01, vec_k02, vec_k10, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
+        transfer4x12(vec_k11, vec_k12, vec_k20, vec_k21, data_output);
+        data_output += 48;
+        // OC2
+        data_input = data_im_block + input_idx + padding_size;
+        LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
+        transfer4x12(vec_k22, vec_k00, vec_k01, vec_k02, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
+        LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
+        transfer4x12(vec_k10, vec_k11, vec_k12, vec_k20, data_output);
+        data_output += 48;
+        // OC3
+        data_input = data_im_block + input_idx + 2 * padding_size;
+        LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
+        transfer4x12(vec_k21, vec_k22, vec_k00, vec_k01, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k02, vec_k10, vec_k11, vec_k12, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
+        // OC4
+        data_input = data_im_block + input_idx + 3 * padding_size;
+        LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
+        transfer4x12(vec_k20, vec_k21, vec_k22, vec_k00, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
+        transfer4x12(vec_k01, vec_k02, vec_k10, vec_k11, data_output);
+        data_output += 48;
+        LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
+        transfer4x12(vec_k12, vec_k20, vec_k21, vec_k22, data_output);
+        data_output += 48;
+      }
     }
     for (; loop_col + 7 < loopw; loop_col += 8) {
-      auto data_col_8_block = data_col + loop_col * looph + 8 * loop_row;
-      loop_func_36x8(data_im_pad, loop_row, loop_col, data_col_8_block);
+      auto data_out_block = data_col + loop_col * looph + 8 * loop_row;
+      cur_ow = loop_col % output_w;
+      cur_oh = loop_col / output_w;
+      input_idx = cur_oh * win + cur_ow;
+      data_output = data_out_block;
+      data_input = data_im_block;
+      if (cur_ow + 7 < output_w) {
+        // OC1
+        data_input = data_im_block + input_idx;
+        LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+        LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+        transfer4x8(vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, data_output);
+        data_output += 32;
+        LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+        transfer4x8(vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, data_output);
+        data_output += 32;
+        // OC2
+        data_input = data_im_block + input_idx + padding_size;
+        LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+        transfer4x8(vec_k22_h, vec_k00_h, vec_k01_h, vec_k02_h, data_output);
+        data_output += 32;
+        LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+        LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+        transfer4x8(vec_k10_h, vec_k11_h, vec_k12_h, vec_k20_h, data_output);
+        data_output += 32;
+        // OC3
+        data_input = data_im_block + input_idx + 2 * padding_size;
+        LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+        transfer4x8(vec_k21_h, vec_k22_h, vec_k00_h, vec_k01_h, data_output);
+        data_output += 32;
+        LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+        LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+        transfer4x8(vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h, data_output);
+        data_output += 32;
+        // OC4
+        data_input = data_im_block + input_idx + 3 * padding_size;
+        LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+        transfer4x8(vec_k20_h, vec_k21_h, vec_k22_h, vec_k00_h, data_output);
+        data_output += 32;
+        LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+        LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+        transfer4x8(vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, data_output);
+        data_output += 32;
+        transfer4x8(vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h, data_output);
+        data_output += 32;
+      } else {
+        // OC1
+        data_input = data_im_block + input_idx;
+        LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+        LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+        transfer4x8(vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, data_output);
+        data_output += 32;
+        LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+        transfer4x8(vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, data_output);
+        data_output += 32;
+        // OC2
+        data_input = data_im_block + input_idx + padding_size;
+        LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+        transfer4x8(vec_k22_h, vec_k00_h, vec_k01_h, vec_k02_h, data_output);
+        data_output += 32;
+        LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+        LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+        transfer4x8(vec_k10_h, vec_k11_h, vec_k12_h, vec_k20_h, data_output);
+        data_output += 32;
+        // OC3
+        data_input = data_im_block + input_idx + padding_size * 2;
+        LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+        transfer4x8(vec_k21_h, vec_k22_h, vec_k00_h, vec_k01_h, data_output);
+        data_output += 32;
+        LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+        LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+        transfer4x8(vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h, data_output);
+        data_output += 32;
+        // OC4
+        data_input = data_im_block + input_idx + padding_size * 3;
+        LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+        transfer4x8(vec_k20_h, vec_k21_h, vec_k22_h, vec_k00_h, data_output);
+        data_output += 32;
+        LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+        transfer4x8(vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, data_output);
+        data_output += 32;
+        LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+        transfer4x8(vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h, data_output);
+        data_output += 32;
+      }
     }
     for (; loop_col + 3 < loopw; loop_col += 4) {
-      auto data_col_4_block = data_col + loop_col * looph + 4 * loop_row;
-      loop_func_36x4(data_im_pad, loop_row, loop_col, data_col_4_block);
+      auto data_out_block = data_col + loop_col * looph + 4 * loop_row;
+      cur_ow = loop_col % output_w;
+      cur_oh = loop_col / output_w;
+      input_idx = cur_oh * win + cur_ow;
+      data_input = data_im_block;
+      data_output = data_out_block;
+      if (cur_ow + 3 < output_w) {
+        // OC1
+        data_input = data_im_block + input_idx;
+        LOAD_36x4;
+        transfer4x4(out_k00, out_k01, out_k02, out_k10, data_output);
+        data_output += 16;
+        transfer4x4(out_k11, out_k12, out_k20, out_k21, data_output);
+        data_output += 16;
+        // OC2
+        data_input = data_im_block + input_idx + padding_size;
+        LOAD_36x4;
+        transfer4x4(out_k22, out_k00, out_k01, out_k02, data_output);
+        data_output += 16;
+        transfer4x4(out_k10, out_k11, out_k12, out_k20, data_output);
+        data_output += 16;
+        // OC3
+        data_input = data_im_block + input_idx + 2 * padding_size;
+        LOAD_36x4;
+        transfer4x4(out_k21, out_k22, out_k00, out_k01, data_output);
+        data_output += 16;
+        transfer4x4(out_k02, out_k10, out_k11, out_k12, data_output);
+        data_output += 16;
+        // OC4
+        data_input = data_im_block + input_idx + 3 * padding_size;
+        LOAD_36x4;
+        transfer4x4(out_k20, out_k21, out_k22, out_k00, data_output);
+        data_output += 16;
+        transfer4x4(out_k01, out_k02, out_k10, out_k11, data_output);
+        data_output += 16;
+        transfer4x4(out_k12, out_k20, out_k21, out_k22, data_output);
+        data_output += 16;
+      }
     }
   }
 }
@@ -1522,7 +1493,8 @@ void conv_im2col_gemm_int8(const int8_t* i_data,
       ctx->workspace_data<int8_t>() + ctx->llc_size() / sizeof(int8_t);
 
 #if defined(__aarch64__) && defined(WITH_ARM_DOTPROD)
-  // only support 3x3s1p1d1 sdot, win == ow && ih == oh
+  // only support 3x3s1p1d1 sdot, win == ow && ih ==
+  // oh
   bool ker_3 = (kernel_h == kernel_w) && (kernel_w == 3);
   bool stride_1 = (stride_h == stride_w) && (stride_h == 1);
   bool dila_1 = (dila_h == dila_w) && (dila_h == 1);

--- a/lite/backends/arm/math/conv_impl.cc
+++ b/lite/backends/arm/math/conv_impl.cc
@@ -1374,6 +1374,16 @@ void im2col_packb_3x3s1p1(const int8_t* data_im,
   }
 }
 
+#undef transfer4x12
+#undef transfer4x8
+#undef transfer4x4
+#undef LOAD_36x12_K3
+#undef LOAD_36x12_K3_B8
+#undef LOAD_36x12_K3_B4
+#undef LOAD_36x8_K3
+#undef LOAD_36x8_K3_B4
+#undef LOAD_36x4
+
 template <typename Dtype>
 void conv_im2col_gemm_int8_fast(const int8_t* i_data,
                                 Dtype* o_data,

--- a/lite/backends/arm/math/conv_impl.cc
+++ b/lite/backends/arm/math/conv_impl.cc
@@ -921,93 +921,108 @@ void conv_im2col_gemm(const float* i_data,
 #ifdef __aarch64__
 
 // only support 3x3s1p1
-static void padding_zero(const int8_t *data_in, int iw, int ih, int8_t *data_out) {
+static void padding_zero(const int8_t* data_in,
+                         int iw,
+                         int ih,
+                         int8_t* data_out) {
   int ow = iw + 2;
   int oh = ih + 2;
   memset(data_out, 0, ow);
   memset(data_out + (oh - 1) * ow, 0, ow);
   auto data_out_ptr = data_out + ow;
-  for(int row = 0;row<ih;row++) {
+  for (int row = 0; row < ih; row++) {
     data_out_ptr[0] = 0;
     memcpy(data_out_ptr + 1, data_in + row * iw, iw);
-    data_out_ptr[ow-1] = 0;
+    data_out_ptr[ow - 1] = 0;
     data_out_ptr += ow;
   }
 }
 
-#define transfer4x12(line1, line2, line3, line4, data_out) \
-  line_1_2 = vtrnq_s8(line1, line2);\
-  line_3_4 = vtrnq_s8(line3, line4);\
-  out0 = vtrnq_s16(line_1_2.val[0], line_3_4.val[0]);\
-  out1 = vtrnq_s16(line_1_2.val[1], line_3_4.val[1]);\
-  line_1_2_int32 = vtrnq_s32(out0.val[0], out1.val[0]);\
-  line_3_4_int32 = vtrnq_s32(out0.val[1], out1.val[1]);\
-  vst1q_s32((int*)data_out, vcombine_s32(vget_low_s32(line_1_2_int32.val[0]), vget_low_s32(line_3_4_int32.val[0])));\
-  vst1q_s32((int*)(data_out+16), vcombine_s32(vget_low_s32(line_1_2_int32.val[1]), vget_low_s32(line_3_4_int32.val[1])));\
-  vst1q_s32((int*)(data_out+32), vcombine_s32(vget_high_s32(line_1_2_int32.val[0]), vget_high_s32(line_3_4_int32.val[0])));
+#define transfer4x12(line1, line2, line3, line4, data_out)      \
+  line_1_2 = vtrnq_s8(line1, line2);                            \
+  line_3_4 = vtrnq_s8(line3, line4);                            \
+  out0 = vtrnq_s16(line_1_2.val[0], line_3_4.val[0]);           \
+  out1 = vtrnq_s16(line_1_2.val[1], line_3_4.val[1]);           \
+  line_1_2_int32 = vtrnq_s32(out0.val[0], out1.val[0]);         \
+  line_3_4_int32 = vtrnq_s32(out0.val[1], out1.val[1]);         \
+  vst1q_s32(reinterpret_cast<int*>(data_out),                   \
+            vcombine_s32(vget_low_s32(line_1_2_int32.val[0]),   \
+                         vget_low_s32(line_3_4_int32.val[0]))); \
+  vst1q_s32(reinterpret_cast<int*>(data_out + 16),              \
+            vcombine_s32(vget_low_s32(line_1_2_int32.val[1]),   \
+                         vget_low_s32(line_3_4_int32.val[1]))); \
+  vst1q_s32(reinterpret_cast<int*>(data_out + 32),              \
+            vcombine_s32(vget_high_s32(line_1_2_int32.val[0]),  \
+                         vget_high_s32(line_3_4_int32.val[0])));
 
-#define transfer4x8(line1, line2, line3, line4, data_out)\
-  line_1_2 = vtrn_s8(line1, line2);\
-  line_3_4 = vtrn_s8(line3, line4);\
-  out0 = vtrn_s16(line_1_2.val[0], line_3_4.val[0]);\
-  out1 = vtrn_s16(line_1_2.val[1], line_3_4.val[1]);\
-  line_1_2_int32 = vtrn_s32(out0.val[0], out1.val[0]);\
-  line_3_4_int32 = vtrn_s32(out0.val[1], out1.val[1]);\
-  vst1q_s32((int*)data_out, vcombine_s32(line_1_2_int32.val[0], line_3_4_int32.val[0]));\
-  vst1q_s32((int*)(data_out+16), vcombine_s32(line_1_2_int32.val[1], line_3_4_int32.val[1]));
+#define transfer4x8(line1, line2, line3, line4, data_out)                \
+  line_1_2 = vtrn_s8(line1, line2);                                      \
+  line_3_4 = vtrn_s8(line3, line4);                                      \
+  out0 = vtrn_s16(line_1_2.val[0], line_3_4.val[0]);                     \
+  out1 = vtrn_s16(line_1_2.val[1], line_3_4.val[1]);                     \
+  line_1_2_int32 = vtrn_s32(out0.val[0], out1.val[0]);                   \
+  line_3_4_int32 = vtrn_s32(out0.val[1], out1.val[1]);                   \
+  vst1q_s32(reinterpret_cast<int*>(data_out),                            \
+            vcombine_s32(line_1_2_int32.val[0], line_3_4_int32.val[0])); \
+  vst1q_s32(reinterpret_cast<int*>(data_out + 16),                       \
+            vcombine_s32(line_1_2_int32.val[1], line_3_4_int32.val[1]));
 
 #define transfer4x4(line1, line2, line3, line4, data_out) \
-  cnt = 0;\
-  for(int i = 0; i < 4;i++) {\
-    res[cnt++] = line1[i];\
-    res[cnt++] = line2[i];\
-    res[cnt++] = line3[i];\
-    res[cnt++] = line4[i];\
-  }\
+  cnt = 0;                                                \
+  for (int i = 0; i < 4; i++) {                           \
+    res[cnt++] = line1[i];                                \
+    res[cnt++] = line2[i];                                \
+    res[cnt++] = line3[i];                                \
+    res[cnt++] = line4[i];                                \
+  }                                                       \
   vst1q_s8(data_out, res);
 
-#define LOAD_36x12_K3(vec_k0, vec_k1, vec_k2, data_input)\
-      vec_k0 = vld1q_s8((data_input));\
-      vec_k1 = vextq_s8(vec_k0, vec_zero, 1);\
-      vec_k2 = vextq_s8(vec_k0, vec_zero, 2);
+#define LOAD_36x12_K3(vec_k0, vec_k1, vec_k2, data_input) \
+  vec_k0 = vld1q_s8((data_input));                        \
+  vec_k1 = vextq_s8(vec_k0, vec_zero, 1);                 \
+  vec_k2 = vextq_s8(vec_k0, vec_zero, 2);
 
-#define LOAD_36x12_K3_B8(vec_k0, vec_k1, vec_k2, data_input)\
-      vec_h = vld1_s8((data_input));\
-      vec_tmp = vld1_s8((data_input) + 8);\
-      vec_k0 = vcombine_s8(vec_h, vtbl1_s8(vec_tmp, vec_idx));\
-      vec_k1 = vcombine_s8(vext_s8(vec_h, vec_tmp, 1), vtbl1_s8(vec_tmp, vec_idx1));\
-      vec_k2 = vcombine_s8(vext_s8(vec_h, vec_tmp, 2), vtbl1_s8(vec_tmp, vec_idx2));
+#define LOAD_36x12_K3_B8(vec_k0, vec_k1, vec_k2, data_input)                \
+  vec_h = vld1_s8((data_input));                                            \
+  vec_tmp = vld1_s8((data_input) + 8);                                      \
+  vec_k0 = vcombine_s8(vec_h, vtbl1_s8(vec_tmp, vec_idx));                  \
+  vec_k1 =                                                                  \
+      vcombine_s8(vext_s8(vec_h, vec_tmp, 1), vtbl1_s8(vec_tmp, vec_idx1)); \
+  vec_k2 = vcombine_s8(vext_s8(vec_h, vec_tmp, 2), vtbl1_s8(vec_tmp, vec_idx2));
 
-#define LOAD_36x12_K3_B4(vec_k0, vec_k1, vec_k2, data_input)\
-      vec_h = vld1_s8((data_input));\
-      vec_tmp = vld1_s8((data_input) + 8);\
-      vec_k0 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx3), vec_tmp, 2), vext_s8(vec_tmp, vec_zero_h, 2));\
-      vec_k1 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx4), vec_tmp, 3), vext_s8(vec_tmp, vec_zero_h, 3));\
-      vec_k2 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx5), vec_tmp, 4), vext_s8(vec_tmp, vec_zero_h, 4));
+#define LOAD_36x12_K3_B4(vec_k0, vec_k1, vec_k2, data_input)           \
+  vec_h = vld1_s8((data_input));                                       \
+  vec_tmp = vld1_s8((data_input) + 8);                                 \
+  vec_k0 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx3), vec_tmp, 2), \
+                       vext_s8(vec_tmp, vec_zero_h, 2));               \
+  vec_k1 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx4), vec_tmp, 3), \
+                       vext_s8(vec_tmp, vec_zero_h, 3));               \
+  vec_k2 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx5), vec_tmp, 4), \
+                       vext_s8(vec_tmp, vec_zero_h, 4));
 
-#define LOAD_36x8_K3(vec_k0, vec_k1, vec_k2, data_input)\
-      vec_k0 = vld1_s8((data_input));\
-      vec_h = vld1_s8((data_input) + 8);\
-      vec_k1 = vext_s8(vec_k0, vec_h, 1);\
-      vec_k2 = vext_s8(vec_k0, vec_h, 2);
+#define LOAD_36x8_K3(vec_k0, vec_k1, vec_k2, data_input) \
+  vec_k0 = vld1_s8((data_input));                        \
+  vec_h = vld1_s8((data_input) + 8);                     \
+  vec_k1 = vext_s8(vec_k0, vec_h, 1);                    \
+  vec_k2 = vext_s8(vec_k0, vec_h, 2);
 
-#define LOAD_36x8_K3_B4(vec_k0, vec_k1, vec_k2, data_input)\
-      vec_h = vld1_s8((data_input));\
-      vec_tmp = vld1_s8((data_input) + 8);\
-      vec_k0 = vext_s8(vtbl1_s8(vec_h, vec_idx3), vec_tmp, 2);\
-      vec_k1 = vext_s8( vtbl1_s8(vec_h, vec_idx4), vec_tmp, 3);\
-      vec_k2 = vext_s8(vtbl1_s8(vec_h, vec_idx5), vec_tmp, 4);
+#define LOAD_36x8_K3_B4(vec_k0, vec_k1, vec_k2, data_input) \
+  vec_h = vld1_s8((data_input));                            \
+  vec_tmp = vld1_s8((data_input) + 8);                      \
+  vec_k0 = vext_s8(vtbl1_s8(vec_h, vec_idx3), vec_tmp, 2);  \
+  vec_k1 = vext_s8(vtbl1_s8(vec_h, vec_idx4), vec_tmp, 3);  \
+  vec_k2 = vext_s8(vtbl1_s8(vec_h, vec_idx5), vec_tmp, 4);
 
-#define LOAD_36x4\
-      out_k00 = data_input;\
-      out_k01 = data_input + 1;\
-      out_k02 = data_input + 2;\
-      out_k10 = data_input + win;\
-      out_k11 = data_input + win + 1;\
-      out_k12 = data_input + win + 2;\
-      out_k20 = data_input + 2 * win;\
-      out_k21 = data_input + 2 * win + 1;\
-      out_k22 = data_input + 2 * win + 2;
+#define LOAD_36x4                     \
+  out_k00 = data_input;               \
+  out_k01 = data_input + 1;           \
+  out_k02 = data_input + 2;           \
+  out_k10 = data_input + win;         \
+  out_k11 = data_input + win + 1;     \
+  out_k12 = data_input + win + 2;     \
+  out_k20 = data_input + 2 * win;     \
+  out_k21 = data_input + 2 * win + 1; \
+  out_k22 = data_input + 2 * win + 2;
 
 /* condition: ow % 8 == 0, ic % 4 == 0, 3x3s1p1d1g1
  workspace needs 4 * (width+2) * (height+2) + 16bytes(overread)*/
@@ -1028,293 +1043,301 @@ void im2col_packb_3x3s1p1(const int8_t* data_im,
   const int output_w = width;
   int8x16_t vec_zero = vdupq_n_s8(0);
   int8x8_t vec_zero_h = vdup_n_s8(0);
-  int8x8_t vec_idx = {2,3,4,5,2,3,4,5};   // for vtbl1
-  int8x8_t vec_idx1 = {3,4,5,6,3,4,5,6};
-  int8x8_t vec_idx2 = {4,5,6,7,4,5,6,7};
-  int8x8_t vec_idx3 = {0,0,0,1,2,3,6,7};
-  int8x8_t vec_idx4 = {0,0,0,1,2,3,4,7};
-  int8x8_t vec_idx5 = {0,0,0,0,2,3,4,5};
+  int8x8_t vec_idx = {2, 3, 4, 5, 2, 3, 4, 5};  // for vtbl1
+  int8x8_t vec_idx1 = {3, 4, 5, 6, 3, 4, 5, 6};
+  int8x8_t vec_idx2 = {4, 5, 6, 7, 4, 5, 6, 7};
+  int8x8_t vec_idx3 = {0, 0, 0, 1, 2, 3, 6, 7};
+  int8x8_t vec_idx4 = {0, 0, 0, 1, 2, 3, 4, 7};
+  int8x8_t vec_idx5 = {0, 0, 0, 0, 2, 3, 4, 5};
 
-  auto loop_func_36x12 = [&](int8_t* data_im_block, int loop_row, int loop_col, 
+  auto loop_func_36x12 = [&](int8_t* data_im_block,
+                             int loop_row,
+                             int loop_col,
                              int8_t* data_out_block) {
     auto cur_ow = loop_col % output_w;
     auto cur_oh = loop_col / output_w;
     int input_idx = cur_oh * win + cur_ow;
     int8_t* data_input = data_im_block;
     int8_t* data_output = data_out_block;
-    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, 
-        vec_k11, vec_k12, vec_k20, vec_k21, vec_k22;
+    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, vec_k11, vec_k12, vec_k20,
+        vec_k21, vec_k22;
     int8x8_t vec_tmp, vec_h;
     int8x16x2_t line_1_2, line_3_4;
     int16x8x2_t out0, out1;
     int32x4x2_t line_1_2_int32, line_3_4_int32;
 
     // for ow % 8 == 0, (ow*oh)%12 must be 4/8/12
-    if(cur_ow + 11 < output_w) { // overread 2bytes(16(neon) - 12(block) - 2(pad))
+    if (cur_ow + 11 <
+        output_w) {  // overread 2bytes(16(neon) - 12(block) - 2(pad))
       // OC1
       data_input = data_im_block + input_idx;
       LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
       LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k00,vec_k01,vec_k02,vec_k10,data_output);
+      transfer4x12(vec_k00, vec_k01, vec_k02, vec_k10, data_output);
       data_output += 48;
       LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k11,vec_k12,vec_k20,vec_k21,data_output);
+      transfer4x12(vec_k11, vec_k12, vec_k20, vec_k21, data_output);
       data_output += 48;
       // OC2
       data_input = data_im_block + input_idx + padding_size;
       LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
       LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k22,vec_k00,vec_k01,vec_k02,data_output);
+      transfer4x12(vec_k22, vec_k00, vec_k01, vec_k02, data_output);
       data_output += 48;
       LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k10,vec_k11,vec_k12,vec_k20,data_output);
+      transfer4x12(vec_k10, vec_k11, vec_k12, vec_k20, data_output);
       data_output += 48;
       // OC3
       data_input = data_im_block + input_idx + padding_size * 2;
       LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
       LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k21,vec_k22,vec_k00,vec_k01,data_output);
+      transfer4x12(vec_k21, vec_k22, vec_k00, vec_k01, data_output);
       data_output += 48;
       LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k02,vec_k10,vec_k11,vec_k12,data_output);
+      transfer4x12(vec_k02, vec_k10, vec_k11, vec_k12, data_output);
       data_output += 48;
       // OC4
       data_input = data_im_block + input_idx + padding_size * 3;
       LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k20,vec_k21,vec_k22,vec_k00,data_output);
+      transfer4x12(vec_k20, vec_k21, vec_k22, vec_k00, data_output);
       data_output += 48;
       LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k01,vec_k02,vec_k10,vec_k11,data_output);
+      transfer4x12(vec_k01, vec_k02, vec_k10, vec_k11, data_output);
       data_output += 48;
       LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k12,vec_k20,vec_k21,vec_k22,data_output);
+      transfer4x12(vec_k12, vec_k20, vec_k21, vec_k22, data_output);
       data_output += 48;
-    } else if(cur_ow + 7 < output_w) { // current line fetch 8 and next line fetch 4
+    } else if (cur_ow + 7 <
+               output_w) {  // current line fetch 8 and next line fetch 4
       // OC1
       data_input = data_im_block + input_idx;
       LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
       LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k00,vec_k01,vec_k02,vec_k10,data_output);
+      transfer4x12(vec_k00, vec_k01, vec_k02, vec_k10, data_output);
       data_output += 48;
       LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k11,vec_k12,vec_k20,vec_k21,data_output);
+      transfer4x12(vec_k11, vec_k12, vec_k20, vec_k21, data_output);
       data_output += 48;
       // OC2
       data_input = data_im_block + input_idx + padding_size;
       LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k22,vec_k00,vec_k01,vec_k02,data_output);
+      transfer4x12(vec_k22, vec_k00, vec_k01, vec_k02, data_output);
       data_output += 48;
       LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
       LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k10,vec_k11,vec_k12,vec_k20,data_output);
+      transfer4x12(vec_k10, vec_k11, vec_k12, vec_k20, data_output);
       data_output += 48;
       // OC3
       data_input = data_im_block + input_idx + 2 * padding_size;
       LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k21,vec_k22,vec_k00,vec_k01,data_output);
+      transfer4x12(vec_k21, vec_k22, vec_k00, vec_k01, data_output);
       data_output += 48;
       LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k02,vec_k10,vec_k11,vec_k12,data_output);
+      transfer4x12(vec_k02, vec_k10, vec_k11, vec_k12, data_output);
       data_output += 48;
       LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
       // OC4
       data_input = data_im_block + input_idx + 3 * padding_size;
       LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k20,vec_k21,vec_k22,vec_k00,data_output);
+      transfer4x12(vec_k20, vec_k21, vec_k22, vec_k00, data_output);
       data_output += 48;
       LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k01,vec_k02,vec_k10,vec_k11,data_output);
+      transfer4x12(vec_k01, vec_k02, vec_k10, vec_k11, data_output);
       data_output += 48;
       LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
-      transfer4x12(vec_k12,vec_k20,vec_k21,vec_k22,data_output);
+      transfer4x12(vec_k12, vec_k20, vec_k21, vec_k22, data_output);
       data_output += 48;
-    } else { // 4, current line fetch 4 and next line fetch 8
+    } else {  // 4, current line fetch 4 and next line fetch 8
       // OC1
       data_input = data_im_block + input_idx;
       LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
       LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k00,vec_k01,vec_k02,vec_k10,data_output);
+      transfer4x12(vec_k00, vec_k01, vec_k02, vec_k10, data_output);
       data_output += 48;
       LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
-      transfer4x12(vec_k11,vec_k12,vec_k20,vec_k21,data_output);
+      transfer4x12(vec_k11, vec_k12, vec_k20, vec_k21, data_output);
       data_output += 48;
       // OC2
       data_input = data_im_block + input_idx + padding_size;
       LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k22,vec_k00,vec_k01,vec_k02,data_output);
+      transfer4x12(vec_k22, vec_k00, vec_k01, vec_k02, data_output);
       data_output += 48;
       LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
       LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
-      transfer4x12(vec_k10,vec_k11,vec_k12,vec_k20,data_output);
+      transfer4x12(vec_k10, vec_k11, vec_k12, vec_k20, data_output);
       data_output += 48;
       // OC3
       data_input = data_im_block + input_idx + 2 * padding_size;
       LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
-      transfer4x12(vec_k21,vec_k22,vec_k00,vec_k01,data_output);
+      transfer4x12(vec_k21, vec_k22, vec_k00, vec_k01, data_output);
       data_output += 48;
       LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k02,vec_k10,vec_k11,vec_k12,data_output);
+      transfer4x12(vec_k02, vec_k10, vec_k11, vec_k12, data_output);
       data_output += 48;
       LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
       // OC4
       data_input = data_im_block + input_idx + 3 * padding_size;
-      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input); 
-      transfer4x12(vec_k20,vec_k21,vec_k22,vec_k00,data_output);
+      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
+      transfer4x12(vec_k20, vec_k21, vec_k22, vec_k00, data_output);
       data_output += 48;
       LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
-      transfer4x12(vec_k01,vec_k02,vec_k10,vec_k11,data_output);
+      transfer4x12(vec_k01, vec_k02, vec_k10, vec_k11, data_output);
       data_output += 48;
       LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
-      transfer4x12(vec_k12,vec_k20,vec_k21,vec_k22,data_output);
+      transfer4x12(vec_k12, vec_k20, vec_k21, vec_k22, data_output);
       data_output += 48;
     }
   };
 
-  auto loop_func_36x8 = [&](int8_t* data_im_block, int loop_row, int loop_col, 
-                             int8_t* data_out_block) {
+  auto loop_func_36x8 = [&](int8_t* data_im_block,
+                            int loop_row,
+                            int loop_col,
+                            int8_t* data_out_block) {
     auto cur_ow = loop_col % output_w;
     auto cur_oh = loop_col / output_w;
     int input_idx = cur_oh * win + cur_ow;
     auto data_output = data_out_block;
     auto data_input = data_im_block;
-    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, 
-        vec_k11, vec_k12, vec_k20, vec_k21, vec_k22;
-    int8x8_t vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, 
-        vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h;
+    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, vec_k11, vec_k12, vec_k20,
+        vec_k21, vec_k22;
+    int8x8_t vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h,
+        vec_k20_h, vec_k21_h, vec_k22_h;
     int8x8_t vec_h, vec_tmp;
     int8x8x2_t line_1_2, line_3_4;
     int16x4x2_t out0, out1;
     int32x2x2_t line_1_2_int32, line_3_4_int32;
 
-    if(cur_ow + 7 < output_w) {
+    if (cur_ow + 7 < output_w) {
       // OC1
       data_input = data_im_block + input_idx;
       LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
       LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
-      transfer4x8(vec_k00_h,vec_k01_h,vec_k02_h,vec_k10_h,data_output);
-      data_output+=32;
+      transfer4x8(vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, data_output);
+      data_output += 32;
       LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k11_h,vec_k12_h,vec_k20_h,vec_k21_h,data_output);
-      data_output+=32;
+      transfer4x8(vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, data_output);
+      data_output += 32;
       // OC2
       data_input = data_im_block + input_idx + padding_size;
       LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      transfer4x8(vec_k22_h,vec_k00_h,vec_k01_h,vec_k02_h,data_output);
-      data_output+=32;
+      transfer4x8(vec_k22_h, vec_k00_h, vec_k01_h, vec_k02_h, data_output);
+      data_output += 32;
       LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
       LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k10_h,vec_k11_h,vec_k12_h,vec_k20_h,data_output);
-      data_output+=32;
+      transfer4x8(vec_k10_h, vec_k11_h, vec_k12_h, vec_k20_h, data_output);
+      data_output += 32;
       // OC3
       data_input = data_im_block + input_idx + 2 * padding_size;
       LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      transfer4x8(vec_k21_h,vec_k22_h,vec_k00_h,vec_k01_h,data_output);
-      data_output+=32;
+      transfer4x8(vec_k21_h, vec_k22_h, vec_k00_h, vec_k01_h, data_output);
+      data_output += 32;
       LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
       LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k02_h,vec_k10_h,vec_k11_h,vec_k12_h,data_output);
-      data_output+=32;
+      transfer4x8(vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h, data_output);
+      data_output += 32;
       // OC4
       data_input = data_im_block + input_idx + 3 * padding_size;
       LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
-      transfer4x8(vec_k20_h,vec_k21_h,vec_k22_h,vec_k00_h,data_output);
-      data_output+=32;
+      transfer4x8(vec_k20_h, vec_k21_h, vec_k22_h, vec_k00_h, data_output);
+      data_output += 32;
       LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
       LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
-      transfer4x8(vec_k01_h,vec_k02_h,vec_k10_h,vec_k11_h,data_output);
-      data_output+=32;
-      transfer4x8(vec_k12_h,vec_k20_h,vec_k21_h,vec_k22_h,data_output);
-      data_output+=32;
+      transfer4x8(vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, data_output);
+      data_output += 32;
+      transfer4x8(vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h, data_output);
+      data_output += 32;
     } else {
       // OC1
       data_input = data_im_block + input_idx;
-      LOAD_36x8_K3_B4(vec_k00_h,vec_k01_h,vec_k02_h,data_input);
-      LOAD_36x8_K3_B4(vec_k10_h,vec_k11_h,vec_k12_h,data_input + win);
-      transfer4x8(vec_k00_h,vec_k01_h,vec_k02_h,vec_k10_h,data_output);
-      data_output+=32;
-      LOAD_36x8_K3_B4(vec_k20_h,vec_k21_h,vec_k22_h,data_input + 2*win);
-      transfer4x8(vec_k11_h,vec_k12_h,vec_k20_h,vec_k21_h,data_output);
-      data_output+=32;
+      LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+      LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+      transfer4x8(vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, data_output);
+      data_output += 32;
+      LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+      transfer4x8(vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, data_output);
+      data_output += 32;
       // OC2
       data_input = data_im_block + input_idx + padding_size;
-      LOAD_36x8_K3_B4(vec_k00_h,vec_k01_h,vec_k02_h,data_input);
-      transfer4x8(vec_k22_h,vec_k00_h,vec_k01_h,vec_k02_h,data_output);
-      data_output+=32;
-      LOAD_36x8_K3_B4(vec_k10_h,vec_k11_h,vec_k12_h,data_input + win);
-      LOAD_36x8_K3_B4(vec_k20_h,vec_k21_h,vec_k22_h,data_input + 2*win);
-      transfer4x8(vec_k10_h,vec_k11_h,vec_k12_h,vec_k20_h,data_output);
-      data_output+=32;
+      LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+      transfer4x8(vec_k22_h, vec_k00_h, vec_k01_h, vec_k02_h, data_output);
+      data_output += 32;
+      LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+      LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+      transfer4x8(vec_k10_h, vec_k11_h, vec_k12_h, vec_k20_h, data_output);
+      data_output += 32;
       // OC3
       data_input = data_im_block + input_idx + padding_size * 2;
-      LOAD_36x8_K3_B4(vec_k00_h,vec_k01_h,vec_k02_h,data_input);
-      transfer4x8(vec_k21_h,vec_k22_h,vec_k00_h,vec_k01_h,data_output);
-      data_output+=32;
-      LOAD_36x8_K3_B4(vec_k10_h,vec_k11_h,vec_k12_h,data_input + win);
-      LOAD_36x8_K3_B4(vec_k20_h,vec_k21_h,vec_k22_h,data_input + 2*win);
-      transfer4x8(vec_k02_h,vec_k10_h,vec_k11_h,vec_k12_h,data_output);
-      data_output+=32;
+      LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+      transfer4x8(vec_k21_h, vec_k22_h, vec_k00_h, vec_k01_h, data_output);
+      data_output += 32;
+      LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+      LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+      transfer4x8(vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h, data_output);
+      data_output += 32;
       // OC4
       data_input = data_im_block + input_idx + padding_size * 3;
-      LOAD_36x8_K3_B4(vec_k00_h,vec_k01_h,vec_k02_h,data_input);
-      transfer4x8(vec_k20_h,vec_k21_h,vec_k22_h,vec_k00_h,data_output);
-      data_output+=32;
-      LOAD_36x8_K3_B4(vec_k10_h,vec_k11_h,vec_k12_h,data_input + win);
-      transfer4x8(vec_k01_h,vec_k02_h,vec_k10_h,vec_k11_h,data_output);
-      data_output+=32;
-      LOAD_36x8_K3_B4(vec_k20_h,vec_k21_h,vec_k22_h,data_input + 2*win);
-      transfer4x8(vec_k12_h,vec_k20_h,vec_k21_h,vec_k22_h,data_output);
-      data_output+=32;
+      LOAD_36x8_K3_B4(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+      transfer4x8(vec_k20_h, vec_k21_h, vec_k22_h, vec_k00_h, data_output);
+      data_output += 32;
+      LOAD_36x8_K3_B4(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+      transfer4x8(vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, data_output);
+      data_output += 32;
+      LOAD_36x8_K3_B4(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+      transfer4x8(vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h, data_output);
+      data_output += 32;
     }
   };
 
-  auto loop_func_36x4 = [&](int8_t* data_im_block, int loop_row, int loop_col, 
-                             int8_t* data_out_block) {
+  auto loop_func_36x4 = [&](int8_t* data_im_block,
+                            int loop_row,
+                            int loop_col,
+                            int8_t* data_out_block) {
     auto cur_ow = loop_col % output_w;
     auto cur_oh = loop_col / output_w;
     int input_idx = cur_oh * win + cur_ow;
     auto data_input = data_im_block;
     auto data_output = data_out_block;
-    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, 
-        vec_k11, vec_k12, vec_k20, vec_k21, vec_k22;
-    int8x8_t vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, 
-        vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h;
+    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, vec_k11, vec_k12, vec_k20,
+        vec_k21, vec_k22;
+    int8x8_t vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, vec_k11_h, vec_k12_h,
+        vec_k20_h, vec_k21_h, vec_k22_h;
     int8x8_t vec_h, vec_tmp, vec_tmp1;
-    int8_t *out_k00, *out_k01,*out_k02,*out_k10,*out_k11,
-      *out_k12,*out_k20,*out_k21,*out_k22;
+    int8_t *out_k00, *out_k01, *out_k02, *out_k10, *out_k11, *out_k12, *out_k20,
+        *out_k21, *out_k22;
     int8x16_t res;
     int cnt = 0;
 
-    if(cur_ow + 3 < output_w) {
+    if (cur_ow + 3 < output_w) {
       // OC1
       data_input = data_im_block + input_idx;
       LOAD_36x4;
-      transfer4x4(out_k00,out_k01,out_k02,out_k10,data_output);
-      data_output+=16;
-      transfer4x4(out_k11,out_k12,out_k20,out_k21,data_output);
-      data_output+=16;
+      transfer4x4(out_k00, out_k01, out_k02, out_k10, data_output);
+      data_output += 16;
+      transfer4x4(out_k11, out_k12, out_k20, out_k21, data_output);
+      data_output += 16;
       // OC2
       data_input = data_im_block + input_idx + padding_size;
       LOAD_36x4;
-      transfer4x4(out_k22,out_k00,out_k01,out_k02,data_output);
-      data_output+=16;
-      transfer4x4(out_k10,out_k11,out_k12,out_k20,data_output);
-      data_output+=16;
+      transfer4x4(out_k22, out_k00, out_k01, out_k02, data_output);
+      data_output += 16;
+      transfer4x4(out_k10, out_k11, out_k12, out_k20, data_output);
+      data_output += 16;
       // OC3
       data_input = data_im_block + input_idx + 2 * padding_size;
       LOAD_36x4;
-      transfer4x4(out_k21,out_k22,out_k00,out_k01,data_output);
-      data_output+=16;
-      transfer4x4(out_k02,out_k10,out_k11,out_k12,data_output);
-      data_output+=16;
+      transfer4x4(out_k21, out_k22, out_k00, out_k01, data_output);
+      data_output += 16;
+      transfer4x4(out_k02, out_k10, out_k11, out_k12, data_output);
+      data_output += 16;
       // OC4
       data_input = data_im_block + input_idx + 3 * padding_size;
       LOAD_36x4;
-      transfer4x4(out_k20,out_k21,out_k22,out_k00,data_output);
-      data_output+=16;
-      transfer4x4(out_k01,out_k02,out_k10,out_k11,data_output);
-      data_output+=16;
-      transfer4x4(out_k12,out_k20,out_k21,out_k22,data_output);
-      data_output+=16;
+      transfer4x4(out_k20, out_k21, out_k22, out_k00, data_output);
+      data_output += 16;
+      transfer4x4(out_k01, out_k02, out_k10, out_k11, data_output);
+      data_output += 16;
+      transfer4x4(out_k12, out_k20, out_k21, out_k22, data_output);
+      data_output += 16;
     }
   };
 
@@ -1322,20 +1345,23 @@ void im2col_packb_3x3s1p1(const int8_t* data_im,
   for (int loop_row = 0; loop_row + 35 < looph; loop_row += 36) {
     int cur_ic = loop_row / kernel_size;
     // padding 4C per cycle
-    for(int c = 0; c < 4; c++)
-      padding_zero(data_im + (cur_ic + c) * channel_size, width, height, workspace + c * padding_size);
+    for (int c = 0; c < 4; c++)
+      padding_zero(data_im + (cur_ic + c) * channel_size,
+                   width,
+                   height,
+                   workspace + c * padding_size);
     auto data_im_pad = workspace;
-    
-    int loop_col = 0; // only support ow % 8 == 0, tail must be 12/8/4
-    for(;loop_col + 11 < loopw; loop_col += 12) {
+
+    int loop_col = 0;  // only support ow % 8 == 0, tail must be 12/8/4
+    for (; loop_col + 11 < loopw; loop_col += 12) {
       auto data_col_12_block = data_col + loop_col * looph + 12 * loop_row;
       loop_func_36x12(data_im_pad, loop_row, loop_col, data_col_12_block);
     }
-    for(;loop_col + 7 < loopw; loop_col += 8) {
+    for (; loop_col + 7 < loopw; loop_col += 8) {
       auto data_col_8_block = data_col + loop_col * looph + 8 * loop_row;
       loop_func_36x8(data_im_pad, loop_row, loop_col, data_col_8_block);
     }
-    for(;loop_col + 3 < loopw; loop_col += 4) {
+    for (; loop_col + 3 < loopw; loop_col += 4) {
       auto data_col_4_block = data_col + loop_col * looph + 4 * loop_row;
       loop_func_36x4(data_im_pad, loop_row, loop_col, data_col_4_block);
     }
@@ -1344,19 +1370,20 @@ void im2col_packb_3x3s1p1(const int8_t* data_im,
 
 template <typename Dtype>
 void conv_im2col_gemm_int8_fast(const int8_t* i_data,
-                           Dtype* o_data,
-                           int num,
-                           int oc,
-                           int oh,
-                           int ow,
-                           int ic,
-                           int ih,
-                           int win,
-                           const int8_t* weights,
-                           const float* bias,
-                           const operators::ConvParam& param,
-                           ARMContext* ctx,
-                           const float* scale) {
+                                Dtype* o_data,
+                                int num,
+                                int oc,
+                                int oh,
+                                int ow,
+                                int ic,
+                                int ih,
+                                int win,
+                                const int8_t* weights,
+                                const float* bias,
+                                const operators::ConvParam& param,
+                                ARMContext* ctx,
+                                const float* scale) {
+  LOG(INFO) << "==================in";
   int group = 1;
   auto filter_dims = param.filter->dims();
   auto paddings = *param.paddings;
@@ -1388,33 +1415,31 @@ void conv_im2col_gemm_int8_fast(const int8_t* i_data,
 
   int8_t* tmp_work_space =
       ctx->workspace_data<int8_t>() + ctx->llc_size() / sizeof(int8_t);
-  auto pad_b =
-      static_cast<int8_t*>(TargetMalloc(TARGET(kARM), 4 * (ih + 2) * (win + 2) + 16));
+  auto pad_b = static_cast<int8_t*>(
+      TargetMalloc(TARGET(kARM), 4 * (ih + 2) * (win + 2) + 16));
 
   for (int b = 0; b < num; ++b) {
     Dtype* dout_group = o_data + (b * oc) * channel_size_out;
-    const int8_t* din_group = static_cast<const int8_t*>(i_data) +
-                              (b * ic) * channel_size_in;
-    const int8_t* weights_group =
-        static_cast<const int8_t*>(weights);
+    const int8_t* din_group =
+        static_cast<const int8_t*>(i_data) + (b * ic) * channel_size_in;
+    const int8_t* weights_group = static_cast<const int8_t*>(weights);
     const float* bias_group = bias;
     int8_t* dB = tmp_work_space;
     const float* scale_group = scale;
-    
+
     im2col_packb_3x3s1p1(din_group, chin_per_group, ih, win, dB, pad_b);
     gemm_prepack_int8_nopack(weights_group,
-                      dB,
-                      bias_group,
-                      dout_group,
-                      m,
-                      n,
-                      k,
-                      flag_bias,
-                      false,
-                      scale_group,
-                      act_param,
-                      ctx);
-
+                             dB,
+                             bias_group,
+                             dout_group,
+                             m,
+                             n,
+                             k,
+                             flag_bias,
+                             false,
+                             scale_group,
+                             act_param,
+                             ctx);
   }
   TargetFree(TARGET(kARM), pad_b);
 }
@@ -1485,14 +1510,29 @@ void conv_im2col_gemm_int8(const int8_t* i_data,
   bool ker_3 = (kernel_h == kernel_w) && (kernel_w == 3);
   bool stride_1 = (stride_h == stride_w) && (stride_h == 1);
   bool dila_1 = (dila_h == dila_w) && (dila_h == 1);
-  bool pad_1 = (paddings[0] == paddings[1]) && (paddings[2] == paddings[3]) && (paddings[0] == paddings[2]) && (paddings[0] == 1);
+  bool pad_1 = (paddings[0] == paddings[1]) && (paddings[2] == paddings[3]) &&
+               (paddings[0] == paddings[2]) && (paddings[0] == 1);
   bool mod_cond = (ic % 4 == 0) && (win % 8 == 0);
-  if(ker_3 && stride_1 && dila_1 && pad_1 && mod_cond) {
-    conv_im2col_gemm_int8_fast(i_data, o_data, num, oc, oh, ow, ic, ih, win, weights, bias, param, ctx, scale); 
+  bool group_1 = (group == 1);
+  bool mn_gt_1 = (m > 1) && (n > 1);
+  if (ker_3 && stride_1 && dila_1 && pad_1 && group_1 && mn_gt_1 && mod_cond) {
+    conv_im2col_gemm_int8_fast(i_data,
+                               o_data,
+                               num,
+                               oc,
+                               oh,
+                               ow,
+                               ic,
+                               ih,
+                               win,
+                               weights,
+                               bias,
+                               param,
+                               ctx,
+                               scale);
     return;
   }
 #endif
-
 
   //! use gemv when the output channel size = 1
   for (int b = 0; b < num; ++b) {

--- a/lite/backends/arm/math/conv_impl.cc
+++ b/lite/backends/arm/math/conv_impl.cc
@@ -917,6 +917,509 @@ void conv_im2col_gemm(const float* i_data,
   }
 }
 
+// fuse im2col and packB
+#ifdef __aarch64__
+
+// only support 3x3s1p1
+static void padding_zero(const int8_t *data_in, int iw, int ih, int8_t *data_out) {
+  int ow = iw + 2;
+  int oh = ih + 2;
+  memset(data_out, 0, ow);
+  memset(data_out + (oh - 1) * ow, 0, ow);
+  auto data_out_ptr = data_out + ow;
+  for(int row = 0;row<ih;row++) {
+    data_out_ptr[0] = 0;
+    memcpy(data_out_ptr + 1, data_in + row * iw, iw);
+    data_out_ptr[ow-1] = 0;
+    data_out_ptr += ow;
+  }
+}
+
+#define transfer4x12(line1, line2, line3, line4, data_out) \
+  line_1_2 = vtrnq_s8(line1, line2);\
+  line_3_4 = vtrnq_s8(line3, line4);\
+  out0 = vtrnq_s16(line_1_2.val[0], line_3_4.val[0]);\
+  out1 = vtrnq_s16(line_1_2.val[1], line_3_4.val[1]);\
+  line_1_2_int32 = vtrnq_s32(out0.val[0], out1.val[0]);\
+  line_3_4_int32 = vtrnq_s32(out0.val[1], out1.val[1]);\
+  vst1q_s32((int*)data_out, vcombine_s32(vget_low_s32(line_1_2_int32.val[0]), vget_low_s32(line_3_4_int32.val[0])));\
+  vst1q_s32((int*)(data_out+16), vcombine_s32(vget_low_s32(line_1_2_int32.val[1]), vget_low_s32(line_3_4_int32.val[1])));\
+  vst1q_s32((int*)(data_out+32), vcombine_s32(vget_high_s32(line_1_2_int32.val[0]), vget_high_s32(line_3_4_int32.val[0])));
+
+#define transfer4x8(line1, line2, line3, line4, data_out)\
+  line_1_2 = vtrn_s8(line1, line2);\
+  line_3_4 = vtrn_s8(line3, line4);\
+  out0 = vtrn_s16(line_1_2.val[0], line_3_4.val[0]);\
+  out1 = vtrn_s16(line_1_2.val[1], line_3_4.val[1]);\
+  line_1_2_int32 = vtrn_s32(out0.val[0], out1.val[0]);\
+  line_3_4_int32 = vtrn_s32(out0.val[1], out1.val[1]);\
+  vst1q_s32((int*)data_out, vcombine_s32(line_1_2_int32.val[0], line_3_4_int32.val[0]));\
+  vst1q_s32((int*)(data_out+16), vcombine_s32(line_1_2_int32.val[1], line_3_4_int32.val[1]));
+
+#define transfer4x4(line1, line2, line3, line4, data_out) \
+  cnt = 0;\
+  for(int i = 0; i < 4;i++) {\
+    res[cnt++] = line1[i];\
+    res[cnt++] = line2[i];\
+    res[cnt++] = line3[i];\
+    res[cnt++] = line4[i];\
+  }\
+  vst1q_s8(data_out, res);
+
+#define LOAD_36x12_K3(vec_k0, vec_k1, vec_k2, data_input)\
+      vec_k0 = vld1q_s8((data_input));\
+      vec_k1 = vextq_s8(vec_k0, vec_zero, 1);\
+      vec_k2 = vextq_s8(vec_k0, vec_zero, 2);
+
+#define LOAD_36x12_K3_B8(vec_k0, vec_k1, vec_k2, data_input)\
+      vec_h = vld1_s8((data_input));\
+      vec_tmp = vld1_s8((data_input) + 8);\
+      vec_k0 = vcombine_s8(vec_h, vtbl1_s8(vec_tmp, vec_idx));\
+      vec_k1 = vcombine_s8(vext_s8(vec_h, vec_tmp, 1), vtbl1_s8(vec_tmp, vec_idx1));\
+      vec_k2 = vcombine_s8(vext_s8(vec_h, vec_tmp, 2), vtbl1_s8(vec_tmp, vec_idx2));
+
+#define LOAD_36x12_K3_B4(vec_k0, vec_k1, vec_k2, data_input)\
+      vec_h = vld1_s8((data_input));\
+      vec_tmp = vld1_s8((data_input) + 8);\
+      vec_k0 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx3), vec_tmp, 2), vext_s8(vec_tmp, vec_zero_h, 2));\
+      vec_k1 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx4), vec_tmp, 3), vext_s8(vec_tmp, vec_zero_h, 3));\
+      vec_k2 = vcombine_s8(vext_s8(vtbl1_s8(vec_h, vec_idx5), vec_tmp, 4), vext_s8(vec_tmp, vec_zero_h, 4));
+
+#define LOAD_36x8_K3(vec_k0, vec_k1, vec_k2, data_input)\
+      vec_k0 = vld1_s8((data_input));\
+      vec_h = vld1_s8((data_input) + 8);\
+      vec_k1 = vext_s8(vec_k0, vec_h, 1);\
+      vec_k2 = vext_s8(vec_k0, vec_h, 2);
+
+#define LOAD_36x8_K3_B4(vec_k0, vec_k1, vec_k2, data_input)\
+      vec_h = vld1_s8((data_input));\
+      vec_tmp = vld1_s8((data_input) + 8);\
+      vec_k0 = vext_s8(vtbl1_s8(vec_h, vec_idx3), vec_tmp, 2);\
+      vec_k1 = vext_s8( vtbl1_s8(vec_h, vec_idx4), vec_tmp, 3);\
+      vec_k2 = vext_s8(vtbl1_s8(vec_h, vec_idx5), vec_tmp, 4);
+
+#define LOAD_36x4\
+      out_k00 = data_input;\
+      out_k01 = data_input + 1;\
+      out_k02 = data_input + 2;\
+      out_k10 = data_input + win;\
+      out_k11 = data_input + win + 1;\
+      out_k12 = data_input + win + 2;\
+      out_k20 = data_input + 2 * win;\
+      out_k21 = data_input + 2 * win + 1;\
+      out_k22 = data_input + 2 * win + 2;
+
+/* condition: ow % 8 == 0, ic % 4 == 0, 3x3s1p1d1g1
+ workspace needs 4 * (width+2) * (height+2) + 16bytes(overread)*/
+void im2col_packb_3x3s1p1(const int8_t* data_im,
+                          int channels,
+                          int height,
+                          int width,
+                          int8_t* data_col,
+                          int8_t* workspace) {
+  const int channel_size = height * width;
+  const int kernel_size = 9;
+  const int step = channels * kernel_size;
+  const int loopw = channel_size;
+  const int looph = ROUNDUP(step, 4);
+  const int win = width + 2;
+  const int hin = height + 2;
+  const int padding_size = win * hin;
+  const int output_w = width;
+  int8x16_t vec_zero = vdupq_n_s8(0);
+  int8x8_t vec_zero_h = vdup_n_s8(0);
+  int8x8_t vec_idx = {2,3,4,5,2,3,4,5};   // for vtbl1
+  int8x8_t vec_idx1 = {3,4,5,6,3,4,5,6};
+  int8x8_t vec_idx2 = {4,5,6,7,4,5,6,7};
+  int8x8_t vec_idx3 = {0,0,0,1,2,3,6,7};
+  int8x8_t vec_idx4 = {0,0,0,1,2,3,4,7};
+  int8x8_t vec_idx5 = {0,0,0,0,2,3,4,5};
+
+  auto loop_func_36x12 = [&](int8_t* data_im_block, int loop_row, int loop_col, 
+                             int8_t* data_out_block) {
+    auto cur_ow = loop_col % output_w;
+    auto cur_oh = loop_col / output_w;
+    int input_idx = cur_oh * win + cur_ow;
+    int8_t* data_input = data_im_block;
+    int8_t* data_output = data_out_block;
+    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, 
+        vec_k11, vec_k12, vec_k20, vec_k21, vec_k22;
+    int8x8_t vec_tmp, vec_h;
+    int8x16x2_t line_1_2, line_3_4;
+    int16x8x2_t out0, out1;
+    int32x4x2_t line_1_2_int32, line_3_4_int32;
+
+    // for ow % 8 == 0, (ow*oh)%12 must be 4/8/12
+    if(cur_ow + 11 < output_w) { // overread 2bytes(16(neon) - 12(block) - 2(pad))
+      // OC1
+      data_input = data_im_block + input_idx;
+      LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
+      LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k00,vec_k01,vec_k02,vec_k10,data_output);
+      data_output += 48;
+      LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+      transfer4x12(vec_k11,vec_k12,vec_k20,vec_k21,data_output);
+      data_output += 48;
+      // OC2
+      data_input = data_im_block + input_idx + padding_size;
+      LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
+      LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k22,vec_k00,vec_k01,vec_k02,data_output);
+      data_output += 48;
+      LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+      transfer4x12(vec_k10,vec_k11,vec_k12,vec_k20,data_output);
+      data_output += 48;
+      // OC3
+      data_input = data_im_block + input_idx + padding_size * 2;
+      LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
+      LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k21,vec_k22,vec_k00,vec_k01,data_output);
+      data_output += 48;
+      LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+      transfer4x12(vec_k02,vec_k10,vec_k11,vec_k12,data_output);
+      data_output += 48;
+      // OC4
+      data_input = data_im_block + input_idx + padding_size * 3;
+      LOAD_36x12_K3(vec_k00, vec_k01, vec_k02, data_input);
+      transfer4x12(vec_k20,vec_k21,vec_k22,vec_k00,data_output);
+      data_output += 48;
+      LOAD_36x12_K3(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k01,vec_k02,vec_k10,vec_k11,data_output);
+      data_output += 48;
+      LOAD_36x12_K3(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+      transfer4x12(vec_k12,vec_k20,vec_k21,vec_k22,data_output);
+      data_output += 48;
+    } else if(cur_ow + 7 < output_w) { // current line fetch 8 and next line fetch 4
+      // OC1
+      data_input = data_im_block + input_idx;
+      LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
+      LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k00,vec_k01,vec_k02,vec_k10,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+      transfer4x12(vec_k11,vec_k12,vec_k20,vec_k21,data_output);
+      data_output += 48;
+      // OC2
+      data_input = data_im_block + input_idx + padding_size;
+      LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
+      transfer4x12(vec_k22,vec_k00,vec_k01,vec_k02,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
+      LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+      transfer4x12(vec_k10,vec_k11,vec_k12,vec_k20,data_output);
+      data_output += 48;
+      // OC3
+      data_input = data_im_block + input_idx + 2 * padding_size;
+      LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
+      transfer4x12(vec_k21,vec_k22,vec_k00,vec_k01,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k02,vec_k10,vec_k11,vec_k12,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+      // OC4
+      data_input = data_im_block + input_idx + 3 * padding_size;
+      LOAD_36x12_K3_B8(vec_k00, vec_k01, vec_k02, data_input);
+      transfer4x12(vec_k20,vec_k21,vec_k22,vec_k00,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B8(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k01,vec_k02,vec_k10,vec_k11,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B8(vec_k20, vec_k21, vec_k22, data_input + 2 * win);
+      transfer4x12(vec_k12,vec_k20,vec_k21,vec_k22,data_output);
+      data_output += 48;
+    } else { // 4, current line fetch 4 and next line fetch 8
+      // OC1
+      data_input = data_im_block + input_idx;
+      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
+      LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k00,vec_k01,vec_k02,vec_k10,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
+      transfer4x12(vec_k11,vec_k12,vec_k20,vec_k21,data_output);
+      data_output += 48;
+      // OC2
+      data_input = data_im_block + input_idx + padding_size;
+      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
+      transfer4x12(vec_k22,vec_k00,vec_k01,vec_k02,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
+      LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
+      transfer4x12(vec_k10,vec_k11,vec_k12,vec_k20,data_output);
+      data_output += 48;
+      // OC3
+      data_input = data_im_block + input_idx + 2 * padding_size;
+      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input);
+      transfer4x12(vec_k21,vec_k22,vec_k00,vec_k01,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k02,vec_k10,vec_k11,vec_k12,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
+      // OC4
+      data_input = data_im_block + input_idx + 3 * padding_size;
+      LOAD_36x12_K3_B4(vec_k00, vec_k01, vec_k02, data_input); 
+      transfer4x12(vec_k20,vec_k21,vec_k22,vec_k00,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B4(vec_k10, vec_k11, vec_k12, data_input + win);
+      transfer4x12(vec_k01,vec_k02,vec_k10,vec_k11,data_output);
+      data_output += 48;
+      LOAD_36x12_K3_B4(vec_k20, vec_k21, vec_k22, data_input + win * 2);
+      transfer4x12(vec_k12,vec_k20,vec_k21,vec_k22,data_output);
+      data_output += 48;
+    }
+  };
+
+  auto loop_func_36x8 = [&](int8_t* data_im_block, int loop_row, int loop_col, 
+                             int8_t* data_out_block) {
+    auto cur_ow = loop_col % output_w;
+    auto cur_oh = loop_col / output_w;
+    int input_idx = cur_oh * win + cur_ow;
+    auto data_output = data_out_block;
+    auto data_input = data_im_block;
+    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, 
+        vec_k11, vec_k12, vec_k20, vec_k21, vec_k22;
+    int8x8_t vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, 
+        vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h;
+    int8x8_t vec_h, vec_tmp;
+    int8x8x2_t line_1_2, line_3_4;
+    int16x4x2_t out0, out1;
+    int32x2x2_t line_1_2_int32, line_3_4_int32;
+
+    if(cur_ow + 7 < output_w) {
+      // OC1
+      data_input = data_im_block + input_idx;
+      LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+      LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+      transfer4x8(vec_k00_h,vec_k01_h,vec_k02_h,vec_k10_h,data_output);
+      data_output+=32;
+      LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+      transfer4x8(vec_k11_h,vec_k12_h,vec_k20_h,vec_k21_h,data_output);
+      data_output+=32;
+      // OC2
+      data_input = data_im_block + input_idx + padding_size;
+      LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+      transfer4x8(vec_k22_h,vec_k00_h,vec_k01_h,vec_k02_h,data_output);
+      data_output+=32;
+      LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+      LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+      transfer4x8(vec_k10_h,vec_k11_h,vec_k12_h,vec_k20_h,data_output);
+      data_output+=32;
+      // OC3
+      data_input = data_im_block + input_idx + 2 * padding_size;
+      LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+      transfer4x8(vec_k21_h,vec_k22_h,vec_k00_h,vec_k01_h,data_output);
+      data_output+=32;
+      LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+      LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+      transfer4x8(vec_k02_h,vec_k10_h,vec_k11_h,vec_k12_h,data_output);
+      data_output+=32;
+      // OC4
+      data_input = data_im_block + input_idx + 3 * padding_size;
+      LOAD_36x8_K3(vec_k00_h, vec_k01_h, vec_k02_h, data_input);
+      transfer4x8(vec_k20_h,vec_k21_h,vec_k22_h,vec_k00_h,data_output);
+      data_output+=32;
+      LOAD_36x8_K3(vec_k10_h, vec_k11_h, vec_k12_h, data_input + win);
+      LOAD_36x8_K3(vec_k20_h, vec_k21_h, vec_k22_h, data_input + 2 * win);
+      transfer4x8(vec_k01_h,vec_k02_h,vec_k10_h,vec_k11_h,data_output);
+      data_output+=32;
+      transfer4x8(vec_k12_h,vec_k20_h,vec_k21_h,vec_k22_h,data_output);
+      data_output+=32;
+    } else {
+      // OC1
+      data_input = data_im_block + input_idx;
+      LOAD_36x8_K3_B4(vec_k00_h,vec_k01_h,vec_k02_h,data_input);
+      LOAD_36x8_K3_B4(vec_k10_h,vec_k11_h,vec_k12_h,data_input + win);
+      transfer4x8(vec_k00_h,vec_k01_h,vec_k02_h,vec_k10_h,data_output);
+      data_output+=32;
+      LOAD_36x8_K3_B4(vec_k20_h,vec_k21_h,vec_k22_h,data_input + 2*win);
+      transfer4x8(vec_k11_h,vec_k12_h,vec_k20_h,vec_k21_h,data_output);
+      data_output+=32;
+      // OC2
+      data_input = data_im_block + input_idx + padding_size;
+      LOAD_36x8_K3_B4(vec_k00_h,vec_k01_h,vec_k02_h,data_input);
+      transfer4x8(vec_k22_h,vec_k00_h,vec_k01_h,vec_k02_h,data_output);
+      data_output+=32;
+      LOAD_36x8_K3_B4(vec_k10_h,vec_k11_h,vec_k12_h,data_input + win);
+      LOAD_36x8_K3_B4(vec_k20_h,vec_k21_h,vec_k22_h,data_input + 2*win);
+      transfer4x8(vec_k10_h,vec_k11_h,vec_k12_h,vec_k20_h,data_output);
+      data_output+=32;
+      // OC3
+      data_input = data_im_block + input_idx + padding_size * 2;
+      LOAD_36x8_K3_B4(vec_k00_h,vec_k01_h,vec_k02_h,data_input);
+      transfer4x8(vec_k21_h,vec_k22_h,vec_k00_h,vec_k01_h,data_output);
+      data_output+=32;
+      LOAD_36x8_K3_B4(vec_k10_h,vec_k11_h,vec_k12_h,data_input + win);
+      LOAD_36x8_K3_B4(vec_k20_h,vec_k21_h,vec_k22_h,data_input + 2*win);
+      transfer4x8(vec_k02_h,vec_k10_h,vec_k11_h,vec_k12_h,data_output);
+      data_output+=32;
+      // OC4
+      data_input = data_im_block + input_idx + padding_size * 3;
+      LOAD_36x8_K3_B4(vec_k00_h,vec_k01_h,vec_k02_h,data_input);
+      transfer4x8(vec_k20_h,vec_k21_h,vec_k22_h,vec_k00_h,data_output);
+      data_output+=32;
+      LOAD_36x8_K3_B4(vec_k10_h,vec_k11_h,vec_k12_h,data_input + win);
+      transfer4x8(vec_k01_h,vec_k02_h,vec_k10_h,vec_k11_h,data_output);
+      data_output+=32;
+      LOAD_36x8_K3_B4(vec_k20_h,vec_k21_h,vec_k22_h,data_input + 2*win);
+      transfer4x8(vec_k12_h,vec_k20_h,vec_k21_h,vec_k22_h,data_output);
+      data_output+=32;
+    }
+  };
+
+  auto loop_func_36x4 = [&](int8_t* data_im_block, int loop_row, int loop_col, 
+                             int8_t* data_out_block) {
+    auto cur_ow = loop_col % output_w;
+    auto cur_oh = loop_col / output_w;
+    int input_idx = cur_oh * win + cur_ow;
+    auto data_input = data_im_block;
+    auto data_output = data_out_block;
+    int8x16_t vec_k00, vec_k01, vec_k02, vec_k10, 
+        vec_k11, vec_k12, vec_k20, vec_k21, vec_k22;
+    int8x8_t vec_k00_h, vec_k01_h, vec_k02_h, vec_k10_h, 
+        vec_k11_h, vec_k12_h, vec_k20_h, vec_k21_h, vec_k22_h;
+    int8x8_t vec_h, vec_tmp, vec_tmp1;
+    int8_t *out_k00, *out_k01,*out_k02,*out_k10,*out_k11,
+      *out_k12,*out_k20,*out_k21,*out_k22;
+    int8x16_t res;
+    int cnt = 0;
+
+    if(cur_ow + 3 < output_w) {
+      // OC1
+      data_input = data_im_block + input_idx;
+      LOAD_36x4;
+      transfer4x4(out_k00,out_k01,out_k02,out_k10,data_output);
+      data_output+=16;
+      transfer4x4(out_k11,out_k12,out_k20,out_k21,data_output);
+      data_output+=16;
+      // OC2
+      data_input = data_im_block + input_idx + padding_size;
+      LOAD_36x4;
+      transfer4x4(out_k22,out_k00,out_k01,out_k02,data_output);
+      data_output+=16;
+      transfer4x4(out_k10,out_k11,out_k12,out_k20,data_output);
+      data_output+=16;
+      // OC3
+      data_input = data_im_block + input_idx + 2 * padding_size;
+      LOAD_36x4;
+      transfer4x4(out_k21,out_k22,out_k00,out_k01,data_output);
+      data_output+=16;
+      transfer4x4(out_k02,out_k10,out_k11,out_k12,data_output);
+      data_output+=16;
+      // OC4
+      data_input = data_im_block + input_idx + 3 * padding_size;
+      LOAD_36x4;
+      transfer4x4(out_k20,out_k21,out_k22,out_k00,data_output);
+      data_output+=16;
+      transfer4x4(out_k01,out_k02,out_k10,out_k11,data_output);
+      data_output+=16;
+      transfer4x4(out_k12,out_k20,out_k21,out_k22,data_output);
+      data_output+=16;
+    }
+  };
+
+  // 4c x 3 x 3, only support c%4==0
+  for (int loop_row = 0; loop_row + 35 < looph; loop_row += 36) {
+    int cur_ic = loop_row / kernel_size;
+    // padding 4C per cycle
+    for(int c = 0; c < 4; c++)
+      padding_zero(data_im + (cur_ic + c) * channel_size, width, height, workspace + c * padding_size);
+    auto data_im_pad = workspace;
+    
+    int loop_col = 0; // only support ow % 8 == 0, tail must be 12/8/4
+    for(;loop_col + 11 < loopw; loop_col += 12) {
+      auto data_col_12_block = data_col + loop_col * looph + 12 * loop_row;
+      loop_func_36x12(data_im_pad, loop_row, loop_col, data_col_12_block);
+    }
+    for(;loop_col + 7 < loopw; loop_col += 8) {
+      auto data_col_8_block = data_col + loop_col * looph + 8 * loop_row;
+      loop_func_36x8(data_im_pad, loop_row, loop_col, data_col_8_block);
+    }
+    for(;loop_col + 3 < loopw; loop_col += 4) {
+      auto data_col_4_block = data_col + loop_col * looph + 4 * loop_row;
+      loop_func_36x4(data_im_pad, loop_row, loop_col, data_col_4_block);
+    }
+  }
+}
+
+template <typename Dtype>
+void conv_im2col_gemm_int8_fast(const int8_t* i_data,
+                           Dtype* o_data,
+                           int num,
+                           int oc,
+                           int oh,
+                           int ow,
+                           int ic,
+                           int ih,
+                           int win,
+                           const int8_t* weights,
+                           const float* bias,
+                           const operators::ConvParam& param,
+                           ARMContext* ctx,
+                           const float* scale) {
+  int group = 1;
+  auto filter_dims = param.filter->dims();
+  auto paddings = *param.paddings;
+  auto dilations = *param.dilations;
+  int kernel_h = filter_dims[2];
+  int kernel_w = filter_dims[3];
+  int stride_h = param.strides[0];
+  int stride_w = param.strides[1];
+  int dila_h = dilations[0];
+  int dila_w = dilations[1];
+  int pad_h = paddings[0];
+  int pad_w = paddings[2];
+  const int m = oc / group;
+  const int n = oh * ow;
+  const int k = ic * kernel_h * kernel_w / group;
+  const int chin_per_group = ic / group;
+  int channel_size_out = ow * oh;
+  int channel_size_in = win * ih;
+  bool flag_relu = param.fuse_relu;
+  bool flag_bias = param.bias != nullptr;
+  auto act_param = param.activation_param;
+  int weights_size_per_group = m * k;
+  int hblock = get_hblock_int8(ctx);
+  int k_roundup = ROUNDUP(k, KBLOCK_INT8);
+  int m_roundup = ROUNDUP(m, hblock);
+  if (n > 1 && m > 1) {
+    weights_size_per_group = ((m_roundup * k_roundup + 15) / 16) * 16;
+  }
+
+  int8_t* tmp_work_space =
+      ctx->workspace_data<int8_t>() + ctx->llc_size() / sizeof(int8_t);
+  auto pad_b =
+      static_cast<int8_t*>(TargetMalloc(TARGET(kARM), 4 * (ih + 2) * (win + 2) + 16));
+
+  for (int b = 0; b < num; ++b) {
+    Dtype* dout_group = o_data + (b * oc) * channel_size_out;
+    const int8_t* din_group = static_cast<const int8_t*>(i_data) +
+                              (b * ic) * channel_size_in;
+    const int8_t* weights_group =
+        static_cast<const int8_t*>(weights);
+    const float* bias_group = bias;
+    int8_t* dB = tmp_work_space;
+    const float* scale_group = scale;
+    
+    im2col_packb_3x3s1p1(din_group, chin_per_group, ih, win, dB, pad_b);
+    gemm_prepack_int8_nopack(weights_group,
+                      dB,
+                      bias_group,
+                      dout_group,
+                      m,
+                      n,
+                      k,
+                      flag_bias,
+                      false,
+                      scale_group,
+                      act_param,
+                      ctx);
+
+  }
+  TargetFree(TARGET(kARM), pad_b);
+}
+#endif
+
 template <typename Dtype>
 void conv_im2col_gemm_int8(const int8_t* i_data,
                            Dtype* o_data,
@@ -977,6 +1480,19 @@ void conv_im2col_gemm_int8(const int8_t* i_data,
 
   int8_t* tmp_work_space =
       ctx->workspace_data<int8_t>() + ctx->llc_size() / sizeof(int8_t);
+
+#ifdef __aarch64__
+  bool ker_3 = (kernel_h == kernel_w) && (kernel_w == 3);
+  bool stride_1 = (stride_h == stride_w) && (stride_h == 1);
+  bool dila_1 = (dila_h == dila_w) && (dila_h == 1);
+  bool pad_1 = (paddings[0] == paddings[1]) && (paddings[2] == paddings[3]) && (paddings[0] == paddings[2]) && (paddings[0] == 1);
+  bool mod_cond = (ic % 4 == 0) && (win % 8 == 0);
+  if(ker_3 && stride_1 && dila_1 && pad_1 && mod_cond) {
+    conv_im2col_gemm_int8_fast(i_data, o_data, num, oc, oh, ow, ic, ih, win, weights, bias, param, ctx, scale); 
+    return;
+  }
+#endif
+
 
   //! use gemv when the output channel size = 1
   for (int b = 0; b < num; ++b) {

--- a/lite/backends/arm/math/conv_impl.cc
+++ b/lite/backends/arm/math/conv_impl.cc
@@ -1514,7 +1514,7 @@ void conv_im2col_gemm_int8(const int8_t* i_data,
   bool group_1 = (group == 1);
   bool mn_gt_1 = (m > 1) && (n > 1);
   if (ker_3 && stride_1 && dila_1 && pad_1 && group_1 && mn_gt_1 && mod_cond &&
-      ctx->has_dot()) {
+      ctx->has_dot() && !ctx->has_sve2_i8mm()) {
     conv_im2col_gemm_int8_fast(i_data,
                                o_data,
                                num,
@@ -1532,7 +1532,6 @@ void conv_im2col_gemm_int8(const int8_t* i_data,
     return;
   }
 #endif
-
   //! use gemv when the output channel size = 1
   for (int b = 0; b < num; ++b) {
     // dC

--- a/lite/backends/arm/math/conv_impl.cc
+++ b/lite/backends/arm/math/conv_impl.cc
@@ -936,30 +936,38 @@ static void padding_zero(const int8_t* data_in,
   }
 }
 
-#define transfer4x12(line1, line2, line3, line4, data_out)      \
-  line_1_2 = vtrnq_s8(line1, line2);                            \
-  line_3_4 = vtrnq_s8(line3, line4);                            \
-  out0 = vtrnq_s16(line_1_2.val[0], line_3_4.val[0]);           \
-  out1 = vtrnq_s16(line_1_2.val[1], line_3_4.val[1]);           \
-  line_1_2_int32 = vtrnq_s32(out0.val[0], out1.val[0]);         \
-  line_3_4_int32 = vtrnq_s32(out0.val[1], out1.val[1]);         \
-  vst1q_s32(reinterpret_cast<int*>(data_out),                   \
-            vcombine_s32(vget_low_s32(line_1_2_int32.val[0]),   \
-                         vget_low_s32(line_3_4_int32.val[0]))); \
-  vst1q_s32(reinterpret_cast<int*>(data_out + 16),              \
-            vcombine_s32(vget_low_s32(line_1_2_int32.val[1]),   \
-                         vget_low_s32(line_3_4_int32.val[1]))); \
-  vst1q_s32(reinterpret_cast<int*>(data_out + 32),              \
-            vcombine_s32(vget_high_s32(line_1_2_int32.val[0]),  \
+#define transfer4x12(line1, line2, line3, line4, data_out)        \
+  line_1_2 = vtrnq_s8(line1, line2);                              \
+  line_3_4 = vtrnq_s8(line3, line4);                              \
+  out0 = vtrnq_s16(vreinterpretq_s16_s8(line_1_2.val[0]),         \
+                   vreinterpretq_s16_s8(line_3_4.val[0]));        \
+  out1 = vtrnq_s16(vreinterpretq_s16_s8(line_1_2.val[1]),         \
+                   vreinterpretq_s16_s8(line_3_4.val[1]));        \
+  line_1_2_int32 = vtrnq_s32(vreinterpretq_s32_s16(out0.val[0]),  \
+                             vreinterpretq_s32_s16(out1.val[0])); \
+  line_3_4_int32 = vtrnq_s32(vreinterpretq_s32_s16(out0.val[1]),  \
+                             vreinterpretq_s32_s16(out1.val[1])); \
+  vst1q_s32(reinterpret_cast<int*>(data_out),                     \
+            vcombine_s32(vget_low_s32(line_1_2_int32.val[0]),     \
+                         vget_low_s32(line_3_4_int32.val[0])));   \
+  vst1q_s32(reinterpret_cast<int*>(data_out + 16),                \
+            vcombine_s32(vget_low_s32(line_1_2_int32.val[1]),     \
+                         vget_low_s32(line_3_4_int32.val[1])));   \
+  vst1q_s32(reinterpret_cast<int*>(data_out + 32),                \
+            vcombine_s32(vget_high_s32(line_1_2_int32.val[0]),    \
                          vget_high_s32(line_3_4_int32.val[0])));
 
 #define transfer4x8(line1, line2, line3, line4, data_out)                \
   line_1_2 = vtrn_s8(line1, line2);                                      \
   line_3_4 = vtrn_s8(line3, line4);                                      \
-  out0 = vtrn_s16(line_1_2.val[0], line_3_4.val[0]);                     \
-  out1 = vtrn_s16(line_1_2.val[1], line_3_4.val[1]);                     \
-  line_1_2_int32 = vtrn_s32(out0.val[0], out1.val[0]);                   \
-  line_3_4_int32 = vtrn_s32(out0.val[1], out1.val[1]);                   \
+  out0 = vtrn_s16(vreinterpret_s16_s8(line_1_2.val[0]),                  \
+                  vreinterpret_s16_s8(line_3_4.val[0]));                 \
+  out1 = vtrn_s16(vreinterpret_s16_s8(line_1_2.val[1]),                  \
+                  vreinterpret_s16_s8(line_3_4.val[1]));                 \
+  line_1_2_int32 = vtrn_s32(vreinterpret_s32_s16(out0.val[0]),           \
+                            vreinterpret_s32_s16(out1.val[0]));          \
+  line_3_4_int32 = vtrn_s32(vreinterpret_s32_s16(out0.val[1]),           \
+                            vreinterpret_s32_s16(out1.val[1]));          \
   vst1q_s32(reinterpret_cast<int*>(data_out),                            \
             vcombine_s32(line_1_2_int32.val[0], line_3_4_int32.val[0])); \
   vst1q_s32(reinterpret_cast<int*>(data_out + 16),                       \

--- a/lite/backends/arm/math/gemm_prepacked_int8.cc
+++ b/lite/backends/arm/math/gemm_prepacked_int8.cc
@@ -5704,6 +5704,239 @@ void gemm_prepack_sdot_int8(const int8_t* A_packed,
   }
 }
 
+// used to fuse im2col and packB
+// ic % 4 == 0 && ow % 8 == 0
+template <typename Dtype>
+void gemm_prepack_sdot_nopack_notrans(const int8_t* A_packed,
+                                      const int8_t* B_packed,
+                                      const float* bias,
+                                      Dtype* C,
+                                      int M,
+                                      int N,
+                                      int K,
+                                      bool is_bias,
+                                      int is_relu,
+                                      bool is_transB,
+                                      const float* scale,
+                                      const float* alpha,
+                                      ARMContext* ctx) {
+  int x_block = N;
+  x_block /= NBLOCK_INT8_DOT;
+  x_block *= NBLOCK_INT8_DOT;
+  int x_num = (N + (x_block - 1)) / x_block;
+  x_block = (N + x_num - 1) / x_num;
+  x_block = (x_block + NBLOCK_INT8_DOT - 1) / NBLOCK_INT8_DOT;
+  x_block *= NBLOCK_INT8_DOT;
+  x_block = x_block < NBLOCK_INT8_DOT ? NBLOCK_INT8_DOT : x_block;
+  int kup = ROUNDUP(K, KBLOCK_INT8);
+  // unroll 2 loop
+  int tail_pre = ((kup / 4) & (KBLOCK_INT8 - 1));
+  int k_pre = (((kup / 4) + KBLOCK_INT8 - 1) / KBLOCK_INT8) - 1;
+
+  bool flag_p_remain = false;
+  int remain = 0;
+  //! apanel is pre_compute outside gemm
+  for (unsigned int x0 = 0; x0 < N; x0 += x_block) {
+    unsigned int xmax = x0 + x_block;
+    xmax = (xmax > N) ? N : xmax;
+    int bblocks = (xmax - x0 + NBLOCK_INT8_DOT - 1) / NBLOCK_INT8_DOT;
+    remain = xmax - x0 - (bblocks - 1) * NBLOCK_INT8_DOT;
+    if (remain == 12) {
+      remain = 0;
+      bblocks++;
+    }
+    if (remain > 0) {
+      flag_p_remain = true;
+    }
+    
+    LITE_PARALLEL_COMMON_BEGIN(y, tid, M, 0, MBLOCK_INT8_DOT) {
+      unsigned int ymax = y + MBLOCK_INT8_DOT;
+      ymax = (ymax > M) ? M : ymax;
+      float32_t bias_local[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+      if (is_bias) {
+        int j = 0;
+        for (int i = y; i < ymax && j < 8; i++, j++) {
+          bias_local[j] = bias[i];
+        }
+      }
+      float32_t scale_local[8];
+      if (scale) {
+        int j = 0;
+        for (int i = y; i < ymax && j < 8; i++, j++) {
+          scale_local[j] = scale[i];
+        }
+      }
+      Dtype cout0[NBLOCK_INT8_DOT];
+      Dtype cout1[NBLOCK_INT8_DOT];
+      Dtype cout2[NBLOCK_INT8_DOT];
+      Dtype cout3[NBLOCK_INT8_DOT];
+      Dtype cout4[NBLOCK_INT8_DOT];
+      Dtype cout5[NBLOCK_INT8_DOT];
+      Dtype cout6[NBLOCK_INT8_DOT];
+      Dtype cout7[NBLOCK_INT8_DOT + 16];
+
+      Dtype* c_ptr0 = C + y * N + x0;
+      Dtype* c_ptr1 = c_ptr0 + N;
+      Dtype* c_ptr2 = c_ptr1 + N;
+      Dtype* c_ptr3 = c_ptr2 + N;
+      Dtype* c_ptr4 = c_ptr3 + N;
+      Dtype* c_ptr5 = c_ptr4 + N;
+      Dtype* c_ptr6 = c_ptr5 + N;
+      Dtype* c_ptr7 = c_ptr6 + N;
+
+      Dtype* pout0 = cout0;
+      Dtype* pout1 = cout1;
+      Dtype* pout2 = cout2;
+      Dtype* pout3 = cout3;
+      Dtype* pout4 = cout4;
+      Dtype* pout5 = cout5;
+      Dtype* pout6 = cout6;
+      Dtype* pout7 = cout7;
+      if ((y + 7) >= ymax) {
+        switch ((y + 7) - ymax) {
+          case 6:
+            c_ptr1 = cout1;
+          case 5:
+            c_ptr2 = cout2;
+          case 4:
+            c_ptr3 = cout3;
+          case 3:
+            c_ptr4 = cout4;
+          case 2:
+            c_ptr5 = cout5;
+          case 1:
+            c_ptr6 = cout6;
+          case 0:
+            c_ptr7 = cout7;
+          default:
+            break;
+        }
+      }
+
+      // const int8_t *a_ptr_l = A_packed + y * K;
+      const int8_t* a_ptr_l = A_packed + y * kup;
+      const int8_t* b_ptr = B_packed;
+      for (int xb = 0; xb < bblocks - 1; xb++) {
+        if ((y + 7) >= ymax) {
+          switch ((y + 7) - ymax) {
+            case 6:
+              c_ptr1 = cout1;
+            case 5:
+              c_ptr2 = cout2;
+            case 4:
+              c_ptr3 = cout3;
+            case 3:
+              c_ptr4 = cout4;
+            case 2:
+              c_ptr5 = cout5;
+            case 1:
+              c_ptr6 = cout6;
+            case 0:
+              c_ptr7 = cout7;
+            default:
+              break;
+          }
+        }
+        const int8_t* a_ptr = a_ptr_l;
+        int tail = tail_pre;
+        int k = k_pre;
+        gemm_sdot_int8_kernel<Dtype>(a_ptr,
+                                     b_ptr,
+                                     bias_local,
+                                     c_ptr0,
+                                     c_ptr1,
+                                     c_ptr2,
+                                     c_ptr3,
+                                     c_ptr4,
+                                     c_ptr5,
+                                     c_ptr6,
+                                     c_ptr7,
+                                     scale_local,
+                                     alpha,
+                                     is_relu,
+                                     k,
+                                     tail);
+      }
+      int remain_a = remain;
+      if (remain_a >= 8) {
+        const int8_t* a_ptr = a_ptr_l;
+        int k = kup / 4;
+        gemm_sdot_int8_kernel_8x8<Dtype>(a_ptr,
+                                         b_ptr,
+                                         bias_local,
+                                         c_ptr0,
+                                         c_ptr1,
+                                         c_ptr2,
+                                         c_ptr3,
+                                         c_ptr4,
+                                         c_ptr5,
+                                         c_ptr6,
+                                         c_ptr7,
+                                         scale_local,
+                                         alpha,
+                                         is_relu,
+                                         k,
+                                         0);
+        remain_a -= 8;
+      }
+      if (remain_a >= 4) {
+        const int8_t* a_ptr = a_ptr_l;
+        int k = kup / 4;
+        gemm_sdot_int8_kernel_8x4<Dtype>(a_ptr,
+                                         b_ptr,
+                                         bias_local,
+                                         c_ptr0,
+                                         c_ptr1,
+                                         c_ptr2,
+                                         c_ptr3,
+                                         c_ptr4,
+                                         c_ptr5,
+                                         c_ptr6,
+                                         c_ptr7,
+                                         scale_local,
+                                         alpha,
+                                         is_relu,
+                                         k,
+                                         0);
+        remain_a -= 4;
+      }
+      if (remain_a) {
+        const int8_t* a_ptr = a_ptr_l;
+        int k = kup / 4;
+        gemm_sdot_int8_kernel_8x4<Dtype>(a_ptr,
+                                         b_ptr,
+                                         bias_local,
+                                         pout0,
+                                         pout1,
+                                         pout2,
+                                         pout3,
+                                         pout4,
+                                         pout5,
+                                         pout6,
+                                         pout7,
+                                         scale_local,
+                                         alpha,
+                                         is_relu,
+                                         k,
+                                         0);
+        for (int i = 0; i < remain_a; ++i) {
+          *c_ptr0++ = cout0[i];
+          *c_ptr1++ = cout1[i];
+          *c_ptr2++ = cout2[i];
+          *c_ptr3++ = cout3[i];
+          *c_ptr4++ = cout4[i];
+          *c_ptr5++ = cout5[i];
+          *c_ptr6++ = cout6[i];
+          *c_ptr7++ = cout7[i];
+        }
+      }
+    }
+    LITE_PARALLEL_COMMON_END();
+  }
+}
+
+
+
 void prepackA_m8k4_int8(int8_t* out,
                         const int8_t* in,
                         const int ldin,
@@ -7418,6 +7651,9 @@ void gemm_prepack_vsdot_int8(const int8_t* A_packed,
 #endif
 #endif  // dotprod  //NOLINT
 
+#define IN_PARAMS \
+  A_packed, B, bias, C, M, N, K, is_bias, flag_act, is_transB, scale, alpha, ctx
+
 template <typename dtype>
 void gemm_prepack_int8(const int8_t* A_packed,
                        const int8_t* B,
@@ -7462,8 +7698,6 @@ void gemm_prepack_int8(const int8_t* A_packed,
     }
   }
 
-#define IN_PARAMS \
-  A_packed, B, bias, C, M, N, K, is_bias, flag_act, is_transB, scale, alpha, ctx
 #ifdef __aarch64__
   if (ctx->has_dot()) {
 #ifdef WITH_ARM_DOTPROD
@@ -7500,6 +7734,74 @@ void gemm_prepack_int8(const int8_t* A_packed,
 GEMM_PREPACK_INT8(int8_t);
 GEMM_PREPACK_INT8(float_t);
 GEMM_PREPACK_INT8(int32_t);
+
+#ifdef __aarch64__
+template <typename dtype>
+void gemm_prepack_int8_nopack(const int8_t* A_packed,
+                       const int8_t* B,
+                       const float* bias,
+                       dtype* C,
+                       int M,
+                       int N,
+                       int K,
+                       bool is_bias,
+                       bool is_transB,
+                       const float* scale,
+                       const operators::ActivationParam act_param,
+                       ARMContext* ctx) {
+  auto act_type = act_param.active_type;
+  float alpha[12] = {
+      0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+  int flag_act = 0x00;  // relu: 1, relu6: 2, leakey: 3
+  if (act_param.has_active) {
+    if (act_type == lite_api::ActivationType::kRelu) {
+      flag_act = 0x01;
+    } else if (act_type == lite_api::ActivationType::kRelu6) {
+      flag_act = 0x02;
+      float local_alpha = act_param.Relu_clipped_coef;
+      alpha[0] = local_alpha;
+      alpha[1] = local_alpha;
+      alpha[2] = local_alpha;
+      alpha[3] = local_alpha;
+    } else if (act_type == lite_api::ActivationType::kLeakyRelu) {
+      flag_act = 0x03;
+      float local_alpha = act_param.Leaky_relu_alpha;
+      alpha[0] = local_alpha;
+      alpha[1] = local_alpha;
+      alpha[2] = local_alpha;
+      alpha[3] = local_alpha;
+    } else if (act_type == lite_api::ActivationType::kHardSwish) {
+      flag_act = 0x04;
+      for (int i = 0; i < 4; i++) {
+        alpha[i] = 1.f / act_param.hard_swish_scale;
+        alpha[i + 4] = act_param.hard_swish_offset;
+        alpha[i + 8] = act_param.hard_swish_threshold;
+      }
+    }
+  }
+  gemm_prepack_sdot_nopack_notrans<dtype>(IN_PARAMS);
+}
+
+#define GEMM_PREPACK_INT8_NOPACK(dtype)           \
+  template void gemm_prepack_int8_nopack<dtype>(  \
+      const int8_t* A_packed,                     \
+      const int8_t* B,                            \
+      const float* bias,                          \
+      dtype* C,                                   \
+      int M,                                      \
+      int N,                                      \
+      int K,                                      \
+      bool is_bias,                               \
+      bool is_transB,                             \
+      const float* scale,                         \
+      const operators::ActivationParam act_param, \
+      ARMContext* ctx);
+GEMM_PREPACK_INT8_NOPACK(int8_t);
+GEMM_PREPACK_INT8_NOPACK(float_t);
+
+#endif
+
+
 #undef IN_PARAMS
 #undef GEMM_PREPACK_INT8
 

--- a/lite/backends/arm/math/gemm_prepacked_int8.cc
+++ b/lite/backends/arm/math/gemm_prepacked_int8.cc
@@ -5704,8 +5704,7 @@ void gemm_prepack_sdot_int8(const int8_t* A_packed,
   }
 }
 
-// used to fuse im2col and packB
-// ic % 4 == 0 && ow % 8 == 0
+// used to fuse im2col and packB, ic % 4 == 0 && ow % 8 == 0
 template <typename Dtype>
 void gemm_prepack_sdot_nopack_notrans(const int8_t* A_packed,
                                       const int8_t* B_packed,
@@ -7713,7 +7712,7 @@ GEMM_PREPACK_INT8(int8_t);
 GEMM_PREPACK_INT8(float_t);
 GEMM_PREPACK_INT8(int32_t);
 
-#ifdef __aarch64__
+#if defined(__aarch64__) && defined(WITH_ARM_DOTPROD)
 template <typename dtype>
 void gemm_prepack_int8_nopack(const int8_t* A_packed,
                               const int8_t* B,
@@ -7776,11 +7775,11 @@ void gemm_prepack_int8_nopack(const int8_t* A_packed,
       ARMContext* ctx);
 GEMM_PREPACK_INT8_NOPACK(int8_t);
 GEMM_PREPACK_INT8_NOPACK(float_t);
-
-#endif
+#endif  // __aarch64__ && WITH_ARM_DOTPROD
 
 #undef IN_PARAMS
 #undef GEMM_PREPACK_INT8
+#undef GEMM_PREPACK_INT8_NOPACK
 
 }  // namespace math
 }  // namespace arm

--- a/lite/backends/arm/math/gemm_prepacked_int8.h
+++ b/lite/backends/arm/math/gemm_prepacked_int8.h
@@ -99,6 +99,20 @@ void gemm_prepack_int8(const int8_t* A_packed,
                        const operators::ActivationParam act_param,
                        ARMContext* ctx);
 
+template <typename dtype>
+void gemm_prepack_int8_nopack(const int8_t* A_packed,
+                       const int8_t* B,
+                       const float* bias,
+                       dtype* C,
+                       int M,
+                       int N,
+                       int K,
+                       bool is_bias,
+                       bool is_transB,
+                       const float* scale,
+                       const operators::ActivationParam act_param,
+                       ARMContext* ctx);
+
 #define ROUNDUP(a, b) ((((a) + (b)-1) / (b)) * (b))
 }  // namespace math
 }  // namespace arm

--- a/lite/backends/arm/math/gemm_prepacked_int8.h
+++ b/lite/backends/arm/math/gemm_prepacked_int8.h
@@ -99,6 +99,7 @@ void gemm_prepack_int8(const int8_t* A_packed,
                        const operators::ActivationParam act_param,
                        ARMContext* ctx);
 
+#if defined(__aarch64__) && defined(WITH_ARM_DOTPROD)
 template <typename dtype>
 void gemm_prepack_int8_nopack(const int8_t* A_packed,
                               const int8_t* B,
@@ -112,6 +113,7 @@ void gemm_prepack_int8_nopack(const int8_t* A_packed,
                               const float* scale,
                               const operators::ActivationParam act_param,
                               ARMContext* ctx);
+#endif
 
 #define ROUNDUP(a, b) ((((a) + (b)-1) / (b)) * (b))
 }  // namespace math

--- a/lite/backends/arm/math/gemm_prepacked_int8.h
+++ b/lite/backends/arm/math/gemm_prepacked_int8.h
@@ -101,17 +101,17 @@ void gemm_prepack_int8(const int8_t* A_packed,
 
 template <typename dtype>
 void gemm_prepack_int8_nopack(const int8_t* A_packed,
-                       const int8_t* B,
-                       const float* bias,
-                       dtype* C,
-                       int M,
-                       int N,
-                       int K,
-                       bool is_bias,
-                       bool is_transB,
-                       const float* scale,
-                       const operators::ActivationParam act_param,
-                       ARMContext* ctx);
+                              const int8_t* B,
+                              const float* bias,
+                              dtype* C,
+                              int M,
+                              int N,
+                              int K,
+                              bool is_bias,
+                              bool is_transB,
+                              const float* scale,
+                              const operators::ActivationParam act_param,
+                              ARMContext* ctx);
 
 #define ROUNDUP(a, b) ((((a) + (b)-1) / (b)) * (b))
 }  // namespace math


### PR DESCRIPTION
### PR Type
optimization
### PR Change
backends
### PR Describe
![image](https://user-images.githubusercontent.com/54735487/208610366-cbb0f179-8a63-455e-8d76-45360e730d98.png)
优化sdot conv3x3s1p1d1 后端，将im2col与矩阵乘重排操作融合