### PR TITLE
[HuaweiAscendNPU] Convert AdaptivePool2d into Pool2d when CANN > 6.0.0

### DIFF
--- a/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/engine.cc
+++ b/lite/backends/nnadapter/nnadapter/src/driver/huawei_ascend_npu/engine.cc
@@ -18,6 +18,7 @@
 #include "driver/huawei_ascend_npu/optimizer/fix_no_inputs_ops.h"
 #include "driver/huawei_ascend_npu/optimizer/fix_quantized_ops.h"
 #include "driver/huawei_ascend_npu/optimizer/fix_reduce_ops_scalar_output.h"
+#include "optimizer/convert_adaptive_pool2d_into_pool2d.h"
 #include "optimizer/fuse_conv2d_activation_into_conv2d.h"
 #include "optimizer/fuse_conv2d_add_into_conv2d.h"
 #include "optimizer/fuse_conv2d_batch_norm_into_conv2d.h"
@@ -238,6 +239,9 @@ int Program::Build(core::Model* model, core::Cache* cache) {
     FuseMatMulDequantAddIntoFullyConnectedDequant(model);
     FuseMatMulAddIntoFullyConnected(model, true);
     FuseReshapeTransposeReshapeIntoChannelShuffle(model);
+#if NNADAPTER_HUAWEI_ASCEND_NPU_CANN_VERSION_GREATER_THAN(6, 0, 0)
+    ConvertAdaptivePool2dIntoPool2d(model);
+#endif
     FixQuantizedOps(model);
     NNADAPTER_VLOG(5) << "Optimized model:" << std::endl << Visualize(model);
     // Convert a NNAdapter model to a GE graph


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
NNadapter + HuaweiAscendNPU
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
OP
### Description
<!-- Describe what this PR does -->
当CANN大于6.0后，CANN内部有对AdaptivePool2d相关算子的Pass，而该Pass内部有bug，会导致对lite_seg、fastrcnn等一些网络产生问题，因此这里将AdaptivePool2d转换为普通Pool2d去计算，后续等华为修复后，再考虑放开。