### PR TITLE
[XPU] Fix argmax to adapt dynamic shape

### DIFF
--- a/lite/kernels/xpu/argmax_compute.cc
+++ b/lite/kernels/xpu/argmax_compute.cc
@@ -54,6 +54,7 @@ void ArgmaxCompute::Run() {
     CHECK_EQ(r, 0);
   } else if (param.dtype == 2) {
     // int32
+    out_int64_xpu_guard_->Reserve(out->numel() * sizeof(int64_t));
     int64_t* out_int64_data =
         reinterpret_cast<int64_t*>(out_int64_xpu_guard_->addr_);
     int r = xdnn::argmax<float, int64_t>(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
XPU

### PR types
Bug fixes

### PR changes
OP

### Description
Fix bug if xpu argmax output size has been changed after the first run
