### PR TITLE
[XShape] Xshape is alternative for flatten op

### DIFF
--- a/lite/operators/flatten_op.cc
+++ b/lite/operators/flatten_op.cc
@@ -80,7 +80,6 @@ bool FlattenOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
 
 bool Flatten2Op::CheckShape() const {
   FlattenOp::CheckShape();
-  if (has_xshape_) CHECK(param_.xshape);
   return true;
 }
 
@@ -88,7 +87,7 @@ bool Flatten2Op::InferShapeImpl() const {
   FlattenOp::InferShapeImpl();
   auto x_shape = param_.x->dims().Vectorize();
   x_shape.insert(x_shape.begin(), 0);
-  if (has_xshape_) param_.xshape->Resize(x_shape);
+  if (param_.xshape) param_.xshape->Resize(x_shape);
   return true;
 }
 
@@ -96,9 +95,6 @@ bool Flatten2Op::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   FlattenOp::AttachImpl(opdesc, scope);
   if (opdesc.HasOutput("XShape")) {
     param_.xshape = scope->FindMutableTensor(opdesc.Output("XShape").front());
-    has_xshape_ = true;
-  } else {
-    has_xshape_ = false;
   }
   return true;
 }
@@ -110,9 +106,6 @@ bool FlattenContiguousRangeOp::AttachImpl(const cpp::OpDesc &opdesc,
 
   if (opdesc.HasOutput("XShape")) {
     param_.xshape = scope->FindMutableTensor(opdesc.Output("XShape").front());
-    has_xshape_ = true;
-  } else {
-    has_xshape_ = false;
   }
   param_.start_axis = opdesc.GetAttr<int>("start_axis");
   param_.stop_axis = opdesc.GetAttr<int>("stop_axis");
@@ -122,7 +115,6 @@ bool FlattenContiguousRangeOp::AttachImpl(const cpp::OpDesc &opdesc,
 bool FlattenContiguousRangeOp::CheckShape() const {
   CHECK(param_.x);
   CHECK(param_.out);
-  if (has_xshape_) CHECK(param_.xshape);
   return true;
 }
 
@@ -144,7 +136,7 @@ bool FlattenContiguousRangeOp::InferShapeImpl() const {
 
   auto x_shape = x_dims.Vectorize();
   x_shape.insert(x_shape.begin(), 0);
-  if (has_xshape_) {
+  if (param_.xshape) {
     param_.xshape->Resize(x_shape);
     param_.xshape->set_lod(param_.x->lod());
   }

--- a/lite/operators/flatten_op.h
+++ b/lite/operators/flatten_op.h
@@ -56,7 +56,7 @@ class Flatten2Op : public FlattenOp {
 
   bool InferType() override {
     param_.output->set_precision(param_.x->precision());
-    if (has_xshape_) param_.xshape->set_precision(PRECISION(kInt64));
+    if (param_.xshape) param_.xshape->set_precision(PRECISION(kInt64));
     return true;
   }
 
@@ -66,9 +66,6 @@ class Flatten2Op : public FlattenOp {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "flatten2"; }
-
- private:
-  bool has_xshape_{false};
 };
 
 class FlattenContiguousRangeOp : public OpLite {
@@ -81,7 +78,7 @@ class FlattenContiguousRangeOp : public OpLite {
 #ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.out->set_precision(param_.x->precision());
-    if (has_xshape_) param_.xshape->set_precision(PRECISION(kInt64));
+    if (param_.xshape) param_.xshape->set_precision(PRECISION(kInt64));
     return true;
   }
 #endif
@@ -97,9 +94,6 @@ class FlattenContiguousRangeOp : public OpLite {
 
  protected:
   mutable FlattenContiguousRangeParam param_;
-
- private:
-  bool has_xshape_{false};
 };
 
 }  // namespace operators

--- a/lite/operators/flatten_op.h
+++ b/lite/operators/flatten_op.h
@@ -56,7 +56,7 @@ class Flatten2Op : public FlattenOp {
 
   bool InferType() override {
     param_.output->set_precision(param_.x->precision());
-    param_.xshape->set_precision(PRECISION(kInt64));
+    if (has_xshape_) param_.xshape->set_precision(PRECISION(kInt64));
     return true;
   }
 
@@ -66,6 +66,9 @@ class Flatten2Op : public FlattenOp {
 
   void AttachKernel(KernelBase *kernel) override { kernel->SetParam(param_); }
   std::string DebugString() const override { return "flatten2"; }
+
+ private:
+  bool has_xshape_{false};
 };
 
 class FlattenContiguousRangeOp : public OpLite {
@@ -78,7 +81,7 @@ class FlattenContiguousRangeOp : public OpLite {
 #ifndef LITE_ON_TINY_PUBLISH
   bool InferType() override {
     param_.out->set_precision(param_.x->precision());
-    param_.xshape->set_precision(PRECISION(kInt64));
+    if (has_xshape_) param_.xshape->set_precision(PRECISION(kInt64));
     return true;
   }
 #endif
@@ -94,6 +97,9 @@ class FlattenContiguousRangeOp : public OpLite {
 
  protected:
   mutable FlattenContiguousRangeParam param_;
+
+ private:
+  bool has_xshape_{false};
 };
 
 }  // namespace operators

--- a/lite/operators/rnn_op.cc
+++ b/lite/operators/rnn_op.cc
@@ -79,11 +79,10 @@ bool RnnOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   param_.hidden_size = opdesc.GetAttr<int>("hidden_size");
   param_.num_layers = opdesc.GetAttr<int>("num_layers");
   param_.mode = opdesc.GetAttr<std::string>("mode");
-  param_.is_test = true;
+  param_.seed = opdesc.GetAttr<int>("seed");
   if (opdesc.HasAttr("is_test")) {
     param_.is_test = opdesc.GetAttr<bool>("is_test");
   }
-  param_.seed = opdesc.GetAttr<int>("seed");
 
   return true;
 }

--- a/lite/operators/rnn_op.cc
+++ b/lite/operators/rnn_op.cc
@@ -79,10 +79,11 @@ bool RnnOp::AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) {
   param_.hidden_size = opdesc.GetAttr<int>("hidden_size");
   param_.num_layers = opdesc.GetAttr<int>("num_layers");
   param_.mode = opdesc.GetAttr<std::string>("mode");
-  param_.seed = opdesc.GetAttr<int>("seed");
+  param_.is_test = true;
   if (opdesc.HasAttr("is_test")) {
     param_.is_test = opdesc.GetAttr<bool>("is_test");
   }
+  param_.seed = opdesc.GetAttr<int>("seed");
 
   return true;
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Host
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
OP
### Description
<!-- Describe what this PR does -->
Xshape is alternative for flatten op;