### PR TITLE
[Arm] change elementwise kernel kInt32/kInt64 to kFloat

### DIFF
--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -323,7 +323,6 @@ void ElementwiseAddCompute<float16_t, PRECISION(kFP16)>::Run() {
   using NeonConfig = arm_math::MergeConfig<
       arm_math::AddConfig<float16_t>,
       arm_math::ActiveConfig<arm_math::ActiveType::NO_ACTIVE, float16_t>>;
-
   elementwise_compute_template<operators::ElementwiseParam,
                                float16_t,
                                OprandSwapable::YES,
@@ -371,7 +370,6 @@ void ElementwiseMulCompute<float16_t, PRECISION(kFP16)>::Run() {
                                OprandSwapable::YES,
                                NeonConfig>(
       this,
-
       lite::arm::math::fp16::elementwise_mul_broadcast<float16_t>,
       lite::arm::math::fp16::elementwise_mul<float16_t>,
       paddle::lite::kernels::host::naive_mul<float16_t>);
@@ -713,7 +711,7 @@ using elementwise_add_fp16_t =
     paddle::lite::kernels::arm::ElementwiseAddCompute<float16_t,
                                                       PRECISION(kFP16)>;
 REGISTER_LITE_KERNEL(
-    elementwise_add, kARM, kFP16, kNCHW, elementwise_add_fp16_t, def)
+    elementwise_add, kARM, kFP16, kNCHW, elementwise_add_fp16_t, def_fp16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
@@ -726,7 +724,7 @@ REGISTER_LITE_KERNEL(fusion_elementwise_add_activation,
                      kFP16,
                      kNCHW,
                      elementwise_add_fp16_t_act,
-                     def)
+                     def_fp16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
@@ -736,7 +734,7 @@ using elementwise_mul_fp16_t =
     paddle::lite::kernels::arm::ElementwiseMulCompute<float16_t,
                                                       PRECISION(kFP16)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mul, kARM, kFP16, kNCHW, elementwise_mul_fp16_t, def)
+    elementwise_mul, kARM, kFP16, kNCHW, elementwise_mul_fp16_t, def_fp16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
@@ -749,7 +747,7 @@ REGISTER_LITE_KERNEL(fusion_elementwise_mul_activation,
                      kFP16,
                      kNCHW,
                      elementwise_mul_fp16_t_act,
-                     def)
+                     def_fp16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
@@ -759,7 +757,7 @@ using elementwise_sub_fp16_t =
     paddle::lite::kernels::arm::ElementwiseSubCompute<float16_t,
                                                       PRECISION(kFP16)>;
 REGISTER_LITE_KERNEL(
-    elementwise_sub, kARM, kFP16, kNCHW, elementwise_sub_fp16_t, def)
+    elementwise_sub, kARM, kFP16, kNCHW, elementwise_sub_fp16_t, def_fp16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
@@ -772,7 +770,7 @@ REGISTER_LITE_KERNEL(fusion_elementwise_sub_activation,
                      kFP16,
                      kNCHW,
                      elementwise_sub_fp16_t_act,
-                     def)
+                     def_fp16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
@@ -782,7 +780,7 @@ using elementwise_div_fp16_t =
     paddle::lite::kernels::arm::ElementwiseDivCompute<float16_t,
                                                       PRECISION(kFP16)>;
 REGISTER_LITE_KERNEL(
-    elementwise_div, kARM, kFP16, kNCHW, elementwise_div_fp16_t, def)
+    elementwise_div, kARM, kFP16, kNCHW, elementwise_div_fp16_t, def_fp16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
@@ -795,64 +793,40 @@ REGISTER_LITE_KERNEL(fusion_elementwise_div_activation,
                      kFP16,
                      kNCHW,
                      elementwise_div_fp16_t_act,
-                     def)
+                     def_fp16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kFP16))})
     .Finalize();
 #endif  // ENABLE_ARM_FP16
 
+// ADD, kAny ensure this kernel can run on FP32/FP16/INT8 Model
 using elementwise_add_float_t =
-    paddle::lite::kernels::arm::ElementwiseAddCompute<float, PRECISION(kFloat)>;
+    paddle::lite::kernels::arm::ElementwiseAddCompute<float, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_add, kARM, kFloat, kNCHW, elementwise_add_float_t, def)
+    elementwise_add, kARM, kAny, kNCHW, elementwise_add_float_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
 using elementwise_add_int32_t =
-    paddle::lite::kernels::arm::ElementwiseAddCompute<int32_t,
-                                                      PRECISION(kInt32)>;
+    paddle::lite::kernels::arm::ElementwiseAddCompute<int32_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_add, kARM, kInt32, kNCHW, elementwise_add_int32_t, def)
+    elementwise_add, kARM, kAny, kNCHW, elementwise_add_int32_t, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
 using elementwise_add_int64_t =
-    paddle::lite::kernels::arm::ElementwiseAddCompute<int64_t,
-                                                      PRECISION(kInt64)>;
+    paddle::lite::kernels::arm::ElementwiseAddCompute<int64_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_add, kARM, kInt64, kNCHW, elementwise_add_int64_t, def)
+    elementwise_add, kARM, kAny, kNCHW, elementwise_add_int64_t, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
-
-#ifdef LITE_BUILD_EXTRA
-// float kernel has higher priority
-using elementwise_add_int32_f =
-    paddle::lite::kernels::arm::ElementwiseAddCompute<int32_t,
-                                                      PRECISION(kFloat)>;
-REGISTER_LITE_KERNEL(
-    elementwise_add, kARM, kFloat, kNCHW, elementwise_add_int32_f, int32)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .Finalize();
-
-using elementwise_add_int64_f =
-    paddle::lite::kernels::arm::ElementwiseAddCompute<int64_t,
-                                                      PRECISION(kFloat)>;
-REGISTER_LITE_KERNEL(
-    elementwise_add, kARM, kFloat, kNCHW, elementwise_add_int64_f, int64)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .Finalize();
-#endif  // LITE_BUILD_EXTRA
 
 using elementwise_add_float_t_act = paddle::lite::kernels::arm::
     ElementwiseAddActivationCompute<float, PRECISION(kFloat)>;
@@ -867,47 +841,33 @@ REGISTER_LITE_KERNEL(fusion_elementwise_add_activation,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
+// SUB
 using elementwise_sub_float_t =
-    paddle::lite::kernels::arm::ElementwiseSubCompute<float, PRECISION(kFloat)>;
+    paddle::lite::kernels::arm::ElementwiseSubCompute<float, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_sub, kARM, kFloat, kNCHW, elementwise_sub_float_t, def)
+    elementwise_sub, kARM, kAny, kNCHW, elementwise_sub_float_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
-using elementwise_sub_int32_t =
-    paddle::lite::kernels::arm::ElementwiseSubCompute<int32_t,
-                                                      PRECISION(kInt32)>;
-REGISTER_LITE_KERNEL(
-    elementwise_sub, kARM, kInt32, kNCHW, elementwise_sub_int32_t, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .Finalize();
-
-#ifdef LITE_BUILD_EXTRA
-// float kernel has higher priority
 using elementwise_sub_int32_f =
-    paddle::lite::kernels::arm::ElementwiseSubCompute<int32_t,
-                                                      PRECISION(kFloat)>;
+    paddle::lite::kernels::arm::ElementwiseSubCompute<int32_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_sub, kARM, kFloat, kNCHW, elementwise_sub_int32_f, int32)
+    elementwise_sub, kARM, kAny, kNCHW, elementwise_sub_int32_f, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
 using elementwise_sub_int64_f =
-    paddle::lite::kernels::arm::ElementwiseSubCompute<int64_t,
-                                                      PRECISION(kFloat)>;
+    paddle::lite::kernels::arm::ElementwiseSubCompute<int64_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_sub, kARM, kFloat, kNCHW, elementwise_sub_int64_f, int64)
+    elementwise_sub, kARM, kAny, kNCHW, elementwise_sub_int64_f, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
-#endif  // LITE_BUILD_EXTRA
 
 using elementwise_sub_act_fp32 = paddle::lite::kernels::arm::
     ElementwiseSubActivationCompute<float, PRECISION(kFloat)>;
@@ -922,57 +882,33 @@ REGISTER_LITE_KERNEL(fusion_elementwise_sub_activation,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
+// MUL
 using elementwise_mul_float_t =
-    paddle::lite::kernels::arm::ElementwiseMulCompute<float, PRECISION(kFloat)>;
+    paddle::lite::kernels::arm::ElementwiseMulCompute<float, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mul, kARM, kFloat, kNCHW, elementwise_mul_float_t, def)
+    elementwise_mul, kARM, kAny, kNCHW, elementwise_mul_float_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
 using elementwise_mul_int32_t =
-    paddle::lite::kernels::arm::ElementwiseMulCompute<int32_t,
-                                                      PRECISION(kInt32)>;
+    paddle::lite::kernels::arm::ElementwiseMulCompute<int32_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mul, kARM, kInt32, kNCHW, elementwise_mul_int32_t, def)
+    elementwise_mul, kARM, kAny, kNCHW, elementwise_mul_int32_t, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
 using elementwise_mul_int64_t =
-    paddle::lite::kernels::arm::ElementwiseMulCompute<int64_t,
-                                                      PRECISION(kInt64)>;
+    paddle::lite::kernels::arm::ElementwiseMulCompute<int64_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mul, kARM, kInt64, kNCHW, elementwise_mul_int64_t, def)
+    elementwise_mul, kARM, kAny, kNCHW, elementwise_mul_int64_t, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
-
-#ifdef LITE_BUILD_EXTRA
-// float kernel has higher priority
-using elementwise_mul_int32_f =
-    paddle::lite::kernels::arm::ElementwiseMulCompute<int32_t,
-                                                      PRECISION(kFloat)>;
-REGISTER_LITE_KERNEL(
-    elementwise_mul, kARM, kFloat, kNCHW, elementwise_mul_int32_f, int32)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .Finalize();
-
-using elementwise_mul_int64_f =
-    paddle::lite::kernels::arm::ElementwiseMulCompute<int64_t,
-                                                      PRECISION(kFloat)>;
-REGISTER_LITE_KERNEL(
-    elementwise_mul, kARM, kFloat, kNCHW, elementwise_mul_int64_f, int64)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .Finalize();
-#endif  // LITE_BUILD_EXTRA
 
 using fusion_elementwise_mul_activation_float_t = paddle::lite::kernels::arm::
     ElementwiseMulActivationCompute<float, PRECISION(kFloat)>;
@@ -988,18 +924,19 @@ REGISTER_LITE_KERNEL(fusion_elementwise_mul_activation,
     .Finalize();
 
 using fusion_elementwise_mul_activation_int64_t = paddle::lite::kernels::arm::
-    ElementwiseMulActivationCompute<int64_t, PRECISION(kInt64)>;
+    ElementwiseMulActivationCompute<int64_t, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(fusion_elementwise_mul_activation,
                      kARM,
-                     kInt64,
+                     kFloat,
                      kNCHW,
                      fusion_elementwise_mul_activation_int64_t,
-                     def)
+                     int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
 
+// MAX
 REGISTER_LITE_KERNEL(elementwise_max,
                      kARM,
                      kFloat,
@@ -1023,6 +960,7 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
+// MIN
 REGISTER_LITE_KERNEL(elementwise_min,
                      kARM,
                      kFloat,
@@ -1046,32 +984,29 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
+// DIV
 using elementwise_div_fp32_t =
-    paddle::lite::kernels::arm::ElementwiseDivCompute<float, PRECISION(kFloat)>;
-
+    paddle::lite::kernels::arm::ElementwiseDivCompute<float, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_div, kARM, kFloat, kNCHW, elementwise_div_fp32_t, def)
+    elementwise_div, kARM, kAny, kNCHW, elementwise_div_fp32_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
 using elementwise_div_int32_t =
-    paddle::lite::kernels::arm::ElementwiseDivCompute<int32_t,
-                                                      PRECISION(kInt32)>;
+    paddle::lite::kernels::arm::ElementwiseDivCompute<int32_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_div, kARM, kInt32, kNCHW, elementwise_div_int32_t, def)
+    elementwise_div, kARM, kAny, kNCHW, elementwise_div_int32_t, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
 using elementwise_div_int64_t =
-    paddle::lite::kernels::arm::ElementwiseDivCompute<int64_t,
-                                                      PRECISION(kInt64)>;
-
+    paddle::lite::kernels::arm::ElementwiseDivCompute<int64_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_div, kARM, kInt64, kNCHW, elementwise_div_int64_t, def)
+    elementwise_div, kARM, kAny, kNCHW, elementwise_div_int64_t, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
@@ -1090,69 +1025,54 @@ REGISTER_LITE_KERNEL(fusion_elementwise_div_activation,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
+// MOD
 using elementwise_mod_int64_t =
-    paddle::lite::kernels::arm::ElementwiseModCompute<int64_t,
-                                                      PRECISION(kInt64)>;
+    paddle::lite::kernels::arm::ElementwiseModCompute<int64_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mod, kARM, kInt64, kNCHW, elementwise_mod_int64_t, def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .Finalize();
-
-#ifdef LITE_BUILD_EXTRA
-// float kernel has higher priority
-using elementwise_mod_int64_f =
-    paddle::lite::kernels::arm::ElementwiseModCompute<int64_t,
-                                                      PRECISION(kFloat)>;
-REGISTER_LITE_KERNEL(
-    elementwise_mod, kARM, kFloat, kNCHW, elementwise_mod_int64_f, int64)
+    elementwise_mod, kARM, kAny, kNCHW, elementwise_mod_int64_t, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
 
 using elementwise_mod_int32_f =
-    paddle::lite::kernels::arm::ElementwiseModCompute<int32_t,
-                                                      PRECISION(kFloat)>;
+    paddle::lite::kernels::arm::ElementwiseModCompute<int32_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mod, kARM, kFloat, kNCHW, elementwise_mod_int32_f, int32_mod)
+    elementwise_mod, kARM, kAny, kNCHW, elementwise_mod_int32_f, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
-#endif  // LITE_BUILD_EXTRA
 
+// POW
 using elementwise_pow_fp32_t =
-    paddle::lite::kernels::arm::ElementwisePowCompute<float, PRECISION(kFloat)>;
-
+    paddle::lite::kernels::arm::ElementwisePowCompute<float, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_pow, kARM, kFloat, kNCHW, elementwise_pow_fp32_t, def)
+    elementwise_pow, kARM, kAny, kNCHW, elementwise_pow_fp32_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
 using elementwise_pow_int32_t =
-    paddle::lite::kernels::arm::ElementwisePowCompute<int32_t,
-                                                      PRECISION(kInt32)>;
-
+    paddle::lite::kernels::arm::ElementwisePowCompute<int32_t, PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(
-    elementwise_pow, kARM, kInt32, kNCHW, elementwise_pow_int32_t, def)
+    elementwise_pow, kARM, kAny, kNCHW, elementwise_pow_int32_t, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
+// FLOOR_DIV
 using elementwise_floor_div_int32_t =
     paddle::lite::kernels::arm::ElementwiseFloorDivCompute<int32_t,
-                                                           PRECISION(kInt32)>;
+                                                           PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(elementwise_floordiv,
                      kARM,
-                     kInt32,
+                     kAny,
                      kNCHW,
                      elementwise_floor_div_int32_t,
-                     def)
+                     int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
@@ -1160,46 +1080,14 @@ REGISTER_LITE_KERNEL(elementwise_floordiv,
 
 using elementwise_floor_div_int64_t =
     paddle::lite::kernels::arm::ElementwiseFloorDivCompute<int64_t,
-                                                           PRECISION(kInt64)>;
-
+                                                           PRECISION(kAny)>;
 REGISTER_LITE_KERNEL(elementwise_floordiv,
                      kARM,
-                     kInt64,
+                     kAny,
                      kNCHW,
                      elementwise_floor_div_int64_t,
-                     def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
-    .Finalize();
-
-#ifdef LITE_BUILD_EXTRA
-// float kernel has higher priority
-using elementwise_floor_div_int32_f =
-    paddle::lite::kernels::arm::ElementwiseFloorDivCompute<int32_t,
-                                                           PRECISION(kFloat)>;
-REGISTER_LITE_KERNEL(elementwise_floordiv,
-                     kARM,
-                     kFloat,
-                     kNCHW,
-                     elementwise_floor_div_int32_f,
-                     def)
-    .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
-    .Finalize();
-
-using elementwise_floor_div_int64_f =
-    paddle::lite::kernels::arm::ElementwiseFloorDivCompute<int64_t,
-                                                           PRECISION(kFloat)>;
-REGISTER_LITE_KERNEL(elementwise_floordiv,
-                     kARM,
-                     kFloat,
-                     kNCHW,
-                     elementwise_floor_div_int64_f,
                      int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
-#endif  // LITE_BUILD_EXTRA

--- a/lite/kernels/arm/elementwise_compute.cc
+++ b/lite/kernels/arm/elementwise_compute.cc
@@ -800,29 +800,30 @@ REGISTER_LITE_KERNEL(fusion_elementwise_div_activation,
     .Finalize();
 #endif  // ENABLE_ARM_FP16
 
-// ADD, kAny ensure this kernel can run on FP32/FP16/INT8 Model
 using elementwise_add_float_t =
-    paddle::lite::kernels::arm::ElementwiseAddCompute<float, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseAddCompute<float, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_add, kARM, kAny, kNCHW, elementwise_add_float_t, def)
+    elementwise_add, kARM, kFloat, kNCHW, elementwise_add_float_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
 using elementwise_add_int32_t =
-    paddle::lite::kernels::arm::ElementwiseAddCompute<int32_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseAddCompute<int32_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_add, kARM, kAny, kNCHW, elementwise_add_int32_t, int32)
+    elementwise_add, kARM, kFloat, kNCHW, elementwise_add_int32_t, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
 using elementwise_add_int64_t =
-    paddle::lite::kernels::arm::ElementwiseAddCompute<int64_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseAddCompute<int64_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_add, kARM, kAny, kNCHW, elementwise_add_int64_t, int64)
+    elementwise_add, kARM, kFloat, kNCHW, elementwise_add_int64_t, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
@@ -841,29 +842,30 @@ REGISTER_LITE_KERNEL(fusion_elementwise_add_activation,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
-// SUB
 using elementwise_sub_float_t =
-    paddle::lite::kernels::arm::ElementwiseSubCompute<float, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseSubCompute<float, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_sub, kARM, kAny, kNCHW, elementwise_sub_float_t, def)
+    elementwise_sub, kARM, kFloat, kNCHW, elementwise_sub_float_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
 using elementwise_sub_int32_f =
-    paddle::lite::kernels::arm::ElementwiseSubCompute<int32_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseSubCompute<int32_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_sub, kARM, kAny, kNCHW, elementwise_sub_int32_f, int32)
+    elementwise_sub, kARM, kFloat, kNCHW, elementwise_sub_int32_f, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
 using elementwise_sub_int64_f =
-    paddle::lite::kernels::arm::ElementwiseSubCompute<int64_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseSubCompute<int64_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_sub, kARM, kAny, kNCHW, elementwise_sub_int64_f, int64)
+    elementwise_sub, kARM, kFloat, kNCHW, elementwise_sub_int64_f, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
@@ -882,29 +884,30 @@ REGISTER_LITE_KERNEL(fusion_elementwise_sub_activation,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
-// MUL
 using elementwise_mul_float_t =
-    paddle::lite::kernels::arm::ElementwiseMulCompute<float, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseMulCompute<float, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mul, kARM, kAny, kNCHW, elementwise_mul_float_t, def)
+    elementwise_mul, kARM, kFloat, kNCHW, elementwise_mul_float_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
 using elementwise_mul_int32_t =
-    paddle::lite::kernels::arm::ElementwiseMulCompute<int32_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseMulCompute<int32_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mul, kARM, kAny, kNCHW, elementwise_mul_int32_t, int32)
+    elementwise_mul, kARM, kFloat, kNCHW, elementwise_mul_int32_t, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
 using elementwise_mul_int64_t =
-    paddle::lite::kernels::arm::ElementwiseMulCompute<int64_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseMulCompute<int64_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mul, kARM, kAny, kNCHW, elementwise_mul_int64_t, int64)
+    elementwise_mul, kARM, kFloat, kNCHW, elementwise_mul_int64_t, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
@@ -936,7 +939,6 @@ REGISTER_LITE_KERNEL(fusion_elementwise_mul_activation,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
 
-// MAX
 REGISTER_LITE_KERNEL(elementwise_max,
                      kARM,
                      kFloat,
@@ -960,7 +962,6 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
-// MIN
 REGISTER_LITE_KERNEL(elementwise_min,
                      kARM,
                      kFloat,
@@ -984,29 +985,30 @@ REGISTER_LITE_KERNEL(
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
-// DIV
 using elementwise_div_fp32_t =
-    paddle::lite::kernels::arm::ElementwiseDivCompute<float, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseDivCompute<float, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_div, kARM, kAny, kNCHW, elementwise_div_fp32_t, def)
+    elementwise_div, kARM, kFloat, kNCHW, elementwise_div_fp32_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
 using elementwise_div_int32_t =
-    paddle::lite::kernels::arm::ElementwiseDivCompute<int32_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseDivCompute<int32_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_div, kARM, kAny, kNCHW, elementwise_div_int32_t, int32)
+    elementwise_div, kARM, kFloat, kNCHW, elementwise_div_int32_t, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
 using elementwise_div_int64_t =
-    paddle::lite::kernels::arm::ElementwiseDivCompute<int64_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseDivCompute<int64_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_div, kARM, kAny, kNCHW, elementwise_div_int64_t, int64)
+    elementwise_div, kARM, kFloat, kNCHW, elementwise_div_int64_t, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
@@ -1025,51 +1027,51 @@ REGISTER_LITE_KERNEL(fusion_elementwise_div_activation,
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
-// MOD
 using elementwise_mod_int64_t =
-    paddle::lite::kernels::arm::ElementwiseModCompute<int64_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseModCompute<int64_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mod, kARM, kAny, kNCHW, elementwise_mod_int64_t, int64)
+    elementwise_mod, kARM, kFloat, kNCHW, elementwise_mod_int64_t, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt64))})
     .Finalize();
 
 using elementwise_mod_int32_f =
-    paddle::lite::kernels::arm::ElementwiseModCompute<int32_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwiseModCompute<int32_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_mod, kARM, kAny, kNCHW, elementwise_mod_int32_f, int32)
+    elementwise_mod, kARM, kFloat, kNCHW, elementwise_mod_int32_f, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
-// POW
 using elementwise_pow_fp32_t =
-    paddle::lite::kernels::arm::ElementwisePowCompute<float, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwisePowCompute<float, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_pow, kARM, kAny, kNCHW, elementwise_pow_fp32_t, def)
+    elementwise_pow, kARM, kFloat, kNCHW, elementwise_pow_fp32_t, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM))})
     .Finalize();
 
 using elementwise_pow_int32_t =
-    paddle::lite::kernels::arm::ElementwisePowCompute<int32_t, PRECISION(kAny)>;
+    paddle::lite::kernels::arm::ElementwisePowCompute<int32_t,
+                                                      PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(
-    elementwise_pow, kARM, kAny, kNCHW, elementwise_pow_int32_t, int32)
+    elementwise_pow, kARM, kFloat, kNCHW, elementwise_pow_int32_t, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kARM), PRECISION(kInt32))})
     .Finalize();
 
-// FLOOR_DIV
 using elementwise_floor_div_int32_t =
     paddle::lite::kernels::arm::ElementwiseFloorDivCompute<int32_t,
-                                                           PRECISION(kAny)>;
+                                                           PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(elementwise_floordiv,
                      kARM,
-                     kAny,
+                     kFloat,
                      kNCHW,
                      elementwise_floor_div_int32_t,
                      int32)
@@ -1080,10 +1082,10 @@ REGISTER_LITE_KERNEL(elementwise_floordiv,
 
 using elementwise_floor_div_int64_t =
     paddle::lite::kernels::arm::ElementwiseFloorDivCompute<int64_t,
-                                                           PRECISION(kAny)>;
+                                                           PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(elementwise_floordiv,
                      kARM,
-                     kAny,
+                     kFloat,
                      kNCHW,
                      elementwise_floor_div_int64_t,
                      int64)

--- a/lite/tests/kernels/elementwise_common_broadcast_test.cc
+++ b/lite/tests/kernels/elementwise_common_broadcast_test.cc
@@ -334,26 +334,26 @@ TEST(elementwise_broadcast, compute_i32) {
   const int TEST_RETEAT_NUM = 10;
   for (int repeat_count = 0; repeat_count < TEST_RETEAT_NUM; ++repeat_count) {
     EXPECT_TRUE(paddle::lite::RunOnRandomArgs<int32_t>(
-        paddle::lite::Place(TARGET(kARM), PRECISION(kInt32)),
-        "def",
+        paddle::lite::Place(TARGET(kARM), PRECISION(kFloat)),
+        "int32",
         "add",
         "",
         [](int32_t l, int32_t r) { return l + r; }));
     EXPECT_TRUE(paddle::lite::RunOnRandomArgs<int32_t>(
-        paddle::lite::Place(TARGET(kARM), PRECISION(kInt32)),
-        "def",
+        paddle::lite::Place(TARGET(kARM), PRECISION(kFloat)),
+        "int32",
         "sub",
         "",
         [](int32_t l, int32_t r) { return l - r; }));
     EXPECT_TRUE(paddle::lite::RunOnRandomArgs<int32_t>(
-        paddle::lite::Place(TARGET(kARM), PRECISION(kInt32)),
-        "def",
+        paddle::lite::Place(TARGET(kARM), PRECISION(kFloat)),
+        "int32",
         "mul",
         "",
         [](int32_t l, int32_t r) { return l * r; }));
     EXPECT_TRUE(paddle::lite::RunOnRandomArgs<int32_t>(
-        paddle::lite::Place(TARGET(kARM), PRECISION(kInt32)),
-        "def",
+        paddle::lite::Place(TARGET(kARM), PRECISION(kFloat)),
+        "int32",
         "div",
         "",
         [](int32_t l, int32_t r) { return l / r; }));

--- a/lite/tests/kernels/elementwise_compute_test.cc
+++ b/lite/tests/kernels/elementwise_compute_test.cc
@@ -324,12 +324,24 @@ void TestEltTypes(Place place, float abs_error) {
   }
 
   if (place.target == TARGET(kARM)) {
-    Place arm_int32_place(TARGET(kARM), PRECISION(kInt32));
-    TestElt<int32_t>(
-        arm_int32_place, abs_error, "floordiv", {2, 3, 4, 5}, {2, 3, 4, 5}, 0);
-    Place arm_int64_place(TARGET(kARM), PRECISION(kInt64));
-    TestElt<int64_t>(
-        arm_int64_place, abs_error, "floordiv", {2, 3, 4, 5}, {3}, 1);
+    Place arm_int32_place(TARGET(kARM), PRECISION(kFloat));
+    TestElt<int32_t>(arm_int32_place,
+                     abs_error,
+                     "floordiv",
+                     {2, 3, 4, 5},
+                     {2, 3, 4, 5},
+                     0,
+                     "",
+                     "int32");
+    Place arm_int64_place(TARGET(kARM), PRECISION(kFloat));
+    TestElt<int64_t>(arm_int64_place,
+                     abs_error,
+                     "floordiv",
+                     {2, 3, 4, 5},
+                     {3},
+                     1,
+                     "",
+                     "int64");
   }
 
   if (place.target == TARGET(kX86)) {
@@ -395,24 +407,58 @@ void TestEltFuseActFloat(Place place, float abs_error) {
 
 #ifdef ENABLE_ARM_FP16
 void TestFp16EltDims(Place place, float abs_error, std::string test_operator) {
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {1, 40, 40, 40},
+                     {1, 40, 40, 40},
+                     0,
+                     "",
+                     "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4, 5},
+                     {2, 3, 4, 5},
+                     0,
+                     "",
+                     "def_fp16");
   TestElt<float16_t>(
-      place, abs_error, test_operator, {1, 40, 40, 40}, {1, 40, 40, 40}, 0);
+      place, abs_error, test_operator, {2, 3, 4}, {2, 3, 4}, 0, "", "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {1, 40, 40, 40},
+                     {1, 40, 1, 1},
+                     0,
+                     "",
+                     "def_fp16");
   TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4, 5}, {2, 3, 4, 5}, 0);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3, 4}, {2, 3, 4}, 0);
+      place, abs_error, test_operator, {2, 3, 4}, {2, 3}, 0, "", "def_fp16");
   TestElt<float16_t>(
-      place, abs_error, test_operator, {1, 40, 40, 40}, {1, 40, 1, 1}, 0);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3, 4}, {2, 3}, 0);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3}, {2}, 0);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3, 4, 5}, {3, 4}, 1);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3, 4}, {3, 4}, 1);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3}, {3}, 1);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3, 4, 5}, {4, 5}, 2);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3, 4}, {4}, 2);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3, 4, 5}, {5}, 3);
+      place, abs_error, test_operator, {2, 3}, {2}, 0, "", "def_fp16");
   TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4, 5}, {3, 4, 5}, -1);
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3, 4}, {3, 4}, -1);
+      place, abs_error, test_operator, {2, 3, 4, 5}, {3, 4}, 1, "", "def_fp16");
+  TestElt<float16_t>(
+      place, abs_error, test_operator, {2, 3, 4}, {3, 4}, 1, "", "def_fp16");
+  TestElt<float16_t>(
+      place, abs_error, test_operator, {2, 3}, {3}, 1, "", "def_fp16");
+  TestElt<float16_t>(
+      place, abs_error, test_operator, {2, 3, 4, 5}, {4, 5}, 2, "", "def_fp16");
+  TestElt<float16_t>(
+      place, abs_error, test_operator, {2, 3, 4}, {4}, 2, "", "def_fp16");
+  TestElt<float16_t>(
+      place, abs_error, test_operator, {2, 3, 4, 5}, {5}, 3, "", "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4, 5},
+                     {3, 4, 5},
+                     -1,
+                     "",
+                     "def_fp16");
+  TestElt<float16_t>(
+      place, abs_error, test_operator, {2, 3, 4}, {3, 4}, -1, "", "def_fp16");
 }
 
 void TestFp16EltFuseAct(Place place,
@@ -424,29 +470,86 @@ void TestFp16EltFuseAct(Place place,
                      {1, 40, 40, 40},
                      {1, 40, 1, 1},
                      0,
-                     "relu");
+                     "relu",
+                     "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4, 5},
+                     {2, 3, 4, 5},
+                     0,
+                     "relu",
+                     "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4},
+                     {2, 3, 4},
+                     0,
+                     "relu",
+                     "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4},
+                     {2, 3},
+                     0,
+                     "relu",
+                     "def_fp16");
   TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4, 5}, {2, 3, 4, 5}, 0, "relu");
+      place, abs_error, test_operator, {2, 3}, {2}, 0, "relu", "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4, 5},
+                     {3, 4},
+                     1,
+                     "relu",
+                     "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4},
+                     {3, 4},
+                     1,
+                     "relu",
+                     "def_fp16");
   TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4}, {2, 3, 4}, 0, "relu");
+      place, abs_error, test_operator, {2, 3}, {3}, 1, "relu", "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4, 5},
+                     {4, 5},
+                     2,
+                     "relu",
+                     "def_fp16");
   TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4}, {2, 3}, 0, "relu");
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3}, {2}, 0, "relu");
-  TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4, 5}, {3, 4}, 1, "relu");
-  TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4}, {3, 4}, 1, "relu");
-  TestElt<float16_t>(place, abs_error, test_operator, {2, 3}, {3}, 1, "relu");
-  TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4, 5}, {4, 5}, 2, "relu");
-  TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4}, {4}, 2, "relu");
-  TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4, 5}, {5}, 3, "relu");
-  TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4, 5}, {3, 4, 5}, -1, "relu");
-  TestElt<float16_t>(
-      place, abs_error, test_operator, {2, 3, 4}, {3, 4}, -1, "relu");
+      place, abs_error, test_operator, {2, 3, 4}, {4}, 2, "relu", "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4, 5},
+                     {5},
+                     3,
+                     "relu",
+                     "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4, 5},
+                     {3, 4, 5},
+                     -1,
+                     "relu",
+                     "def_fp16");
+  TestElt<float16_t>(place,
+                     abs_error,
+                     test_operator,
+                     {2, 3, 4},
+                     {3, 4},
+                     -1,
+                     "relu",
+                     "def_fp16");
 }
 #endif
 
@@ -505,7 +608,6 @@ TEST(Elementwise, precision) {
 #else
   return;
 #endif
-
   TestEltDims(place, abs_error);
   TestEltTypes(place, abs_error);
   TestEltFuseAct(place, abs_error);

--- a/lite/tests/kernels/elementwise_grad_compute_test.cc
+++ b/lite/tests/kernels/elementwise_grad_compute_test.cc
@@ -25,9 +25,9 @@ namespace arm {
 
 using param_t = operators::ElementwiseParam;
 using grad_param_t = operators::ElementwiseGradParam;
-using kernel_add_t = ElementwiseAddCompute<float, PRECISION(kFloat)>;
+using kernel_add_t = ElementwiseAddCompute<float, PRECISION(kAny)>;
 using grad_kernel_add_t = ElementwiseAddGradCompute;
-using kernel_sub_t = ElementwiseSubCompute<float, PRECISION(kFloat)>;
+using kernel_sub_t = ElementwiseSubCompute<float, PRECISION(kAny)>;
 using grad_kernel_sub_t = ElementwiseSubGradCompute;
 
 void elementwise_common(grad_param_t& param,           // NOLINT
@@ -498,4 +498,4 @@ TEST(mul_grad_arm, compute) {
 }  // namespace lite
 }  // namespace paddle
 USE_LITE_KERNEL(elementwise_add_grad, kARM, kFloat, kNCHW, def);
-USE_LITE_KERNEL(elementwise_add, kARM, kFloat, kNCHW, def);
+USE_LITE_KERNEL(elementwise_add, kARM, kAny, kNCHW, def);

--- a/lite/tests/kernels/elementwise_grad_compute_test.cc
+++ b/lite/tests/kernels/elementwise_grad_compute_test.cc
@@ -25,9 +25,9 @@ namespace arm {
 
 using param_t = operators::ElementwiseParam;
 using grad_param_t = operators::ElementwiseGradParam;
-using kernel_add_t = ElementwiseAddCompute<float, PRECISION(kAny)>;
+using kernel_add_t = ElementwiseAddCompute<float, PRECISION(kFloat)>;
 using grad_kernel_add_t = ElementwiseAddGradCompute;
-using kernel_sub_t = ElementwiseSubCompute<float, PRECISION(kAny)>;
+using kernel_sub_t = ElementwiseSubCompute<float, PRECISION(kFloat)>;
 using grad_kernel_sub_t = ElementwiseSubGradCompute;
 
 void elementwise_common(grad_param_t& param,           // NOLINT
@@ -498,4 +498,4 @@ TEST(mul_grad_arm, compute) {
 }  // namespace lite
 }  // namespace paddle
 USE_LITE_KERNEL(elementwise_add_grad, kARM, kFloat, kNCHW, def);
-USE_LITE_KERNEL(elementwise_add, kARM, kAny, kNCHW, def);
+USE_LITE_KERNEL(elementwise_add, kARM, kFloat, kNCHW, def);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Arm
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Kernels
### Description
<!-- Describe what this PR does -->
移除elementwise的无效精度