### PR TITLE
[Pass] fix quant_dequant_fuse_pass when there is no dequant op before weight 

### DIFF
--- a/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
+++ b/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
@@ -708,7 +708,23 @@ void QuantDequantLinearOpFuser::InsertNewNode(SSAGraph* graph,
     std::string op_type = op_info.Type();
     if (std::find(quant_op_types_.begin(), quant_op_types_.end(), op_type) !=
         quant_op_types_.end()) {
-      op_info.SetAttr("enable_int8", true);
+      if (op_type == "conv2d_transpose") {
+        for (auto inlink_node : quantized_node->inlinks) {
+          if (inlink_node->IsArg() && inlink_node->AsArg().is_weight &&
+              inlink_node->inlinks.size() != 0) {
+            for (auto inlink_node_inlink : inlink_node->inlinks) {
+              if (inlink_node_inlink->IsStmt() &&
+                  inlink_node_inlink->AsStmt().op_info()->Type() ==
+                      "dequantize_linear") {
+                op_info.SetAttr("enable_int8", true);
+                break;
+              }
+            }
+          }
+        }
+      } else {
+        op_info.SetAttr("enable_int8", true);
+      }
     }
     op_info.SetInputScale(input_var_name, scales);
     for (auto op_out_var_node : quantized_node->outlinks) {

--- a/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
+++ b/lite/core/optimizer/mir/fusion/quant_dequant_op_fuser.cc
@@ -711,7 +711,15 @@ void QuantDequantLinearOpFuser::InsertNewNode(SSAGraph* graph,
       bool enable_int8_cond = false;
       for (auto& inlink_node : quantized_node->inlinks) {
         enable_int8_cond = true;
-        // no op before weight
+        /*    run int8 kernel          run fp32 kernel
+                            data                    data
+                             /                      /
+              weight    quant_op                quant_op
+                \         /                       /
+           dequant_op  dequant_op       weight dequant_op
+                  \    /                   \   /
+                   conv                    conv
+        */
         if (inlink_node->IsArg() && inlink_node->arg()->is_weight &&
             inlink_node->inlinks.size() == 0) {
           enable_int8_cond = false;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
others
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
PASS
### Description
<!-- Describe what this PR does -->
fix quant_dequant_fuse_pass when there is no dequant op before weight 