### PR TITLE
[Host] fix unique op reporting absent of dtype and unused variable

### DIFF
--- a/lite/kernels/host/unique_compute.cc
+++ b/lite/kernels/host/unique_compute.cc
@@ -373,13 +373,12 @@ void UniqueCompute<InT>::Run() {
   auto index = param.Index;
   auto indices = param.Indices;
   auto count = param.Counts;
+  auto dtype = param.dtype;
   bool return_index = param.return_index;
   bool return_inverse = param.return_inverse;
   bool return_counts = param.return_counts;
   auto axis_vec = param.axis;
   auto is_sorted = param.is_sorted;
-  lite_api::PrecisionType index_type = index->precision();
-  lite_api::PrecisionType x_type = x->precision();
   CHECK(dtype == 3 || dtype == 2) << "dtype must be int or int64, but now is "
                                   << static_cast<int>(dtype);
   // set output precision


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Host
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
OP
### Description
<!-- Describe what this PR does -->
fix unique op reporting absent of dtype and unused variable.
