### PR TITLE
[Core] Fix the duplicate deletion of input scale node of fake_quantize_dequantize_moving_average_abs_max (#9871)

### DIFF
--- a/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
+++ b/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
@@ -578,11 +578,6 @@ void QuantDequantOpFuser::InsertNewNode(SSAGraph* graph,
   // 3. Delete nodes and edges
   std::set<const Node*> nodes2rm = {
       quant_dequant_node, output_scale_node, output_var_node};
-  if (quant_dequant_op_type_ ==
-      "fake_quantize_dequantize_moving_average_abs_max") {
-    auto* input_scale_node = matched.at("input_scale_node");
-    nodes2rm.insert(input_scale_node);
-  }
   GraphSafeRemoveNodes(graph, nodes2rm);
 }
 


### PR DESCRIPTION
Change-Id: I19d89b0064a01684b43439c4cb4471a73aff7ed7