### PR TITLE
[XPU] Fix argmax, strided_slice when L3 cache and auto-tune is enabled.

### DIFF
--- a/lite/kernels/xpu/argmax_compute.cc
+++ b/lite/kernels/xpu/argmax_compute.cc
@@ -22,6 +22,15 @@ namespace lite {
 namespace kernels {
 namespace xpu {
 
+void ArgmaxCompute::PrepareForRun() {
+  auto& param = this->template Param<param_t>();
+  if (param.dtype == 2) {
+    auto out = param.Out;
+    out_int64_xpu_guard_ = 
+      TargetWrapperXPU::MallocScratchPad(out->numel() * sizeof(int64_t));
+  }
+}
+
 void ArgmaxCompute::Run() {
   auto& param = this->template Param<param_t>();
   auto& ctx = this->ctx_->template As<XPUContext>();
@@ -45,19 +54,18 @@ void ArgmaxCompute::Run() {
     CHECK_EQ(r, 0);
   } else if (param.dtype == 2) {
     // int32
-    Tensor out_int64;
-    out_int64.Resize(out->dims());
+    int64_t* out_int64_data = reinterpret_cast<int64_t*>(out_int64_xpu_guard_->addr_);
     int r = xdnn::argmax<float, int64_t>(
         ctx.GetRawContext(),
         x->data<float>(),
-        out_int64.mutable_data<int64_t>(TARGET(kXPU)),
+        out_int64_data,
         x_dims,
         axis);
     CHECK_EQ(r, 0);
     r = xdnn::cast_v2<int64_t, int>(ctx.GetRawContext(),
-                                    out_int64.data<int64_t>(),
+                                    out_int64_data,
                                     out->mutable_data<int>(TARGET(kXPU)),
-                                    out_int64.numel());
+                                    static_cast<int>(out->numel()));
     CHECK_EQ(r, 0);
   } else {
     LOG(FATAL) << "argmax unsupported param type for xpu: " << param.dtype;

--- a/lite/kernels/xpu/argmax_compute.cc
+++ b/lite/kernels/xpu/argmax_compute.cc
@@ -26,8 +26,8 @@ void ArgmaxCompute::PrepareForRun() {
   auto& param = this->template Param<param_t>();
   if (param.dtype == 2) {
     auto out = param.Out;
-    out_int64_xpu_guard_ = 
-      TargetWrapperXPU::MallocScratchPad(out->numel() * sizeof(int64_t));
+    out_int64_xpu_guard_ =
+        TargetWrapperXPU::MallocScratchPad(out->numel() * sizeof(int64_t));
   }
 }
 
@@ -54,13 +54,10 @@ void ArgmaxCompute::Run() {
     CHECK_EQ(r, 0);
   } else if (param.dtype == 2) {
     // int32
-    int64_t* out_int64_data = reinterpret_cast<int64_t*>(out_int64_xpu_guard_->addr_);
+    int64_t* out_int64_data =
+        reinterpret_cast<int64_t*>(out_int64_xpu_guard_->addr_);
     int r = xdnn::argmax<float, int64_t>(
-        ctx.GetRawContext(),
-        x->data<float>(),
-        out_int64_data,
-        x_dims,
-        axis);
+        ctx.GetRawContext(), x->data<float>(), out_int64_data, x_dims, axis);
     CHECK_EQ(r, 0);
     r = xdnn::cast_v2<int64_t, int>(ctx.GetRawContext(),
                                     out_int64_data,

--- a/lite/kernels/xpu/argmax_compute.h
+++ b/lite/kernels/xpu/argmax_compute.h
@@ -30,6 +30,7 @@ class ArgmaxCompute : public KernelLite<TARGET(kXPU), PRECISION(kFloat)> {
   virtual void Run();
 
   virtual ~ArgmaxCompute() = default;
+
  private:
   XPUScratchPadGuard out_int64_xpu_guard_;
 };

--- a/lite/kernels/xpu/argmax_compute.h
+++ b/lite/kernels/xpu/argmax_compute.h
@@ -25,9 +25,13 @@ class ArgmaxCompute : public KernelLite<TARGET(kXPU), PRECISION(kFloat)> {
  public:
   using param_t = operators::ArgmaxParam;
 
+  void PrepareForRun() override;
+
   virtual void Run();
 
   virtual ~ArgmaxCompute() = default;
+ private:
+  XPUScratchPadGuard out_int64_xpu_guard_;
 };
 
 }  // namespace xpu

--- a/lite/kernels/xpu/strided_slice_compute.cc
+++ b/lite/kernels/xpu/strided_slice_compute.cc
@@ -297,7 +297,7 @@ void StridedSliceCompute<T, PType>::Run() {
 
   if (need_reverse) {
     XPUScratchPadGuard tmp_xpu_guard =
-      TargetWrapperXPU::MallocScratchPad(param.Out->numel() * sizeof(T));
+        TargetWrapperXPU::MallocScratchPad(param.Out->numel() * sizeof(T));
     auto tmp_t = reinterpret_cast<T*>(tmp_xpu_guard->addr_);
     int r = xdnn::strided_slice<T>(ctx.GetRawContext(),
                                    in_t,

--- a/lite/kernels/xpu/strided_slice_compute.cc
+++ b/lite/kernels/xpu/strided_slice_compute.cc
@@ -296,9 +296,9 @@ void StridedSliceCompute<T, PType>::Run() {
   auto* out_t = param.Out->template mutable_data<T>(TARGET(kXPU));
 
   if (need_reverse) {
-    lite::Tensor* tmp = new lite::Tensor();
-    tmp->Resize(out_dims);
-    auto* tmp_t = tmp->template mutable_data<T>(TARGET(kXPU));
+    XPUScratchPadGuard tmp_xpu_guard =
+      TargetWrapperXPU::MallocScratchPad(param.Out->numel() * sizeof(T));
+    auto tmp_t = reinterpret_cast<T*>(tmp_xpu_guard->addr_);
     int r = xdnn::strided_slice<T>(ctx.GetRawContext(),
                                    in_t,
                                    tmp_t,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
XPU

### PR types
Bug fixes

### PR changes
OP

### Description
Fix XPU ops: argmax, strided_slice
[[DLTP-65579]](https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-65579/show?source=drawer-header)

报错：Check failed: (plan->size() == xpu_runtime_ptr->xpu_l3_block_dict.size() + 1): 235!==236
原因为模型运行中 argmax op里创建了临时tensor，触发了XPUBuffer的构造，从而导致 xpu_l3_block_dict.size()在模型运行过程中持续增加，在之后轮数的运行中L3 Cache分配时检查plan和xpu_l3_block_dict.size()是否匹配时出错。

