### PR TITLE
[ARM] Fix query cpu online statue error

### DIFF
--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -527,8 +527,8 @@ bool check_cpu_online(const std::vector<int>& cpu_ids) {
     }
     fclose(fp);
   } else {
-    LOG(WARNING)
-        << "Failed to query all cpus online status list failed. Try to query single cpu online status";
+    LOG(WARNING) << "Failed to query all cpus online status list failed. Try "
+                    "to query single cpu online status";
     char path[256];
     for (int i = 0; i < cpu_ids.size(); ++i) {
       snprintf(path,

--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -528,7 +528,7 @@ bool check_cpu_online(const std::vector<int>& cpu_ids) {
     fclose(fp);
   } else {
     LOG(WARNING)
-        << "Get all cpus online info failed. Try to get single cpu online info";
+        << "Failed to query all cpus online status list failed. Try to query single cpu online status";
     char path[256];
     for (int i = 0; i < cpu_ids.size(); ++i) {
       snprintf(path,
@@ -541,7 +541,7 @@ bool check_cpu_online(const std::vector<int>& cpu_ids) {
         fscanf(fp, "%d", &is_online);
         fclose(fp);
       } else {
-        LOG(ERROR) << "Failed to query the online statue of CPU id:"
+        LOG(ERROR) << "Failed to query the online status of CPU id:"
                    << cpu_ids[i];
       }
       if (is_online == 0) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Arm

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Core

### Description
<!-- Describe what this PR does -->
In some arm devices like raspberry 4B, `/sys/devices/system/cpu/cpux/online` does not exist, so the original query cpu online status method via `/sys/devices/system/cpu/cpux/online` is not valid. This will cause paddle-lite switches to no bind mode even if you set it to any other core bind mode.
Some recent issues with this bug: [issue1](https://github.com/PaddlePaddle/Paddle-Lite/issues/10014) [issue2](https://github.com/PaddlePaddle/Paddle-Lite/issues/8974)

The alternative method is to query `/sys/devices/system/cpu/online` for an online cpu list. Then, check if the used cpu ids are in this list and set the `all_online` flag. Also when this method fails we will roll back to the original method.

At the same time, the original log info has a typo that mistakes `status` for `statue`.