### PR TITLE
[Cherry-pick][Framework] Support custom allocator (#10013)

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -371,6 +371,13 @@ void ConfigBase::add_discarded_pass(const std::string pass) {
   return;
 }
 
+// Set external custom allocator
+void ConfigBase::set_custom_allocator(TargetType target_type,
+                                      CustomAllocator custom_allocator) {
+  // TODO(shentanyue): TargetType will be supported in the future.
+  lite::Allocator::Global().SetCustomAllocator(custom_allocator);
+}
+
 #ifdef LITE_WITH_X86
 void ConfigBase::set_x86_math_num_threads(int threads) {
   x86_math_num_threads_ = threads;

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -346,6 +346,10 @@ class LITE_API ConfigBase {
   const std::vector<std::string> get_discarded_passes() const {
     return discarded_passes_;
   }
+
+  // Set external custom allocator
+  void set_custom_allocator(TargetType target_type,
+                            CustomAllocator custom_allocator);
 };
 
 class LITE_API CxxModelBuffer {

--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -278,5 +278,10 @@ struct LITE_API Place {
   std::string DebugString() const;
 };
 
+struct LITE_API CustomAllocator {
+  void* (*alloc)(size_t size, size_t alignment) = nullptr;
+  void (*free)(void* ptr) = nullptr;
+};
+
 }  // namespace lite_api
 }  // namespace paddle

--- a/lite/backends/host/target_wrapper.cc
+++ b/lite/backends/host/target_wrapper.cc
@@ -38,11 +38,13 @@ void* TargetWrapper<TARGET(kHost)>::Malloc(size_t size) {
   static_cast<void**>(r)[-1] = p;
   return r;
 }
+
 void TargetWrapper<TARGET(kHost)>::Free(void* ptr) {
   if (ptr) {
     free(static_cast<void**>(ptr)[-1]);
   }
 }
+
 void TargetWrapper<TARGET(kHost)>::MemcpySync(void* dst,
                                               const void* src,
                                               size_t size,

--- a/lite/core/target_wrapper.h
+++ b/lite/core/target_wrapper.h
@@ -34,6 +34,7 @@ using lite_api::DataLayoutToStr;
 using lite_api::TargetRepr;
 using lite_api::PrecisionRepr;
 using lite_api::DataLayoutRepr;
+using lite_api::CustomAllocator;
 
 namespace host {
 const int MALLOC_ALIGN = 64;
@@ -91,6 +92,25 @@ enum class IoDirection {
   HtoD,      // Host to device
   DtoH,      // Device to host
   DtoD,      // Device to device
+};
+
+// Allocator
+class Allocator {
+ public:
+  static Allocator& Global() {
+    static auto* allocator = new Allocator;
+    return *allocator;
+  }
+
+  void SetCustomAllocator(CustomAllocator custom_allocator) {
+    custom_allocator_ = custom_allocator;
+  }
+
+  CustomAllocator GetCustomAllocator() { return custom_allocator_; }
+
+ private:
+  CustomAllocator custom_allocator_;
+  Allocator() = default;
 };
 
 // This interface should be specified by each kind of target.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Framework
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
API
### Description
<!-- Describe what this PR does -->
新增外部 API 用于设置 Allocator，其中 PaddleLite 框架传入默认 alignment 值为64，用于Byte alignment，用户可自定义。

使用方法：
```

void* allocfunc(size_t size, size_t alignment) {
  size_t offset = sizeof(void*) + alignment - 1;
  char* p = static_cast<char*>(std::malloc(offset + size));
  // Byte alignment
  void* r = reinterpret_cast<void*>(reinterpret_cast<size_t>(p + offset) &
                                    (~(alignment - 1)));
  static_cast<void**>(r)[-1] = p;
  return r;
}

void freefunc(void* ptr) {
  if (ptr) {
    std::free(static_cast<void**>(ptr)[-1]);
  }
}

```

```
paddle::lite_api::MobileConfig mobile_config;
paddle::lite_api::CustomAllocator custom_allocator;
custom_allocator.alloc = allocfunc;
custom_allocator.free = freefunc;
mobile_config.set_custom_allocator(TARGET(kHost), custom_allocator);
```
