### PR TITLE
[ARM] fix cast op when fp16_to_int32

### DIFF
--- a/lite/kernels/host/cast_compute.cc
+++ b/lite/kernels/host/cast_compute.cc
@@ -35,6 +35,11 @@ void CastCompute::Run() {
   if (param.X->precision() == PrecisionType::kFloat) {
     param.in_dtype = 5;
   }
+#if defined(ENABLE_ARM_FP16) && defined(LITE_WITH_ARM)
+  if (param.X->precision() == PrecisionType::kFP16) {
+    param.in_dtype = 4;
+  }
+#endif
   // BOOL = 0;INT16 = 1;INT32 = 2;INT64 = 3;FP16 = 4;FP32 = 5;FP64 = 6;
   // SIZE_T = 19;UINT8 = 20;INT8 = 21;
   if (param.in_dtype == param.out_dtype && param.in_dtype == 5) {
@@ -148,6 +153,13 @@ void CastCompute::Run() {
     const float* in_data = param.X->data<float>();
     float16_t* out_data = param.Out->mutable_data<float16_t>();
     lite::arm::math::fp16::fp32_to_fp16(in_data, out_data, param.X->numel());
+  } else if (param.in_dtype == 4 &&
+             param.out_dtype == 2) {  // float16 -> int32
+    const float16_t* in_data = param.X->data<float16_t>();
+    int* out_data = param.Out->mutable_data<int>();
+    for(int i = 0; i < param.X->numel(); i++) {
+      out_data[i] = static_cast<int>(in_data[i]);
+    }
 #endif
   } else {
     LOG(FATAL) << "other has not been implemented transform with dtype"

--- a/lite/kernels/host/cast_compute.cc
+++ b/lite/kernels/host/cast_compute.cc
@@ -153,11 +153,10 @@ void CastCompute::Run() {
     const float* in_data = param.X->data<float>();
     float16_t* out_data = param.Out->mutable_data<float16_t>();
     lite::arm::math::fp16::fp32_to_fp16(in_data, out_data, param.X->numel());
-  } else if (param.in_dtype == 4 &&
-             param.out_dtype == 2) {  // float16 -> int32
+  } else if (param.in_dtype == 4 && param.out_dtype == 2) {  // float16 -> int32
     const float16_t* in_data = param.X->data<float16_t>();
     int* out_data = param.Out->mutable_data<int>();
-    for(int i = 0; i < param.X->numel(); i++) {
+    for (int i = 0; i < param.X->numel(); i++) {
       out_data[i] = static_cast<int>(in_data[i]);
     }
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Arm
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Backends
### Description
<!-- Describe what this PR does -->
新增elementwise_div fp16实现后，cast的in_dtype并不会改成fp16的enum值，导致cast以fp32去读fp16
<img width="952" alt="86db1b0ba1827449f96409d07a8e0d10" src="https://user-images.githubusercontent.com/54735487/224216948-05dbfc23-c797-4586-994f-c72a5f9e5126.png">
