### PR TITLE
    [ARM] add Linear_interp && Linear_interp_v2 op;fix scale_act_fuse_pass and conv_scale_fuse_pass

### DIFF
--- a/lite/backends/arm/math/interpolate.cc
+++ b/lite/backends/arm/math/interpolate.cc
@@ -497,6 +497,133 @@ void nearest_interp(const float* src,
   }
 }
 
+void linear_interp(const float* din,
+                   float* dout,
+                   float ratio_w,
+                   int in_w,
+                   int n,
+                   int c,
+                   int out_w,
+                   bool align_corners,
+                   int align_mode,
+                   DataLayoutType data_layout) {
+  bool align_flag = (align_mode == 0 && !align_corners);
+  std::vector<int> vx_w, vx_e;
+  std::vector<float> vd_w, vd_e;
+  vx_w.reserve(out_w);
+  vx_e.reserve(out_w);
+  vd_w.reserve(out_w);
+  vd_e.reserve(out_w);
+  for (int l = 0; l < out_w; l++) {
+    int x_w = align_flag ? static_cast<int>(ratio_w * (l + 0.5) - 0.5)
+                         : static_cast<int>(ratio_w * l);
+    x_w = (x_w > 0) ? x_w : 0;                       // w
+    int x_e = (x_w < (in_w - 1)) ? (x_w + 1) : x_w;  // w_id
+    float idx_src_x = ratio_w * (l + 0.5) - 0.5;
+    idx_src_x = (idx_src_x > 0) ? idx_src_x : 0;
+    float d_w = align_flag ? idx_src_x - x_w : ratio_w * l - x_w;  // w1lambda
+    float d_e = 1.f - d_w;                                         // w2lambda
+    {
+      vx_w[l] = x_w;
+      vx_e[l] = x_e;
+      vd_w[l] = d_w;
+      vd_e[l] = d_e;
+    }
+  }
+  int count = n * c;
+  if (data_layout == DATALAYOUT(kNCHW)) {
+    LITE_PARALLEL_BEGIN(i, tid, count) {
+      auto input_data = din + i * in_w;
+      for (int l = 0; l < out_w; l++) {
+        dout[i * out_w + l] =
+            input_data[vx_w[l]] * vd_e[l] + input_data[vx_e[l]] * vd_w[l];
+      }
+    }
+    LITE_PARALLEL_END()
+  } else {
+    LITE_PARALLEL_BEGIN(i, tid, n) {  // loop for batches
+      for (int j = 0; j < c; j++) {   // loop for channels
+        for (int l = 0; l < out_w; l++) {
+          int idx = i * c * out_w + vx_w[l] * c + j;
+          int idy = i * c * out_w + vx_e[l] * c + j;
+          int idout = i * c * out_w + l * c + j;
+          dout[idout] = din[idx] * vd_e[l] + din[idy] * vd_w[l];
+        }
+      }
+    }
+    LITE_PARALLEL_END()
+  }
+}
+
+void interpolate1D(lite::Tensor* X,
+                   lite::Tensor* OutSize,
+                   std::vector<const lite::Tensor*> SizeTensor,
+                   lite::Tensor* Scale,
+                   lite::Tensor* Out,
+                   int out_w,
+                   float scale,
+                   bool align_corners,
+                   int align_mode,
+                   DataLayoutType data_layout) {
+  int in_w, in_c, in_n;
+  if (data_layout == DATALAYOUT(kNCHW)) {
+    in_n = X->dims()[0];
+    in_c = X->dims()[1];
+    in_w = X->dims()[2];
+  } else {
+    in_n = X->dims()[0];
+    in_c = X->dims()[2];
+    in_w = X->dims()[1];
+  }
+  if (SizeTensor.size() > 0) {
+    auto new_size = get_new_shape(SizeTensor);
+    out_w = new_size[0];
+  } else {
+    float scale_tmp;
+    if (Scale) {
+      auto scale_data = get_new_data_from_tensor<float>(Scale);
+      scale_tmp = scale_data[0];
+    } else {
+      scale_tmp = scale;
+    }
+    if (scale_tmp > 0) {
+      out_w = static_cast<int>(in_w * scale_tmp);
+    }
+    if (OutSize) {
+      auto out_size_data = get_new_data_from_tensor<int>(OutSize);
+      out_w = out_size_data[0];
+    }
+  }
+  CHECK_GT(out_w, 0) << "out_w in Attr(out_shape) of Op(interpolate)"
+                     << "should be greater than 0.";
+  if (data_layout == DATALAYOUT(kNCHW)) {
+    Out->Resize({in_n, in_c, out_w});
+  } else {
+    Out->Resize({in_n, out_w, in_c});
+  }
+  float* dout = Out->mutable_data<float>();
+  const float* din = X->data<float>();
+  if (in_w == out_w) {
+    memcpy(dout, din, Out->numel() * sizeof(float));
+    return;
+  }
+  float ratio_w = 0.f;
+  if (out_w > 1) {
+    ratio_w = (align_corners) ? static_cast<float>(in_w - 1) / (out_w - 1)
+                              : static_cast<float>(in_w) / out_w;
+  }
+  linear_interp(din,
+                dout,
+                ratio_w,
+                in_w,
+                in_n,
+                in_c,
+                out_w,
+                align_corners,
+                align_mode,
+                data_layout);
+}
+
 void interpolate(lite::Tensor* X,
                  lite::Tensor* OutSize,
                  std::vector<const lite::Tensor*> SizeTensor,

--- a/lite/backends/arm/math/interpolate.cc
+++ b/lite/backends/arm/math/interpolate.cc
@@ -555,16 +555,16 @@ void linear_interp(const float* din,
   }
 }
 
-void interpolate1D(lite::Tensor* X,
-                   lite::Tensor* OutSize,
-                   std::vector<const lite::Tensor*> SizeTensor,
-                   lite::Tensor* Scale,
-                   lite::Tensor* Out,
-                   int out_w,
-                   float scale,
-                   bool align_corners,
-                   int align_mode,
-                   DataLayoutType data_layout) {
+void interpolate_linear(lite::Tensor* X,
+                        lite::Tensor* OutSize,
+                        std::vector<const lite::Tensor*> SizeTensor,
+                        lite::Tensor* Scale,
+                        lite::Tensor* Out,
+                        int out_w,
+                        float scale,
+                        bool align_corners,
+                        int align_mode,
+                        DataLayoutType data_layout) {
   int in_w, in_c, in_n;
   if (data_layout == DATALAYOUT(kNCHW)) {
     in_n = X->dims()[0];

--- a/lite/backends/arm/math/interpolate.h
+++ b/lite/backends/arm/math/interpolate.h
@@ -94,16 +94,16 @@ void nearest_interp_v2_compute(const T* src,
   }
 }
 
-void interpolate1D(lite::Tensor* X,
-                   lite::Tensor* OutSize,
-                   std::vector<const lite::Tensor*> SizeTensor,
-                   lite::Tensor* Scale,
-                   lite::Tensor* Out,
-                   int out_w,
-                   float scale,
-                   bool align_corners,
-                   int align_mode,
-                   DataLayoutType data_layout);
+void interpolate_linear(lite::Tensor* X,
+                        lite::Tensor* OutSize,
+                        std::vector<const lite::Tensor*> SizeTensor,
+                        lite::Tensor* Scale,
+                        lite::Tensor* Out,
+                        int out_w,
+                        float scale,
+                        bool align_corners,
+                        int align_mode,
+                        DataLayoutType data_layout);
 
 void interpolate(lite::Tensor* X,
                  lite::Tensor* OutSize,

--- a/lite/backends/arm/math/interpolate.h
+++ b/lite/backends/arm/math/interpolate.h
@@ -94,6 +94,17 @@ void nearest_interp_v2_compute(const T* src,
   }
 }
 
+void interpolate1D(lite::Tensor* X,
+                   lite::Tensor* OutSize,
+                   std::vector<const lite::Tensor*> SizeTensor,
+                   lite::Tensor* Scale,
+                   lite::Tensor* Out,
+                   int out_w,
+                   float scale,
+                   bool align_corners,
+                   int align_mode,
+                   DataLayoutType data_layout);
+
 void interpolate(lite::Tensor* X,
                  lite::Tensor* OutSize,
                  std::vector<const lite::Tensor*> SizeTensor,

--- a/lite/core/optimizer/mir/fusion/scale_activation_fuser.cc
+++ b/lite/core/optimizer/mir/fusion/scale_activation_fuser.cc
@@ -69,9 +69,28 @@ cpp::OpDesc ScaleActivationFuser::GenOpDesc(const key2nodes_t& matched) {
   } else if (act_type_ == "relu6") {
     float alpha = act_op_desc->GetAttr<float>("threshold");
     op_desc.SetAttr("alpha", alpha);
+    op_desc.SetAttr("threshold", alpha);
   } else if (act_type_ == "leaky_relu") {
     float alpha = act_op_desc->GetAttr<float>("alpha");
     op_desc.SetAttr("alpha", alpha);
+  } else if (act_type_ == "hard_swish") {
+    float threshold = act_op_desc->GetAttr<float>("threshold");
+    float scale = act_op_desc->GetAttr<float>("scale");
+    float offset = act_op_desc->GetAttr<float>("offset");
+    op_desc.SetAttr("threshold", threshold);
+    op_desc.SetAttr("scale", scale);
+    op_desc.SetAttr("offset", offset);
+  } else if (act_type_ == "hard_sigmoid") {
+    float slope = act_op_desc->GetAttr<float>("slope");
+    float offset = act_op_desc->GetAttr<float>("offset");
+    op_desc.SetAttr("slope", slope);
+    op_desc.SetAttr("offset", offset);
+  } else if (act_type_ == "prelu") {
+    auto prelu_mode = act_op_desc->GetAttr<std::string>("mode");
+    op_desc.SetAttr("mode", prelu_mode);
+  } else if (act_type_ == "swish") {
+    float scale = act_op_desc->GetAttr<float>("beta");
+    op_desc.SetAttr("beta", scale);
   }
   auto& out_name = matched.at("output")->arg()->name;
   op_desc.SetOutput("Out", {out_name});

--- a/lite/kernels/arm/interpolate_compute.cc
+++ b/lite/kernels/arm/interpolate_compute.cc
@@ -49,16 +49,16 @@ namespace arm {
 template <>
 void LinearInterpCompute<PRECISION(kFloat)>::Run() {
   INIT_PARAM("Linear")
-  lite::arm::math::interpolate1D(X,
-                                 OutSize,
-                                 SizeTensor,
-                                 Scale,
-                                 Out,
-                                 out_w,
-                                 scale,
-                                 align_corners,
-                                 align_mode,
-                                 param.data_layout);
+  lite::arm::math::interpolate_linear(X,
+                                      OutSize,
+                                      SizeTensor,
+                                      Scale,
+                                      Out,
+                                      out_w,
+                                      scale,
+                                      align_corners,
+                                      align_mode,
+                                      param.data_layout);
 }
 
 template <>

--- a/lite/kernels/arm/interpolate_compute.cc
+++ b/lite/kernels/arm/interpolate_compute.cc
@@ -47,6 +47,21 @@ namespace arm {
       align_mode, interp_method, scale_v
 
 template <>
+void LinearInterpCompute<PRECISION(kFloat)>::Run() {
+  INIT_PARAM("Linear")
+  lite::arm::math::interpolate1D(X,
+                                 OutSize,
+                                 SizeTensor,
+                                 Scale,
+                                 Out,
+                                 out_w,
+                                 scale,
+                                 align_corners,
+                                 align_mode,
+                                 param.data_layout);
+}
+
+template <>
 void BilinearInterpCompute<PRECISION(kFloat)>::Run() {
   INIT_PARAM("Bilinear")
   lite::arm::math::interpolate(INTERP_PARAM);
@@ -146,12 +161,25 @@ typedef paddle::lite::kernels::arm::BilinearInterpCompute<PRECISION(kFloat)>
     bilinear_interp_fp32;
 typedef paddle::lite::kernels::arm::NearestInterpCompute<PRECISION(kFloat)>
     nearest_interp_fp32;
+typedef paddle::lite::kernels::arm::LinearInterpCompute<PRECISION(kFloat)>
+    linear_interp_fp32;
 
 typedef paddle::lite::kernels::arm::NearestInterpComputeV2<PRECISION(kFloat)>
     nearest_interp_v2_fp32;
 
 REGISTER_LITE_KERNEL(
     bilinear_interp, kARM, kFloat, kNCHW, bilinear_interp_fp32, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("OutSize",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("SizeTensor",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("Scale", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    linear_interp, kARM, kFloat, kNCHW, linear_interp_fp32, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("OutSize",
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
@@ -174,6 +202,17 @@ REGISTER_LITE_KERNEL(
 
 REGISTER_LITE_KERNEL(
     bilinear_interp_v2, kARM, kFloat, kNCHW, bilinear_interp_fp32, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindInput("OutSize",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("SizeTensor",
+               {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
+    .BindInput("Scale", {LiteType::GetTensorTy(TARGET(kARM))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    linear_interp_v2, kARM, kFloat, kNCHW, linear_interp_fp32, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("OutSize",
                {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})

--- a/lite/kernels/arm/interpolate_compute.h
+++ b/lite/kernels/arm/interpolate_compute.h
@@ -22,6 +22,14 @@ namespace lite {
 namespace kernels {
 namespace arm {
 template <PrecisionType Ptype>
+class LinearInterpCompute : public KernelLite<TARGET(kARM), Ptype> {
+ public:
+  void Run() override;
+
+  virtual ~LinearInterpCompute() = default;
+};
+
+template <PrecisionType Ptype>
 class BilinearInterpCompute : public KernelLite<TARGET(kARM), Ptype> {
  public:
   void Run() override;

--- a/lite/operators/interpolate_op.cc
+++ b/lite/operators/interpolate_op.cc
@@ -136,9 +136,79 @@ bool InterpolateOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   return true;
 }
 
+bool InterpolateOp1D::CheckShape() const {
+  auto* X = param_.X;
+  auto* OutSize = param_.OutSize;
+  CHECK_OR_FALSE(X);
+  CHECK_EQ(X->dims().size(), 3)
+      << "Linear_interp only supports input's dim size = 3, but now is "
+      << X->dims().size();
+  if (OutSize != nullptr) {
+    CHECK_OR_FALSE(OutSize);
+  }
+  CHECK_OR_FALSE(param_.Out);
+  return true;
+}
+
+bool InterpolateOp1D::AttachImpl(const cpp::OpDesc& op_desc,
+                                 lite::Scope* scope) {
+  auto X = op_desc.Input("X").front();
+  if (op_desc.HasInput("OutSize")) {
+    auto out_size_var_names = op_desc.Input("OutSize");
+    if (out_size_var_names.size() > 0) {
+      param_.OutSize = scope->FindVar(out_size_var_names.front())
+                           ->GetMutable<lite::Tensor>();
+    }
+  } else {
+    param_.OutSize = nullptr;
+  }
+
+  if (op_desc.HasInput("SizeTensor")) {
+    param_.SizeTensor.clear();
+    auto size_tensor = op_desc.Input("SizeTensor");
+    for (auto var : size_tensor) {
+      param_.SizeTensor.push_back(
+          scope->FindVar(var)->GetMutable<lite::Tensor>());
+    }
+  }
+
+  if (op_desc.HasInput("Scale")) {
+    auto scale_var_names = op_desc.Input("Scale");
+    if (scale_var_names.size() > 0) {
+      param_.Scale =
+          scope->FindVar(scale_var_names.front())->GetMutable<lite::Tensor>();
+    }
+  } else {
+    param_.Scale = nullptr;
+  }
+  auto Out = op_desc.Output("Out").front();
+  param_.X = scope->FindVar(X)->GetMutable<lite::Tensor>();
+  param_.Out = scope->FindVar(Out)->GetMutable<lite::Tensor>();
+  if (op_desc.HasAttr("scale")) {
+    param_.scale = op_desc.GetAttr<float>("scale");
+  }
+  if (op_desc.HasAttr("out_w")) {
+    param_.out_w = op_desc.GetAttr<int>("out_w");
+  }
+  if (op_desc.HasAttr("align_mode")) {
+    param_.align_mode = op_desc.GetAttr<int>("align_mode");
+  }
+  param_.align_corners = op_desc.GetAttr<bool>("align_corners");
+  param_.interp_method = op_desc.GetAttr<std::string>("interp_method");
+  auto layout = op_desc.GetAttr<std::string>("data_layout");
+  if (layout == "NCHW")
+    param_.data_layout = DATALAYOUT(kNCHW);
+  else if (layout == "NHWC")
+    param_.data_layout = DATALAYOUT(kNHWC);
+  else
+    LOG(FATAL) << "Linear_interp not support data layout!";
+  return true;
+}
+
 } /* namespace operators */
 } /* namespace lite */
 } /* namespace paddle */
 
 REGISTER_LITE_OP(nearest_interp, paddle::lite::operators::InterpolateOp);
 REGISTER_LITE_OP(bilinear_interp, paddle::lite::operators::InterpolateOp);
+REGISTER_LITE_OP(linear_interp, paddle::lite::operators::InterpolateOp1D);

--- a/lite/operators/interpolate_op.cc
+++ b/lite/operators/interpolate_op.cc
@@ -136,7 +136,7 @@ bool InterpolateOp::AttachImpl(const cpp::OpDesc& op_desc, lite::Scope* scope) {
   return true;
 }
 
-bool InterpolateOp1D::CheckShape() const {
+bool LinearInterpolateOp::CheckShape() const {
   auto* X = param_.X;
   auto* OutSize = param_.OutSize;
   CHECK_OR_FALSE(X);
@@ -150,8 +150,8 @@ bool InterpolateOp1D::CheckShape() const {
   return true;
 }
 
-bool InterpolateOp1D::AttachImpl(const cpp::OpDesc& op_desc,
-                                 lite::Scope* scope) {
+bool LinearInterpolateOp::AttachImpl(const cpp::OpDesc& op_desc,
+                                     lite::Scope* scope) {
   auto X = op_desc.Input("X").front();
   if (op_desc.HasInput("OutSize")) {
     auto out_size_var_names = op_desc.Input("OutSize");
@@ -211,4 +211,4 @@ bool InterpolateOp1D::AttachImpl(const cpp::OpDesc& op_desc,
 
 REGISTER_LITE_OP(nearest_interp, paddle::lite::operators::InterpolateOp);
 REGISTER_LITE_OP(bilinear_interp, paddle::lite::operators::InterpolateOp);
-REGISTER_LITE_OP(linear_interp, paddle::lite::operators::InterpolateOp1D);
+REGISTER_LITE_OP(linear_interp, paddle::lite::operators::LinearInterpolateOp);

--- a/lite/operators/interpolate_op.h
+++ b/lite/operators/interpolate_op.h
@@ -52,11 +52,11 @@ class InterpolateOp : public OpLite {
   mutable InterpolateParam param_;
 };
 
-class InterpolateOp1D : public OpLite {
+class LinearInterpolateOp : public OpLite {
  public:
-  InterpolateOp1D() {}
+  LinearInterpolateOp() {}
 
-  explicit InterpolateOp1D(const std::string &op_type) : OpLite(op_type) {}
+  explicit LinearInterpolateOp(const std::string &op_type) : OpLite(op_type) {}
 
   bool CheckShape() const override;
 

--- a/lite/operators/interpolate_op.h
+++ b/lite/operators/interpolate_op.h
@@ -52,6 +52,35 @@ class InterpolateOp : public OpLite {
   mutable InterpolateParam param_;
 };
 
+class InterpolateOp1D : public OpLite {
+ public:
+  InterpolateOp1D() {}
+
+  explicit InterpolateOp1D(const std::string &op_type) : OpLite(op_type) {}
+
+  bool CheckShape() const override;
+
+  bool InferShapeImpl() const override { return true; };
+
+  bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+
+  std::string DebugString() const override { return "interpolate"; }
+
+#ifdef LITE_WITH_PROFILE
+  void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
+    ch->input_shape = ch->DimToStr(param_.X->dims());
+    ch->output_shape = ch->DimToStr(param_.Out->dims());
+    ch->remark = param_.interp_method;
+    ch->macs = param_.Out->numel() * 14.f;
+  }
+#endif
+
+ private:
+  mutable InterpolateParam param_;
+};
+
 } /* namespace operators */
 } /* namespace lite */
 } /* namespace paddle */

--- a/lite/operators/interpolate_v2_op.cc
+++ b/lite/operators/interpolate_v2_op.cc
@@ -146,9 +146,84 @@ bool InterpolateV2Op::AttachImpl(const cpp::OpDesc& op_desc,
   return true;
 }
 
+bool InterpolateV2Op1D::CheckShape() const {
+  auto* X = param_.X;
+  auto* OutSize = param_.OutSize;
+  CHECK_OR_FALSE(X);
+  CHECK_EQ(X->dims().size(), 3)
+      << "Linear_interp only supports input's dim size = 3, but now is "
+      << X->dims().size();
+  if (OutSize != nullptr) {
+    CHECK_OR_FALSE(OutSize);
+  }
+  CHECK_OR_FALSE(param_.Out);
+  return true;
+}
+
+bool InterpolateV2Op1D::AttachImpl(const cpp::OpDesc& op_desc,
+                                   lite::Scope* scope) {
+  param_.version_2 = true;
+  auto X = op_desc.Input("X").front();
+  if (op_desc.HasInput("OutSize")) {
+    auto out_size_var_names = op_desc.Input("OutSize");
+    if (out_size_var_names.size() > 0) {
+      param_.OutSize = scope->FindVar(out_size_var_names.front())
+                           ->GetMutable<lite::Tensor>();
+    }
+  } else {
+    param_.OutSize = nullptr;
+  }
+
+  if (op_desc.HasInput("SizeTensor")) {
+    param_.SizeTensor.clear();
+    auto size_tensor = op_desc.Input("SizeTensor");
+    for (auto var : size_tensor) {
+      param_.SizeTensor.push_back(
+          scope->FindVar(var)->GetMutable<lite::Tensor>());
+    }
+  }
+
+  if (op_desc.HasInput("Scale")) {
+    auto scale_var_names = op_desc.Input("Scale");
+    if (scale_var_names.size() > 0) {
+      param_.Scale =
+          scope->FindVar(scale_var_names.front())->GetMutable<lite::Tensor>();
+    }
+  } else {
+    param_.Scale = nullptr;
+  }
+  auto Out = op_desc.Output("Out").front();
+  param_.X = scope->FindVar(X)->GetMutable<lite::Tensor>();
+  param_.Out = scope->FindVar(Out)->GetMutable<lite::Tensor>();
+  if (op_desc.HasAttr("scale")) {
+    auto vs = op_desc.GetAttr<std::vector<float>>("scale");
+    if (vs.size() > 0) {
+      param_.scale_v = vs;
+      param_.scale = vs[0];
+    }
+  }
+  if (op_desc.HasAttr("out_w")) {
+    param_.out_w = op_desc.GetAttr<int>("out_w");
+  }
+  if (op_desc.HasAttr("align_mode")) {
+    param_.align_mode = op_desc.GetAttr<int>("align_mode");
+  }
+  param_.align_corners = op_desc.GetAttr<bool>("align_corners");
+  param_.interp_method = op_desc.GetAttr<std::string>("interp_method");
+  auto layout = op_desc.GetAttr<std::string>("data_layout");
+  if (layout == "NCHW")
+    param_.data_layout = DATALAYOUT(kNCHW);
+  else if (layout == "NHWC")
+    param_.data_layout = DATALAYOUT(kNHWC);
+  else
+    LOG(FATAL) << "Linear_interp_v2 not support data layout!";
+  return true;
+}
+
 } /* namespace operators */
 } /* namespace lite */
 } /* namespace paddle */
 
 REGISTER_LITE_OP(bilinear_interp_v2, paddle::lite::operators::InterpolateV2Op);
 REGISTER_LITE_OP(nearest_interp_v2, paddle::lite::operators::InterpolateV2Op);
+REGISTER_LITE_OP(linear_interp_v2, paddle::lite::operators::InterpolateV2Op1D);

--- a/lite/operators/interpolate_v2_op.cc
+++ b/lite/operators/interpolate_v2_op.cc
@@ -146,7 +146,7 @@ bool InterpolateV2Op::AttachImpl(const cpp::OpDesc& op_desc,
   return true;
 }
 
-bool InterpolateV2Op1D::CheckShape() const {
+bool LinearInterpolateV2Op::CheckShape() const {
   auto* X = param_.X;
   auto* OutSize = param_.OutSize;
   CHECK_OR_FALSE(X);
@@ -160,8 +160,8 @@ bool InterpolateV2Op1D::CheckShape() const {
   return true;
 }
 
-bool InterpolateV2Op1D::AttachImpl(const cpp::OpDesc& op_desc,
-                                   lite::Scope* scope) {
+bool LinearInterpolateV2Op::AttachImpl(const cpp::OpDesc& op_desc,
+                                       lite::Scope* scope) {
   param_.version_2 = true;
   auto X = op_desc.Input("X").front();
   if (op_desc.HasInput("OutSize")) {
@@ -226,4 +226,5 @@ bool InterpolateV2Op1D::AttachImpl(const cpp::OpDesc& op_desc,
 
 REGISTER_LITE_OP(bilinear_interp_v2, paddle::lite::operators::InterpolateV2Op);
 REGISTER_LITE_OP(nearest_interp_v2, paddle::lite::operators::InterpolateV2Op);
-REGISTER_LITE_OP(linear_interp_v2, paddle::lite::operators::InterpolateV2Op1D);
+REGISTER_LITE_OP(linear_interp_v2,
+                 paddle::lite::operators::LinearInterpolateV2Op);

--- a/lite/operators/interpolate_v2_op.h
+++ b/lite/operators/interpolate_v2_op.h
@@ -52,11 +52,12 @@ class InterpolateV2Op : public OpLite {
   mutable InterpolateParam param_;
 };
 
-class InterpolateV2Op1D : public OpLite {
+class LinearInterpolateV2Op : public OpLite {
  public:
-  InterpolateV2Op1D() {}
+  LinearInterpolateV2Op() {}
 
-  explicit InterpolateV2Op1D(const std::string &op_type) : OpLite(op_type) {}
+  explicit LinearInterpolateV2Op(const std::string &op_type)
+      : OpLite(op_type) {}
 
   bool CheckShape() const override;
 

--- a/lite/operators/interpolate_v2_op.h
+++ b/lite/operators/interpolate_v2_op.h
@@ -52,6 +52,35 @@ class InterpolateV2Op : public OpLite {
   mutable InterpolateParam param_;
 };
 
+class InterpolateV2Op1D : public OpLite {
+ public:
+  InterpolateV2Op1D() {}
+
+  explicit InterpolateV2Op1D(const std::string &op_type) : OpLite(op_type) {}
+
+  bool CheckShape() const override;
+
+  bool InferShapeImpl() const override { return true; };
+
+  bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
+
+  void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
+
+  std::string DebugString() const override { return "interpolate"; }
+
+#ifdef LITE_WITH_PROFILE
+  void GetOpRuntimeInfo(paddle::lite::profile::OpCharacter *ch) {
+    ch->input_shape = ch->DimToStr(param_.X->dims());
+    ch->output_shape = ch->DimToStr(param_.Out->dims());
+    ch->remark = param_.interp_method;
+    ch->macs = param_.Out->numel() * 14.f;
+  }
+#endif
+
+ private:
+  mutable InterpolateParam param_;
+};
+
 } /* namespace operators */
 } /* namespace lite */
 } /* namespace paddle */


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Arm
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features && Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
OP && PASS && Kernels && Backends
### Description
<!-- Describe what this PR does -->
在Arm端新增Linear_interp/Linear_interp_v2 OP实现；
修复 scale_fuse_activation_pass 和 conv_fuse_scale_pass 对激活函数设置不正确的bug