### PR TITLE
[HuaweiAscendNPU] Fix adaptive_max_pool2d

### DIFF
--- a/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/converter/adaptive_pool2d.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/converter/adaptive_pool2d.cc
@@ -30,7 +30,6 @@ int ConvertAdaptivePool2D(Converter* converter, core::Operation* operation) {
     input_operator = converter->ConvertOperand(input_operand);
   }
   if (operation->type == NNADAPTER_ADAPTIVE_MAX_POOL_2D) {
-#if NNADAPTER_HUAWEI_ASCEND_NPU_CANN_VERSION_LESS_THAN(5, 1, 1)
     auto pool2d_op =
         converter->AddOperator<ge::op::AdaptiveMaxPool2d>(output_operand);
     pool2d_op->set_attr_output_size(
@@ -60,10 +59,6 @@ int ConvertAdaptivePool2D(Converter* converter, core::Operation* operation) {
     SET_INPUT(dummy_add_op, x1, adaptive_pool2d_operator);
     SET_INPUT(dummy_add_op, x2, dummy_sub_operator);
     MAP_OUTPUT(dummy_add_op, y, output_operand);
-#else
-    NNADAPTER_LOG(FATAL) << "AdaptiveMaxPool2d has bugs when CANN >= 5.1.rc1, "
-                            "it will be fixed later";
-#endif
   } else {
     auto pool2d_op =
         converter->AddOperator<ge::op::AdaptiveAvgPool2d>(output_operand);

--- a/lite/tests/kernels/adaptive_pool_compute_test.cc
+++ b/lite/tests/kernels/adaptive_pool_compute_test.cc
@@ -154,7 +154,7 @@ void TestAdaptiveAveragePool2D(Place place, float abs_error = 2e-5) {
 }
 
 void TestAdaptiveMaxPool2D(Place place, float abs_error = 2e-5) {
-  for (auto dims : std::vector<std::vector<int64_t>>{{2, 3, 4, 5}}) {
+  for (auto dims : std::vector<std::vector<int64_t>>{{2, 3, 6, 6}}) {
     std::unique_ptr<arena::TestCase> tester(
         new AdaptivePoolTester(place, "def", DDim(dims), "max", false));
     arena::Arena arena(std::move(tester), place, abs_error);
@@ -192,7 +192,6 @@ TEST(AdaptiveMaxPool2D, precision) {
   place = TARGET(kNNAdapter);
 #if defined(NNADAPTER_WITH_HUAWEI_ASCEND_NPU)
   abs_error = 1e-2;
-  return;
 #else
   return;
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
NNadapter Ascend
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
OP
### Description
<!-- Describe what this PR does -->
修复 adaptive_max_pool2d 算子单测问题