### PR TITLE
[OpenCL]Fix remove_scale1_pass bug

### DIFF
--- a/lite/core/optimizer/mir/elimination/remove_scale1_pass.cc
+++ b/lite/core/optimizer/mir/elimination/remove_scale1_pass.cc
@@ -68,6 +68,8 @@ void RemoveScale1Pass::Apply(const std::unique_ptr<SSAGraph>& graph) {
         if (scale_node->inlinks.size() == 1 &&  // input arg of scale is 1
             scale_node->inlinks.front()->inlinks.size() ==
                 1 &&  // last node of scale is 1
+            scale_node->inlinks.front()->inlinks.front()->outlinks.size() ==
+                1 &&
             scale_node->inlinks.front()
                 ->inlinks.front()
                 ->IsStmt() &&                    // last node of scale is stmt


### PR DESCRIPTION
修复yolo系列模型remove_scale1_pass之后模型结构连接错误的bug
原始模型结构
<img width="163" alt="image" src="https://user-images.githubusercontent.com/89541335/209803840-a2b69b2f-075b-4ca0-a0e2-7eb62dd5dc93.png">

错误结构
<img width="245" alt="image" src="https://user-images.githubusercontent.com/89541335/209803649-840edfc4-f52e-4a3a-b9f2-def5b8d9ae95.png">
正确结构
<img width="176" alt="image" src="https://user-images.githubusercontent.com/89541335/209803764-ae5e00e0-8d6f-454f-978d-3fb2c939b536.png">

