### PR TITLE
[xpu] set out lod in sequence_expand only when x has lod; fix bug in …

### DIFF
--- a/lite/core/optimizer/mir/fusion/__xpu__conv2d_transpose_fuse_pass.cc
+++ b/lite/core/optimizer/mir/fusion/__xpu__conv2d_transpose_fuse_pass.cc
@@ -336,7 +336,7 @@ class XPUConv2dTransFuser : public FuseBase {
         graph->GraphCreateInstructNode(new_conv_op, valid_places);
     DirectedLink(matched.at("input"), new_op_node);
     DirectedLink(matched.at("conv2d_trans_filter"), new_op_node);
-    if (with_bn_ || with_conv_bias_) {
+    if (with_bn_ || with_conv_bias_ || with_ew_bias_) {
       DirectedLink(fusion_bias_node, new_op_node);
     }
     DirectedLink(new_op_node, matched.at(output_node_name));

--- a/lite/kernels/xpu/conv2d_transpose_compute.cc
+++ b/lite/kernels/xpu/conv2d_transpose_compute.cc
@@ -60,6 +60,18 @@ void Conv2dTransposeCompute<TGEMM, TW, TX, TY, PType>::PrepareForRun() {
     xpu_quant_filter_ =
         TargetWrapperXPU::ConvertCPUWeightToXPUQuantWeight<float, TW>(
             cpu_weights.data(), filter_dims, false, max_ptr_size);
+
+    if (param.activation_param.has_active) {
+      if (param.fuse_relu) {
+        act_ = xdnn::Activation_t::RELU;
+      } else if (param.fuse_sigmoid) {
+        act_ = xdnn::Activation_t::SIGMOID;
+      } else if (param.fuse_tanh) {
+        act_ = xdnn::Activation_t::TANH;
+      } else {
+        act_ = xdnn::Activation_t::LINEAR;
+      }
+    }
   }
 }
 
@@ -104,22 +116,37 @@ void Conv2dTransposeCompute<TGEMM, TW, TX, TY, PType>::Run() {
           nullptr,
           true);
       CHECK_EQ(ret, 0);
+    } else if (param.output_size.size()) {
+      const auto* bias = (param.bias != nullptr)
+                             ? param.bias->template data<float>()
+                             : nullptr;
+      int ret = xdnn::conv2d_transpose_fusion_v2<TX, TW, TY, int16_t>(
+          ctx.GetRawContext(),
+          param.x->template data<TX>(),
+          reinterpret_cast<const TW*>(xpu_quant_filter_.data_ptr_),
+          param.output->template mutable_data<TY>(TARGET(kXPU)),
+          in_dims[0],
+          in_dims[1],
+          out_dims[2],
+          out_dims[3],
+          out_dims[1],
+          std::vector<int>{static_cast<int>(w_dims[2]),
+                           static_cast<int>(w_dims[3])},
+          strides,
+          paddings,
+          dilations,
+          groups,
+          nullptr,
+          reinterpret_cast<const float*>(xpu_quant_filter_.max_ptr_),
+          nullptr,
+          bias,
+          act_,
+          true);
+      CHECK_EQ(ret, 0);
     } else {
       const auto* bias = (param.bias != nullptr)
                              ? param.bias->template data<float>()
                              : nullptr;
-      xdnn::Activation_t act = xdnn::Activation_t::LINEAR;
-      if (param.activation_param.has_active) {
-        if (param.fuse_relu) {
-          act = xdnn::Activation_t::RELU;
-        } else if (param.fuse_sigmoid) {
-          act = xdnn::Activation_t::SIGMOID;
-        } else if (param.fuse_tanh) {
-          act = xdnn::Activation_t::TANH;
-        } else {
-          act = xdnn::Activation_t::LINEAR;
-        }
-      }
       int ret = xdnn::conv2d_transpose_fusion<TX, TW, TY, int16_t>(
           ctx.GetRawContext(),
           param.x->template data<TX>(),
@@ -140,7 +167,7 @@ void Conv2dTransposeCompute<TGEMM, TW, TX, TY, PType>::Run() {
           reinterpret_cast<const float*>(xpu_quant_filter_.max_ptr_),
           nullptr,
           bias,
-          act,
+          act_,
           true);
       CHECK_EQ(ret, 0);
     }

--- a/lite/kernels/xpu/conv2d_transpose_compute.cc
+++ b/lite/kernels/xpu/conv2d_transpose_compute.cc
@@ -116,60 +116,59 @@ void Conv2dTransposeCompute<TGEMM, TW, TX, TY, PType>::Run() {
           nullptr,
           true);
       CHECK_EQ(ret, 0);
-    } else if (param.output_size.size()) {
-      const auto* bias = (param.bias != nullptr)
-                             ? param.bias->template data<float>()
-                             : nullptr;
-      int ret = xdnn::conv2d_transpose_fusion_v2<TX, TW, TY, int16_t>(
-          ctx.GetRawContext(),
-          param.x->template data<TX>(),
-          reinterpret_cast<const TW*>(xpu_quant_filter_.data_ptr_),
-          param.output->template mutable_data<TY>(TARGET(kXPU)),
-          in_dims[0],
-          in_dims[1],
-          out_dims[2],
-          out_dims[3],
-          out_dims[1],
-          std::vector<int>{static_cast<int>(w_dims[2]),
-                           static_cast<int>(w_dims[3])},
-          strides,
-          paddings,
-          dilations,
-          groups,
-          nullptr,
-          reinterpret_cast<const float*>(xpu_quant_filter_.max_ptr_),
-          nullptr,
-          bias,
-          act_,
-          true);
-      CHECK_EQ(ret, 0);
     } else {
       const auto* bias = (param.bias != nullptr)
                              ? param.bias->template data<float>()
                              : nullptr;
-      int ret = xdnn::conv2d_transpose_fusion<TX, TW, TY, int16_t>(
-          ctx.GetRawContext(),
-          param.x->template data<TX>(),
-          reinterpret_cast<const TW*>(xpu_quant_filter_.data_ptr_),
-          param.output->template mutable_data<TY>(TARGET(kXPU)),
-          in_dims[0],
-          in_dims[1],
-          in_dims[2],
-          in_dims[3],
-          out_dims[1],
-          std::vector<int>{static_cast<int>(w_dims[2]),
-                           static_cast<int>(w_dims[3])},
-          strides,
-          paddings,
-          dilations,
-          groups,
-          nullptr,
-          reinterpret_cast<const float*>(xpu_quant_filter_.max_ptr_),
-          nullptr,
-          bias,
-          act_,
-          true);
-      CHECK_EQ(ret, 0);
+      if (param.output_size.size()) {
+        int ret = xdnn::conv2d_transpose_fusion_v2<TX, TW, TY, int16_t>(
+            ctx.GetRawContext(),
+            param.x->template data<TX>(),
+            reinterpret_cast<const TW*>(xpu_quant_filter_.data_ptr_),
+            param.output->template mutable_data<TY>(TARGET(kXPU)),
+            in_dims[0],
+            in_dims[1],
+            out_dims[2],
+            out_dims[3],
+            out_dims[1],
+            std::vector<int>{static_cast<int>(w_dims[2]),
+                             static_cast<int>(w_dims[3])},
+            strides,
+            paddings,
+            dilations,
+            groups,
+            nullptr,
+            reinterpret_cast<const float*>(xpu_quant_filter_.max_ptr_),
+            nullptr,
+            bias,
+            act_,
+            true);
+        CHECK_EQ(ret, 0);
+      } else {
+        int ret = xdnn::conv2d_transpose_fusion<TX, TW, TY, int16_t>(
+            ctx.GetRawContext(),
+            param.x->template data<TX>(),
+            reinterpret_cast<const TW*>(xpu_quant_filter_.data_ptr_),
+            param.output->template mutable_data<TY>(TARGET(kXPU)),
+            in_dims[0],
+            in_dims[1],
+            in_dims[2],
+            in_dims[3],
+            out_dims[1],
+            std::vector<int>{static_cast<int>(w_dims[2]),
+                             static_cast<int>(w_dims[3])},
+            strides,
+            paddings,
+            dilations,
+            groups,
+            nullptr,
+            reinterpret_cast<const float*>(xpu_quant_filter_.max_ptr_),
+            nullptr,
+            bias,
+            act_,
+            true);
+        CHECK_EQ(ret, 0);
+      }
     }
   } else {
     int n = in_dims[0];

--- a/lite/kernels/xpu/conv2d_transpose_compute.h
+++ b/lite/kernels/xpu/conv2d_transpose_compute.h
@@ -40,6 +40,7 @@ class Conv2dTransposeCompute : public KernelLite<TARGET(kXPU), PType> {
  private:
   uint64_t cur_dev_attr_ = 0;
   XPUQuantData xpu_quant_filter_;
+  xdnn::Activation_t act_ = xdnn::Activation_t::LINEAR;
 };
 
 }  // namespace xpu

--- a/lite/kernels/xpu/pad2d_compute.cc
+++ b/lite/kernels/xpu/pad2d_compute.cc
@@ -22,6 +22,23 @@ namespace kernels {
 namespace xpu {
 
 template <class T>
+void Pad2dCompute<T>::PrepareForRun() {
+  int cur_dev_idx = 0;
+
+  XPU_CALL(xpu_current_device(&cur_dev_idx));
+  XPU_CALL(xpu_device_get_attr(&cur_dev_attr_, XPUATTR_MODEL, cur_dev_idx));
+  if (cur_dev_attr_ <= 1) {
+    VLOG(4) << "Currents XPU device : XPU1";
+  } else if (cur_dev_attr_ >= 2 && cur_dev_attr_ <= 299) {
+    VLOG(4) << "Currents XPU device : XPU2";
+  } else if (cur_dev_attr_ >= 300 && cur_dev_attr_ <= 599) {
+    VLOG(4) << "Currents XPU device : XPU3";
+  } else {
+    VLOG(4) << "invaid XPU device";
+  }
+}
+
+template <class T>
 void Pad2dCompute<T>::Run() {
   auto& param = this->template Param<param_t>();
   auto& ctx = this->ctx_->template As<XPUContext>();
@@ -47,32 +64,51 @@ void Pad2dCompute<T>::Run() {
   }
   T* out_data = out->template mutable_data<T>(TARGET(kXPU));
 
-  if (mode == "reflect") {
-    int r = xdnn::reflection_pad2d<T>(ctx.GetRawContext(),
-                                      in_data,
-                                      out_data,
-                                      in_dims[0],
-                                      in_dims[1],
-                                      in_dims[2],
-                                      in_dims[3],
-                                      pads,
-                                      (data_format == "NCHW"));
-    CHECK_EQ(r, 0);
-  } else if (mode == "constant" || mode == "edge") {
-    int r = xdnn::pad2d<T>(ctx.GetRawContext(),
-                           in_data,
-                           out_data,
-                           in_dims[0],
-                           in_dims[1],
-                           in_dims[2],
-                           in_dims[3],
-                           pads,
-                           mode.c_str(),
-                           value,
-                           (data_format == "NCHW"));
-    CHECK_EQ(r, 0);
+  if (cur_dev_attr_ <= 1) {
+    if (mode == "constant" || mode == "edge" || mode == "reflect") {
+      int r = xdnn::pad2d<T>(ctx.GetRawContext(),
+                             in_data,
+                             out_data,
+                             in_dims[0],
+                             in_dims[1],
+                             in_dims[2],
+                             in_dims[3],
+                             pads,
+                             mode.c_str(),
+                             value,
+                             (data_format == "NCHW"));
+      CHECK_EQ(r, 0);
+    } else {
+      LOG(FATAL) << "xpu unsupport mode: " << mode;
+    }
   } else {
-    LOG(FATAL) << "xpu unsupport mode: " << mode;
+    if (mode == "reflect") {
+      int r = xdnn::reflection_pad2d<T>(ctx.GetRawContext(),
+                                        in_data,
+                                        out_data,
+                                        in_dims[0],
+                                        in_dims[1],
+                                        in_dims[2],
+                                        in_dims[3],
+                                        pads,
+                                        (data_format == "NCHW"));
+      CHECK_EQ(r, 0);
+    } else if (mode == "constant" || mode == "edge") {
+      int r = xdnn::pad2d<T>(ctx.GetRawContext(),
+                             in_data,
+                             out_data,
+                             in_dims[0],
+                             in_dims[1],
+                             in_dims[2],
+                             in_dims[3],
+                             pads,
+                             mode.c_str(),
+                             value,
+                             (data_format == "NCHW"));
+      CHECK_EQ(r, 0);
+    } else {
+      LOG(FATAL) << "xpu unsupport mode: " << mode;
+    }
   }
 }
 

--- a/lite/kernels/xpu/pad2d_compute.cc
+++ b/lite/kernels/xpu/pad2d_compute.cc
@@ -47,7 +47,18 @@ void Pad2dCompute<T>::Run() {
   }
   T* out_data = out->template mutable_data<T>(TARGET(kXPU));
 
-  if (mode == "reflect" || mode == "constant" || mode == "edge") {
+  if (mode == "reflect") {
+    int r = xdnn::reflection_pad2d<T>(ctx.GetRawContext(),
+                                      in_data,
+                                      out_data,
+                                      in_dims[0],
+                                      in_dims[1],
+                                      in_dims[2],
+                                      in_dims[3],
+                                      pads,
+                                      (data_format == "NCHW"));
+    CHECK_EQ(r, 0);
+  } else if (mode == "constant" || mode == "edge") {
     int r = xdnn::pad2d<T>(ctx.GetRawContext(),
                            in_data,
                            out_data,

--- a/lite/kernels/xpu/pad2d_compute.h
+++ b/lite/kernels/xpu/pad2d_compute.h
@@ -26,9 +26,13 @@ class Pad2dCompute : public KernelLite<TARGET(kXPU), PRECISION(kFloat)> {
  public:
   using param_t = operators::Pad2dParam;
 
+  void PrepareForRun() override;
   virtual void Run();
 
   virtual ~Pad2dCompute() = default;
+
+ private:
+  uint64_t cur_dev_attr_ = 0;
 };
 
 }  // namespace xpu

--- a/lite/kernels/xpu/sequence_expand_compute.cc
+++ b/lite/kernels/xpu/sequence_expand_compute.cc
@@ -82,9 +82,12 @@ void SequenceExpandCompute<T, PType>::Run() {
     }
     ref_out_lod[i] = ref_out_lod[i - 1] + seq_len * repeat_num;
   }
+  // write lod to out if x has lod
+  if (x->lod().size()) {
+    auto& ref_lod = *out->mutable_lod();
+    ref_lod[0] = out_lod;
+  }
 
-  auto& ref_lod = *out->mutable_lod();
-  ref_lod[0] = out_lod;
   int lod_len = ref_y_lod.size();
   for (int i = 0; i < lod_len; ++i) {
     lodx_cpu_[i] = ref_x_lod[i];


### PR DESCRIPTION
…conv2d_transponse_fuse_pass

<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Buf fixes

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
PASS Kernels

### Description
1. if batchnorm is not in pattern,  bias_node will not be linked. otherwise it will crash
2. if x has not lod,  the lod of output shoud not be set，otherwise it will crash
3. conv2d_transpose_fusion cause precision problem when output_size in attributes is not empty, change conv2d_transpose_fusion to conv2d_transpose_fusion_v2 to spupport output_size
4. change xdnn::pad2d to xdnn::reflection_pad2d, can be significantly faster