### PR TITLE
[Arm] fix viterbi_decode compute best_path

### DIFF
--- a/lite/backends/arm/math/viterbi_decode.cc
+++ b/lite/backends/arm/math/viterbi_decode.cc
@@ -359,7 +359,7 @@ void viterbi_decode(
              batch_path_ptr + (actual_len - last_ids_index) * batch,
              batch);
   arange(batch_offset_ptr, batch, n_labels);
-  for (int sl = 0; sl < max_seq_len - 1; sl++) {
+  for (int sl = max_seq_len - 2; sl >= 0; sl--) {
     ++last_ids_index;
     vector_add(1, left_length_ptr, left_length_ptr, batch);
     vector_add(batch_offset_ptr, last_ids_ptr, gather_idx_ptr, batch);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Arm
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Backends
### Description
<!-- Describe what this PR does -->
修复viterbi_decode计算path输出时的错误