### PR TITLE
[WIP][HuaweiAscendNPU] Support AIPP

### DIFF
--- a/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/engine.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/engine.cc
@@ -77,6 +77,15 @@ Context::Context(void* device, const char* properties) : device_(device) {
   }
   NNADAPTER_LOG(INFO) << "profiling path: "
                       << ascend_config_params_.profiling_file_path;
+  // HUAWEI_ASCEND_NPU_AIPP_FILE_PATH
+  if (key_values.count(HUAWEI_ASCEND_NPU_AIPP_FILE_PATH)) {
+    ascend_config_params_.aipp_file_path =
+        key_values[HUAWEI_ASCEND_NPU_AIPP_FILE_PATH];
+  } else {
+    ascend_config_params_.aipp_file_path =
+        GetStringFromEnv(HUAWEI_ASCEND_NPU_AIPP_FILE_PATH);
+  }
+  NNADAPTER_LOG(INFO) << "aipp path: " << ascend_config_params_.aipp_file_path;
   // HUAWEI_ASCEND_NPU_DUMP_MODEL_FILE_PATH
   if (key_values.count(HUAWEI_ASCEND_NPU_DUMP_MODEL_FILE_PATH)) {
     ascend_config_params_.dump_model_path =

--- a/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/model_client.h
+++ b/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/model_client.h
@@ -36,6 +36,7 @@ typedef enum {
 
 typedef struct AscendConfigParams {
   std::string profiling_file_path = "";
+  std::string aipp_file_path = "";
   std::string dump_model_path = "";
   std::string precision_mode = "";
   std::string modify_mixlist_path = "";

--- a/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/utility.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/utility.cc
@@ -312,11 +312,17 @@ bool BuildOMModelToBuffer(
     options.insert(
         std::make_pair(ge::ir_option::INPUT_SHAPE, input_shape_info.data()));
   }
+  // Config AIPP
+  if (!config_params->aipp_file_path.empty()) {
+    options.insert(std::make_pair(ge::ir_option::INSERT_OP_FILE,
+                                  config_params->aipp_file_path.c_str()));
+  }
+  // Build graph model
   ATC_CALL(aclgrphBuildModel(ir_graph, options, om_buffer));
   // For debug: save ascend offline model to local.
   if (!config_params->dump_model_path.empty()) {
     ATC_CALL(aclgrphSaveModel(
-        std::string(config_params->dump_model_path + "ir_graph_model").c_str(),
+        std::string(config_params->dump_model_path + "/ir_graph_model").c_str(),
         om_buffer));
   }
   // Copy from om model buffer
@@ -412,6 +418,11 @@ ge::DataType GetGEDataType<float>() {
 }
 
 template <>
+ge::DataType GetGEDataType<uint8_t>() {
+  return ge::DT_UINT8;
+}
+
+template <>
 ge::DataType GetGEDataType<int8_t>() {
   return ge::DT_INT8;
 }
@@ -444,6 +455,9 @@ ge::DataType ConvertACLDataTypeToGEDataType(aclDataType input_data_type) {
       break;
     case ACL_FLOAT16:
       output_data_type = ge::DT_FLOAT16;
+      break;
+    case ACL_UINT8:
+      output_data_type = ge::DT_UINT8;
       break;
     case ACL_INT8:
       output_data_type = ge::DT_INT8;

--- a/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/utility.h
+++ b/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/utility.h
@@ -41,6 +41,9 @@ namespace huawei_ascend_npu {
 #define HUAWEI_ASCEND_NPU_PROFILING_FILE_PATH \
   "HUAWEI_ASCEND_NPU_PROFILING_FILE_PATH"
 
+// Specify the file path of the aipp config file
+#define HUAWEI_ASCEND_NPU_AIPP_FILE_PATH "HUAWEI_ASCEND_NPU_AIPP_FILE_PATH"
+
 // Specify the file path to dump the model
 #define HUAWEI_ASCEND_NPU_DUMP_MODEL_FILE_PATH \
   "HUAWEI_ASCEND_NPU_DUMP_MODEL_FILE_PATH"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
NNadapter
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Backends
### Description
<!-- Describe what this PR does -->
增加Ascend对AIPP功能的支持，AIPP（AI PreProcessing）用于在AI Core上完成图像预处理，包括色域转换（转换图像格式）、图像归一化（减均值/乘系数）和抠图（指定抠图起始点，抠出神经网络需要大小的图片）

目前只增加了相应接口，若要真正使用上，由于 AIPP 仅支持 uint8 和 NHWC 的输入，需要修改 Paddle 模型的输入类型为 uint8 和数据排布为 NHWC，步骤较为繁琐。

FD那边测试反馈性能提升不明显，后续若有强需求，再来跟进 AIPP 功能的集成，可能遗留的问题：dequant 和 quant op 的插入 Pass 需要做些修改。