### PR TITLE
add fp16 kernel for instance_norm/pad2d on xpu && fix bug in _xpu__co…

### DIFF
--- a/lite/core/optimizer/mir/fusion/__xpu__conv2d_transpose_fuse_pass.cc
+++ b/lite/core/optimizer/mir/fusion/__xpu__conv2d_transpose_fuse_pass.cc
@@ -303,6 +303,11 @@ class XPUConv2dTransFuser : public FuseBase {
           "padding_algorithm",
           conv_op_desc->GetAttr<std::string>("padding_algorithm"));
     }
+    if ((conv_op_desc->HasAttr("output_size"))) {
+      op_desc.SetAttr<std::vector<int>>(
+          "output_size",
+          conv_op_desc->GetAttr<std::vector<int>>("output_size"));
+    }
     op_desc.SetAttr<int>("groups", conv_op_desc->GetAttr<int>("groups"));
     op_desc.SetAttr<std::vector<int>>(
         "paddings", conv_op_desc->GetAttr<std::vector<int>>("paddings"));
@@ -357,7 +362,7 @@ class XPUConv2dTransFusePass : public ProgramPass {
     for (auto with_conv_bias : {true, false}) {
       for (auto with_ew_bias : {true, false}) {
         for (auto with_bn : {true, false}) {
-          for (auto act_type : {"relu"}) {
+          for (auto act_type : {"relu", "linear"}) {
             fusion::XPUConv2dTransFuser fuser(
                 act_type, with_conv_bias, with_ew_bias, with_bn);
             fuser(graph.get());

--- a/lite/kernels/xpu/instance_norm_compute.cc
+++ b/lite/kernels/xpu/instance_norm_compute.cc
@@ -21,7 +21,8 @@ namespace lite {
 namespace kernels {
 namespace xpu {
 
-void InstanceNormCompute::Run() {
+template <typename T, PrecisionType PType>
+void InstanceNormCompute<T, PType>::Run() {
   auto& param = this->template Param<param_t>();
   auto& ctx = this->ctx_->template As<XPUContext>();
   auto x_dims = param.x->dims();
@@ -53,19 +54,20 @@ void InstanceNormCompute::Run() {
     int ret = xdnn::constant<float>(ctx.GetRawContext(), xpu_bias, c, 0.0f);
     CHECK_EQ(ret, 0);
   }
-  int ret = xdnn::instance_norm<float>(
+  int ret = xdnn::instance_norm<T>(
       ctx.GetRawContext(),
-      param.x->data<float>(),
-      param.out->mutable_data<float>(TARGET(kXPU)),
+      param.x->template data<T>(),
+      param.out->template mutable_data<T>(TARGET(kXPU)),
       n,
       c,
       h,
       w,
       param.epsilon,
-      (param.scale == nullptr) ? xpu_scale : param.scale->data<float>(),
-      (param.bias == nullptr) ? xpu_bias : param.bias->data<float>(),
-      param.saved_mean->mutable_data<float>(TARGET(kXPU)),
-      param.saved_variance->mutable_data<float>(TARGET(kXPU)),
+      (param.scale == nullptr) ? xpu_scale
+                               : param.scale->template data<float>(),
+      (param.bias == nullptr) ? xpu_bias : param.bias->template data<float>(),
+      param.saved_mean->template mutable_data<float>(TARGET(kXPU)),
+      param.saved_variance->template mutable_data<float>(TARGET(kXPU)),
       true);
   CHECK_EQ(ret, 0);
 }
@@ -75,16 +77,26 @@ void InstanceNormCompute::Run() {
 }  // namespace lite
 }  // namespace paddle
 
-REGISTER_LITE_KERNEL(instance_norm,
-                     kXPU,
-                     kFloat,
-                     kNCHW,
-                     paddle::lite::kernels::xpu::InstanceNormCompute,
-                     def)
+namespace xpu = paddle::lite::kernels::xpu;
+
+using InstanceNorm_FP32 = xpu::InstanceNormCompute<float, PRECISION(kFloat)>;
+using InstanceNorm_FP16 = xpu::InstanceNormCompute<float16, PRECISION(kFP16)>;
+
+REGISTER_LITE_KERNEL(instance_norm, kXPU, kFloat, kNCHW, InstanceNorm_FP32, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU))})
     .BindInput("Scale", {LiteType::GetTensorTy(TARGET(kXPU))})
     .BindInput("Bias", {LiteType::GetTensorTy(TARGET(kXPU))})
     .BindOutput("Y", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .BindOutput("SavedMean", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .BindOutput("SavedVariance", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(
+    instance_norm, kXPU, kFP16, kNCHW, InstanceNorm_FP16, DISABLE_XPU1_fp16)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindInput("Scale", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .BindInput("Bias", {LiteType::GetTensorTy(TARGET(kXPU))})
+    .BindOutput("Y", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
     .BindOutput("SavedMean", {LiteType::GetTensorTy(TARGET(kXPU))})
     .BindOutput("SavedVariance", {LiteType::GetTensorTy(TARGET(kXPU))})
     .Finalize();

--- a/lite/kernels/xpu/instance_norm_compute.h
+++ b/lite/kernels/xpu/instance_norm_compute.h
@@ -21,7 +21,8 @@ namespace lite {
 namespace kernels {
 namespace xpu {
 
-class InstanceNormCompute : public KernelLite<TARGET(kXPU), PRECISION(kFloat)> {
+template <typename T, PrecisionType PType>
+class InstanceNormCompute : public KernelLite<TARGET(kXPU), PType> {
  public:
   using param_t = operators::InstanceNormParam;
 

--- a/lite/kernels/xpu/pad2d_compute.h
+++ b/lite/kernels/xpu/pad2d_compute.h
@@ -21,8 +21,8 @@ namespace lite {
 namespace kernels {
 namespace xpu {
 
-template <class T>
-class Pad2dCompute : public KernelLite<TARGET(kXPU), PRECISION(kFloat)> {
+template <typename T, PrecisionType PType>
+class Pad2dCompute : public KernelLite<TARGET(kXPU), PType> {
  public:
   using param_t = operators::Pad2dParam;
 

--- a/lite/operators/pad_op.cc
+++ b/lite/operators/pad_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lite/operators/pad_op.h
+++ b/lite/operators/pad_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
PASS Kernels

### Description
<!-- Describe what this PR does -->
1、add fp16 kernel for instance_norm/pad2d on xpu
2、conv2d_transpose and ew_add cannot be fused when there is no activation
