### PR TITLE
[XPU]: Get api_l3_size_res in func.

### DIFF
--- a/lite/backends/xpu/target_wrapper.cc
+++ b/lite/backends/xpu/target_wrapper.cc
@@ -20,8 +20,6 @@
 namespace paddle {
 namespace lite {
 
-const char* API_L3_SIZE_RES_CHAR = std::getenv("API_L3_SIZE_RES");
-
 XPUL3CacheBlock* TargetWrapperXPU::CreateL3CacheBlock() {
   if (xpu_runtime_ptr == nullptr) {
     return nullptr;
@@ -67,10 +65,7 @@ void TargetWrapperXPU::ScatterL3Cache(
   }
   CHECK(xpu_runtime_ptr->xpu_l3_planner);
   size_t total_block_l3_size = 0, xdnn_ctx_l3_size = 0;
-  xpu_runtime_ptr->api_l3_reserve =
-      (API_L3_SIZE_RES_CHAR && atoi(API_L3_SIZE_RES_CHAR) > 0)
-          ? atoi(API_L3_SIZE_RES_CHAR)
-          : 0;
+  xpu_runtime_ptr->api_l3_reserve = GetIntFromEnv("API_L3_SIZE_RES");
 
   // When set "API_L3_SIZE_RES", be careful that it should not be greater than
   // l3_size.
@@ -177,10 +172,7 @@ void TargetWrapperXPU::FreeL3Cache() {
           nullptr, 0));
     }
     if (xpu_runtime_ptr->xpu_local_l3_autotune) {
-      xpu_runtime_ptr->api_l3_reserve =
-          (API_L3_SIZE_RES_CHAR && atoi(API_L3_SIZE_RES_CHAR) > 0)
-              ? atoi(API_L3_SIZE_RES_CHAR)
-              : 0;
+      xpu_runtime_ptr->api_l3_reserve = GetIntFromEnv("API_L3_SIZE_RES");
       CHECK_GT(xpu_runtime_ptr->xpu_local_l3_size,
                xpu_runtime_ptr->api_l3_reserve);
       if (xpu_runtime_ptr->api_l3_reserve) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Backends
### Description
<!-- Describe what this PR does -->
Acquire API_L3_SIZE_RES in function so that paddle_lite_demo can set this env value for specific models