### PR TITLE
[NNAdapter] add meshgrid, stack, quant, dequant into ConstantFold; An…

### DIFF
--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
@@ -17,7 +17,7 @@
 #include <cstring>
 #include <memory>
 #include <vector>
-
+#include "utility/logging.h"
 namespace nnadapter {
 namespace operation {
 namespace math {
@@ -39,7 +39,7 @@ static int meshgrid(const std::vector<T*>& input_datas,
   int32_t num = input_datas.size();
   std::vector<int32_t> shape(num);
   for (int32_t i = 0; i < num; ++i) {
-    switch (input_shapes.size()) {
+    switch (input_shapes[i].size()) {
       case 1:
         shape[i] = input_shapes[i][0];
         break;
@@ -47,7 +47,6 @@ static int meshgrid(const std::vector<T*>& input_datas,
         return NNADAPTER_INVALID_DIMENSIONS;
     }
   }
-
   for (int32_t i = 0; i < num; ++i) {
     T* dst = output_datas[i];
 
@@ -84,6 +83,7 @@ static int meshgrid(const std::vector<T*>& input_datas,
       inner_num *= bcast_dims[idx];
     }
   }
+  return 0;
 }
 
 }  // namespace math

--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
@@ -17,7 +17,8 @@
 #include <cstring>
 #include <memory>
 #include <vector>
-#include "utility/logging.h"
+#include "operation/math/utility.h"
+
 namespace nnadapter {
 namespace operation {
 namespace math {
@@ -60,7 +61,7 @@ static int meshgrid(const std::vector<T*>& input_datas,
     bcast_dims[i] = 1;
     int inner_num = 1;
     int idx = num - 1;
-    int outer_num = count(0, idx, view_shape);
+    int outer_num = shape_production(shape_slice(view_shape, 0, idx));
     inner_num *= view_shape[idx];
     for (int j = 0; j < outer_num; ++j) {
       for (int k = 0; k < bcast_dims[idx]; ++k) {
@@ -71,7 +72,7 @@ static int meshgrid(const std::vector<T*>& input_datas,
     }
     inner_num *= bcast_dims[idx];
     for (int idx = num - 2; idx >= 0; --idx) {
-      int outer_num = count(0, idx, view_shape);
+      int outer_num = shape_production(shape_slice(view_shape, 0, idx));
       inner_num *= view_shape[idx];
       for (int j = outer_num - 1; j >= 0; --j) {
         for (int k = bcast_dims[idx] - 1; k >= 0; --k) {

--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace nnadapter {
+namespace operation {
+namespace math {
+
+static int count(int start_axis,
+                 int end_axis,
+                 const std::vector<int32_t>& shape) {
+  int count = 1;
+  for (int i = start_axis; i < end_axis; ++i) {
+    count *= shape[i];
+  }
+  return count;
+}
+
+template <typename T>
+static int meshgrid(const std::vector<T*>& input_datas,
+                    const std::vector<std::vector<int32_t>>& input_shapes,
+                    std::vector<T*> output_datas) {
+  int32_t num = input_datas.size();
+  std::vector<int32_t> shape(num);
+  for (int32_t i = 0; i < num; ++i) {
+    switch (input_shapes.size()) {
+      case 1:
+        shape[i] = input_shapes[i][0];
+        break;
+      default:
+        return NNADAPTER_INVALID_DIMENSIONS;
+    }
+  }
+
+  for (int32_t i = 0; i < num; ++i) {
+    T* dst = output_datas[i];
+
+    std::vector<int32_t> view_shape(num, 1);
+    view_shape[i] = shape[i];
+    const T* src = input_datas[i];
+    std::vector<int> bcast_dims(num);
+    for (int32_t j = 0; j < num; j++) {
+      bcast_dims[j] = shape[j];
+    }
+    bcast_dims[i] = 1;
+    int inner_num = 1;
+    int idx = num - 1;
+    int outer_num = count(0, idx, view_shape);
+    inner_num *= view_shape[idx];
+    for (int j = 0; j < outer_num; ++j) {
+      for (int k = 0; k < bcast_dims[idx]; ++k) {
+        memcpy(dst + (j * bcast_dims[idx] + k) * inner_num,
+               src + j * inner_num,
+               sizeof(T) * inner_num);
+      }
+    }
+    inner_num *= bcast_dims[idx];
+    for (int idx = num - 2; idx >= 0; --idx) {
+      int outer_num = count(0, idx, view_shape);
+      inner_num *= view_shape[idx];
+      for (int j = outer_num - 1; j >= 0; --j) {
+        for (int k = bcast_dims[idx] - 1; k >= 0; --k) {
+          memcpy(dst + (j * bcast_dims[idx] + k) * inner_num,
+                 dst + j * inner_num,
+                 sizeof(T) * inner_num);
+        }
+      }
+      inner_num *= bcast_dims[idx];
+    }
+  }
+}
+
+}  // namespace math
+}  // namespace operation
+}  // namespace nnadapter

--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
@@ -35,7 +35,7 @@ static int meshgrid(const std::vector<T*>& input_datas,
         shape[i] = input_shapes[i][0];
         break;
       default:
-        return NNADAPTER_INVALID_DIMENSIONS;
+        return -1;
     }
   }
   for (int32_t i = 0; i < num; ++i) {

--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/meshgrid.h
@@ -23,16 +23,6 @@ namespace nnadapter {
 namespace operation {
 namespace math {
 
-static int count(int start_axis,
-                 int end_axis,
-                 const std::vector<int32_t>& shape) {
-  int count = 1;
-  for (int i = start_axis; i < end_axis; ++i) {
-    count *= shape[i];
-  }
-  return count;
-}
-
 template <typename T>
 static int meshgrid(const std::vector<T*>& input_datas,
                     const std::vector<std::vector<int32_t>>& input_shapes,

--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/stack.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/stack.h
@@ -57,6 +57,7 @@ static int stack(const std::vector<T*>& input_datas,
     }
     x_offset += post;
   }
+  return 0;
 }
 
 }  // namespace math

--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/stack.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/stack.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <vector>
+#include "operation/math/utility.h"
+
+namespace nnadapter {
+namespace operation {
+namespace math {
+
+template <typename T>
+static int stack(const std::vector<T*>& input_datas,
+                 const std::vector<std::vector<int32_t>>& input_shapes,
+                 int axis,
+                 T* output_data) {
+  // auto &param = this->template Param<operators::StackParam>();
+  // std::vector<lite::Tensor *> x = param.X;
+  // lite::Tensor *y = param.Out;
+  // int axis = param.axis;
+
+  if (axis < 0) axis += (input_shapes[0].size() + 1);
+  int num = input_datas.size();
+  auto* y_data = output_data;
+  std::vector<const T*> x_datas(num);
+  for (int i = 0; i < num; i++) x_datas[i] = input_datas[i];
+
+  int pre = 1, post = 1;
+  auto dim = input_shapes[0];
+  for (int i = 0; i < axis; ++i) pre *= dim[i];
+  for (int i = axis; i < dim.size(); ++i) post *= dim[i];
+
+  auto x_data_arr = x_datas.data();
+
+  int x_offset = 0;
+  int y_offset = 0;
+  for (int i = 0; i < pre; i++) {
+    for (int j = 0; j < num; j++) {
+      std::memcpy(
+          y_data + y_offset, x_data_arr[j] + x_offset, post * sizeof(T));
+      y_offset += post;
+    }
+    x_offset += post;
+  }
+}
+
+}  // namespace math
+}  // namespace operation
+}  // namespace nnadapter

--- a/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/stack.h
+++ b/lite/backends/nnadapter/nnadapter/include/nnadapter/operation/math/stack.h
@@ -29,11 +29,6 @@ static int stack(const std::vector<T*>& input_datas,
                  const std::vector<std::vector<int32_t>>& input_shapes,
                  int axis,
                  T* output_data) {
-  // auto &param = this->template Param<operators::StackParam>();
-  // std::vector<lite::Tensor *> x = param.X;
-  // lite::Tensor *y = param.Out;
-  // int axis = param.axis;
-
   if (axis < 0) axis += (input_shapes[0].size() + 1);
   int num = input_datas.size();
   auto* y_data = output_data;
@@ -51,8 +46,7 @@ static int stack(const std::vector<T*>& input_datas,
   int y_offset = 0;
   for (int i = 0; i < pre; i++) {
     for (int j = 0; j < num; j++) {
-      std::memcpy(
-          y_data + y_offset, x_data_arr[j] + x_offset, post * sizeof(T));
+      memcpy(y_data + y_offset, x_data_arr[j] + x_offset, post * sizeof(T));
       y_offset += post;
     }
     x_offset += post;

--- a/lite/backends/nnadapter/nnadapter/src/driver/verisilicon_timvx/engine.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/verisilicon_timvx/engine.cc
@@ -120,8 +120,8 @@ int Program::Build(core::Model* model, core::Cache* cache) {
     // Build from model
     NNADAPTER_VLOG(5) << "Origin model:" << std::endl << Visualize(model);
     ConvertFillLikeIntoMulAdd(model);
-    ConvertMeshgridIntoReshapeExpand(model);
     ConstantFoldOperations(model);
+    ConvertMeshgridIntoReshapeExpand(model);
     FuseConv2DBatchNormIntoConv2D(
         model, context_->batchnorm_fusion_max_allowed_quant_scale_deviation());
     FuseConv2DAddIntoConv2D(model);

--- a/lite/backends/nnadapter/nnadapter/src/operation/cast.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/cast.cc
@@ -30,7 +30,7 @@ OutType TransOp(InType in) {
 }
 
 NNADAPTER_EXPORT bool ValidateCast(const core::Operation* operation) {
-  return false;
+  return true;
 }
 
 NNADAPTER_EXPORT int ExecuteCast(core::Operation* operation) {
@@ -84,6 +84,11 @@ NNADAPTER_EXPORT int ExecuteCast(core::Operation* operation) {
     auto output_data = reinterpret_cast<int32_t*>(output_buffer);
     std::transform(
         input_data, input_data + size, output_data, TransOp<float, int32_t>);
+  } else if (input_precision == dtype) {
+    NNADAPTER_LOG(WARNING) << "Input precision code == output precision code, ("
+                           << OperandPrecisionCodeToString(input_precision)
+                           << "), "
+                           << "skip the cast OP";
   } else {
     NNADAPTER_LOG(FATAL) << "Unsupported input precision code("
                          << OperandPrecisionCodeToString(input_precision) << ")"

--- a/lite/backends/nnadapter/nnadapter/src/operation/cast.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/cast.cc
@@ -54,6 +54,11 @@ NNADAPTER_EXPORT int ExecuteCast(core::Operation* operation) {
     auto input_data = reinterpret_cast<float*>(input_operand->buffer);
     auto output_data = reinterpret_cast<float*>(output_buffer);
     memcpy(output_data, input_data, sizeof(float) * size);
+  } else if (input_precision == NNADAPTER_QUANT_INT8_SYMM_PER_LAYER &&
+             dtype == NNADAPTER_QUANT_INT8_SYMM_PER_LAYER) {
+    auto input_data = reinterpret_cast<int8_t*>(input_operand->buffer);
+    auto output_data = reinterpret_cast<int8_t*>(output_buffer);
+    memcpy(output_data, input_data, sizeof(int8_t) * size);
   } else if (input_precision == NNADAPTER_INT32 && dtype == NNADAPTER_INT64) {
     auto input_data = reinterpret_cast<int32_t*>(input_operand->buffer);
     auto output_data = reinterpret_cast<int64_t*>(output_buffer);
@@ -84,11 +89,6 @@ NNADAPTER_EXPORT int ExecuteCast(core::Operation* operation) {
     auto output_data = reinterpret_cast<int32_t*>(output_buffer);
     std::transform(
         input_data, input_data + size, output_data, TransOp<float, int32_t>);
-  } else if (input_precision == dtype) {
-    NNADAPTER_LOG(WARNING) << "Input precision code == output precision code, ("
-                           << OperandPrecisionCodeToString(input_precision)
-                           << "), "
-                           << "skip the cast OP";
   } else {
     NNADAPTER_LOG(FATAL) << "Unsupported input precision code("
                          << OperandPrecisionCodeToString(input_precision) << ")"

--- a/lite/backends/nnadapter/nnadapter/src/operation/concat.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/concat.cc
@@ -67,6 +67,17 @@ NNADAPTER_EXPORT int ExecuteConcat(core::Operation* operation) {
                             axis,
                             reinterpret_cast<float*>(output_buffer));
     } break;
+    case NNADAPTER_QUANT_INT8_SYMM_PER_LAYER: {
+      std::vector<int8_t*> input_datas;
+      for (int i = 0; i < input_count - 1; i++) {
+        input_datas.push_back(
+            reinterpret_cast<int8_t*>(input_operands[i]->buffer));
+      }
+      status = math::concat(input_datas,
+                            input_shapes,
+                            axis,
+                            reinterpret_cast<int8_t*>(output_buffer));
+    } break;
     default:
       NNADAPTER_LOG(FATAL) << "Unsupported precision code("
                            << OperandPrecisionCodeToString(input_precision)

--- a/lite/backends/nnadapter/nnadapter/src/operation/dequantize.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/dequantize.cc
@@ -14,6 +14,7 @@
 
 #include "operation/dequantize.h"
 #include "core/types.h"
+#include "operation/math/dequantize.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
 #include "utility/micros.h"
@@ -38,7 +39,36 @@ NNADAPTER_EXPORT int PrepareDequantize(core::Operation* operation) {
 }
 
 NNADAPTER_EXPORT int ExecuteDequantize(core::Operation* operation) {
-  return NNADAPTER_FEATURE_NOT_SUPPORTED;
+  DEQUANTIZE_OPERATION_EXTRACT_INPUTS_OUTPUTS
+
+  // Allocate and calculate the output operands
+  int status = -1;
+  auto& input_type = input_operand->type;
+  auto input_shape = std::vector<int32_t>(
+      input_type.dimensions.data,
+      input_type.dimensions.data + input_type.dimensions.count);
+  const auto input_buffer = input_operand->buffer;
+  NNADAPTER_CHECK(input_buffer);
+  auto& output_type = output_operand->type;
+  auto output_buffer = AllocateOperand(output_operand);
+  NNADAPTER_CHECK_EQ(input_type.precision, output_type.precision);
+  if (input_type.precision == NNADAPTER_QUANT_INT8_SYMM_PER_LAYER &&
+      output_type.precision == NNADAPTER_FLOAT32) {
+    const auto input_data = reinterpret_cast<const int8_t*>(input_buffer);
+    auto output_data = reinterpret_cast<float*>(output_buffer);
+    status = math::dequantize<int8_t>(
+        input_data,
+        input_shape,
+        input_operand->type.symm_per_layer_params.scale,
+        output_data);
+  } else {
+    NNADAPTER_LOG(FATAL) << "Unsupported precision code("
+                         << OperandPrecisionCodeToString(input_type.precision)
+                         << ") for " << OperationTypeToString(operation->type)
+                         << " is found!";
+  }
+  NNADAPTER_CHECK_EQ(status, 0);
+  return NNADAPTER_NO_ERROR;
 }
 
 }  // namespace operation

--- a/lite/backends/nnadapter/nnadapter/src/operation/dequantize.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/dequantize.cc
@@ -25,7 +25,7 @@ namespace nnadapter {
 namespace operation {
 
 NNADAPTER_EXPORT bool ValidateDequantize(const core::Operation* operation) {
-  return false;
+  return true;
 }
 
 NNADAPTER_EXPORT int PrepareDequantize(core::Operation* operation) {
@@ -51,7 +51,6 @@ NNADAPTER_EXPORT int ExecuteDequantize(core::Operation* operation) {
   NNADAPTER_CHECK(input_buffer);
   auto& output_type = output_operand->type;
   auto output_buffer = AllocateOperand(output_operand);
-  NNADAPTER_CHECK_EQ(input_type.precision, output_type.precision);
   if (input_type.precision == NNADAPTER_QUANT_INT8_SYMM_PER_LAYER &&
       output_type.precision == NNADAPTER_FLOAT32) {
     const auto input_data = reinterpret_cast<const int8_t*>(input_buffer);

--- a/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
@@ -26,7 +26,7 @@ namespace nnadapter {
 namespace operation {
 
 NNADAPTER_EXPORT bool ValidateMeshgrid(const core::Operation* operation) {
-  return false;
+  return true;
 }
 
 NNADAPTER_EXPORT int PrepareMeshgrid(core::Operation* operation) {
@@ -80,22 +80,21 @@ NNADAPTER_EXPORT int ExecuteMeshgrid(core::Operation* operation) {
   // auto output_buffer = AllocateOperand(output_operand);
   auto input_precision = input_operands[0]->type.precision;
   std::vector<std::vector<int32_t>> input_shapes;
-  for (int i = 0; i < input_count - 1; i++) {
+  for (int i = 0; i < input_count; i++) {
     auto in_dims = input_operands[i]->type.dimensions.data;
     auto in_dims_count = input_operands[i]->type.dimensions.count;
     input_shapes.push_back(
         std::vector<int32_t>(in_dims, in_dims + in_dims_count));
   }
-
   switch (input_precision) {
     case NNADAPTER_FLOAT32: {
       std::vector<float*> input_datas;
-      for (int i = 0; i < input_count - 1; i++) {
+      for (int i = 0; i < input_count; i++) {
         input_datas.push_back(
             reinterpret_cast<float*>(input_operands[i]->buffer));
       }
       std::vector<float*> output_datas;
-      for (int i = 0; i < output_count - 1; i++) {
+      for (int i = 0; i < output_count; i++) {
         output_datas.push_back(
             reinterpret_cast<float*>(AllocateOperand(output_operands[i])));
       }
@@ -103,12 +102,12 @@ NNADAPTER_EXPORT int ExecuteMeshgrid(core::Operation* operation) {
     } break;
     case NNADAPTER_QUANT_INT8_SYMM_PER_LAYER: {
       std::vector<int8_t*> input_datas;
-      for (int i = 0; i < input_count - 1; i++) {
+      for (int i = 0; i < input_count; i++) {
         input_datas.push_back(
             reinterpret_cast<int8_t*>(input_operands[i]->buffer));
       }
       std::vector<int8_t*> output_datas;
-      for (int i = 0; i < output_count - 1; i++) {
+      for (int i = 0; i < output_count; i++) {
         output_datas.push_back(
             reinterpret_cast<int8_t*>(AllocateOperand(output_operands[i])));
       }

--- a/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
@@ -77,7 +77,6 @@ NNADAPTER_EXPORT int ExecuteMeshgrid(core::Operation* operation) {
 
   // Allocate and calculate the output operands
   int status = -1;
-  // auto output_buffer = AllocateOperand(output_operand);
   auto input_precision = input_operands[0]->type.precision;
   std::vector<std::vector<int32_t>> input_shapes;
   for (int i = 0; i < input_count; i++) {

--- a/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/meshgrid.cc
@@ -15,6 +15,7 @@
 #include "operation/meshgrid.h"
 #include <vector>
 #include "core/types.h"
+#include "operation/math/meshgrid.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
 #include "utility/micros.h"
@@ -72,7 +73,56 @@ NNADAPTER_EXPORT int PrepareMeshgrid(core::Operation* operation) {
 }
 
 NNADAPTER_EXPORT int ExecuteMeshgrid(core::Operation* operation) {
-  return NNADAPTER_FEATURE_NOT_SUPPORTED;
+  MESHGRID_OPERATION_EXTRACT_INPUTS_OUTPUTS
+
+  // Allocate and calculate the output operands
+  int status = -1;
+  // auto output_buffer = AllocateOperand(output_operand);
+  auto input_precision = input_operands[0]->type.precision;
+  std::vector<std::vector<int32_t>> input_shapes;
+  for (int i = 0; i < input_count - 1; i++) {
+    auto in_dims = input_operands[i]->type.dimensions.data;
+    auto in_dims_count = input_operands[i]->type.dimensions.count;
+    input_shapes.push_back(
+        std::vector<int32_t>(in_dims, in_dims + in_dims_count));
+  }
+
+  switch (input_precision) {
+    case NNADAPTER_FLOAT32: {
+      std::vector<float*> input_datas;
+      for (int i = 0; i < input_count - 1; i++) {
+        input_datas.push_back(
+            reinterpret_cast<float*>(input_operands[i]->buffer));
+      }
+      std::vector<float*> output_datas;
+      for (int i = 0; i < output_count - 1; i++) {
+        output_datas.push_back(
+            reinterpret_cast<float*>(AllocateOperand(output_operands[i])));
+      }
+      status = math::meshgrid(input_datas, input_shapes, output_datas);
+    } break;
+    case NNADAPTER_QUANT_INT8_SYMM_PER_LAYER: {
+      std::vector<int8_t*> input_datas;
+      for (int i = 0; i < input_count - 1; i++) {
+        input_datas.push_back(
+            reinterpret_cast<int8_t*>(input_operands[i]->buffer));
+      }
+      std::vector<int8_t*> output_datas;
+      for (int i = 0; i < output_count - 1; i++) {
+        output_datas.push_back(
+            reinterpret_cast<int8_t*>(AllocateOperand(output_operands[i])));
+      }
+      status = math::meshgrid(input_datas, input_shapes, output_datas);
+    } break;
+    default:
+      NNADAPTER_LOG(FATAL) << "Unsupported precision code("
+                           << OperandPrecisionCodeToString(input_precision)
+                           << ") for " << OperationTypeToString(operation->type)
+                           << " is found!";
+      break;
+  }
+  NNADAPTER_CHECK_EQ(status, 0);
+  return NNADAPTER_NO_ERROR;
 }
 
 }  // namespace operation

--- a/lite/backends/nnadapter/nnadapter/src/operation/quantize.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/quantize.cc
@@ -25,7 +25,7 @@ namespace nnadapter {
 namespace operation {
 
 NNADAPTER_EXPORT bool ValidateQuantize(const core::Operation* operation) {
-  return false;
+  return true;
 }
 
 NNADAPTER_EXPORT int PrepareQuantize(core::Operation* operation) {
@@ -59,7 +59,6 @@ NNADAPTER_EXPORT int ExecuteQuantize(core::Operation* operation) {
   NNADAPTER_CHECK(input_buffer);
   auto& output_type = output_operand->type;
   auto output_buffer = AllocateOperand(output_operand);
-  NNADAPTER_CHECK_EQ(input_type.precision, output_type.precision);
   if (input_type.precision == NNADAPTER_FLOAT32 &&
       output_type.precision == NNADAPTER_QUANT_INT8_SYMM_PER_LAYER) {
     const auto input_data = reinterpret_cast<const float*>(input_buffer);

--- a/lite/backends/nnadapter/nnadapter/src/operation/quantize.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/quantize.cc
@@ -14,6 +14,7 @@
 
 #include "operation/quantize.h"
 #include "core/types.h"
+#include "operation/math/quantize.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
 #include "utility/micros.h"
@@ -46,7 +47,33 @@ NNADAPTER_EXPORT int PrepareQuantize(core::Operation* operation) {
 }
 
 NNADAPTER_EXPORT int ExecuteQuantize(core::Operation* operation) {
-  return NNADAPTER_FEATURE_NOT_SUPPORTED;
+  QUANTIZE_OPERATION_EXTRACT_INPUTS_OUTPUTS
+
+  // Allocate and calculate the output operands
+  int status = -1;
+  auto& input_type = input_operand->type;
+  auto input_shape = std::vector<int32_t>(
+      input_type.dimensions.data,
+      input_type.dimensions.data + input_type.dimensions.count);
+  const auto input_buffer = input_operand->buffer;
+  NNADAPTER_CHECK(input_buffer);
+  auto& output_type = output_operand->type;
+  auto output_buffer = AllocateOperand(output_operand);
+  NNADAPTER_CHECK_EQ(input_type.precision, output_type.precision);
+  if (input_type.precision == NNADAPTER_FLOAT32 &&
+      output_type.precision == NNADAPTER_QUANT_INT8_SYMM_PER_LAYER) {
+    const auto input_data = reinterpret_cast<const float*>(input_buffer);
+    auto output_data = reinterpret_cast<int8_t*>(output_buffer);
+    status = math::quantize<int8_t>(
+        input_data, input_shape, scale_data[0], output_data);
+  } else {
+    NNADAPTER_LOG(FATAL) << "Unsupported precision code("
+                         << OperandPrecisionCodeToString(input_type.precision)
+                         << ") for " << OperationTypeToString(operation->type)
+                         << " is found!";
+  }
+  NNADAPTER_CHECK_EQ(status, 0);
+  return NNADAPTER_NO_ERROR;
 }
 
 }  // namespace operation

--- a/lite/backends/nnadapter/nnadapter/src/operation/stack.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/stack.cc
@@ -25,7 +25,7 @@ namespace nnadapter {
 namespace operation {
 
 NNADAPTER_EXPORT bool ValidateStack(const core::Operation* operation) {
-  return false;
+  return true;
 }
 
 NNADAPTER_EXPORT int PrepareStack(core::Operation* operation) {

--- a/lite/backends/nnadapter/nnadapter/src/operation/stack.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/stack.cc
@@ -14,6 +14,7 @@
 
 #include "operation/stack.h"
 #include "core/types.h"
+#include "operation/math/stack.h"
 #include "utility/debug.h"
 #include "utility/logging.h"
 #include "utility/micros.h"
@@ -62,7 +63,62 @@ NNADAPTER_EXPORT int PrepareStack(core::Operation* operation) {
 }
 
 NNADAPTER_EXPORT int ExecuteStack(core::Operation* operation) {
-  return NNADAPTER_FEATURE_NOT_SUPPORTED;
+  STACK_OPERATION_EXTRACT_INPUTS_OUTPUTS
+
+  // Allocate and calculate the output operands
+  int status = -1;
+  auto output_buffer = AllocateOperand(output_operand);
+  auto input_precision = input_operands[0]->type.precision;
+  std::vector<std::vector<int32_t>> input_shapes;
+  for (int i = 0; i < input_count - 1; i++) {
+    auto in_dims = input_operands[i]->type.dimensions.data;
+    auto in_dims_count = input_operands[i]->type.dimensions.count;
+    input_shapes.push_back(
+        std::vector<int32_t>(in_dims, in_dims + in_dims_count));
+  }
+  switch (input_precision) {
+    case NNADAPTER_INT32: {
+      std::vector<int32_t*> input_datas;
+      for (int i = 0; i < input_count - 1; i++) {
+        input_datas.push_back(
+            reinterpret_cast<int32_t*>(input_operands[i]->buffer));
+      }
+      status = math::stack(input_datas,
+                           input_shapes,
+                           axis,
+                           reinterpret_cast<int32_t*>(output_buffer));
+    } break;
+    case NNADAPTER_FLOAT32: {
+      std::vector<float*> input_datas;
+      for (int i = 0; i < input_count - 1; i++) {
+        input_datas.push_back(
+            reinterpret_cast<float*>(input_operands[i]->buffer));
+      }
+      status = math::stack(input_datas,
+                           input_shapes,
+                           axis,
+                           reinterpret_cast<float*>(output_buffer));
+    } break;
+    case NNADAPTER_QUANT_INT8_SYMM_PER_LAYER: {
+      std::vector<int8_t*> input_datas;
+      for (int i = 0; i < input_count - 1; i++) {
+        input_datas.push_back(
+            reinterpret_cast<int8_t*>(input_operands[i]->buffer));
+      }
+      status = math::stack(input_datas,
+                           input_shapes,
+                           axis,
+                           reinterpret_cast<int8_t*>(output_buffer));
+    } break;
+    default:
+      NNADAPTER_LOG(FATAL) << "Unsupported precision code("
+                           << OperandPrecisionCodeToString(input_precision)
+                           << ") for " << OperationTypeToString(operation->type)
+                           << " is found!";
+      break;
+  }
+  NNADAPTER_CHECK_EQ(status, 0);
+  return NNADAPTER_NO_ERROR;
 }
 
 }  // namespace operation

--- a/lite/backends/nnadapter/nnadapter/src/operation/stack.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/stack.cc
@@ -71,10 +71,10 @@ NNADAPTER_EXPORT int ExecuteStack(core::Operation* operation) {
   auto input_precision = input_operands[0]->type.precision;
   std::vector<std::vector<int32_t>> input_shapes;
   for (int i = 0; i < input_count - 1; i++) {
-    auto in_dims = input_operands[i]->type.dimensions.data;
-    auto in_dims_count = input_operands[i]->type.dimensions.count;
     input_shapes.push_back(
-        std::vector<int32_t>(in_dims, in_dims + in_dims_count));
+        std::vector<int32_t>(input_operands[i]->type.dimensions.data,
+                             input_operands[i]->type.dimensions.data +
+                                 input_operands[i]->type.dimensions.count));
   }
   switch (input_precision) {
     case NNADAPTER_INT32: {

--- a/lite/kernels/nnadapter/converter/all.h
+++ b/lite/kernels/nnadapter/converter/all.h
@@ -387,9 +387,10 @@ REGISTER_CONVERTER(squeeze2,
                    "huawei_ascend_npu,verisilicon_timvx,kunlunxin_xtcl,"
                    "cambricon_mlu,huawei_kirin_npu,nvidia_tensorrt,intel_"
                    "openvino,qualcomm_qnn");
-REGISTER_CONVERTER(range,
-                   ConvertRange,
-                   "huawei_ascend_npu,intel_openvino,kunlunxin_xtcl");
+REGISTER_CONVERTER(
+    range,
+    ConvertRange,
+    "huawei_ascend_npu,intel_openvino,kunlunxin_xtcl,verisilicon_timvx");
 REGISTER_CONVERTER(stack,
                    ConvertStack,
                    "huawei_ascend_npu,nvidia_tensorrt,intel_openvino,"

--- a/lite/kernels/nnadapter/converter/all.h
+++ b/lite/kernels/nnadapter/converter/all.h
@@ -387,10 +387,9 @@ REGISTER_CONVERTER(squeeze2,
                    "huawei_ascend_npu,verisilicon_timvx,kunlunxin_xtcl,"
                    "cambricon_mlu,huawei_kirin_npu,nvidia_tensorrt,intel_"
                    "openvino,qualcomm_qnn");
-REGISTER_CONVERTER(
-    range,
-    ConvertRange,
-    "huawei_ascend_npu,intel_openvino,kunlunxin_xtcl,verisilicon_timvx");
+REGISTER_CONVERTER(range,
+                   ConvertRange,
+                   "huawei_ascend_npu,intel_openvino,kunlunxin_xtcl");
 REGISTER_CONVERTER(stack,
                    ConvertStack,
                    "huawei_ascend_npu,nvidia_tensorrt,intel_openvino,"

--- a/lite/kernels/nnadapter/converter/cast.cc
+++ b/lite/kernels/nnadapter/converter/cast.cc
@@ -43,7 +43,13 @@ int ConvertCast(Converter* converter, OpInfo* op, Scope* scope) {
   // Input operand
   auto input_operand = converter->AddInputOperand(scope, x_name, {}, x_scales);
   // Dtype operand
-  int32_t dtype = ConvertFluidDataTypeToNNPrecisionCode(out_dtype);
+  int32_t dtype = 0;
+  if (op->HasOutputScale(output_scale_name, true)) {
+    dtype = ConvertFluidDataTypeToNNPrecisionCode(
+        out_dtype, output_scales.data(), 1, 1);
+  } else {
+    dtype = ConvertFluidDataTypeToNNPrecisionCode(out_dtype);
+  }
   auto dtype_operand = converter->AddConstantOperand(dtype);
   // Output operand
   auto output_operand = converter->AddOutputOperand(output_name, output_scales);

--- a/lite/kernels/nnadapter/converter/cast.cc
+++ b/lite/kernels/nnadapter/converter/cast.cc
@@ -36,6 +36,7 @@ int ConvertCast(Converter* converter, OpInfo* op, Scope* scope) {
   std::vector<float> output_scales;
   if (op->HasOutputScale(output_scale_name, true)) {
     output_scales = op->GetOutputScale(output_scale_name, true);
+    out_dtype = 21;  //  INT8 = 21
   }
 
   // Convert to NNAdapter operands and operation


### PR DESCRIPTION
### PR devices
NNadapter

### PR types
New features

### PR changes
Backends

### Description
1，新增常量折叠op的ExecuteFunc：meshgrid、stack、quantize、dequantize
2，新增数学计算meshgrid、stack，用于被上述相关op调用
3，全量化模型中cast OP的datatype以量化信息为主,且如果cast OP的input type == output type则直接skip该OP并删除节点
4，新增部分常量折叠OP的量化场景
5，修复TIM-VX PASS的bug
6，上述修改点主要用于提升yolov8 neck部分的性能，可折叠掉大片op，耗时降低25~35ms，如下图
<img width="896" alt="image" src="https://user-images.githubusercontent.com/74164525/217470421-3ba80a96-4ce7-4e82-b4cc-30b5d0d76af9.png">
