### PR TITLE
[XPU] remove CHECK_EQ in host pin memory, only warning when xpu drive…

### DIFF
--- a/lite/core/memory.h
+++ b/lite/core/memory.h
@@ -106,8 +106,8 @@ class Buffer {
   void host_pinned_register() {
     if (!pinned_ && target_ == TargetType::kHost) {
       pinned_ = true;
-      if (int ret = xpu_host_register(data_, space_, 0) != 0) {
-        LOG(WARNING) << "xpu_host_register failed, errocode " << ret;
+      if (0 != xpu_host_register(data_, space_, 0)) {
+        LOG(WARNING) << "xpu_host_register failed";
       }
     }
   }
@@ -203,8 +203,8 @@ class Buffer {
 #ifdef LITE_WITH_XPU
         if (pinned_ && target_ == TargetType::kHost) {
           pinned_ = false;
-          if (int ret = xpu_host_unregister(data_) != 0) {
-            LOG(WARNING) << "xpu_host_unregister failed, errocode = " << ret;
+          if (0 != xpu_host_unregister(data_)) {
+            LOG(WARNING) << "xpu_host_unregister failed";
           }
         }
 #endif

--- a/lite/core/memory.h
+++ b/lite/core/memory.h
@@ -106,8 +106,9 @@ class Buffer {
   void host_pinned_register() {
     if (!pinned_ && target_ == TargetType::kHost) {
       pinned_ = true;
-      CHECK_EQ(xpu_host_register(data_, space_, 0), 0)
-          << "xpu_host_register failed";
+      if (int ret = xpu_host_register(data_, space_, 0) != 0) {
+        LOG(WARNING) << "xpu_host_register failed, errocode " << ret;
+      }
     }
   }
 #endif
@@ -202,8 +203,9 @@ class Buffer {
 #ifdef LITE_WITH_XPU
         if (pinned_ && target_ == TargetType::kHost) {
           pinned_ = false;
-          CHECK_EQ(xpu_host_unregister(data_), 0)
-              << "xpu_host_unregister failed";
+          if (int ret = xpu_host_unregister(data_) != 0) {
+            LOG(WARNING) << "xpu_host_unregister failed, errocode = " << ret;
+          }
         }
 #endif
         TargetFree(target_, data_);

--- a/lite/kernels/xpu/io_copy_compute.cc
+++ b/lite/kernels/xpu/io_copy_compute.cc
@@ -21,7 +21,7 @@ namespace lite {
 namespace kernels {
 namespace xpu {
 
-// xpu runtime support pinned memory from 4.0.20 in xpu2
+// xpu runtime support pinned memory from 4.0.23 in xpu2
 // if buffersize > 1MB, we use pinned mem to improve DMA performace,
 #define PINNED_MEM_SIZE (1024 * 1024)
 


### PR DESCRIPTION
…r is low.

<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
XPU

### PR changes
remove CHECK_EQ