### PR TITLE
[XPU] Support several ops on precision of fp16.

### DIFF
--- a/lite/kernels/x86/calib_compute.cc
+++ b/lite/kernels/x86/calib_compute.cc
@@ -35,6 +35,26 @@ void CalibComputeFp32ToInt8<Ptype, DLType>::Run() {
 }
 
 template <PrecisionType Ptype, DataLayoutType DLType>
+void CalibComputeFp32ToFp16<Ptype, DLType>::Run() {
+  auto& param = this->template Param<operators::CalibParam>();
+  const auto* din = param.input->template data<float>();
+  auto* dout = param.output->template mutable_data<float16>();
+  for (auto i = 0; i < param.input->numel(); ++i) {
+    dout[i] = static_cast<float16>(din[i]);
+  }
+}
+
+template <PrecisionType Ptype, DataLayoutType DLType>
+void CalibComputeFp16ToFp32<Ptype, DLType>::Run() {
+  auto& param = this->template Param<operators::CalibParam>();
+  const auto* din = param.input->template data<float16>();
+  auto* dout = param.output->template mutable_data<float>();
+  for (auto i = 0; i < param.input->numel(); ++i) {
+    dout[i] = static_cast<float>(din[i]);
+  }
+}
+
+template <PrecisionType Ptype, DataLayoutType DLType>
 void CalibComputeInt64ToInt32<Ptype, DLType>::Run() {
   auto& param = this->template Param<operators::CalibParam>();
   const auto* din = param.input->template data<int64_t>();
@@ -78,6 +98,26 @@ template <PrecisionType Ptype, DataLayoutType DLType>
 void CalibComputeFp32ToInt32<Ptype, DLType>::Run() {
   auto& param = this->template Param<operators::CalibParam>();
   const auto* din = param.input->template data<float>();
+  auto* dout = param.output->template mutable_data<int32_t>();
+  for (auto i = 0; i < param.input->numel(); ++i) {
+    dout[i] = static_cast<int32_t>(din[i]);
+  }
+}
+
+template <PrecisionType Ptype, DataLayoutType DLType>
+void CalibComputeInt32ToFp16<Ptype, DLType>::Run() {
+  auto& param = this->template Param<operators::CalibParam>();
+  const auto* din = param.input->template data<int32_t>();
+  auto* dout = param.output->template mutable_data<float16>();
+  for (auto i = 0; i < param.input->numel(); ++i) {
+    dout[i] = static_cast<float16>(din[i]);
+  }
+}
+
+template <PrecisionType Ptype, DataLayoutType DLType>
+void CalibComputeFp16ToInt32<Ptype, DLType>::Run() {
+  auto& param = this->template Param<operators::CalibParam>();
+  const auto* din = param.input->template data<float16>();
   auto* dout = param.output->template mutable_data<int32_t>();
   for (auto i = 0; i < param.input->numel(); ++i) {
     dout[i] = static_cast<int32_t>(din[i]);
@@ -171,6 +211,23 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kFloat))})
     .Finalize();
 
+typedef paddle::lite::kernels::x86::CalibComputeFp32ToFp16<PRECISION(kFloat),
+                                                           DATALAYOUT(kNCHW)>
+    fp_fp32_to_fp16;
+REGISTER_LITE_KERNEL(calib, kX86, kFloat, kNCHW, fp_fp32_to_fp16, fp32_to_fp16)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kFloat))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kFP16))})
+    .Finalize();
+
+typedef paddle::lite::kernels::x86::CalibComputeFp16ToFp32<PRECISION(kFP16),
+                                                           DATALAYOUT(kNCHW)>
+    fp16_fp16_to_fp32;
+REGISTER_LITE_KERNEL(calib, kX86, kFP16, kNCHW, fp16_fp16_to_fp32, fp16_to_fp32)
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kFloat))})
+    .Finalize();
+
 REGISTER_LITE_KERNEL(
     calib_once, kX86, kInt8, kNCHW, i8_fp32_to_int8, fp32_to_int8)
     .BindInput("Input",
@@ -222,4 +279,22 @@ REGISTER_LITE_KERNEL(
     .BindInput("Input",
                {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kFloat))})
+    .Finalize();
+
+typedef paddle::lite::kernels::x86::CalibComputeInt32ToFp16<PRECISION(kFloat),
+                                                            DATALAYOUT(kNCHW)>
+    fp_int32_to_fp16;
+REGISTER_LITE_KERNEL(
+    calib, kX86, kFloat, kNCHW, fp_int32_to_fp16, int32_to_fp16)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kFP16))})
+    .Finalize();
+typedef paddle::lite::kernels::x86::CalibComputeFp16ToInt32<PRECISION(kFloat),
+                                                            DATALAYOUT(kNCHW)>
+    fp_fp16_to_int32;
+REGISTER_LITE_KERNEL(
+    calib, kX86, kFloat, kNCHW, fp_fp16_to_int32, fp16_to_int32)
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kX86), PRECISION(kInt32))})
     .Finalize();

--- a/lite/kernels/x86/calib_compute.h
+++ b/lite/kernels/x86/calib_compute.h
@@ -21,6 +21,7 @@ namespace lite {
 namespace kernels {
 namespace x86 {
 
+typedef uint16_t float16;
 template <PrecisionType Ptype, DataLayoutType DLType>
 class CalibComputeFp32ToInt8 : public KernelLite<TARGET(kX86), Ptype, DLType> {
  public:
@@ -29,6 +30,30 @@ class CalibComputeFp32ToInt8 : public KernelLite<TARGET(kX86), Ptype, DLType> {
   void Run() override;
 
   ~CalibComputeFp32ToInt8() override{};
+
+ private:
+};
+
+template <PrecisionType Ptype, DataLayoutType DLType>
+class CalibComputeFp32ToFp16 : public KernelLite<TARGET(kX86), Ptype, DLType> {
+ public:
+  using param_t = operators::CalibParam;
+
+  void Run() override;
+
+  ~CalibComputeFp32ToFp16() override{};
+
+ private:
+};
+
+template <PrecisionType Ptype, DataLayoutType DLType>
+class CalibComputeFp16ToFp32 : public KernelLite<TARGET(kX86), Ptype, DLType> {
+ public:
+  using param_t = operators::CalibParam;
+
+  void Run() override;
+
+  ~CalibComputeFp16ToFp32() override{};
 
  private:
 };
@@ -103,6 +128,29 @@ class CalibComputeInt64ToFp32 : public KernelLite<TARGET(kX86), Ptype, DLType> {
   void Run() override;
 
   ~CalibComputeInt64ToFp32() override{};
+
+ private:
+};
+
+template <PrecisionType Ptype, DataLayoutType DLType>
+class CalibComputeInt32ToFp16 : public KernelLite<TARGET(kX86), Ptype, DLType> {
+ public:
+  using param_t = operators::CalibParam;
+
+  void Run() override;
+
+  ~CalibComputeInt32ToFp16() override{};
+
+ private:
+};
+template <PrecisionType Ptype, DataLayoutType DLType>
+class CalibComputeFp16ToInt32 : public KernelLite<TARGET(kX86), Ptype, DLType> {
+ public:
+  using param_t = operators::CalibParam;
+
+  void Run() override;
+
+  ~CalibComputeFp16ToInt32() override{};
 
  private:
 };

--- a/lite/kernels/xpu/CMakeLists.txt
+++ b/lite/kernels/xpu/CMakeLists.txt
@@ -110,6 +110,8 @@ add_kernel(lod_reset_compute_xpu XPU extra SRCS lod_reset_compute.cc)
 add_kernel(select_input_compute_xpu XPU extra SRCS select_input_compute.cc)
 add_kernel(group_norm_compute_xpu XPU extra SRCS group_norm_compute.cc)
 add_kernel(deformable_conv_compute_xpu XPU extra SRCS deformable_conv_compute.cc)
+add_kernel(sin_compute_xpu XPU extra SRCS sin_compute.cc)
+add_kernel(cos_compute_xpu XPU extra SRCS cos_compute.cc)
 
 # extra(fused kernel)
 add_kernel(__xpu__resnet50_compute_xpu XPU extra SRCS __xpu__resnet50_compute.cc)

--- a/lite/kernels/xpu/activation_compute.cc
+++ b/lite/kernels/xpu/activation_compute.cc
@@ -389,15 +389,6 @@ using siluFP32 =
     paddle::lite::kernels::xpu::SiluCompute<float, PRECISION(kFloat)>;
 using siluFP16 =
     paddle::lite::kernels::xpu::SiluCompute<float16, PRECISION(kFP16)>;
-REGISTER_LITE_KERNEL(silu, kXPU, kFloat, kNCHW, siluFP32, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU))})
-    .Finalize();
-REGISTER_LITE_KERNEL(silu, kXPU, kFP16, kNCHW, siluFP16, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU))})
-    .Finalize();
-
 using eluFP32 =
     paddle::lite::kernels::xpu::EluCompute<float, PRECISION(kFloat)>;
 using eluFP16 =
@@ -409,6 +400,14 @@ REGISTER_LITE_KERNEL(elu, kXPU, kFloat, kNCHW, eluFP32, DISABLE_XPU1_eluFP32)
 REGISTER_LITE_KERNEL(elu, kXPU, kFP16, kNCHW, eluFP16, DISABLE_XPU1_eluFP16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .Finalize();
+REGISTER_LITE_KERNEL(silu, kXPU, kFloat, kNCHW, siluFP32, silu_fp32)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .Finalize();
+REGISTER_LITE_KERNEL(silu, kXPU, kFP16, kNCHW, siluFP16, silu_fp16)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(

--- a/lite/kernels/xpu/calib_compute.cc
+++ b/lite/kernels/xpu/calib_compute.cc
@@ -113,6 +113,29 @@ using xpu_calib_fp32_to_fp16 =
 using xpu_calib_fp16_to_fp32 =
     paddle::lite::kernels::xpu::CalibCompute<float16, float, PRECISION(kFloat)>;
 
+using xpu_calib_fp32_to_fp16_kfp16 =
+    paddle::lite::kernels::xpu::CalibCompute<float, float16, PRECISION(kFP16)>;
+using xpu_calib_fp16_to_fp32_kfp16 =
+    paddle::lite::kernels::xpu::CalibCompute<float16, float, PRECISION(kFP16)>;
+
+using xpu_calib_int64_to_fp16 =
+    paddle::lite::kernels::xpu::CalibCompute<int64_t,
+                                             float16,
+                                             PRECISION(kFP16)>;
+using xpu_calib_fp16_to_int64 =
+    paddle::lite::kernels::xpu::CalibCompute<float16,
+                                             int64_t,
+                                             PRECISION(kFP16)>;
+
+using xpu_calib_int32_to_fp16 =
+    paddle::lite::kernels::xpu::CalibCompute<int32_t,
+                                             float16,
+                                             PRECISION(kFP16)>;
+using xpu_calib_fp16_to_int32 =
+    paddle::lite::kernels::xpu::CalibCompute<float16,
+                                             int32_t,
+                                             PRECISION(kFP16)>;
+
 REGISTER_LITE_KERNEL(
     calib, kXPU, kFloat, kNCHW, xpu_calib_int64_to_int32, calib_int64_to_int32)
     .BindInput("Input",
@@ -138,6 +161,45 @@ REGISTER_LITE_KERNEL(
     calib, kXPU, kFloat, kNCHW, xpu_calib_fp16_to_fp32, calib_fp16_to_fp32)
     .BindInput("Input", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFloat))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    calib, kXPU, kFP16, kNCHW, xpu_calib_fp16_to_fp32_kfp16, calib_fp16_to_fp32)
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFloat))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    calib, kXPU, kFP16, kNCHW, xpu_calib_fp32_to_fp16_kfp16, calib_fp32_to_fp16)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFloat))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    calib, kXPU, kFP16, kNCHW, xpu_calib_int64_to_fp16, calib_int64_to_fp16)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt64))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    calib, kXPU, kFP16, kNCHW, xpu_calib_fp16_to_int64, calib_fp16_to_int64)
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt64))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    calib, kXPU, kFP16, kNCHW, xpu_calib_int32_to_fp16, calib_int32_to_fp16)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    calib, kXPU, kFP16, kNCHW, xpu_calib_fp16_to_int32, calib_fp16_to_int32)
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(calib_once,
@@ -173,6 +235,27 @@ REGISTER_LITE_KERNEL(
     calib_once, kXPU, kFloat, kNCHW, xpu_calib_fp16_to_fp32, calib_fp16_to_fp32)
     .BindInput("Input", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFloat))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(calib_once,
+                     kXPU,
+                     kFP16,
+                     kNCHW,
+                     xpu_calib_int64_to_fp16,
+                     calib_int64_to_fp16)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt64))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(calib_once,
+                     kXPU,
+                     kFP16,
+                     kNCHW,
+                     xpu_calib_fp16_to_int64,
+                     calib_fp16_to_int64)
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt64))})
     .Finalize();
 
 using xpu_calib_fp32_to_int8 =

--- a/lite/kernels/xpu/cos_compute.cc
+++ b/lite/kernels/xpu/cos_compute.cc
@@ -1,0 +1,54 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/xpu/cos_compute.h"
+#include "lite/backends/xpu/xpu_header_sitter.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace xpu {
+
+template <typename T, PrecisionType PType>
+void CosCompute<T, PType>::Run() {
+  auto& param = this->template Param<param_t>();
+  auto& ctx = this->ctx_->template As<XPUContext>();
+
+  int r = xdnn::cos(ctx.GetRawContext(),
+                    param.X->template data<T>(),
+                    param.Out->template mutable_data<T>(TARGET(kXPU)),
+                    param.X->numel());
+  CHECK_EQ(r, 0);
+}
+
+}  // namespace xpu
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+namespace xpu = paddle::lite::kernels::xpu;
+
+using cosFP32 =
+    paddle::lite::kernels::xpu::CosCompute<float, PRECISION(kFloat)>;
+using cosFP16 =
+    paddle::lite::kernels::xpu::CosCompute<float16, PRECISION(kFP16)>;
+REGISTER_LITE_KERNEL(cos, kXPU, kFloat, kNCHW, cosFP32, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .Finalize();
+REGISTER_LITE_KERNEL(cos, kXPU, kFP16, kNCHW, cosFP16, cosFP16)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();

--- a/lite/kernels/xpu/cos_compute.h
+++ b/lite/kernels/xpu/cos_compute.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <vector>
 #include "lite/core/kernel.h"
 
 namespace paddle {
@@ -22,14 +21,14 @@ namespace lite {
 namespace kernels {
 namespace xpu {
 
-template <typename T, PrecisionType PType>
-class SliceCompute : public KernelLite<TARGET(kXPU), PType, DATALAYOUT(kAny)> {
+template <typename InType, PrecisionType PType>
+class CosCompute : public KernelLite<TARGET(kXPU), PType> {
  public:
-  using param_t = operators::SliceParam;
+  using param_t = operators::CosParam;
 
   virtual void Run();
 
-  virtual ~SliceCompute() = default;
+  virtual ~CosCompute() = default;
 };
 
 }  // namespace xpu

--- a/lite/kernels/xpu/sin_compute.cc
+++ b/lite/kernels/xpu/sin_compute.cc
@@ -1,0 +1,54 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/kernels/xpu/sin_compute.h"
+#include "lite/backends/xpu/xpu_header_sitter.h"
+#include "lite/core/op_registry.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace xpu {
+
+template <typename T, PrecisionType PType>
+void SinCompute<T, PType>::Run() {
+  auto& param = this->template Param<param_t>();
+  auto& ctx = this->ctx_->template As<XPUContext>();
+
+  int r = xdnn::sin(ctx.GetRawContext(),
+                    param.X->template data<T>(),
+                    param.Out->template mutable_data<T>(TARGET(kXPU)),
+                    param.X->numel());
+  CHECK_EQ(r, 0);
+}
+
+}  // namespace xpu
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+namespace xpu = paddle::lite::kernels::xpu;
+
+using sinFP32 =
+    paddle::lite::kernels::xpu::SinCompute<float, PRECISION(kFloat)>;
+using sinFP16 =
+    paddle::lite::kernels::xpu::SinCompute<float16, PRECISION(kFP16)>;
+REGISTER_LITE_KERNEL(sin, kXPU, kFloat, kNCHW, sinFP32, def)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .Finalize();
+REGISTER_LITE_KERNEL(sin, kXPU, kFP16, kNCHW, sinFP16, sinFP16)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();

--- a/lite/kernels/xpu/sin_compute.h
+++ b/lite/kernels/xpu/sin_compute.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <vector>
 #include "lite/core/kernel.h"
 
 namespace paddle {
@@ -22,14 +21,14 @@ namespace lite {
 namespace kernels {
 namespace xpu {
 
-template <typename T, PrecisionType PType>
-class SliceCompute : public KernelLite<TARGET(kXPU), PType, DATALAYOUT(kAny)> {
+template <typename InType, PrecisionType PType>
+class SinCompute : public KernelLite<TARGET(kXPU), PType> {
  public:
-  using param_t = operators::SliceParam;
+  using param_t = operators::SinParam;
 
   virtual void Run();
 
-  virtual ~SliceCompute() = default;
+  virtual ~SinCompute() = default;
 };
 
 }  // namespace xpu

--- a/lite/kernels/xpu/slice_compute.cc
+++ b/lite/kernels/xpu/slice_compute.cc
@@ -130,8 +130,8 @@ inline std::vector<int> GetIntDataFromTensor(const Tensor* tensor) {
   return vec_data;
 }
 
-template <class T>
-void SliceCompute<T>::Run() {
+template <typename T, PrecisionType PType>
+void SliceCompute<T, PType>::Run() {
   auto& param = this->template Param<param_t>();
   auto& ctx = this->ctx_->template As<XPUContext>();
 
@@ -260,7 +260,8 @@ void SliceCompute<T>::Run() {
 }  // namespace lite
 }  // namespace paddle
 
-using SliceFloat32 = paddle::lite::kernels::xpu::SliceCompute<float>;
+using SliceFloat32 =
+    paddle::lite::kernels::xpu::SliceCompute<float, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceFloat32, def)
     .BindInput("Input",
                {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFloat))})
@@ -275,7 +276,8 @@ REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceFloat32, def)
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFloat))})
     .Finalize();
 
-using SliceFloat32 = paddle::lite::kernels::xpu::SliceCompute<float>;
+using SliceFloat32 =
+    paddle::lite::kernels::xpu::SliceCompute<float, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceFloat32, array_def)
     .BindInput("Input",
                {LiteType::GetTensorListTy(TARGET(kXPU), PRECISION(kFloat))})
@@ -290,7 +292,39 @@ REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceFloat32, array_def)
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFloat))})
     .Finalize();
 
-using SliceInt32 = paddle::lite::kernels::xpu::SliceCompute<int32_t>;
+using SliceFloat16 =
+    paddle::lite::kernels::xpu::SliceCompute<float16, PRECISION(kFP16)>;
+REGISTER_LITE_KERNEL(slice, kXPU, kFP16, kAny, SliceFloat16, float16)
+    .BindInput("Input", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindInput("StartsTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();
+
+using SliceFloat16 =
+    paddle::lite::kernels::xpu::SliceCompute<float16, PRECISION(kFP16)>;
+REGISTER_LITE_KERNEL(slice, kXPU, kFP16, kAny, SliceFloat16, array_float16)
+    .BindInput("Input",
+               {LiteType::GetTensorListTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindInput("StartsTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();
+
+using SliceInt32 =
+    paddle::lite::kernels::xpu::SliceCompute<int32_t, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceInt32, int32)
     .BindInput("Input",
                {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
@@ -305,7 +339,8 @@ REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceInt32, int32)
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
     .Finalize();
 
-using SliceInt32 = paddle::lite::kernels::xpu::SliceCompute<int32_t>;
+using SliceInt32 =
+    paddle::lite::kernels::xpu::SliceCompute<int32_t, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceInt32, array_int32)
     .BindInput("Input",
                {LiteType::GetTensorListTy(TARGET(kXPU), PRECISION(kInt32))})
@@ -320,7 +355,8 @@ REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceInt32, array_int32)
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
     .Finalize();
 
-using SliceInt64 = paddle::lite::kernels::xpu::SliceCompute<int64_t>;
+using SliceInt64 =
+    paddle::lite::kernels::xpu::SliceCompute<int64_t, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceInt64, int64)
     .BindInput("Input",
                {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt64))})
@@ -335,7 +371,8 @@ REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceInt64, int64)
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt64))})
     .Finalize();
 
-using SliceInt64 = paddle::lite::kernels::xpu::SliceCompute<int64_t>;
+using SliceInt64 =
+    paddle::lite::kernels::xpu::SliceCompute<int64_t, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceInt64, array_int64)
     .BindInput("Input",
                {LiteType::GetTensorListTy(TARGET(kXPU), PRECISION(kInt64))})

--- a/lite/tests/kernels/activation_compute_test.cc
+++ b/lite/tests/kernels/activation_compute_test.cc
@@ -415,7 +415,7 @@ void TestAct(const Place& place,
              float abs_error = 2e-5) {
   std::unique_ptr<arena::TestCase> tester(
       new ActivationComputeTester<T>(place,
-                                     "def",
+                                     alias,
                                      leaky_relu_alpha,
                                      relu_clipped_coef,
                                      prelu_mode,
@@ -687,17 +687,21 @@ TEST(Activation_sigmoid, precision) {
 TEST(Activation_silu, precision) {
   Place place;
   float abs_error = 2e-5;
+  std::string alias = "def";
   std::vector<std::vector<int64_t>> test_dims{
       {1, 3, 2, 4}, {2, 3, 4}, {5, 4}, {8}};
 #if defined(LITE_WITH_ARM)
   place = TARGET(kARM);
+#elif defined(LITE_WITH_XPU)
+  place = TARGET(kXPU);
+  alias = "silu_fp32";
+  abs_error = 2e-4;
 #else
   return;
 #endif
-
   for (auto dims : test_dims) {
     TestAct(place,
-            "def",
+            alias,
             0.01,
             6.,
             "all",
@@ -1463,7 +1467,7 @@ TEST(Activation_sigmoid_fp32, precision) {
 
   for (auto dims : test_dims) {
     TestAct(place,
-            "sigmoid_fp32_precision",
+            "def",
             0.01,
             6.,
             "all",
@@ -1614,7 +1618,7 @@ TEST(Activation_sigmoid_fp16, precision) {
       {1, 3, 4, 5}, {1, 3, 5}, {5, 4}, {8}};
   for (auto dims : test_dims) {
     TestAct<float16_t>(place,
-                       "sigmoid_fp16_precision",
+                       "def",
                        0.01,
                        6.,
                        "all",

--- a/lite/tests/kernels/cos_compute_test.cc
+++ b/lite/tests/kernels/cos_compute_test.cc
@@ -74,8 +74,11 @@ void test_sin(Place place) {
 
 TEST(Cos, precision) {
   LOG(INFO) << "test cos op";
-#ifdef LITE_WITH_ARM
+#if defined(LITE_WITH_ARM)
   Place place(TARGET(kHost));
+  test_sin(place);
+#elif defined(LITE_WITH_XPU)
+  Place place(TARGET(kXPU), PRECISION(kFloat));
   test_sin(place);
 #endif
 }

--- a/lite/tests/kernels/sin_compute_test.cc
+++ b/lite/tests/kernels/sin_compute_test.cc
@@ -81,6 +81,9 @@ TEST(Sin, precision) {
 #elif defined(LITE_WITH_ARM)
   Place place(TARGET(kHost));
   test_sin(place);
+#elif defined(LITE_WITH_XPU)
+  Place place(TARGET(kXPU), PRECISION(kFloat));
+  test_sin(place);
 #endif
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
OP 
### Description
<!-- Describe what this PR does -->
Add silu/sin/cos/slice ops for fp16 precision on XPU backend.