### PR TITLE
[xpu] add kernel pick info init to init of XPUStaticKernelPickPass

### DIFF
--- a/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
+++ b/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
@@ -54,7 +54,7 @@ class XPUStaticKernelPickPass : public mir::StmtPass {
  private:
   void Init() {
 #ifdef LITE_WITH_XPU
-    // clear kernel pick info
+    // clear kernel pick info to avoid crash when init two models respectively
     xpu_input_type_.clear();
     xpu_output_type_.clear();
     xpu_special_op_.clear();

--- a/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
+++ b/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
@@ -54,6 +54,12 @@ class XPUStaticKernelPickPass : public mir::StmtPass {
  private:
   void Init() {
 #ifdef LITE_WITH_XPU
+    // clear kernel pick info at first
+    xpu_input_type_.clear();
+    xpu_output_type_.clear();
+    xpu_special_op_.clear();
+    xpu_use_int8_optimizer_ = false;
+    xpu_use_fp16_optimizer_ = false;
     // get xpu device type
     int cur_dev_idx = 0;
     uint64_t cur_dev_attr = 0;

--- a/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
+++ b/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
@@ -54,7 +54,7 @@ class XPUStaticKernelPickPass : public mir::StmtPass {
  private:
   void Init() {
 #ifdef LITE_WITH_XPU
-    // clear kernel pick info at first
+    // clear kernel pick info
     xpu_input_type_.clear();
     xpu_output_type_.clear();
     xpu_special_op_.clear();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### XPU
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->

### BUG fixes
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->

### PASS
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->

### To avoid crash when initializing a fp16 and a int8 model respectively
<!-- Describe what this PR does -->
