### PR TITLE
[Framework] Support custom allocator

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -380,18 +380,9 @@ void ConfigBase::add_discarded_pass(const std::string pass) {
 }
 
 // Set external allocator
-void ConfigBase::set_allocator_malloc_func(void *(*malloc)(size_t)) {
-  lite::Allocator::Global().SetAllocatorMallocFunc(malloc);
-}
-
-void ConfigBase::set_allocator_free_func(void (*free)(void *)) {
-  lite::Allocator::Global().SetAllocatorFreeFunc(free);
-}
-
-void ConfigBase::set_allocator_memcpy_func(void (*memcpy)(void *,
-                                                          const void *,
-                                                          size_t)) {
-  lite::Allocator::Global().SetAllocatorMemcpyFunc(memcpy);
+void ConfigBase::set_allocator(
+    std::map<TargetType, AllocatorFuncs> allocator_funcs_map) {
+  lite::Allocator::Global().SetAllocatorFuncsMap(allocator_funcs_map);
 }
 
 #ifdef LITE_WITH_X86

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -379,6 +379,21 @@ void ConfigBase::add_discarded_pass(const std::string pass) {
   return;
 }
 
+// Set external allocator
+void ConfigBase::set_allocator_malloc_func(void *(*malloc)(size_t)) {
+  lite::Allocator::Global().SetAllocatorMallocFunc(malloc);
+}
+
+void ConfigBase::set_allocator_free_func(void (*free)(void *)) {
+  lite::Allocator::Global().SetAllocatorFreeFunc(free);
+}
+
+void ConfigBase::set_allocator_memcpy_func(void (*memcpy)(void *,
+                                                          const void *,
+                                                          size_t)) {
+  lite::Allocator::Global().SetAllocatorMemcpyFunc(memcpy);
+}
+
 #ifdef LITE_WITH_X86
 void ConfigBase::set_x86_math_num_threads(int threads) {
   x86_math_num_threads_ = threads;
@@ -769,6 +784,20 @@ bool MobileConfig::check_fp16_valid() {
   return false;
 #endif
 }
+
+// // Set external allocator
+// void MobileConfig::set_allocator_malloc_func(void* (*malloc)(size_t)) {
+//   lite::Allocator::Global().SetAllocatorMallocFunc(malloc);
+// }
+
+// void MobileConfig::set_allocator_free_func(void (*free)(void*)) {
+//   lite::Allocator::Global().SetAllocatorFreeFunc(free);
+// }
+
+// void MobileConfig::set_allocator_memcpy_func(void (*memcpy)(void*, const
+// void*, size_t)) {
+//   lite::Allocator::Global().SetAllocatorMemcpyFunc(memcpy);
+// }
 
 }  // namespace lite_api
 }  // namespace paddle

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -379,7 +379,7 @@ void ConfigBase::add_discarded_pass(const std::string pass) {
   return;
 }
 
-// Set external allocator
+// Set external custom allocator
 void ConfigBase::set_custom_allocator(TargetType target_type,
                                       CustomAllocator custom_allocator) {
   // TODO(shentanyue): TargetType will be supported in the future.

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -785,19 +785,5 @@ bool MobileConfig::check_fp16_valid() {
 #endif
 }
 
-// // Set external allocator
-// void MobileConfig::set_allocator_malloc_func(void* (*malloc)(size_t)) {
-//   lite::Allocator::Global().SetAllocatorMallocFunc(malloc);
-// }
-
-// void MobileConfig::set_allocator_free_func(void (*free)(void*)) {
-//   lite::Allocator::Global().SetAllocatorFreeFunc(free);
-// }
-
-// void MobileConfig::set_allocator_memcpy_func(void (*memcpy)(void*, const
-// void*, size_t)) {
-//   lite::Allocator::Global().SetAllocatorMemcpyFunc(memcpy);
-// }
-
 }  // namespace lite_api
 }  // namespace paddle

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -380,9 +380,10 @@ void ConfigBase::add_discarded_pass(const std::string pass) {
 }
 
 // Set external allocator
-void ConfigBase::set_allocator(
-    std::map<TargetType, AllocatorFuncs> allocator_funcs_map) {
-  lite::Allocator::Global().SetAllocatorFuncsMap(allocator_funcs_map);
+void ConfigBase::set_custom_allocator(TargetType target_type,
+                                      CustomAllocator custom_allocator) {
+  // TODO(shentanyue): TargetType will be supported in the future.
+  lite::Allocator::Global().SetCustomAllocator(custom_allocator);
 }
 
 #ifdef LITE_WITH_X86

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -353,7 +353,7 @@ class LITE_API ConfigBase {
     return target_configs_;
   }
 
-  // Set external allocator
+  // Set external custom allocator
   void set_custom_allocator(TargetType target_type,
                             CustomAllocator custom_allocator);
 };

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -354,9 +354,7 @@ class LITE_API ConfigBase {
   }
 
   // Set external allocator
-  void set_allocator_malloc_func(void* (*malloc)(size_t));
-  void set_allocator_free_func(void (*free)(void*));
-  void set_allocator_memcpy_func(void (*memcpy)(void*, const void*, size_t));
+  void set_allocator(std::map<TargetType, AllocatorFuncs> allocator_funcs_map);
 };
 
 class LITE_API CxxModelBuffer {

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -352,6 +352,11 @@ class LITE_API ConfigBase {
   std::map<TargetType, std::shared_ptr<void>> target_configs() const {
     return target_configs_;
   }
+
+  // Set external allocator
+  void set_allocator_malloc_func(void* (*malloc)(size_t));
+  void set_allocator_free_func(void (*free)(void*));
+  void set_allocator_memcpy_func(void (*memcpy)(void*, const void*, size_t));
 };
 
 class LITE_API CxxModelBuffer {

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -354,7 +354,8 @@ class LITE_API ConfigBase {
   }
 
   // Set external allocator
-  void set_allocator(std::map<TargetType, AllocatorFuncs> allocator_funcs_map);
+  void set_custom_allocator(TargetType target_type,
+                            CustomAllocator custom_allocator);
 };
 
 class LITE_API CxxModelBuffer {

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -284,5 +284,11 @@ struct LITE_API Place {
   std::string DebugString() const;
 };
 
+struct LITE_API AllocatorFuncs {
+  void* (*malloc)(size_t) = nullptr;
+  void (*free)(void*) = nullptr;
+  void (*memcpy)(void*, const void*, size_t) = nullptr;
+};
+
 }  // namespace lite_api
 }  // namespace paddle

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -285,9 +285,9 @@ struct LITE_API Place {
 };
 
 struct LITE_API CustomAllocator {
-  void* (*malloc)(size_t) = nullptr;
-  void (*free)(void*) = nullptr;
-  void (*memcpy)(void*, const void*, size_t) = nullptr;
+  void* (*malloc)(size_t size) = nullptr;
+  void (*free)(void* ptr) = nullptr;
+  void (*copy)(void* dst, const void* src, size_t size) = nullptr;
 };
 
 }  // namespace lite_api

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -285,9 +285,8 @@ struct LITE_API Place {
 };
 
 struct LITE_API CustomAllocator {
-  void* (*malloc)(size_t size) = nullptr;
+  void* (*alloc)(size_t size, size_t alignment) = nullptr;
   void (*free)(void* ptr) = nullptr;
-  void (*copy)(void* dst, const void* src, size_t size) = nullptr;
 };
 
 }  // namespace lite_api

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -284,7 +284,7 @@ struct LITE_API Place {
   std::string DebugString() const;
 };
 
-struct LITE_API AllocatorFuncs {
+struct LITE_API CustomAllocator {
   void* (*malloc)(size_t) = nullptr;
   void (*free)(void*) = nullptr;
   void (*memcpy)(void*, const void*, size_t) = nullptr;

--- a/lite/backends/host/target_wrapper.cc
+++ b/lite/backends/host/target_wrapper.cc
@@ -23,10 +23,6 @@ const int MALLOC_ALIGN = 64;
 const int MALLOC_EXTRA = 64;
 
 void* TargetWrapper<TARGET(kHost)>::Malloc(size_t size) {
-  if (lite::Allocator::Global().GetMallocFunc()) {
-    auto r = lite::Allocator::Global().GetMallocFunc()(size);
-    return r;
-  }
   size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;
   CHECK(size);
   CHECK_GT(offset + size, size);
@@ -45,10 +41,6 @@ void* TargetWrapper<TARGET(kHost)>::Malloc(size_t size) {
 
 void TargetWrapper<TARGET(kHost)>::Free(void* ptr) {
   if (ptr) {
-    if (lite::Allocator::Global().GetFreeFunc()) {
-      lite::Allocator::Global().GetFreeFunc()(ptr);
-      return;
-    }
     free(static_cast<void**>(ptr)[-1]);
   }
 }
@@ -60,10 +52,6 @@ void TargetWrapper<TARGET(kHost)>::MemcpySync(void* dst,
   if (size > 0) {
     CHECK(dst) << "Error: the destination of MemcpySync can not be nullptr.";
     CHECK(src) << "Error: the source of MemcpySync can not be nullptr.";
-    if (lite::Allocator::Global().GetMemcpyFunc()) {
-      lite::Allocator::Global().GetMemcpyFunc()(dst, src, size);
-      return;
-    }
     memcpy(dst, src, size);
   }
 }

--- a/lite/core/memory.cc
+++ b/lite/core/memory.cc
@@ -97,8 +97,8 @@ void TargetFree(TargetType target, void* data, std::string free_flag) {
 }
 
 void TargetCopy(TargetType target, void* dst, const void* src, size_t size) {
-  if (lite::Allocator::Global().GetCustomAllocator().malloc) {
-    lite::Allocator::Global().GetCustomAllocator().memcpy(dst, src, size);
+  if (lite::Allocator::Global().GetCustomAllocator().copy) {
+    lite::Allocator::Global().GetCustomAllocator().copy(dst, src, size);
   } else {
     switch (target) {
       case TargetType::kHost:

--- a/lite/core/memory.cc
+++ b/lite/core/memory.cc
@@ -24,14 +24,8 @@ namespace lite {
 
 void* TargetMalloc(TargetType target, size_t size) {
   void* data{nullptr};
-  if (lite::Allocator::Global().GetAllocatorFuncsMap().count(target)) {
-    auto allocator_malloc_func =
-        lite::Allocator::Global().GetAllocatorFuncsMap()[target].malloc;
-    if (allocator_malloc_func) {
-      data = allocator_malloc_func(size);
-    } else {
-      LOG(FATAL) << "The [malloc] function of Allocator is not set";
-    }
+  if (lite::Allocator::Global().GetCustomAllocator().malloc) {
+    data = lite::Allocator::Global().GetCustomAllocator().malloc(size);
   } else {
     switch (target) {
       case TargetType::kHost:
@@ -63,14 +57,8 @@ void* TargetMalloc(TargetType target, size_t size) {
 }
 
 void TargetFree(TargetType target, void* data, std::string free_flag) {
-  if (lite::Allocator::Global().GetAllocatorFuncsMap().count(target)) {
-    auto allocator_free_func =
-        lite::Allocator::Global().GetAllocatorFuncsMap()[target].free;
-    if (allocator_free_func) {
-      allocator_free_func(data);
-    } else {
-      LOG(FATAL) << "The [free] function of Allocator is not set";
-    }
+  if (lite::Allocator::Global().GetCustomAllocator().free) {
+    lite::Allocator::Global().GetCustomAllocator().free(data);
   } else {
     switch (target) {
       case TargetType::kHost:
@@ -109,14 +97,8 @@ void TargetFree(TargetType target, void* data, std::string free_flag) {
 }
 
 void TargetCopy(TargetType target, void* dst, const void* src, size_t size) {
-  if (lite::Allocator::Global().GetAllocatorFuncsMap().count(target)) {
-    auto allocator_memcpy_func =
-        lite::Allocator::Global().GetAllocatorFuncsMap()[target].memcpy;
-    if (allocator_memcpy_func) {
-      allocator_memcpy_func(dst, src, size);
-    } else {
-      LOG(FATAL) << "The [memcpy] function of Allocator is not set";
-    }
+  if (lite::Allocator::Global().GetCustomAllocator().malloc) {
+    lite::Allocator::Global().GetCustomAllocator().memcpy(dst, src, size);
   } else {
     switch (target) {
       case TargetType::kHost:

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -15,7 +15,6 @@
 #pragma once
 #include <cstring>
 #include <iostream>
-#include <map>
 #include <sstream>
 #include <string>
 #include "lite/api/paddle_place.h"

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <cstring>
 #include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 #include "lite/api/paddle_place.h"
@@ -34,6 +35,7 @@ using lite_api::DataLayoutToStr;
 using lite_api::TargetRepr;
 using lite_api::PrecisionRepr;
 using lite_api::DataLayoutRepr;
+using lite_api::AllocatorFuncs;
 
 namespace host {
 const int MALLOC_ALIGN = 64;
@@ -94,9 +96,6 @@ enum class IoDirection {
 };
 
 // Allocator
-using MallocType = void* (*)(size_t);
-using FreeType = void (*)(void*);
-using MemcpyType = void (*)(void*, const void*, size_t);
 class Allocator {
  public:
   static Allocator& Global() {
@@ -104,24 +103,16 @@ class Allocator {
     return *alloc;
   }
 
-  void SetAllocatorMallocFunc(void* (*malloc)(size_t)) { malloc_ = malloc; }
-
-  void SetAllocatorFreeFunc(void (*free)(void*)) { free_ = free; }
-
-  void SetAllocatorMemcpyFunc(void (*memcpy)(void*, const void*, size_t)) {
-    memcpy_ = memcpy;
+  void SetAllocatorFuncsMap(std::map<TargetType, AllocatorFuncs> funcs_map) {
+    funcs_map_ = funcs_map;
   }
 
-  MallocType GetMallocFunc() { return malloc_; }
-
-  FreeType GetFreeFunc() { return free_; }
-
-  MemcpyType GetMemcpyFunc() { return memcpy_; }
+  std::map<TargetType, AllocatorFuncs> GetAllocatorFuncsMap() {
+    return funcs_map_;
+  }
 
  private:
-  void* (*malloc_)(size_t) = nullptr;
-  void (*free_)(void*) = nullptr;
-  void (*memcpy_)(void*, const void*, size_t) = nullptr;
+  std::map<TargetType, AllocatorFuncs> funcs_map_;
   Allocator() = default;
 };
 

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -35,7 +35,7 @@ using lite_api::DataLayoutToStr;
 using lite_api::TargetRepr;
 using lite_api::PrecisionRepr;
 using lite_api::DataLayoutRepr;
-using lite_api::AllocatorFuncs;
+using lite_api::CustomAllocator;
 
 namespace host {
 const int MALLOC_ALIGN = 64;
@@ -103,16 +103,14 @@ class Allocator {
     return *alloc;
   }
 
-  void SetAllocatorFuncsMap(std::map<TargetType, AllocatorFuncs> funcs_map) {
-    funcs_map_ = funcs_map;
+  void SetCustomAllocator(CustomAllocator custom_allocator) {
+    custom_allocator_ = custom_allocator;
   }
 
-  std::map<TargetType, AllocatorFuncs> GetAllocatorFuncsMap() {
-    return funcs_map_;
-  }
+  CustomAllocator GetCustomAllocator() { return custom_allocator_; }
 
  private:
-  std::map<TargetType, AllocatorFuncs> funcs_map_;
+  CustomAllocator custom_allocator_;
   Allocator() = default;
 };
 

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -93,6 +93,38 @@ enum class IoDirection {
   DtoD,      // Device to device
 };
 
+// Allocator
+using MallocType = void* (*)(size_t);
+using FreeType = void (*)(void*);
+using MemcpyType = void (*)(void*, const void*, size_t);
+class Allocator {
+ public:
+  static Allocator& Global() {
+    static auto* alloc = new Allocator;
+    return *alloc;
+  }
+
+  void SetAllocatorMallocFunc(void* (*malloc)(size_t)) { malloc_ = malloc; }
+
+  void SetAllocatorFreeFunc(void (*free)(void*)) { free_ = free; }
+
+  void SetAllocatorMemcpyFunc(void (*memcpy)(void*, const void*, size_t)) {
+    memcpy_ = memcpy;
+  }
+
+  MallocType GetMallocFunc() { return malloc_; }
+
+  FreeType GetFreeFunc() { return free_; }
+
+  MemcpyType GetMemcpyFunc() { return memcpy_; }
+
+ private:
+  void* (*malloc_)(size_t) = nullptr;
+  void (*free_)(void*) = nullptr;
+  void (*memcpy_)(void*, const void*, size_t) = nullptr;
+  Allocator() = default;
+};
+
 // This interface should be specified by each kind of target.
 template <TargetType Target, typename StreamTy = int, typename EventTy = int>
 class TargetWrapper {

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -98,8 +98,8 @@ enum class IoDirection {
 class Allocator {
  public:
   static Allocator& Global() {
-    static auto* alloc = new Allocator;
-    return *alloc;
+    static auto* allocator = new Allocator;
+    return *allocator;
   }
 
   void SetCustomAllocator(CustomAllocator custom_allocator) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Framework
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
API
### Description
<!-- Describe what this PR does -->
新增外部 API 用于设置 Allocator，其中 PaddleLite 框架传入默认 alignment 值为64，用于Byte alignment，用户可自定义。

使用方法：
```

void* allocfunc(size_t size, size_t alignment) {
  size_t offset = sizeof(void*) + alignment - 1;
  char* p = static_cast<char*>(std::malloc(offset + size));
  // Byte alignment
  void* r = reinterpret_cast<void*>(reinterpret_cast<size_t>(p + offset) &
                                    (~(alignment - 1)));
  static_cast<void**>(r)[-1] = p;
  return r;
}

void freefunc(void* ptr) {
  if (ptr) {
    std::free(static_cast<void**>(ptr)[-1]);
  }
}

```

```
paddle::lite_api::MobileConfig mobile_config;
paddle::lite_api::CustomAllocator custom_allocator;
custom_allocator.alloc = allocfunc;
custom_allocator.free = freefunc;
mobile_config.set_custom_allocator(TARGET(kHost), custom_allocator);
```
