### PR TITLE
Fix quant dequant fuse pass doesn't set op's output_scale info.

### DIFF
--- a/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
+++ b/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
@@ -717,7 +717,17 @@ void QuantDequantLinearOpFuser::InsertNewNode(SSAGraph* graph,
         if (!out_scale_node->IsStmt()) continue;
         auto* out_scale_scope = out_scale_node->stmt()->op()->scope();
         auto out_scale_op_info = *out_scale_node->stmt()->op_info();
-        if (out_scale_op_info.Type() != "quantize_linear") continue;
+        if (out_scale_op_info.Type() != "quantize_linear") {
+          if (out_scale_op_info.HasInputScale(op_out_var_node->arg()->name,
+                                              false)) {
+            auto input_scales = out_scale_op_info.GetInputScale(
+                op_out_var_node->arg()->name, false);
+            op_info.SetOutputScale(op_out_var_node->arg()->name, input_scales);
+            break;
+          } else {
+            continue;
+          }
+        }
         if (!out_scale_op_info.HasInput("Scale")) continue;
         std::string out_scale_name = out_scale_op_info.Input("Scale").front();
         auto* out_scale_tensor =


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Framework

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
PASS

### Description
<!-- Describe what this PR does -->
![image](https://user-images.githubusercontent.com/78470701/215470880-91bc484d-9fdc-4c12-a09a-a2c33a2fd939.png)
Lite 的 quant_dequant_fuse_pass 在进行pattern 检测时没有按照固定拓补结构顺序进行遍历，所以会出现上图中：
    1. pattern2 先于 pattern1 执行
    2. 导致 sigmoid 前面的quant dequant 算子先被删除掉
    3. 按照现在的 pass 逻辑，elementwise 算子后面只有是 quantize_linear 算子的时候才能设置 output_scale 信息，但是由于该算子已经被 pattern2 执行时删除掉，所以会导致elementwise算子缺少 output_scale 信息

修复上述问题。
