### PR TITLE
[Framework] Move GetAllOps api to paddle_api.h

### DIFF
--- a/lite/api/cxx_api.cc
+++ b/lite/api/cxx_api.cc
@@ -30,10 +30,6 @@
 namespace paddle {
 namespace lite {
 
-std::vector<std::string> GetAllOps() {
-  return OpLiteFactory::Global().GetAllOps();
-}
-
 bool IsQuantizedMode(const std::shared_ptr<cpp::ProgramDesc> &program_desc) {
   const std::vector<std::string> quant_dequant_op = {
       "fake_quantize_abs_max",

--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -36,8 +36,6 @@ static const char TAILORD_KERNELS_SOURCE_LIST_FILENAME[] =
     ".tailored_kernels_source_list";
 static const char TAILORD_KERNELS_LIST_NAME[] = ".tailored_kernels_list";
 
-std::vector<std::string> GetAllOps();
-
 #ifdef LITE_WITH_XPU
 class LoadPredictorConfig {
  public:

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -18,6 +18,7 @@
 
 #include "lite/core/context.h"
 #include "lite/core/device_info.h"
+#include "lite/core/op_registry.h"
 #include "lite/core/target_wrapper.h"
 #include "lite/core/tensor.h"
 
@@ -38,6 +39,10 @@
 
 namespace paddle {
 namespace lite_api {
+
+std::vector<std::string> GetAllOps() {
+  return paddle::lite::OpLiteFactory::Global().GetAllOps();
+}
 
 bool IsOpenCLBackendValid(bool check_fp16_valid) {
 #ifdef LITE_WITH_LOG

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -43,6 +43,9 @@ enum class L3CacheSetMethod {
   // kAutoGrow = 3,   // Not supported yet, least memory consumption.
 };
 
+// Return all supported operators
+LITE_API std::vector<std::string> GetAllOps();
+
 // return true if current device supports OpenCL model
 LITE_API bool IsOpenCLBackendValid(bool check_fp16_valid = false);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Framework
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
API
### Description
<!-- Describe what this PR does -->
背景：当前将 Paddle Inference 集成 Lite 方式从源码集成改为编译库集成，由于 Paddle Inference 需要感知 Lite 已支持的所有算子，而通过引用 paddle_api.h 头文件来调用。见 https://github.com/PaddlePaddle/Paddle/pull/51405
解决方案：将 GetAllOps 暴露至 paddle_api.h 头文件。

$ ./lite/tools/build_linux.sh --arch=armv8 --with_extra=ON --with_cv=ON --with_exception=ON full_publish 编译命令库体积
改动前：
101581886	libpaddle_api_full_bundled.a
101094808	libpaddle_api_light_bundled.a
22147760	libpaddle_full_api_shared.so
17627872	libpaddle_light_api_shared.so

改动后：
101580898	libpaddle_api_full_bundled.a
101096404	libpaddle_api_light_bundled.a
22118992	libpaddle_full_api_shared.so
17602768	libpaddle_light_api_shared.so

$ ./lite/tools/build_linux.sh --arch=armv8 --with_extra=ON --with_cv=ON --with_exception=ON 编译命令库体积
改动前：
3559672	libpaddle_light_api_shared.so
改动后：
3588360	libpaddle_light_api_shared.so