### PR TITLE
[Cherry-pick][release/v2.12] Update set model from buffer api

### DIFF
--- a/lite/api/light_api.h
+++ b/lite/api/light_api.h
@@ -44,12 +44,20 @@ class LITE_API LightPredictor {
   // model file or buffer,`model_from_memory` refers to whther to load model
   // from memory.
   LightPredictor(const std::string& lite_model_file,
-                 bool model_from_memory = false,
                  bool use_low_precision = false) {
     use_low_precision_ = use_low_precision;
     scope_ = std::make_shared<Scope>();
     program_desc_ = std::make_shared<cpp::ProgramDesc>();
-    Build(lite_model_file, model_from_memory);
+    Build(lite_model_file);
+  }
+
+  LightPredictor(const char* lite_model_buffer_ptr,
+                 size_t lite_model_buffer_size,
+                 bool use_low_precision = false) {
+    use_low_precision_ = use_low_precision;
+    scope_ = std::make_shared<Scope>();
+    program_desc_ = std::make_shared<cpp::ProgramDesc>();
+    Build(lite_model_buffer_ptr, lite_model_buffer_size);
   }
 
   // NOTE: This is a deprecated API and will be removed in latter release.
@@ -118,8 +126,8 @@ class LITE_API LightPredictor {
   // would be called in Run().
   void CheckInputValid();
 
-  void Build(const std::string& lite_model_file,
-             bool model_from_memory = false);
+  void Build(const std::string& lite_model_file);
+  void Build(const char* lite_model_buffer_ptr, size_t lite_model_buffer_size);
 
   // NOTE: This is a deprecated API and will be removed in latter release.
   void Build(

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -688,7 +688,8 @@ void MobileConfig::set_model_from_buffer(std::string &&x) {
 }
 
 void MobileConfig::set_model_from_buffer(const char *buffer, size_t length) {
-  lite_model_file_.assign(buffer, length);
+  lite_model_buffer_ptr_ = buffer;
+  lite_model_buffer_size_ = length;
   model_from_memory_ = true;
 }
 

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -534,8 +534,11 @@ class LITE_API MobileConfig : public ConfigBase {
   bool model_from_memory_{false};
   PrecisionMode precision_mode_{LITE_PRECISION_NORMAL};
 
-  // model data readed from file or memory buffer in combined format.
+  // model data readed from file in combined format.
   std::string lite_model_file_;
+  // model data readed from memory buffer in combined format.
+  const char* lite_model_buffer_ptr_ = nullptr;
+  size_t lite_model_buffer_size_{0};
 
   // NOTE: This is a deprecated variable and will be removed in latter release.
   std::string model_buffer_;
@@ -551,16 +554,15 @@ class LITE_API MobileConfig : public ConfigBase {
   void set_model_from_buffer(const char* buffer, size_t length);
   void set_precision_mode(PrecisionMode mode) { precision_mode_ = mode; }
   PrecisionMode precision_mode() const { return precision_mode_; }
-  // return model data in lite_model_file_, which is in combined format.
+  // return model file path.
   const std::string& lite_model_file() const { return lite_model_file_; }
+  // return model buffer data, which is in combined format.
+  const char* lite_model_buffer_ptr() const { return lite_model_buffer_ptr_; }
+  size_t lite_model_buffer_size() const { return lite_model_buffer_size_; }
 
   // return model_from_memory_, which indicates whether to load model from
   // memory buffer.
   bool is_model_from_memory() const { return model_from_memory_; }
-  // note: `model_from_memory` has the same effect as `is_model_from_memory`,
-  // but is_model_from_memory is recommended and `model_from_memory` will be
-  // abandoned in v3.0.
-  bool model_from_memory() const { return model_from_memory_; }
 
   // NOTE: This is a deprecated API and will be removed in latter release.
   void set_model_buffer(const char* model_buffer,

--- a/lite/core/model/base/io.cc
+++ b/lite/core/model/base/io.cc
@@ -69,6 +69,12 @@ void StringBufferReader::Read(void* dst, size_t size) const {
   cur_ += size;
 }
 
+void CharBufferReader::Read(void* dst, size_t size) const {
+  CHECK(dst);
+  lite::TargetCopy(TargetType::kHost, dst, buf_ + cur_, size);
+  cur_ += size;
+}
+
 }  // namespace model_parser
 }  // namespace lite
 }  // namespace paddle

--- a/lite/core/model/base/io.h
+++ b/lite/core/model/base/io.h
@@ -198,6 +198,24 @@ class StringBufferReader : public ByteReader {
   mutable size_t cur_{0};
 };
 
+class CharBufferReader : public ByteReader {
+ public:
+  explicit CharBufferReader(const char* buffer, size_t length)
+      : buf_(buffer), length_(length) {
+    CHECK(buf_);
+  }
+  ~CharBufferReader() = default;
+  void Read(void* dst, size_t size) const override;
+  bool ReachEnd() const override { return cur_ >= length_; }
+  size_t length() const override { return length_; }
+  size_t current() const override { return cur_; }
+
+ private:
+  const char* buf_;
+  size_t length_;
+  mutable size_t cur_{0};
+};
+
 }  // namespace model_parser
 }  // namespace lite
 }  // namespace paddle

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "lite/model_parser/model_parser.h"
+
 #include <algorithm>
 #include <fstream>
 #include <limits>
@@ -29,6 +30,7 @@
 #include "lite/model_parser/pb/tensor_io.h"
 #ifndef LITE_ON_TINY_PUBLISH
 #include <cstdio>
+
 #include "lite/model_parser/naive_buffer/combined_params_desc.h"
 #include "lite/model_parser/naive_buffer/param_desc.h"
 #include "lite/model_parser/naive_buffer/program_desc.h"
@@ -737,7 +739,7 @@ void LoadModelNaiveFromMemory(const std::string &model_buffer,
  *      topo_size:    length of `topo_data`.
  *      topo_data:    contains model's topology data.
  *      param_data:   contains model's params data.
-*/
+ */
 
 void LoadModelNaiveFromFile(const std::string &filename,
                             Scope *scope,
@@ -898,7 +900,8 @@ void LoadModelFbsFromFile(model_parser::BinaryFileReader *reader,
   }
 }
 
-void LoadModelNaiveFromMemory(const std::string &model_buffer,
+void LoadModelNaiveFromMemory(const char *model_buffer,
+                              size_t model_buffer_size,
                               Scope *scope,
                               cpp::ProgramDesc *cpp_prog) {
   CHECK(cpp_prog);
@@ -907,7 +910,7 @@ void LoadModelNaiveFromMemory(const std::string &model_buffer,
 
   // (1)get meta version
   uint16_t meta_version;
-  model_parser::StringBufferReader reader(model_buffer);
+  model_parser::CharBufferReader reader(model_buffer, model_buffer_size);
   reader.Read(&meta_version, sizeof(uint16_t));
   VLOG(4) << "Meta_version:" << meta_version;
 
@@ -933,6 +936,7 @@ void LoadModelNaiveFromMemory(const std::string &model_buffer,
       break;
   }
 }
+
 #ifndef LITE_ON_TINY_PUBLISH
 void LoadModelNaiveV0FromMemory(const std::string &model_buffer,
                                 Scope *scope,
@@ -973,7 +977,7 @@ void LoadModelNaiveV0FromMemory(const std::string &model_buffer,
 ///////////////////////////////////////////////////////////////////
 // Meta_version=1,2
 ///////////////////////////////////////////////////////////////////
-void LoadModelFbsFromMemory(model_parser::StringBufferReader *reader,
+void LoadModelFbsFromMemory(model_parser::CharBufferReader *reader,
                             Scope *scope,
                             cpp::ProgramDesc *cpp_prog,
                             uint16_t meta_version) {

--- a/lite/model_parser/model_parser.h
+++ b/lite/model_parser/model_parser.h
@@ -148,10 +148,11 @@ void LoadModelNaiveFromFile(const std::string& filename,
                             lite::Scope* scope,
                             cpp::ProgramDesc* prog);
 
-void LoadModelNaiveFromMemory(const std::string& model_buffer,
+void LoadModelNaiveFromMemory(const char* model_buffer,
+                              size_t model_buffer_size,
                               lite::Scope* scope,
                               cpp::ProgramDesc* cpp_prog);
-void LoadModelFbsFromMemory(model_parser::StringBufferReader* reader,
+void LoadModelFbsFromMemory(model_parser::CharBufferReader* reader,
                             Scope* scope,
                             cpp::ProgramDesc* cpp_prog,
                             uint16_t meta_version);

--- a/lite/model_parser/model_parser_test.cc
+++ b/lite/model_parser/model_parser_test.cc
@@ -136,7 +136,8 @@ TEST(ModelParser, LoadModelNaiveFromMemory) {
 
   auto model_path = std::string(FLAGS_model_dir) + ".saved.nb";
   std::string model_buffer = lite::ReadFile(model_path);
-  LoadModelNaiveFromMemory(model_buffer, &scope, &prog);
+  LoadModelNaiveFromMemory(
+      model_buffer.c_str(), model_buffer.length(), &scope, &prog);
 }
 
 }  // namespace lite


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Framework
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
API
### Description
<!-- Describe what this PR does -->
之前的 set_model_from_buffer 内部存储会使用 std::string 数据结构，会将传入的 buffer 再拷贝构造一份，造成内存上的重复消耗。
目前改为 const char* 进行数据传递，buffer 的内存释放由用户侧管理。