### PR TITLE
[Framework][Pass] fix MixedPrecisionAutoInsertCalibFuser

### DIFF
--- a/lite/core/optimizer/mir/subgraph/subgraph_detector.cc
+++ b/lite/core/optimizer/mir/subgraph/subgraph_detector.cc
@@ -623,6 +623,7 @@ void MixedPrecisionAutoInsertCalibFuser::InsertQuantCalib(
           {"concat", {"AxisTensor"}},
           {"split", {"AxisTensor", "SectionsTensorList"}},
           {"gather", {"Axis"}},
+          {"reshape2", {"ShapeTensor"}},
       };
 
   std::vector<Node *> nodes_org = *nodes;


### PR DESCRIPTION
### PR devices
Framework

### PR types
 Bug fixes

### PR changes
PASS

### Description
在自动插入calib算子时，不校验reshape2的shape tensor输入。
