### PR TITLE
[HuaweiAscendNPU] Fix the meshgrid op of Ascend

### DIFF
--- a/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/converter/meshgrid.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/converter/meshgrid.cc
@@ -32,16 +32,16 @@ int ConvertMeshgrid(Converter* converter, core::Operation* operation) {
     if (!input_operator) {
       input_operator = converter->ConvertOperand(input_operand);
     }
-    std::vector<int32_t> shape(input_operand->type.dimensions.data,
-                               input_operand->type.dimensions.data +
-                                   input_operand->type.dimensions.count);
-    auto shape_operator = converter->AddInt32ConstantOperator(shape);
     auto output_operand = output_operands[i];
-    auto broadcastToOp =
+    std::vector<int32_t> shape(output_operand->type.dimensions.data,
+                               output_operand->type.dimensions.data +
+                                   output_operand->type.dimensions.count);
+    auto shape_operator = converter->AddInt32ConstantOperator(shape);
+    auto broadcast_to_op =
         converter->AddOperator<ge::op::BroadcastTo>(output_operands[i]);
-    SET_INPUT(broadcastToOp, x, input_operator);
-    SET_INPUT(broadcastToOp, shape, shape_operator);
-    MAP_OUTPUT(broadcastToOp, y, output_operand);
+    SET_INPUT(broadcast_to_op, x, input_operator);
+    SET_INPUT(broadcast_to_op, shape, shape_operator);
+    MAP_OUTPUT(broadcast_to_op, y, output_operand);
   }
   return NNADAPTER_NO_ERROR;
 }

--- a/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
@@ -15,7 +15,6 @@
 #include "operation/meshgrid.h"
 #include <vector>
 #include "core/types.h"
-#include "operation/math/meshgrid.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
 #include "utility/micros.h"

--- a/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
@@ -73,34 +73,6 @@ NNADAPTER_EXPORT int PrepareMeshgrid(core::Operation* operation) {
 }
 
 NNADAPTER_EXPORT int ExecuteMeshgrid(core::Operation* operation) {
-  // SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
-
-  // // Allocate and calculate the output operands
-  // int status = -1;
-  // auto& input_type = input_operand->type;
-  // auto input_shape = std::vector<int32_t>(
-  //     input_type.dimensions.data,
-  //     input_type.dimensions.data + input_type.dimensions.count);
-  // const auto input_buffer = input_operand->buffer;
-  // NNADAPTER_CHECK(input_buffer);
-  // auto& output_type = output_operand->type;
-  // auto output_buffer = AllocateOperand(output_operand);
-  // NNADAPTER_CHECK_EQ(input_type.precision, output_type.precision);
-  // if (input_type.precision == NNADAPTER_FLOAT32) {
-  //   const auto input_data = reinterpret_cast<const float*>(input_buffer);
-  //   auto output_data = reinterpret_cast<float*>(output_buffer);
-  //   status = math::softmax<float>(input_data, input_shape, axis,
-  //   output_data);
-  // } else {
-  //   NNADAPTER_LOG(FATAL) << "Unsupported precision code("
-  //                        <<
-  //                        OperandPrecisionCodeToString(input_type.precision)
-  //                        << ") for " <<
-  //                        OperationTypeToString(operation->type)
-  //                        << " is found!";
-  // }
-  // NNADAPTER_CHECK_EQ(status, 0);
-  // return NNADAPTER_NO_ERROR;
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 

--- a/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
@@ -15,6 +15,7 @@
 #include "operation/meshgrid.h"
 #include <vector>
 #include "core/types.h"
+#include "operation/math/meshgrid.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
 #include "utility/micros.h"
@@ -31,9 +32,9 @@ NNADAPTER_EXPORT bool ValidateMeshgrid(const core::Operation* operation) {
 NNADAPTER_EXPORT int PrepareMeshgrid(core::Operation* operation) {
   MESHGRID_OPERATION_EXTRACT_INPUTS_OUTPUTS
   for (auto output_operand : output_operands) {
-    output_operand->type.dimensions.count = input_count;
     CopyOperandTypeExceptQuantParams(&output_operand->type,
                                      input_operands[0]->type);
+    output_operand->type.dimensions.count = input_count;
   }
 
   // Infer the shape and type of output operands
@@ -72,6 +73,34 @@ NNADAPTER_EXPORT int PrepareMeshgrid(core::Operation* operation) {
 }
 
 NNADAPTER_EXPORT int ExecuteMeshgrid(core::Operation* operation) {
+  // SOFTMAX_OPERATION_EXTRACT_INPUTS_OUTPUTS
+
+  // // Allocate and calculate the output operands
+  // int status = -1;
+  // auto& input_type = input_operand->type;
+  // auto input_shape = std::vector<int32_t>(
+  //     input_type.dimensions.data,
+  //     input_type.dimensions.data + input_type.dimensions.count);
+  // const auto input_buffer = input_operand->buffer;
+  // NNADAPTER_CHECK(input_buffer);
+  // auto& output_type = output_operand->type;
+  // auto output_buffer = AllocateOperand(output_operand);
+  // NNADAPTER_CHECK_EQ(input_type.precision, output_type.precision);
+  // if (input_type.precision == NNADAPTER_FLOAT32) {
+  //   const auto input_data = reinterpret_cast<const float*>(input_buffer);
+  //   auto output_data = reinterpret_cast<float*>(output_buffer);
+  //   status = math::softmax<float>(input_data, input_shape, axis,
+  //   output_data);
+  // } else {
+  //   NNADAPTER_LOG(FATAL) << "Unsupported precision code("
+  //                        <<
+  //                        OperandPrecisionCodeToString(input_type.precision)
+  //                        << ") for " <<
+  //                        OperationTypeToString(operation->type)
+  //                        << " is found!";
+  // }
+  // NNADAPTER_CHECK_EQ(status, 0);
+  // return NNADAPTER_NO_ERROR;
   return NNADAPTER_FEATURE_NOT_SUPPORTED;
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
NNadapter Ascend
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
OP
### Description
<!-- Describe what this PR does -->
修复meshgrid算子shape推导和映射为Ascend IR时存在的bug