### PR TITLE
[PASS] Fix compile error on win32 for range_calc_offline_pass

### DIFF
--- a/lite/core/optimizer/mir/elimination/range_calc_offline_pass.cc
+++ b/lite/core/optimizer/mir/elimination/range_calc_offline_pass.cc
@@ -38,25 +38,6 @@ int64_t GetSpanCount(T start, T end, T step) {
              : std::ceil(std::abs((end - start) / step));
 }
 
-// template <typename T>
-// void RangeCompute(lite::Tensor* start_tensor,
-//                   lite::Tensor* end_tensor,
-//                   lite::Tensor* step_tensor,
-//                   lite::Tensor* output_tensor) {
-//   auto start = start_tensor->mutable_data<T>()[0];
-//   auto end = end_tensor->mutable_data<T>()[0];
-//   auto step = step_tensor->mutable_data<T>()[0];
-//   // Calc range
-//   int64_t size = GetSpanCount(start, end, step);
-//   output_tensor->Resize(DDim({size}));
-//   auto out_data = output_tensor->mutable_data<T>();
-//   T value = start;
-//   for (int64_t i = 0; i < size; ++i) {
-//     out_data[i] = value;
-//     value += step;
-//   }
-// }
-
 template <typename T>
 void RangeCompute(
     int64_t size, T start, T end, T step, lite::Tensor* output_tensor) {

--- a/lite/core/optimizer/mir/elimination/range_calc_offline_pass.cc
+++ b/lite/core/optimizer/mir/elimination/range_calc_offline_pass.cc
@@ -31,6 +31,9 @@ namespace paddle {
 namespace lite {
 namespace mir {
 
+#if defined(_MSC_VER) && !defined(_WIN64)
+#pragma optimize("", off)
+#endif
 template <typename T>
 int64_t GetSpanCount(T start, T end, T step) {
   return std::is_integral<T>::value
@@ -38,9 +41,6 @@ int64_t GetSpanCount(T start, T end, T step) {
              : std::ceil(std::abs((end - start) / step));
 }
 
-#if defined(_MSC_VER) && !defined(_WIN64)
-#pragma optimize("", off)
-#endif
 template <typename T>
 void RangeCompute(lite::Tensor* start_tensor,
                   lite::Tensor* end_tensor,

--- a/lite/core/optimizer/mir/elimination/range_calc_offline_pass.cc
+++ b/lite/core/optimizer/mir/elimination/range_calc_offline_pass.cc
@@ -38,6 +38,9 @@ int64_t GetSpanCount(T start, T end, T step) {
              : std::ceil(std::abs((end - start) / step));
 }
 
+#if defined(_MSC_VER) && !defined(_WIN64)
+#pragma optimize("", off)
+#endif
 template <typename T>
 void RangeCompute(lite::Tensor* start_tensor,
                   lite::Tensor* end_tensor,
@@ -56,6 +59,9 @@ void RangeCompute(lite::Tensor* start_tensor,
     value += step;
   }
 }
+#if defined(_MSC_VER) && !defined(_WIN64)
+#pragma optimize("", on)
+#endif
 
 void RangeCalcOfflinePass::Apply(const std::unique_ptr<SSAGraph>& graph) {
   RemoveRangePattern(graph);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Host
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
PASS
### Description
<!-- Describe what this PR does -->

编译WIN32时，会在range_calc_offline_pass.cc第58行报错：fatal error C1001: An internal error has occurred in compiler
【解决方法】解决方法是将强制设置对RangeCompute()函数不进行编译优化
参考 https://github.com/PaddlePaddle/Paddle-Lite/pull/4921

【上述方法经测试无效】
改写了RangeCompute()函数，目前可以通过CI，原因猜测仍为WIN32对函数作了错误的编译优化。