### PR TITLE
[ARM] Add winograd F(8, 3) speedup on ARM

### DIFF
--- a/lite/backends/arm/math/conv3x3_winograd_fp32_c4.cc
+++ b/lite/backends/arm/math/conv3x3_winograd_fp32_c4.cc
@@ -26,19 +26,19 @@ namespace lite {
 namespace arm {
 namespace math {
 void input_trans_c4_10x10(const float* src,
-                        int src_stride,
-                        float* dest,
-                        int dest_stride);
+                          int src_stride,
+                          float* dest,
+                          int dest_stride);
 void output_trans_c4_8x10(const float* src,
-                         int src_stride,
-                         float* dest,
-                         int dest_stride);
+                          int src_stride,
+                          float* dest,
+                          int dest_stride);
 void output_trans_c4_post_8x10(const float* src,
-                              int src_stride,
-                              float* dest,
-                              int dest_stride,
-                              float* bias_value,
-                              bool has_relu);
+                               int src_stride,
+                               float* dest,
+                               int dest_stride,
+                               float* bias_value,
+                               bool has_relu);
 void input_trans_c4_8x8(const float* src,
                         int src_stride,
                         float* dest,
@@ -91,12 +91,11 @@ void weight_trans_c4_4x4(
     float* dest, const float* src, int ic, int oc, void* workspace);
 
 /*
-*The following function conv_compute_6x6_3x3 and conv_compute_2x2_3x3[_small] is
-*base on
-*MNN[https://github.com/alibaba/MNN]
-*
-*Copyright © 2018, Alibaba Group Holding Limited
-*/
+ *The following function conv_compute_6x6_3x3 and conv_compute_2x2_3x3[_small]
+ *is base on MNN[https://github.com/alibaba/MNN]
+ *
+ *Copyright © 2018, Alibaba Group Holding Limited
+ */
 
 // F(8,3)
 void conv_compute_8x8_3x3(const float* input,
@@ -224,9 +223,9 @@ void conv_compute_8x8_3x3(const float* input,
             float* dst_ci = dst_ptr + ci * tile_count * 4;
             for (int i = 0; i < 10; ++i) {
               input_trans_c4_10x10(trans_tmp_data + i * 40,
-                                 4,
-                                 dst_ci + i * b_gi_stride * 10,
-                                 b_gi_stride);
+                                   4,
+                                   dst_ci + i * b_gi_stride * 10,
+                                   b_gi_stride);
             }
           }
         } else {
@@ -251,9 +250,9 @@ void conv_compute_8x8_3x3(const float* input,
             float* dst_ci = dst_ptr + ci * tile_count * 4;
             for (int i = 0; i < 10; ++i) {
               input_trans_c4_10x10(trans_tmp_data + i * 40,
-                                 4,
-                                 dst_ci + i * b_gi_stride * 10,
-                                 b_gi_stride);
+                                   4,
+                                   dst_ci + i * b_gi_stride * 10,
+                                   b_gi_stride);
             }
           }  // for ci_4
         }
@@ -312,17 +311,17 @@ void conv_compute_8x8_3x3(const float* input,
             float* src_ci = src_ptr + ci * tile_count * 4;
             for (int i = 0; i < 10; ++i) {
               output_trans_c4_8x10(src_ci + i * c_gi_stride * 10,
-                                  c_gi_stride,
-                                  trans_tmp_data + i * 4,
-                                  40);
+                                   c_gi_stride,
+                                   trans_tmp_data + i * 4,
+                                   40);
             }
             for (int i = 0; i < ey; ++i) {
               output_trans_c4_post_8x10(trans_tmp_data + i * 40,
-                                       4,
-                                       trans_remain_tmp_data + i * 32,
-                                       4,
-                                       bias_value,
-                                       param.fuse_relu);
+                                        4,
+                                        trans_remain_tmp_data + i * 32,
+                                        4,
+                                        bias_value,
+                                        param.fuse_relu);
             }
             write_to_output_c4_fp32(trans_remain_tmp_data,
                                     output_ptr,
@@ -358,17 +357,17 @@ void conv_compute_8x8_3x3(const float* input,
             float* src_ci = src_ptr + ci * tile_count * 4;
             for (int i = 0; i < 10; ++i) {
               output_trans_c4_8x10(src_ci + i * c_gi_stride * 10,
-                                  c_gi_stride,
-                                  trans_tmp_data + i * 4,
-                                  40);
+                                   c_gi_stride,
+                                   trans_tmp_data + i * 4,
+                                   40);
             }
             for (int i = 0; i < ey; ++i) {
               output_trans_c4_post_8x10(trans_tmp_data + i * 40,
-                                       4,
-                                       trans_remain_tmp_data + i * 32,
-                                       4,
-                                       bias_value,
-                                       param.fuse_relu);
+                                        4,
+                                        trans_remain_tmp_data + i * 32,
+                                        4,
+                                        bias_value,
+                                        param.fuse_relu);
             }
             // copy to dest
             memset(trans_tmp_data, 0, 256 * sizeof(float));
@@ -1566,9 +1565,9 @@ AT = [
 ]
 */
 void output_trans_c4_8x10(const float* src,
-                         int src_stride,
-                         float* dest,
-                         int dest_stride) {
+                          int src_stride,
+                          float* dest,
+                          int dest_stride) {
   const float32x4_t src0 = vld1q_f32(src);
   const float32x4_t src1 = vld1q_f32(src + src_stride);
   const float32x4_t src2 = vld1q_f32(src + src_stride * 2);
@@ -1589,32 +1588,39 @@ void output_trans_c4_8x10(const float* src,
   float32x4_t tmp0246d = vaddq_f32(src7, src8);
   float32x4_t tmp1357d = vsubq_f32(src7, src8);
 
-  float32x4_t dest0 =
-      vaddq_f32(vaddq_f32(vaddq_f32(vaddq_f32(src0, tmp0246a), tmp0246b), tmp0246c), tmp0246d);
-  float32x4_t dest2 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 4)),
-                                vmulq_n_f32(tmp0246c, 0.25f)),
-                                vmulq_n_f32(tmp0246d, 2.25f));
-  float32x4_t dest4 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 16)),
-                                vmulq_n_f32(tmp0246c, 0.0625f)),
-                                vmulq_n_f32(tmp0246d, 5.0625f));
-  float32x4_t dest6 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 64)),
-                                vmulq_n_f32(tmp0246c, 0.015625f)),
-                                vmulq_n_f32(tmp0246d, 11.390625f));
+  float32x4_t dest0 = vaddq_f32(
+      vaddq_f32(vaddq_f32(vaddq_f32(src0, tmp0246a), tmp0246b), tmp0246c),
+      tmp0246d);
+  float32x4_t dest2 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 4)),
+                          vmulq_n_f32(tmp0246c, 0.25f)),
+                vmulq_n_f32(tmp0246d, 2.25f));
+  float32x4_t dest4 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 16)),
+                          vmulq_n_f32(tmp0246c, 0.0625f)),
+                vmulq_n_f32(tmp0246d, 5.0625f));
+  float32x4_t dest6 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 64)),
+                          vmulq_n_f32(tmp0246c, 0.015625f)),
+                vmulq_n_f32(tmp0246d, 11.390625f));
 
-  float32x4_t dest1 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 2)),
-                                vmulq_n_f32(tmp1357c, 0.5f)),
-                                vmulq_n_f32(tmp1357d, 1.5f));
-  float32x4_t dest3 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 8)),
-                                vmulq_n_f32(tmp1357c, 0.125f)),
-                                vmulq_n_f32(tmp1357d, 3.375f));
-  float32x4_t dest5 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 32)),
-                                vmulq_n_f32(tmp1357c, 0.03125f)),
-                                vmulq_n_f32(tmp1357d, 7.59375f));
-  float32x4_t dest7 =
-      vaddq_f32(src9,
-                vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 128)),
+  float32x4_t dest1 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 2)),
+                          vmulq_n_f32(tmp1357c, 0.5f)),
+                vmulq_n_f32(tmp1357d, 1.5f));
+  float32x4_t dest3 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 8)),
+                          vmulq_n_f32(tmp1357c, 0.125f)),
+                vmulq_n_f32(tmp1357d, 3.375f));
+  float32x4_t dest5 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 32)),
+                          vmulq_n_f32(tmp1357c, 0.03125f)),
+                vmulq_n_f32(tmp1357d, 7.59375f));
+  float32x4_t dest7 = vaddq_f32(
+      src9,
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 128)),
                           vmulq_n_f32(tmp1357c, 0.0078125f)),
-                          vmulq_n_f32(tmp1357d, 17.0859375f)));
+                vmulq_n_f32(tmp1357d, 17.0859375f)));
 
   vst1q_f32(dest, dest0);
   vst1q_f32(dest + dest_stride, dest1);
@@ -1627,11 +1633,11 @@ void output_trans_c4_8x10(const float* src,
 }
 
 void output_trans_c4_post_8x10(const float* src,
-                              int src_stride,
-                              float* dest,
-                              int dest_stride,
-                              float* bias_value,
-                              bool has_relu = false) {
+                               int src_stride,
+                               float* dest,
+                               int dest_stride,
+                               float* bias_value,
+                               bool has_relu = false) {
   const float32x4_t src0 = vld1q_f32(src);
   const float32x4_t src1 = vld1q_f32(src + src_stride);
   const float32x4_t src2 = vld1q_f32(src + src_stride * 2);
@@ -1652,32 +1658,39 @@ void output_trans_c4_post_8x10(const float* src,
   float32x4_t tmp0246d = vaddq_f32(src7, src8);
   float32x4_t tmp1357d = vsubq_f32(src7, src8);
 
-  float32x4_t dest0 =
-      vaddq_f32(vaddq_f32(vaddq_f32(vaddq_f32(src0, tmp0246a), tmp0246b), tmp0246c), tmp0246d);
-  float32x4_t dest2 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 4)),
-                                vmulq_n_f32(tmp0246c, 0.25f)),
-                                vmulq_n_f32(tmp0246d, 2.25f));
-  float32x4_t dest4 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 16)),
-                                vmulq_n_f32(tmp0246c, 0.0625f)),
-                                vmulq_n_f32(tmp0246d, 5.0625f));
-  float32x4_t dest6 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 64)),
-                                vmulq_n_f32(tmp0246c, 0.015625f)),
-                                vmulq_n_f32(tmp0246d, 11.390625f));
+  float32x4_t dest0 = vaddq_f32(
+      vaddq_f32(vaddq_f32(vaddq_f32(src0, tmp0246a), tmp0246b), tmp0246c),
+      tmp0246d);
+  float32x4_t dest2 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 4)),
+                          vmulq_n_f32(tmp0246c, 0.25f)),
+                vmulq_n_f32(tmp0246d, 2.25f));
+  float32x4_t dest4 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 16)),
+                          vmulq_n_f32(tmp0246c, 0.0625f)),
+                vmulq_n_f32(tmp0246d, 5.0625f));
+  float32x4_t dest6 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 64)),
+                          vmulq_n_f32(tmp0246c, 0.015625f)),
+                vmulq_n_f32(tmp0246d, 11.390625f));
 
-  float32x4_t dest1 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 2)),
-                                vmulq_n_f32(tmp1357c, 0.5f)),
-                                vmulq_n_f32(tmp1357d, 1.5f));
-  float32x4_t dest3 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 8)),
-                                vmulq_n_f32(tmp1357c, 0.125f)),
-                                vmulq_n_f32(tmp1357d, 3.375f));
-  float32x4_t dest5 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 32)),
-                                vmulq_n_f32(tmp1357c, 0.03125f)),
-                                vmulq_n_f32(tmp1357d, 7.59375f));
-  float32x4_t dest7 =
-      vaddq_f32(src9,
-                vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 128)),
+  float32x4_t dest1 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 2)),
+                          vmulq_n_f32(tmp1357c, 0.5f)),
+                vmulq_n_f32(tmp1357d, 1.5f));
+  float32x4_t dest3 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 8)),
+                          vmulq_n_f32(tmp1357c, 0.125f)),
+                vmulq_n_f32(tmp1357d, 3.375f));
+  float32x4_t dest5 =
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 32)),
+                          vmulq_n_f32(tmp1357c, 0.03125f)),
+                vmulq_n_f32(tmp1357d, 7.59375f));
+  float32x4_t dest7 = vaddq_f32(
+      src9,
+      vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 128)),
                           vmulq_n_f32(tmp1357c, 0.0078125f)),
-                          vmulq_n_f32(tmp1357d, 17.0859375f)));
+                vmulq_n_f32(tmp1357d, 17.0859375f)));
 
   float32x4_t bias = vld1q_f32(bias_value);
   dest0 = vaddq_f32(dest0, bias);
@@ -1894,9 +1907,9 @@ BT = [
 ]
 */
 void input_trans_c4_10x10(const float* src,
-                        int src_stride,
-                        float* dest,
-                        int dest_stride) {
+                          int src_stride,
+                          float* dest,
+                          int dest_stride) {
   float32x4_t src0 = vld1q_f32(src);
   float32x4_t src1 = vld1q_f32(src + src_stride);
   float32x4_t src2 = vld1q_f32(src + src_stride * 2);
@@ -1908,58 +1921,60 @@ void input_trans_c4_10x10(const float* src,
   float32x4_t src8 = vld1q_f32(src + src_stride * 8);
   float32x4_t src9 = vld1q_f32(src + src_stride * 9);
 
-  float32x4_t dst0 = vaddq_f32(vsubq_f32(vaddq_f32(vsubq_f32(vmulq_n_f32(src0, 2.25),
-                               vmulq_n_f32(src2, 12.8125)),
-                               vmulq_n_f32(src4, 17.0625)),
-                               vmulq_n_f32(src6, 7.5)),
-                               src8);
-  float32x4_t dst9 = vaddq_f32(vsubq_f32(vaddq_f32(vsubq_f32(vmulq_n_f32(src1, 2.25),
-                               vmulq_n_f32(src3, 12.8125)),
-                               vmulq_n_f32(src5, 17.0625)),
-                               vmulq_n_f32(src7, 7.5)),
-                               src9);
+  float32x4_t dst0 =
+      vaddq_f32(vsubq_f32(vaddq_f32(vsubq_f32(vmulq_n_f32(src0, 2.25),
+                                              vmulq_n_f32(src2, 12.8125)),
+                                    vmulq_n_f32(src4, 17.0625)),
+                          vmulq_n_f32(src6, 7.5)),
+                src8);
+  float32x4_t dst9 =
+      vaddq_f32(vsubq_f32(vaddq_f32(vsubq_f32(vmulq_n_f32(src1, 2.25),
+                                              vmulq_n_f32(src3, 12.8125)),
+                                    vmulq_n_f32(src5, 17.0625)),
+                          vmulq_n_f32(src7, 7.5)),
+                src9);
 
-  float32x4_t tmp12a = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 10.5625),
-                                 vmulq_n_f32(src2, 2.25)),
-                                 vmulq_n_f32(src6, 6.5)),
-                                 src8);
-  float32x4_t tmp12b = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 10.5625),
-                                 vmulq_n_f32(src1, 2.25)),
-                                 vmulq_n_f32(src5, 6.5)),
-                                 src7);
+  float32x4_t tmp12a = vaddq_f32(
+      vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 10.5625), vmulq_n_f32(src2, 2.25)),
+                vmulq_n_f32(src6, 6.5)),
+      src8);
+  float32x4_t tmp12b = vaddq_f32(
+      vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 10.5625), vmulq_n_f32(src1, 2.25)),
+                vmulq_n_f32(src5, 6.5)),
+      src7);
   float32x4_t dst1 = vaddq_f32(tmp12a, tmp12b);
   float32x4_t dst2 = vsubq_f32(tmp12a, tmp12b);
 
-  float32x4_t tmp34a = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 3.0625),
-                                 vmulq_n_f32(src2, 0.5625)),
-                                 vmulq_n_f32(src6, 3.5)),
-                                 src8);
-  float32x4_t tmp34b = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 6.125),
-                                 vmulq_n_f32(src1, 1.125)),
-                                 vmulq_n_f32(src5, 7)),
-                                 vmulq_n_f32(src7, 2));
+  float32x4_t tmp34a = vaddq_f32(
+      vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 3.0625), vmulq_n_f32(src2, 0.5625)),
+                vmulq_n_f32(src6, 3.5)),
+      src8);
+  float32x4_t tmp34b = vaddq_f32(
+      vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 6.125), vmulq_n_f32(src1, 1.125)),
+                vmulq_n_f32(src5, 7)),
+      vmulq_n_f32(src7, 2));
   float32x4_t dst3 = vaddq_f32(tmp34a, tmp34b);
   float32x4_t dst4 = vsubq_f32(tmp34a, tmp34b);
 
-  float32x4_t tmp56a = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 15.25),
-                                 vmulq_n_f32(src2, 9)),
-                                 vmulq_n_f32(src6, 7.25)),
-                                 src8);
-  float32x4_t tmp56b = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 7.625),
-                                 vmulq_n_f32(src1, 4.5)),
-                                 vmulq_n_f32(src5, 3.625)),
-                                 vmulq_n_f32(src7, 0.5));
+  float32x4_t tmp56a = vaddq_f32(
+      vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 15.25), vmulq_n_f32(src2, 9)),
+                vmulq_n_f32(src6, 7.25)),
+      src8);
+  float32x4_t tmp56b = vaddq_f32(
+      vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 7.625), vmulq_n_f32(src1, 4.5)),
+                vmulq_n_f32(src5, 3.625)),
+      vmulq_n_f32(src7, 0.5));
   float32x4_t dst5 = vaddq_f32(tmp56a, tmp56b);
   float32x4_t dst6 = vsubq_f32(tmp56a, tmp56b);
 
-  float32x4_t tmp78a = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 5.25),
-                                 src2),
-                                 vmulq_n_f32(src6, 5.25)),
-                                 src8);
-  float32x4_t tmp78b = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 7.875),
-                                 vmulq_n_f32(src1, 1.5)),
-                                 vmulq_n_f32(src5, 7.875)),
-                                 vmulq_n_f32(src7, 1.5));
+  float32x4_t tmp78a =
+      vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 5.25), src2),
+                          vmulq_n_f32(src6, 5.25)),
+                src8);
+  float32x4_t tmp78b = vaddq_f32(
+      vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 7.875), vmulq_n_f32(src1, 1.5)),
+                vmulq_n_f32(src5, 7.875)),
+      vmulq_n_f32(src7, 1.5));
   float32x4_t dst7 = vaddq_f32(tmp78a, tmp78b);
   float32x4_t dst8 = vsubq_f32(tmp78a, tmp78b);
 
@@ -2229,15 +2244,15 @@ void output_trans_c4_post_2x4(const float* src,
 void weight_trans_c4_10x10(
     float* dest, const float* din, int ch_in, int ch_out, void* workspace) {
   const float coeff[10][3] = {{4.0f / 9, 0.0f, 0.0f},
-                             {8.0f / 45, 8.0f / 45, 8.0f / 45},
-                             {8.0f / 45, -8.0f / 45, 8.0f / 45},
-                             {2.0f / 315, 4.0f / 315, 8.0f / 315},
-                             {2.0f / 315, -4.0f / 315, 8.0f / 315},
-                             {-16.0f / 45, -8.0f / 45, -4.0f / 45},
-                             {-16.0f / 45, 8.0f / 45, -4.0f / 45},
-                             {-16.0f / 315, -8.0f / 105, -4.0f / 35},
-                             {-16.0f / 315, 8.0f / 105, -4.0f / 35},
-                             {0.0f, 0.0f, 1.0f}};
+                              {8.0f / 45, 8.0f / 45, 8.0f / 45},
+                              {8.0f / 45, -8.0f / 45, 8.0f / 45},
+                              {2.0f / 315, 4.0f / 315, 8.0f / 315},
+                              {2.0f / 315, -4.0f / 315, 8.0f / 315},
+                              {-16.0f / 45, -8.0f / 45, -4.0f / 45},
+                              {-16.0f / 45, 8.0f / 45, -4.0f / 45},
+                              {-16.0f / 315, -8.0f / 105, -4.0f / 35},
+                              {-16.0f / 315, 8.0f / 105, -4.0f / 35},
+                              {0.0f, 0.0f, 1.0f}};
 
   float* ptr_out = static_cast<float*>(workspace);
 
@@ -2268,8 +2283,8 @@ void weight_trans_c4_10x10(
         float* tmpp = &tmp[j][0];
         for (int i = 0; i < 10; i++) {
           ptr_channel[j * 10 + i] = tmpp[0] * coeff[i][0] +
-                                   tmpp[1] * coeff[i][1] +
-                                   tmpp[2] * coeff[i][2];
+                                    tmpp[1] * coeff[i][1] +
+                                    tmpp[2] * coeff[i][2];
         }
       }
     }

--- a/lite/backends/arm/math/conv3x3_winograd_fp32_c4.cc
+++ b/lite/backends/arm/math/conv3x3_winograd_fp32_c4.cc
@@ -25,6 +25,20 @@ namespace paddle {
 namespace lite {
 namespace arm {
 namespace math {
+void input_trans_c4_10x10(const float* src,
+                        int src_stride,
+                        float* dest,
+                        int dest_stride);
+void output_trans_c4_8x10(const float* src,
+                         int src_stride,
+                         float* dest,
+                         int dest_stride);
+void output_trans_c4_post_8x10(const float* src,
+                              int src_stride,
+                              float* dest,
+                              int dest_stride,
+                              float* bias_value,
+                              bool has_relu);
 void input_trans_c4_8x8(const float* src,
                         int src_stride,
                         float* dest,
@@ -67,6 +81,8 @@ void output_trans_c4_post_2x4(const float* src,
                               int dest_h_stride,
                               float* bias_value,
                               bool has_relu);
+void weight_trans_c4_10x10(
+    float* dest, const float* src, int ic, int oc, void* workspace);
 void weight_trans_c4_8x8(
     float* dest, const float* src, int ic, int oc, void* workspace);
 void weight_trans_c4_6x6(
@@ -81,6 +97,308 @@ void weight_trans_c4_4x4(
 *
 *Copyright © 2018, Alibaba Group Holding Limited
 */
+
+// F(8,3)
+void conv_compute_8x8_3x3(const float* input,
+                          float* output,
+                          int num,
+                          int chout,
+                          int hout,
+                          int wout,
+                          int chin,
+                          int hin,
+                          int win,
+                          const float* weight,
+                          const float* bias,
+                          const operators::ConvParam& param,
+                          ARMContext* ctx) {
+  auto act_param = param.activation_param;
+  const int pad_h0 = (*param.paddings)[0];
+  const int pad_h1 = (*param.paddings)[1];
+  const int pad_w0 = (*param.paddings)[2];
+  const int pad_w1 = (*param.paddings)[3];
+  float* tmp_work_space =
+      ctx->workspace_data<float>() + ctx->llc_size() / sizeof(float);
+
+  int in_n_stride = chin * hin * win;
+  int out_n_stride = chout * hout * wout;
+  int ic_stride = win * hin;
+  int oc_stride = wout * hout;
+  int ic_4 = (chin + 3) / 4;
+  int oc_4 = (chout + 3) / 4;
+
+  int tile_w = (wout + 7) / 8;
+  int tile_h = (hout + 7) / 8;
+  int size_tile = tile_h * tile_w;
+
+  int w_pad = win + pad_w0 + pad_w1;
+  int h_pad = hin + pad_h0 + pad_h1;
+
+  const int zero_len = w_pad;
+  float zero_ptr[zero_len];  // NOLINT
+  memset(zero_ptr, 0, zero_len * sizeof(float));
+
+  float* input_c4 = tmp_work_space;
+  int new_h_stride = w_pad * 4;
+  int new_c_stride = new_h_stride * h_pad;
+
+  int ic_4_stride = w_pad * h_pad * 4;
+  int oc_4_stride = wout * hout * 4;
+
+  int tile_block = 8;
+  int block_count = (size_tile + tile_block - 1) / tile_block;
+
+  int threads = ctx->threads();
+  float* g_tmp_data = tmp_work_space + ic_4 * new_c_stride;
+  int tmp_data_thread_stride = tile_block * (oc_4 + ic_4) * 400;
+  memset(g_tmp_data, 0, threads * tmp_data_thread_stride * sizeof(float));
+  float* g_trans_tmp_data = g_tmp_data + threads * tmp_data_thread_stride;
+  float* g_trans_remain_tmp_data = g_trans_tmp_data + threads * 400;
+
+  // begin compute
+  for (int ni = 0; ni < num; ++ni) {
+    // trans input to c4
+    for (int i = 0; i < ic_4; ++i) {
+      prepack_input_nxwc4_dw(input + ni * in_n_stride,
+                             input_c4 + i * new_c_stride,
+                             i * 4,
+                             -pad_h0,
+                             hin + pad_h1,
+                             -pad_w0,
+                             win + pad_w1,
+                             chin,
+                             win,
+                             hin,
+                             zero_ptr);
+    }
+    float* output_ptr = output + ni * out_n_stride;
+
+    const float* weight_ptr = weight;
+    const float* bias_ptr = bias;
+    LITE_PARALLEL_BEGIN(tbi, tid, block_count) {
+#ifdef LITE_USE_THREAD_POOL
+      float* tmp_data = g_tmp_data + tid * tmp_data_thread_stride;
+      float* trans_tmp_data = g_trans_tmp_data + tid * 400;
+      float* trans_remain_tmp_data = g_trans_remain_tmp_data + tid * 400;
+#elif defined(ARM_WITH_OMP)
+      float* tmp_data =
+          g_tmp_data + omp_get_thread_num() * tmp_data_thread_stride;
+      float* trans_tmp_data = g_trans_tmp_data + omp_get_thread_num() * 400;
+      float* trans_remain_tmp_data =
+          g_trans_remain_tmp_data + omp_get_thread_num() * 400;
+#else
+      float* tmp_data = g_tmp_data;
+      float* trans_tmp_data = g_trans_tmp_data;
+      float* trans_remain_tmp_data = g_trans_remain_tmp_data;
+#endif
+      int tile_index = tbi * tile_block;
+      int tile_remain = size_tile - tile_index;
+      int tile_count = tile_remain > tile_block ? tile_block : tile_remain;
+
+      // input trans
+      int c_gi_stride = tile_count * oc_4 * 4;
+      int b_gi_stride = tile_count * ic_4 * 4;
+      //*
+      for (int ti = 0; ti < tile_count; ++ti) {
+        int index = tile_index + ti;
+
+        int tw_index = index % tile_w;
+        int th_index = index / tile_w;
+
+        int src_x = tw_index * 8;
+        int src_y = th_index * 8;
+        int ex = src_x + 10 > w_pad ? w_pad - src_x : 10;
+        int ey = src_y + 10 > h_pad ? h_pad - src_y : 10;
+
+        float* dst_ptr = tmp_data + ti * 4;
+        const float* src_ptr = input_c4 + (src_y * w_pad + src_x) * 4;
+
+        if (ex == 10 && ey == 10) {
+          // trans input
+          for (int ci = 0; ci < ic_4; ++ci) {
+            const float* src_ci = src_ptr + ci * ic_4_stride;
+            for (int i = 0; i < 10; ++i) {
+              const float* ci_ptr = src_ci + i * w_pad * 4;
+              input_trans_c4_10x10(ci_ptr, 4, trans_tmp_data + i * 4, 40);
+            }
+            float* dst_ci = dst_ptr + ci * tile_count * 4;
+            for (int i = 0; i < 10; ++i) {
+              input_trans_c4_10x10(trans_tmp_data + i * 40,
+                                 4,
+                                 dst_ci + i * b_gi_stride * 10,
+                                 b_gi_stride);
+            }
+          }
+        } else {
+          // trans remain input
+          int x_size = ex;
+          for (int ci = 0; ci < ic_4; ++ci) {
+            const float* src_ci = src_ptr + ci * ic_4_stride;
+            // pad
+            memset(trans_remain_tmp_data, 0, 400 * sizeof(float));
+            if (x_size > 0) {
+              for (int yi = 0; yi < ey; ++yi) {
+                float* dst_yi = trans_remain_tmp_data + yi * 40;
+                const float* src_yi = src_ci + w_pad * yi * 4;
+                memcpy(dst_yi, src_yi, x_size * sizeof(float) * 4);
+              }
+            }
+            // trans
+            for (int i = 0; i < 10; ++i) {
+              float* ci_ptr = trans_remain_tmp_data + i * 40;
+              input_trans_c4_10x10(ci_ptr, 4, trans_tmp_data + i * 4, 40);
+            }
+            float* dst_ci = dst_ptr + ci * tile_count * 4;
+            for (int i = 0; i < 10; ++i) {
+              input_trans_c4_10x10(trans_tmp_data + i * 40,
+                                 4,
+                                 dst_ci + i * b_gi_stride * 10,
+                                 b_gi_stride);
+            }
+          }  // for ci_4
+        }
+      }
+      //*/
+      // input trans end
+      // *begin compute dot
+      // *
+      //*
+      float* dst_temp_data = tmp_data + tile_block * ic_4 * 400;
+      float* b_ptr = tmp_data;
+      int w_gi_stride = ic_4 * oc_4 * 16;
+      for (int gi = 0; gi < 100; ++gi) {
+        float* origin_C = dst_temp_data + gi * c_gi_stride;
+        float* origin_B = b_ptr + gi * b_gi_stride;
+        const float* origin_A = weight + gi * w_gi_stride;
+        sgemm_prepack_c4_small(
+            oc_4 * 4, tile_count, ic_4 * 4, origin_A, origin_B, origin_C, ctx);
+      }
+      //*/
+      //*
+      // output trans
+      float bias_value[4];
+      memset(bias_value, 0, 4 * sizeof(float));
+      for (int ti = 0; ti < tile_count; ++ti) {
+        int index = tile_index + ti;
+
+        int tw_index = index % tile_w;
+        int th_index = index / tile_w;
+
+        int dst_x = tw_index * 8;
+        int dst_y = th_index * 8;
+
+        int ex = dst_x + 8 > wout ? wout - dst_x : 8;
+        int ey = dst_y + 8 > hout ? hout - dst_y : 8;
+
+        float* dst_ptr = output + (dst_y * wout + dst_x) * 4;
+        float* src_ptr = dst_temp_data + ti * 4;
+        if (ex == 8) {
+          // trans output
+          for (int ci = 0; ci < oc_4; ++ci) {
+            if (param.bias) {
+              if (ci * 4 + 4 < chout) {
+                bias_value[0] = bias[ci * 4];
+                bias_value[1] = bias[ci * 4 + 1];
+                bias_value[2] = bias[ci * 4 + 2];
+                bias_value[3] = bias[ci * 4 + 3];
+              } else {
+                for (int p = 0; p < 4 && ci * 4 + p < chout; p++) {
+                  bias_value[p] = bias[ci * 4 + p];
+                }
+              }
+            }
+
+            float* dst_ci = dst_ptr + ci * oc_4_stride;
+            float* src_ci = src_ptr + ci * tile_count * 4;
+            for (int i = 0; i < 10; ++i) {
+              output_trans_c4_8x10(src_ci + i * c_gi_stride * 10,
+                                  c_gi_stride,
+                                  trans_tmp_data + i * 4,
+                                  40);
+            }
+            for (int i = 0; i < ey; ++i) {
+              output_trans_c4_post_8x10(trans_tmp_data + i * 40,
+                                       4,
+                                       trans_remain_tmp_data + i * 32,
+                                       4,
+                                       bias_value,
+                                       param.fuse_relu);
+            }
+            write_to_output_c4_fp32(trans_remain_tmp_data,
+                                    output_ptr,
+                                    ci * 4,
+                                    ci * 4 + 4,
+                                    dst_y,
+                                    dst_y + ey,
+                                    dst_x,
+                                    dst_x + ex,
+                                    chout,
+                                    hout,
+                                    wout,
+                                    false,
+                                    zero_ptr,
+                                    &act_param);
+          }
+        } else {
+          for (int ci = 0; ci < oc_4; ++ci) {
+            if (param.bias) {
+              if (ci * 4 + 4 < chout) {
+                bias_value[0] = bias[ci * 4];
+                bias_value[1] = bias[ci * 4 + 1];
+                bias_value[2] = bias[ci * 4 + 2];
+                bias_value[3] = bias[ci * 4 + 3];
+              } else {
+                for (int p = 0; p < 4 && ci * 4 + p < chout; p++) {
+                  bias_value[p] = bias[ci * 4 + p];
+                }
+              }
+            }
+            // trans output
+            float* dst_ci = dst_ptr + ci * oc_4_stride;
+            float* src_ci = src_ptr + ci * tile_count * 4;
+            for (int i = 0; i < 10; ++i) {
+              output_trans_c4_8x10(src_ci + i * c_gi_stride * 10,
+                                  c_gi_stride,
+                                  trans_tmp_data + i * 4,
+                                  40);
+            }
+            for (int i = 0; i < ey; ++i) {
+              output_trans_c4_post_8x10(trans_tmp_data + i * 40,
+                                       4,
+                                       trans_remain_tmp_data + i * 32,
+                                       4,
+                                       bias_value,
+                                       param.fuse_relu);
+            }
+            // copy to dest
+            memset(trans_tmp_data, 0, 256 * sizeof(float));
+            for (int i = 0; i < ey; ++i) {
+              memcpy(trans_tmp_data + i * ex * 4,
+                     trans_remain_tmp_data + i * 32,
+                     ex * sizeof(float) * 4);
+            }
+            write_to_output_c4_fp32(trans_tmp_data,
+                                    output_ptr,
+                                    ci * 4,
+                                    ci * 4 + 4,
+                                    dst_y,
+                                    dst_y + ey,
+                                    dst_x,
+                                    dst_x + ex,
+                                    chout,
+                                    hout,
+                                    wout,
+                                    false,
+                                    zero_ptr,
+                                    &act_param);
+          }
+        }
+      }
+      //*/
+    }  // for block_count
+    LITE_PARALLEL_END();
+  }  // for num
+}  // conv_compute
 
 // F(6,3)
 void conv_compute_6x6_3x3(const float* input,
@@ -1237,6 +1555,152 @@ void conv_compute_2x2_3x3_small(const float* input,
 
 /*
 AT = [
+    1   1   1   1    1     1       1       1         1          0
+    0   1   -1  2    -2    1/2     -1/2    3/2       -3/2       0
+    0   1   1   4    4     1/4     1/4     9/4       9/4        0
+    0   1   -1  8    -8    1/8     -1/8    27/8      -27/8      0
+    0   1   1   16   16    1/16    1/16    81/16     81/16      0
+    0   1   -1  32   -32   1/32    -1/32   243/32    -243/32    0
+    0   1   1   64   64    1/64    1/64    729/64    729/64     0
+    0   1   -1  128  -128  1/128   -1/128  2187/128  -2187/128  1
+]
+*/
+void output_trans_c4_8x10(const float* src,
+                         int src_stride,
+                         float* dest,
+                         int dest_stride) {
+  const float32x4_t src0 = vld1q_f32(src);
+  const float32x4_t src1 = vld1q_f32(src + src_stride);
+  const float32x4_t src2 = vld1q_f32(src + src_stride * 2);
+  const float32x4_t src3 = vld1q_f32(src + src_stride * 3);
+  const float32x4_t src4 = vld1q_f32(src + src_stride * 4);
+  const float32x4_t src5 = vld1q_f32(src + src_stride * 5);
+  const float32x4_t src6 = vld1q_f32(src + src_stride * 6);
+  const float32x4_t src7 = vld1q_f32(src + src_stride * 7);
+  const float32x4_t src8 = vld1q_f32(src + src_stride * 8);
+  const float32x4_t src9 = vld1q_f32(src + src_stride * 9);
+
+  float32x4_t tmp0246a = vaddq_f32(src1, src2);
+  float32x4_t tmp1357a = vsubq_f32(src1, src2);
+  float32x4_t tmp0246b = vaddq_f32(src3, src4);
+  float32x4_t tmp1357b = vsubq_f32(src3, src4);
+  float32x4_t tmp0246c = vaddq_f32(src5, src6);
+  float32x4_t tmp1357c = vsubq_f32(src5, src6);
+  float32x4_t tmp0246d = vaddq_f32(src7, src8);
+  float32x4_t tmp1357d = vsubq_f32(src7, src8);
+
+  float32x4_t dest0 =
+      vaddq_f32(vaddq_f32(vaddq_f32(vaddq_f32(src0, tmp0246a), tmp0246b), tmp0246c), tmp0246d);
+  float32x4_t dest2 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 4)),
+                                vmulq_n_f32(tmp0246c, 0.25f)),
+                                vmulq_n_f32(tmp0246d, 2.25f));
+  float32x4_t dest4 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 16)),
+                                vmulq_n_f32(tmp0246c, 0.0625f)),
+                                vmulq_n_f32(tmp0246d, 5.0625f));
+  float32x4_t dest6 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 64)),
+                                vmulq_n_f32(tmp0246c, 0.015625f)),
+                                vmulq_n_f32(tmp0246d, 11.390625f));
+
+  float32x4_t dest1 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 2)),
+                                vmulq_n_f32(tmp1357c, 0.5f)),
+                                vmulq_n_f32(tmp1357d, 1.5f));
+  float32x4_t dest3 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 8)),
+                                vmulq_n_f32(tmp1357c, 0.125f)),
+                                vmulq_n_f32(tmp1357d, 3.375f));
+  float32x4_t dest5 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 32)),
+                                vmulq_n_f32(tmp1357c, 0.03125f)),
+                                vmulq_n_f32(tmp1357d, 7.59375f));
+  float32x4_t dest7 =
+      vaddq_f32(src9,
+                vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 128)),
+                          vmulq_n_f32(tmp1357c, 0.0078125f)),
+                          vmulq_n_f32(tmp1357d, 17.0859375f)));
+
+  vst1q_f32(dest, dest0);
+  vst1q_f32(dest + dest_stride, dest1);
+  vst1q_f32(dest + dest_stride * 2, dest2);
+  vst1q_f32(dest + dest_stride * 3, dest3);
+  vst1q_f32(dest + dest_stride * 4, dest4);
+  vst1q_f32(dest + dest_stride * 5, dest5);
+  vst1q_f32(dest + dest_stride * 6, dest6);
+  vst1q_f32(dest + dest_stride * 7, dest7);
+}
+
+void output_trans_c4_post_8x10(const float* src,
+                              int src_stride,
+                              float* dest,
+                              int dest_stride,
+                              float* bias_value,
+                              bool has_relu = false) {
+  const float32x4_t src0 = vld1q_f32(src);
+  const float32x4_t src1 = vld1q_f32(src + src_stride);
+  const float32x4_t src2 = vld1q_f32(src + src_stride * 2);
+  const float32x4_t src3 = vld1q_f32(src + src_stride * 3);
+  const float32x4_t src4 = vld1q_f32(src + src_stride * 4);
+  const float32x4_t src5 = vld1q_f32(src + src_stride * 5);
+  const float32x4_t src6 = vld1q_f32(src + src_stride * 6);
+  const float32x4_t src7 = vld1q_f32(src + src_stride * 7);
+  const float32x4_t src8 = vld1q_f32(src + src_stride * 8);
+  const float32x4_t src9 = vld1q_f32(src + src_stride * 9);
+
+  float32x4_t tmp0246a = vaddq_f32(src1, src2);
+  float32x4_t tmp1357a = vsubq_f32(src1, src2);
+  float32x4_t tmp0246b = vaddq_f32(src3, src4);
+  float32x4_t tmp1357b = vsubq_f32(src3, src4);
+  float32x4_t tmp0246c = vaddq_f32(src5, src6);
+  float32x4_t tmp1357c = vsubq_f32(src5, src6);
+  float32x4_t tmp0246d = vaddq_f32(src7, src8);
+  float32x4_t tmp1357d = vsubq_f32(src7, src8);
+
+  float32x4_t dest0 =
+      vaddq_f32(vaddq_f32(vaddq_f32(vaddq_f32(src0, tmp0246a), tmp0246b), tmp0246c), tmp0246d);
+  float32x4_t dest2 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 4)),
+                                vmulq_n_f32(tmp0246c, 0.25f)),
+                                vmulq_n_f32(tmp0246d, 2.25f));
+  float32x4_t dest4 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 16)),
+                                vmulq_n_f32(tmp0246c, 0.0625f)),
+                                vmulq_n_f32(tmp0246d, 5.0625f));
+  float32x4_t dest6 = vaddq_f32(vaddq_f32(vaddq_f32(tmp0246a, vmulq_n_f32(tmp0246b, 64)),
+                                vmulq_n_f32(tmp0246c, 0.015625f)),
+                                vmulq_n_f32(tmp0246d, 11.390625f));
+
+  float32x4_t dest1 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 2)),
+                                vmulq_n_f32(tmp1357c, 0.5f)),
+                                vmulq_n_f32(tmp1357d, 1.5f));
+  float32x4_t dest3 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 8)),
+                                vmulq_n_f32(tmp1357c, 0.125f)),
+                                vmulq_n_f32(tmp1357d, 3.375f));
+  float32x4_t dest5 = vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 32)),
+                                vmulq_n_f32(tmp1357c, 0.03125f)),
+                                vmulq_n_f32(tmp1357d, 7.59375f));
+  float32x4_t dest7 =
+      vaddq_f32(src9,
+                vaddq_f32(vaddq_f32(vaddq_f32(tmp1357a, vmulq_n_f32(tmp1357b, 128)),
+                          vmulq_n_f32(tmp1357c, 0.0078125f)),
+                          vmulq_n_f32(tmp1357d, 17.0859375f)));
+
+  float32x4_t bias = vld1q_f32(bias_value);
+  dest0 = vaddq_f32(dest0, bias);
+  dest1 = vaddq_f32(dest1, bias);
+  dest2 = vaddq_f32(dest2, bias);
+  dest3 = vaddq_f32(dest3, bias);
+  dest4 = vaddq_f32(dest4, bias);
+  dest5 = vaddq_f32(dest5, bias);
+  dest6 = vaddq_f32(dest6, bias);
+  dest7 = vaddq_f32(dest7, bias);
+
+  vst1q_f32(dest, dest0);
+  vst1q_f32(dest + dest_stride, dest1);
+  vst1q_f32(dest + dest_stride * 2, dest2);
+  vst1q_f32(dest + dest_stride * 3, dest3);
+  vst1q_f32(dest + dest_stride * 4, dest4);
+  vst1q_f32(dest + dest_stride * 5, dest5);
+  vst1q_f32(dest + dest_stride * 6, dest6);
+  vst1q_f32(dest + dest_stride * 7, dest7);
+}
+
+/*
+AT = [
     1   1   1   1   1   1     1     0
     0   1   -1  2   -2  1/2   -1/2  0
     0   1   1   4   4   1/4   1/4   0
@@ -1413,6 +1877,102 @@ void output_trans_c4_post_4x6(const float* src,
   vst1q_f32(dest + dest_stride, dest1);
   vst1q_f32(dest + dest_stride * 2, dest2);
   vst1q_f32(dest + dest_stride * 3, dest3);
+}
+
+/*
+BT = [
+   9/4    0      -205/16   0         273/16    0       -15/2   0      1    0
+   0      -9/4   -9/4      169/16    169/16    -13/2   -13/2   1      1    0
+   0      9/4    -9/4      -169/16   169/16    13/2    -13/2   -1     1    0
+   0      -9/8   -9/16     49/8      49/16     -7      -7/2    2      1    0
+   0      9/8    -9/16     -49/8     49/16     7       -7/2    -2     1    0
+   0      -9/2   -9        61/8      61/4      -29/8   -29/4   1/2    1    0
+   0      9/2    -9        -61/8     61/4      29/8    -29/4   -1/2   1    0
+   0      -3/2   -1        63/8      21/4      -63/8   -21/4   3/2    1    0
+   0      3/2    -1        -63/8     21/4      63/8    -21/4   -3/2   1    0
+   0      9/4    0         -205/16   0         273/16  0       -15/2  0    1
+]
+*/
+void input_trans_c4_10x10(const float* src,
+                        int src_stride,
+                        float* dest,
+                        int dest_stride) {
+  float32x4_t src0 = vld1q_f32(src);
+  float32x4_t src1 = vld1q_f32(src + src_stride);
+  float32x4_t src2 = vld1q_f32(src + src_stride * 2);
+  float32x4_t src3 = vld1q_f32(src + src_stride * 3);
+  float32x4_t src4 = vld1q_f32(src + src_stride * 4);
+  float32x4_t src5 = vld1q_f32(src + src_stride * 5);
+  float32x4_t src6 = vld1q_f32(src + src_stride * 6);
+  float32x4_t src7 = vld1q_f32(src + src_stride * 7);
+  float32x4_t src8 = vld1q_f32(src + src_stride * 8);
+  float32x4_t src9 = vld1q_f32(src + src_stride * 9);
+
+  float32x4_t dst0 = vaddq_f32(vsubq_f32(vaddq_f32(vsubq_f32(vmulq_n_f32(src0, 2.25),
+                               vmulq_n_f32(src2, 12.8125)),
+                               vmulq_n_f32(src4, 17.0625)),
+                               vmulq_n_f32(src6, 7.5)),
+                               src8);
+  float32x4_t dst9 = vaddq_f32(vsubq_f32(vaddq_f32(vsubq_f32(vmulq_n_f32(src1, 2.25),
+                               vmulq_n_f32(src3, 12.8125)),
+                               vmulq_n_f32(src5, 17.0625)),
+                               vmulq_n_f32(src7, 7.5)),
+                               src9);
+
+  float32x4_t tmp12a = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 10.5625),
+                                 vmulq_n_f32(src2, 2.25)),
+                                 vmulq_n_f32(src6, 6.5)),
+                                 src8);
+  float32x4_t tmp12b = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 10.5625),
+                                 vmulq_n_f32(src1, 2.25)),
+                                 vmulq_n_f32(src5, 6.5)),
+                                 src7);
+  float32x4_t dst1 = vaddq_f32(tmp12a, tmp12b);
+  float32x4_t dst2 = vsubq_f32(tmp12a, tmp12b);
+
+  float32x4_t tmp34a = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 3.0625),
+                                 vmulq_n_f32(src2, 0.5625)),
+                                 vmulq_n_f32(src6, 3.5)),
+                                 src8);
+  float32x4_t tmp34b = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 6.125),
+                                 vmulq_n_f32(src1, 1.125)),
+                                 vmulq_n_f32(src5, 7)),
+                                 vmulq_n_f32(src7, 2));
+  float32x4_t dst3 = vaddq_f32(tmp34a, tmp34b);
+  float32x4_t dst4 = vsubq_f32(tmp34a, tmp34b);
+
+  float32x4_t tmp56a = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 15.25),
+                                 vmulq_n_f32(src2, 9)),
+                                 vmulq_n_f32(src6, 7.25)),
+                                 src8);
+  float32x4_t tmp56b = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 7.625),
+                                 vmulq_n_f32(src1, 4.5)),
+                                 vmulq_n_f32(src5, 3.625)),
+                                 vmulq_n_f32(src7, 0.5));
+  float32x4_t dst5 = vaddq_f32(tmp56a, tmp56b);
+  float32x4_t dst6 = vsubq_f32(tmp56a, tmp56b);
+
+  float32x4_t tmp78a = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src4, 5.25),
+                                 src2),
+                                 vmulq_n_f32(src6, 5.25)),
+                                 src8);
+  float32x4_t tmp78b = vaddq_f32(vsubq_f32(vsubq_f32(vmulq_n_f32(src3, 7.875),
+                                 vmulq_n_f32(src1, 1.5)),
+                                 vmulq_n_f32(src5, 7.875)),
+                                 vmulq_n_f32(src7, 1.5));
+  float32x4_t dst7 = vaddq_f32(tmp78a, tmp78b);
+  float32x4_t dst8 = vsubq_f32(tmp78a, tmp78b);
+
+  vst1q_f32(dest, dst0);
+  vst1q_f32(dest + dest_stride, dst1);
+  vst1q_f32(dest + dest_stride * 2, dst2);
+  vst1q_f32(dest + dest_stride * 3, dst3);
+  vst1q_f32(dest + dest_stride * 4, dst4);
+  vst1q_f32(dest + dest_stride * 5, dst5);
+  vst1q_f32(dest + dest_stride * 6, dst6);
+  vst1q_f32(dest + dest_stride * 7, dst7);
+  vst1q_f32(dest + dest_stride * 8, dst8);
+  vst1q_f32(dest + dest_stride * 9, dst9);
 }
 
 /*
@@ -1664,6 +2224,69 @@ void output_trans_c4_post_2x4(const float* src,
   dest += dest_h_stride;
   vst1q_f32(dest, dest01);
   vst1q_f32(dest + dest_stride, dest11);
+}
+
+void weight_trans_c4_10x10(
+    float* dest, const float* din, int ch_in, int ch_out, void* workspace) {
+  const float coeff[10][3] = {{4.0f / 9, 0.0f, 0.0f},
+                             {8.0f / 45, 8.0f / 45, 8.0f / 45},
+                             {8.0f / 45, -8.0f / 45, 8.0f / 45},
+                             {2.0f / 315, 4.0f / 315, 8.0f / 315},
+                             {2.0f / 315, -4.0f / 315, 8.0f / 315},
+                             {-16.0f / 45, -8.0f / 45, -4.0f / 45},
+                             {-16.0f / 45, 8.0f / 45, -4.0f / 45},
+                             {-16.0f / 315, -8.0f / 105, -4.0f / 35},
+                             {-16.0f / 315, 8.0f / 105, -4.0f / 35},
+                             {0.0f, 0.0f, 1.0f}};
+
+  float* ptr_out = static_cast<float*>(workspace);
+
+  for (int i = 0; i < ch_out; i++) {
+    for (int j = 0; j < ch_in; j++) {
+      const float* kernel0 =
+          static_cast<const float*>(din) + (i * ch_in + j) * 9;
+      float* ptr_channel = ptr_out + (i * ch_in + j) * 100;
+
+      //! transform kernel, transposed
+      const float* k0 = kernel0;
+      const float* k1 = kernel0 + 3;
+      const float* k2 = kernel0 + 6;
+
+      //! h
+      float tmp[10][3];
+      for (int i = 0; i < 10; i++) {
+        tmp[i][0] =
+            k0[0] * coeff[i][0] + k0[1] * coeff[i][1] + k0[2] * coeff[i][2];
+        tmp[i][1] =
+            k1[0] * coeff[i][0] + k1[1] * coeff[i][1] + k1[2] * coeff[i][2];
+        tmp[i][2] =
+            k2[0] * coeff[i][0] + k2[1] * coeff[i][1] + k2[2] * coeff[i][2];
+      }
+
+      //! v
+      for (int j = 0; j < 10; j++) {
+        float* tmpp = &tmp[j][0];
+        for (int i = 0; i < 10; i++) {
+          ptr_channel[j * 10 + i] = tmpp[0] * coeff[i][0] +
+                                   tmpp[1] * coeff[i][1] +
+                                   tmpp[2] * coeff[i][2];
+        }
+      }
+    }
+  }
+
+  int oc_pad = (ch_out + 3) / 4 * 4;
+  int ic_pad = (ch_in + 3) / 4 * 4;
+  int c_stride = ic_pad * oc_pad;
+  for (int i = 0; i < ch_out * ch_in * 100; ++i) {
+    int new_c = i % 100;
+    int new_oc = i / ch_in / 100 / 4;
+    int new_ic = i / 100 % ch_in;
+    int new_inner = i / ch_in / 100 % 4;
+    int dest_ind =
+        new_c * c_stride + new_oc * ic_pad * 4 + new_ic * 4 + new_inner;
+    dest[dest_ind] = ptr_out[i];
+  }
 }
 
 void weight_trans_c4_8x8(

--- a/lite/backends/arm/math/conv_impl.h
+++ b/lite/backends/arm/math/conv_impl.h
@@ -226,12 +226,27 @@ void winograd_transform_weights(
     void* dout, const void* din, int ch_out, int ch_in, void* work_space);
 
 // new winograd
+void weight_trans_c4_10x10(
+    float* dest, const float* src, int ic, int oc, void* workspace);
 void weight_trans_c4_8x8(
     float* dest, const float* src, int ic, int oc, void* workspace);
 void weight_trans_c4_6x6(
     float* dest, const float* src, int ic, int oc, void* workspace);
 void weight_trans_c4_4x4(
     float* dest, const float* src, int ic, int oc, void* workspace);
+void conv_compute_8x8_3x3(const float* input,
+                          float* output,
+                          int num,
+                          int chout,
+                          int hout,
+                          int wout,
+                          int chin,
+                          int hin,
+                          int win,
+                          const float* weight,
+                          const float* bias,
+                          const operators::ConvParam& param,
+                          ARMContext* ctx);
 void conv_compute_6x6_3x3(const float* input,
                           float* output,
                           int num,

--- a/lite/kernels/arm/conv_winograd.cc
+++ b/lite/kernels/arm/conv_winograd.cc
@@ -67,12 +67,18 @@ void WinogradConv<PRECISION(kFloat), PRECISION(kFloat)>::ReInitWhenNeeded() {
       return;
     }
     last_function_ = 1;
-  } else {
+  } else if (wino_unit < 64) {
     wino_iw = 8;
     if (last_function_ == 2) {
       return;
     }
     last_function_ = 2;
+  } else {
+    wino_iw = 10;
+    if (last_function_ == 3) {
+      return;
+    }
+    last_function_ = 3;
   }
   last_function_ = -1;
 
@@ -92,6 +98,10 @@ void WinogradConv<PRECISION(kFloat), PRECISION(kFloat)>::ReInitWhenNeeded() {
          0,
          weights_.numel() * sizeof(float));
   switch (wino_iw) {
+    case 10:
+      lite::arm::math::weight_trans_c4_10x10(
+          weights_data_, param.filter->data<float>(), ic, oc, trans_tmp_ptr);
+      break;
     case 8:
       lite::arm::math::weight_trans_c4_8x8(
           weights_data_, param.filter->data<float>(), ic, oc, trans_tmp_ptr);
@@ -105,7 +115,7 @@ void WinogradConv<PRECISION(kFloat), PRECISION(kFloat)>::ReInitWhenNeeded() {
           weights_data_, param.filter->data<float>(), ic, oc, trans_tmp_ptr);
       break;
     default:
-      lite::arm::math::weight_trans_c4_8x8(
+      lite::arm::math::weight_trans_c4_10x10(
           weights_data_, param.filter->data<float>(), ic, oc, trans_tmp_ptr);
   }
 
@@ -141,7 +151,10 @@ void WinogradConv<PRECISION(kFloat), PRECISION(kFloat)>::Run() {
   int ow = o_dims[3];
   int oc = o_dims[1];
 
-  if (wino_iw == 8) {
+  if (wino_iw == 10) {
+    lite::arm::math::conv_compute_8x8_3x3(FUNCS_PARAM, param, &ctx);
+    KERNEL_FUNC_NAME("conv_compute_8x8_3x3")
+  } else if (wino_iw == 8) {
     lite::arm::math::conv_compute_6x6_3x3(FUNCS_PARAM, param, &ctx);
     KERNEL_FUNC_NAME("conv_compute_6x6_3x3")
   } else if (wino_iw == 6) {

--- a/lite/kernels/arm/conv_winograd.cc
+++ b/lite/kernels/arm/conv_winograd.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "lite/kernels/arm/conv_winograd.h"
+
 #include "lite/backends/arm/math/conv_impl.h"
 #include "lite/backends/arm/math/packed_sgemm.h"
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Arm

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Kernels | Backends

### Description
<!-- Describe what this PR does -->
Add winograd convolution `F(8, 3)` implementation to further speed up inference speed, in order to largely replace original `F(6, 3)` speedup, especially in median and large resolution networks. 

The formulation of `F(8, 3)` is caculated by [wincnn](https://github.com/andravin/wincnn), refer to this [issue](https://github.com/andravin/wincnn/issues/8). I finally use the formulation calculated by `wincnn.showCookToomFilter((0,1,-1,2,-2,Rational(1,2),-Rational(1,2), Rational(3,2), -Rational(3,2)), 8, 3)`.

For speedup rate, I test with my segmentation network on Raspberry 4 model B with ARMv8. Here's some profiler log:

with `F(6, 3)`:
> [I  2/ 1  3:52: 5.341 ...rossplat/Paddle-Lite/lite/core/program.h:210 ~RuntimeProgram] 
Timing cycle = 100
===== Concise Dispatch Profiler Summary: N/A, Exclude 10 warm-ups =====
OperatorType         KerneAttr(Place)               KernelFuncName           Avg(ms) Min(ms) Max(ms) Avg(%)  GOPs    CalledTimes
bilinear_interp_v2   arm/float/NCHW                 NotImpl                  39.009  37.124  47.856  5.67%    0.098   38         
concat               arm/any/NCHW                   NotImpl                  28.184  25.433  46.752  4.10%    0.000   51         
conv2d               arm/float/NCHW                 conv1x1s1_gemm_fp32      3.669   3.304   5.567   0.53%    0.004   1          
conv2d               arm/float/NCHW                 conv_compute_2x2_3x3     2.070   1.859   3.603   0.30%    0.015   20         
conv2d               arm/float/NCHW                 **conv_compute_6x6_3x3**     **580.909** 551.713 718.845 84.41%    6.865   75         
conv2d               arm/float/NCHW                 conv_im2col_gemm_fp32    5.913   5.363   10.706  0.86%    0.025   23         
elementwise_add      arm/float/NCHW                 NotImpl                  19.015  17.370  29.636  2.76%    0.006   11         
pool2d               arm/float/NCHW                 NotImpl                  8.797   7.765   17.156  1.28%    0.006   33         
shape                host/any/any                   NotImpl                  0.081   0.045   0.389   0.01%    0.000   38         
slice                arm/float/NCHW                 NotImpl                  0.519   0.425   1.438   0.08%    0.000   38         

with added `F(8, 3)`:
> [I  2/ 2  7:59: 4.344 ...rossplat/Paddle-Lite/lite/core/program.h:210 ~RuntimeProgram] 
Timing cycle = 100
===== Concise Dispatch Profiler Summary: N/A, Exclude 10 warm-ups =====
OperatorType         KerneAttr(Place)               KernelFuncName           Avg(ms) Min(ms) Max(ms) Avg(%)  GOPs    CalledTimes
bilinear_interp_v2   arm/float/NCHW                 NotImpl                  38.475  36.810  47.435  6.28%    0.098   38         
concat               arm/any/NCHW                   NotImpl                  25.960  23.213  40.384  4.24%    0.000   51         
conv2d               arm/float/NCHW                 conv1x1s1_gemm_fp32      4.000   3.573   6.741   0.65%    0.004   1          
conv2d               arm/float/NCHW                 conv_compute_2x2_3x3     2.032   1.822   3.570   0.33%    0.015   20         
conv2d               arm/float/NCHW                 **conv_compute_6x6_3x3**     **9.661**   8.535   16.607  1.58%    0.127   23         
conv2d               arm/float/NCHW                 **conv_compute_8x8_3x3**     **497.343** 470.543 618.817 81.21%    6.738   52         
conv2d               arm/float/NCHW                 conv_im2col_gemm_fp32    5.953   5.389   10.260  0.97%    0.025   23         
elementwise_add      arm/float/NCHW                 NotImpl                  19.403  17.538  32.004  3.17%    0.006   11         
pool2d               arm/float/NCHW                 NotImpl                  9.005   7.780   17.220  1.47%    0.006   33         
shape                host/any/any                   NotImpl                  0.090   0.052   0.346   0.01%    0.000   38         
slice                arm/float/NCHW                 NotImpl                  0.522   0.430   1.545   0.09%    0.000   38         

We can see that the speedup rate is about `580.909/(497.343+9.661)=1.145`.
It has consistency with the theoretical speedup rate, as mentioned in this [paper](https://www.ecva.net/papers/eccv_2020/papers_ECCV/papers/123640052.pdf). The theoretical speedup rate should be `5.76/5.06=1.138`.

> Algorithm DW (bit) Arithmetic Reduction
F (2 × 2, 3 × 3) 12 2.25×
F (4 × 4, 3 × 3) 18 4.00×
**F (6 × 6, 3 × 3)** 24 **5.06×**
**F (8 × 8, 3 × 3)** 36 **5.76×**
F (8 × 8, 5 × 5) 43 11.1×
F (10 × 10, 3 × 3) 50 6.26×
F (10 × 10, 5 × 5) 60 12.7×