### PR TITLE
[XPU] add xpu io copy by custome,add xpu dump tensor.

### DIFF
--- a/lite/api/cxx_api.h
+++ b/lite/api/cxx_api.h
@@ -372,6 +372,11 @@ class CxxPaddleApiImpl : public lite_api::PaddlePredictor {
       bool record_info = false) override;
 
   void SetStream(TargetType target, void* stream) override;
+  void Synchronize() {
+#ifdef LITE_WITH_XPU
+    XPU_CALL(xpu_wait());
+#endif
+  }
 
  private:
   std::shared_ptr<Predictor> raw_predictor_;

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -646,11 +646,13 @@ void CxxConfig::set_xpu_sdnn_num(const int num) {
 #endif
 }
 
-void CxxConfig::set_xpu_dump_tensor_path(const std::string dump_tensor_path) {
+void CxxConfig::set_xpu_dump_tensor_path(const std::string &dump_tensor_path) {
 #ifdef LITE_WITH_XPU
   reinterpret_cast<lite::XPURunTimeOption *>(
       target_configs()[TARGET(kXPU)].get())
       ->xpu_dump_tensor_path = dump_tensor_path;
+  add_discarded_pass("xpu_memory_optimize_pass");
+  add_discarded_pass("memory_optimize_pass");
 #else
   LOG(WARNING) << "The invoking of the function "
                   "'set_xpu_dump_tensor_path' is ignored, please "
@@ -658,11 +660,13 @@ void CxxConfig::set_xpu_dump_tensor_path(const std::string dump_tensor_path) {
 #endif
 }
 
-void CxxConfig::set_xpu_dump_log_path(const std::string dump_log_path) {
+void CxxConfig::set_xpu_dump_log_path(const std::string &dump_log_path) {
 #ifdef LITE_WITH_XPU
   reinterpret_cast<lite::XPURunTimeOption *>(
       target_configs()[TARGET(kXPU)].get())
       ->xpu_dump_log_path = dump_log_path;
+  add_discarded_pass("xpu_memory_optimize_pass");
+  add_discarded_pass("memory_optimize_pass");
 #else
   LOG(WARNING) << "The invoking of the function "
                   "'set_xpu_dump_log_path' is ignored, please "

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -465,8 +465,8 @@ class LITE_API CxxConfig : public ConfigBase {
   void set_xpu_sdnn_num(const int num);
   void set_xpu_local_quant(bool local_quant = false);
   void set_xpu_compute_precision(const std::string& precision = "int16");
-  void set_xpu_dump_tensor_path(const std::string dump_tensor_path = "");
-  void set_xpu_dump_log_path(const std::string dump_log_path = "");
+  void set_xpu_dump_tensor_path(const std::string& dump_tensor_path = "");
+  void set_xpu_dump_log_path(const std::string& dump_log_path = "");
 
   // set input tensor for warmup.
   // It is optional. If you set prefered_inputs, model wil run immediately when

--- a/lite/api/python/pybind/pybind.cc
+++ b/lite/api/python/pybind/pybind.cc
@@ -394,7 +394,8 @@ void BindLiteCxxPredictor(py::module *m) {
            [](CxxPaddleApiImpl &self, const std::string &output_dir) {
              self.SaveOptimizedModel(output_dir,
                                      lite_api::LiteModelType::kNaiveBuffer);
-           });
+           })
+      .def("Synchronize", &CxxPaddleApiImpl::Synchronize);
 }
 #endif
 

--- a/lite/api/python/pybind/tensor_py.h
+++ b/lite/api/python/pybind/tensor_py.h
@@ -89,11 +89,36 @@ inline py::array TensorToPyArray(const Tensor &tensor,
   }
   std::string py_dtype_str = TensorDTypeToPyDTypeStr(tensor.precision());
 
-  if (!tensor.IsInitialized()) {
+  if (!tensor.IsInitialized() || numel <= 0) {
     return py::array(py::dtype(py_dtype_str.c_str()), py_dims);
   }
 
-  const void *tensor_buf_ptr = static_cast<const void *>(tensor.data<int8_t>());
+  const void *tensor_buf_ptr = nullptr;
+  if (TargetType::kXPU == tensor.target()) {
+    std::vector<int8_t> buf_host(sizeof_dtype * numel, 0);
+#ifdef LITE_WITH_XPU
+    xpu_wait();
+    xpu_memcpy(buf_host.data(),
+               tensor.data<int8_t>(),
+               sizeof_dtype * numel,
+               XPU_DEVICE_TO_HOST);
+#endif
+
+    tensor_buf_ptr = static_cast<const void *>(buf_host.data());
+    // TODO(quwei:) buffer zero copy to np.array .
+    // std::unique_ptr<std::vector<int8_t>> vec_ptr(
+    //     new std::vector<int8_t>(std::move(buf_host)));
+    // auto capsule = py::capsule(vec_ptr.get(), [](void *p) {
+    //   std::unique_ptr<std::vector<int8_t>>(
+    //       reinterpret_cast<std::vector<int8_t> *>(p));
+    // });
+    return py::array(py::dtype(py_dtype_str.c_str()),
+                     py_dims,
+                     py_strides,
+                     const_cast<void *>(tensor_buf_ptr));
+  }
+
+  tensor_buf_ptr = static_cast<const void *>(tensor.data<int8_t>());
   auto base = py::cast(std::move(tensor));
   return py::array(py::dtype(py_dtype_str.c_str()),
                    py_dims,
@@ -119,7 +144,13 @@ void SetTensorFromPyArrayT(
   self->Resize(dims);
 
   auto dst = self->mutable_data<T>(place);
-  std::memcpy(dst, array.data(), array.nbytes());
+  if (TargetType::kXPU == place) {
+#ifdef LITE_WITH_XPU
+    xpu_memcpy(dst, array.data(), array.nbytes(), XPU_HOST_TO_DEVICE);
+#endif
+  } else {
+    std::memcpy(dst, array.data(), array.nbytes());
+  }
 }
 
 ////////////////////////////////////////////////////////////////

--- a/lite/backends/xpu/npy_dump.h
+++ b/lite/backends/xpu/npy_dump.h
@@ -1,0 +1,617 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <complex>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "lite/backends/xpu/xpu_header_sitter.h"
+
+namespace paddle {
+namespace lite {
+namespace xpu {
+namespace npy {
+
+/* Compile-time test for byte order.
+   If your compiler does not define these per default, you may want to define
+   one of these constants manually.
+   Defaults to little endian order. */
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN ||                 \
+    defined(__BIG_ENDIAN__) || defined(__ARMEB__) || defined(__THUMBEB__) || \
+    defined(__AARCH64EB__) || defined(_MIBSEB) || defined(__MIBSEB) ||       \
+    defined(__MIBSEB__)
+const bool big_endian = true;
+#else
+const bool big_endian = false;
+#endif
+
+typedef uint64_t ndarray_len_t;  // NOLINT
+const char magic_string[] = "\x93NUMPY";
+const size_t magic_string_length = 6;
+
+const char little_endian_char = '<';
+const char big_endian_char = '>';
+const char no_endian_char = '|';
+
+constexpr std::array<char, 3> endian_chars = {
+    little_endian_char, big_endian_char, no_endian_char};
+constexpr std::array<char, 4> numtype_chars = {'f', 'i', 'u', 'c'};
+
+constexpr char host_endian_char =
+    (big_endian ? big_endian_char : little_endian_char);
+
+typedef std::pair<char, char> version_t;
+
+struct dtype_t {
+  const char byteorder;
+  const char kind;
+  const unsigned int itemsize;
+
+  // TODO(llohse): implement as constexpr
+  inline std::string str() const {
+    const size_t max_buflen = 16;
+    char buf[max_buflen];  // NOLINT
+    std::snprintf(buf, max_buflen, "%c%c%u", byteorder, kind, itemsize);
+    return std::string(buf);
+  }
+
+  inline std::tuple<const char, const char, const unsigned int> tie() const {
+    return std::tie(byteorder, kind, itemsize);
+  }
+};
+
+struct header_t {
+  const dtype_t dtype;
+  const bool fortran_order;
+  const std::vector<ndarray_len_t> shape;
+};
+
+inline void write_magic(std::ostream& ostream, version_t version) {
+  ostream.write(magic_string, magic_string_length);
+  ostream.put(version.first);
+  ostream.put(version.second);
+}
+
+inline version_t read_magic(std::istream& istream) {
+  char buf[magic_string_length + 2];  // NOLINT
+  istream.read(buf, magic_string_length + 2);
+
+  if (!istream) {
+    throw std::runtime_error("io error: failed reading file");
+  }
+
+  if (0 != std::memcmp(buf, magic_string, magic_string_length)) {
+    throw std::runtime_error("this file does not have a valid npy format.");
+  }
+
+  version_t version;
+  version.first = buf[magic_string_length];
+  version.second = buf[magic_string_length + 1];
+
+  return version;
+}
+
+// typestring magic
+
+template <typename T>
+struct has_typestring {
+  static const bool value = false;
+};
+template <>
+struct has_typestring<float> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {host_endian_char, 'f', sizeof(float)};
+};
+constexpr dtype_t has_typestring<float>::dtype;
+
+// add fp16 for api
+template <>
+struct has_typestring<float16> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {host_endian_char, 'f', sizeof(float16)};
+};
+constexpr dtype_t has_typestring<float16>::dtype;
+
+template <>
+struct has_typestring<double> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {host_endian_char, 'f', sizeof(double)};
+};
+constexpr dtype_t has_typestring<double>::dtype;
+
+template <>
+struct has_typestring<char> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {no_endian_char, 'i', sizeof(char)};
+};
+constexpr dtype_t has_typestring<char>::dtype;
+template <>
+struct has_typestring<signed char> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {no_endian_char, 'i', sizeof(signed char)};
+};
+constexpr dtype_t has_typestring<signed char>::dtype;
+template <>
+struct has_typestring<int16_t> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {host_endian_char, 'i', sizeof(int16_t)};
+};
+constexpr dtype_t has_typestring<int16_t>::dtype;
+template <>
+struct has_typestring<int> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {host_endian_char, 'i', sizeof(int)};
+};
+constexpr dtype_t has_typestring<int>::dtype;
+template <>  // load numpy can not show dtype int64 or int64_t
+struct has_typestring<int64_t> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {host_endian_char, 'i', sizeof(int64_t)};
+};
+constexpr dtype_t has_typestring<int64_t>::dtype;
+
+template <>
+struct has_typestring<unsigned char> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {no_endian_char, 'u', sizeof(unsigned char)};
+};
+constexpr dtype_t has_typestring<unsigned char>::dtype;
+template <>
+struct has_typestring<uint16_t> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {host_endian_char, 'u', sizeof(uint16_t)};
+};
+constexpr dtype_t has_typestring<uint16_t>::dtype;
+template <>
+struct has_typestring<unsigned int> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {
+      host_endian_char, 'u', sizeof(unsigned int)};
+};
+constexpr dtype_t has_typestring<unsigned int>::dtype;
+template <>
+struct has_typestring<uint64_t> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {host_endian_char, 'u', sizeof(uint64_t)};
+};
+constexpr dtype_t has_typestring<uint64_t>::dtype;
+
+template <>
+struct has_typestring<std::complex<float>> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {
+      host_endian_char, 'c', sizeof(std::complex<float>)};
+};
+constexpr dtype_t has_typestring<std::complex<float>>::dtype;
+template <>
+struct has_typestring<std::complex<double>> {
+  static const bool value = true;
+  static constexpr dtype_t dtype = {
+      host_endian_char, 'c', sizeof(std::complex<double>)};
+};
+constexpr dtype_t has_typestring<std::complex<double>>::dtype;
+
+// helpers
+inline bool is_digits(const std::string& str) {
+  return std::all_of(str.begin(), str.end(), ::isdigit);
+}
+
+template <typename T, size_t N>
+inline bool in_array(T val, const std::array<T, N>& arr) {
+  return std::find(std::begin(arr), std::end(arr), val) != std::end(arr);
+}
+
+inline dtype_t parse_descr(std::string typestring) {
+  if (typestring.length() < 3) {
+    throw std::runtime_error("invalid typestring (length)");
+  }
+
+  char byteorder_c = typestring.at(0);
+  char kind_c = typestring.at(1);
+  std::string itemsize_s = typestring.substr(2);
+
+  if (!in_array(byteorder_c, endian_chars)) {
+    throw std::runtime_error("invalid typestring (byteorder)");
+  }
+
+  if (!in_array(kind_c, numtype_chars)) {
+    throw std::runtime_error("invalid typestring (kind)");
+  }
+
+  if (!is_digits(itemsize_s)) {
+    throw std::runtime_error("invalid typestring (itemsize)");
+  }
+  unsigned int itemsize = std::stoul(itemsize_s);
+
+  return {byteorder_c, kind_c, itemsize};
+}
+
+namespace pyparse {
+
+/**
+  Removes leading and trailing whitespaces
+  */
+inline std::string trim(const std::string& str) {
+  const std::string whitespace = " \t";
+  auto begin = str.find_first_not_of(whitespace);
+
+  if (begin == std::string::npos) {
+    return "";
+  }
+
+  auto end = str.find_last_not_of(whitespace);
+
+  return str.substr(begin, end - begin + 1);
+}
+
+inline std::string get_value_from_map(const std::string& mapstr) {
+  size_t sep_pos = mapstr.find_first_of(":");
+  if (sep_pos == std::string::npos) {
+    return "";
+  }
+
+  std::string tmp = mapstr.substr(sep_pos + 1);
+  return trim(tmp);
+}
+
+/**
+   Parses the string representation of a Python dict
+
+   The keys need to be known and may not appear anywhere else in the data.
+ */
+inline std::unordered_map<std::string, std::string> parse_dict(
+    std::string in, const std::vector<std::string>& keys) {
+  std::unordered_map<std::string, std::string> map;
+
+  if (keys.size() == 0) {
+    return map;
+  }
+
+  in = trim(in);
+
+  // unwrap dictionary
+  if ((in.front() == '{') && (in.back() == '}')) {
+    in = in.substr(1, in.length() - 2);
+  } else {
+    throw std::runtime_error("Not a Python dictionary.");
+  }
+
+  std::vector<std::pair<size_t, std::string>> positions;
+
+  for (auto const& value : keys) {
+    size_t pos = in.find("'" + value + "'");
+
+    if (pos == std::string::npos) {
+      throw std::runtime_error("Missing '" + value + "' key.");
+    }
+
+    std::pair<size_t, std::string> position_pair{pos, value};
+    positions.push_back(position_pair);
+  }
+
+  // sort by position in dict
+  std::sort(positions.begin(), positions.end());
+
+  for (size_t i = 0; i < positions.size(); ++i) {
+    std::string raw_value;
+    size_t begin{positions[i].first};
+    size_t end{std::string::npos};
+
+    std::string key = positions[i].second;
+
+    if (i + 1 < positions.size()) {
+      end = positions[i + 1].first;
+    }
+
+    raw_value = in.substr(begin, end - begin);
+
+    raw_value = trim(raw_value);
+
+    if (raw_value.back() == ',') {
+      raw_value.pop_back();
+    }
+
+    map[key] = get_value_from_map(raw_value);
+  }
+
+  return map;
+}
+
+/**
+  Parses the string representation of a Python boolean
+  */
+inline bool parse_bool(const std::string& in) {
+  if (in == "True") {
+    return true;
+  }
+  if (in == "False") {
+    return false;
+  }
+
+  throw std::runtime_error("Invalid python boolan.");
+}
+
+/**
+  Parses the string representation of a Python str
+  */
+inline std::string parse_str(const std::string& in) {
+  if ((in.front() == '\'') && (in.back() == '\'')) {
+    return in.substr(1, in.length() - 2);
+  }
+
+  throw std::runtime_error("Invalid python string.");
+}
+
+/**
+  Parses the string represenatation of a Python tuple into a vector of its items
+ */
+inline std::vector<std::string> parse_tuple(std::string in) {
+  std::vector<std::string> v;
+  const char seperator = ',';
+
+  in = trim(in);
+
+  if ((in.front() == '(') && (in.back() == ')')) {
+    in = in.substr(1, in.length() - 2);
+  } else {
+    throw std::runtime_error("Invalid Python tuple.");
+  }
+
+  std::istringstream iss(in);
+
+  for (std::string token; std::getline(iss, token, seperator);) {
+    v.push_back(token);
+  }
+
+  return v;
+}
+
+template <typename T>
+inline std::string write_tuple(const std::vector<T>& v) {
+  if (v.size() == 0) {
+    return "()";
+  }
+
+  std::ostringstream ss;
+
+  if (v.size() == 1) {
+    ss << "(" << v.front() << ",)";
+  } else {
+    const std::string delimiter = ", ";
+    // v.size() > 1
+    ss << "(";
+    std::copy(v.begin(),
+              v.end() - 1,
+              std::ostream_iterator<T>(ss, delimiter.c_str()));
+    ss << v.back();
+    ss << ")";
+  }
+
+  return ss.str();
+}
+
+inline std::string write_boolean(bool b) {
+  if (b) {
+    return "True";
+  } else {
+    return "False";
+  }
+}
+
+}  // namespace pyparse
+
+inline header_t parse_header(std::string header) {
+  /*
+     The first 6 bytes are a magic string: exactly "x93NUMPY".
+     The next 1 byte is an unsigned byte: the major version number of the file
+     format, e.g. x01.
+     The next 1 byte is an unsigned byte: the minor version number of the file
+     format, e.g. x00. Note: the version of the file format is not tied to the
+     version of the numpy package.
+     The next 2 bytes form a little-endian unsigned int16_t int: the length of
+     the
+     header data HEADER_LEN.
+     The next HEADER_LEN bytes form the header data describing the array's
+     format. It is an ASCII string which contains a Python literal expression of
+     a dictionary. It is terminated by a newline ('n') and padded with spaces
+     ('x20') to make the total length of the magic string + 4 + HEADER_LEN be
+     evenly divisible by 16 for alignment purposes.
+     The dictionary contains three keys:
+
+     "descr" : dtype.descr
+     An object that can be passed as an argument to the numpy.dtype()
+     constructor to create the array's dtype.
+     "fortran_order" : bool
+     Whether the array data is Fortran-contiguous or not. Since
+     Fortran-contiguous arrays are a common form of non-C-contiguity, we allow
+     them to be written directly to disk for efficiency.
+     "shape" : tuple of int
+     The shape of the array.
+     For repeatability and readability, this dictionary is formatted using
+     pprint.pformat() so the keys are in alphabetic order.
+   */
+
+  // remove trailing newline
+  if (header.back() != '\n') {
+    throw std::runtime_error("invalid header");
+  }
+  header.pop_back();
+
+  // parse the dictionary
+  std::vector<std::string> keys{"descr", "fortran_order", "shape"};
+  auto dict_map = npy::pyparse::parse_dict(header, keys);
+
+  if (dict_map.size() == 0) {
+    throw std::runtime_error("invalid dictionary in header");
+  }
+
+  std::string descr_s = dict_map["descr"];
+  std::string fortran_s = dict_map["fortran_order"];
+  std::string shape_s = dict_map["shape"];
+
+  std::string descr = npy::pyparse::parse_str(descr_s);
+  dtype_t dtype = parse_descr(descr);
+
+  // convert literal Python bool to C++ bool
+  bool fortran_order = npy::pyparse::parse_bool(fortran_s);
+
+  // parse the shape tuple
+  auto shape_v = npy::pyparse::parse_tuple(shape_s);
+
+  std::vector<ndarray_len_t> shape;
+  for (auto item : shape_v) {
+    ndarray_len_t dim = static_cast<ndarray_len_t>(std::stoul(item));
+    shape.push_back(dim);
+  }
+
+  return {dtype, fortran_order, shape};
+}
+
+inline std::string write_header_dict(const std::string& descr,
+                                     bool fortran_order,
+                                     const std::vector<ndarray_len_t>& shape) {
+  std::string s_fortran_order = npy::pyparse::write_boolean(fortran_order);
+  std::string shape_s = npy::pyparse::write_tuple(shape);
+
+  return "{'descr': '" + descr + "', 'fortran_order': " + s_fortran_order +
+         ", 'shape': " + shape_s + ", }";
+}
+
+inline void write_header(std::ostream& out, const header_t& header) {
+  std::string header_dict =
+      write_header_dict(header.dtype.str(), header.fortran_order, header.shape);
+
+  size_t length = magic_string_length + 2 + 2 + header_dict.length() + 1;
+
+  version_t version{1, 0};
+  if (length >= 255 * 255) {
+    length = magic_string_length + 2 + 4 + header_dict.length() + 1;
+    version = {2, 0};
+  }
+  size_t padding_len = 16 - length % 16;
+  std::string padding(padding_len, ' ');
+
+  // write magic
+  write_magic(out, version);
+
+  // write header length
+  if (version == version_t{1, 0}) {
+    uint8_t header_len_le16[2];
+    uint16_t header_len =
+        static_cast<uint16_t>(header_dict.length() + padding.length() + 1);
+
+    header_len_le16[0] = (header_len >> 0) & 0xff;
+    header_len_le16[1] = (header_len >> 8) & 0xff;
+    out.write(reinterpret_cast<char*>(header_len_le16), 2);
+  } else {
+    uint8_t header_len_le32[4];
+    uint32_t header_len =
+        static_cast<uint32_t>(header_dict.length() + padding.length() + 1);
+
+    header_len_le32[0] = (header_len >> 0) & 0xff;
+    header_len_le32[1] = (header_len >> 8) & 0xff;
+    header_len_le32[2] = (header_len >> 16) & 0xff;
+    header_len_le32[3] = (header_len >> 24) & 0xff;
+    out.write(reinterpret_cast<char*>(header_len_le32), 4);
+  }
+
+  out << header_dict << padding << '\n';
+}
+
+inline std::string read_header(std::istream& istream) {
+  // check magic bytes an version number
+  version_t version = read_magic(istream);
+
+  uint32_t header_length;
+  if (version == version_t{1, 0}) {
+    uint8_t header_len_le16[2];
+    istream.read(reinterpret_cast<char*>(header_len_le16), 2);
+    header_length = (header_len_le16[0] << 0) | (header_len_le16[1] << 8);
+
+    if ((magic_string_length + 2 + 2 + header_length) % 16 != 0) {
+      // TODO(llohse): display warning
+    }
+  } else if (version == version_t{2, 0}) {
+    uint8_t header_len_le32[4];
+    istream.read(reinterpret_cast<char*>(header_len_le32), 4);
+
+    header_length = (header_len_le32[0] << 0) | (header_len_le32[1] << 8) |
+                    (header_len_le32[2] << 16) | (header_len_le32[3] << 24);
+
+    if ((magic_string_length + 2 + 4 + header_length) % 16 != 0) {
+      // TODO(llohse): display warning
+    }
+  } else {
+    throw std::runtime_error("unsupported file format version");
+  }
+
+  auto buf_v = std::vector<char>();
+  buf_v.reserve(header_length);
+  istream.read(buf_v.data(), header_length);
+  std::string header(buf_v.data(), header_length);
+
+  return header;
+}
+
+inline ndarray_len_t comp_size(const std::vector<ndarray_len_t>& shape) {
+  ndarray_len_t size = 1;
+  for (ndarray_len_t i : shape) {
+    size *= i;
+  }
+
+  return size;
+}
+
+template <typename Scalar>
+void SaveArrayAsNumpy(const std::string& filename,
+                      bool fortran_order,
+                      const size_t shape_len,
+                      const Scalar* data) {
+  if (filename.empty()) {
+    return;
+  }
+
+  static_assert(has_typestring<Scalar>::value, "scalar type not understood");
+  dtype_t dtype = has_typestring<Scalar>::dtype;
+
+  std::ofstream stream(filename, std::ofstream::out | std::ofstream::binary);
+  if (!stream) {
+    throw std::runtime_error("io error: failed to open a file.");
+  }
+
+  header_t header{
+      dtype, fortran_order, {static_cast<ndarray_len_t>(shape_len)}};
+  write_header(stream, header);
+
+  auto size = shape_len;
+
+  stream.write(reinterpret_cast<const char*>(data), sizeof(Scalar) * size);
+}
+
+}  // namespace npy
+}  // namespace xpu
+}  // namespace lite
+}  // namespace paddle

--- a/lite/backends/xpu/tensor_dump.h
+++ b/lite/backends/xpu/tensor_dump.h
@@ -1,0 +1,330 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <unistd.h>  // getcwd, access, F_OK
+#include <cstring>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+#include "lite/backends/xpu/npy_dump.h"
+#include "lite/backends/xpu/target_wrapper.h"
+#include "lite/core/op_lite.h"
+
+namespace paddle {
+namespace lite {
+namespace xpu {
+namespace npy {
+
+const static std::set<std::string> invalid_op_nodes = {  // NOLINT
+    "while",
+    "conditional_block",
+    "conditional_block_infer",
+    "subgraph"};                                               // NOLINT
+const static std::string target_trans_name = "/target_trans";  // NOLINT
+
+static thread_local int op_count = 0;
+
+bool create_dirs(const std::string& path) {
+  uint32_t beginCmpPath = 0;
+  uint32_t endCmpPath = 0;
+  std::string fullPath = "";
+
+  if ('/' != path[0]) {  // relative path
+    // get current path
+    fullPath = getcwd(nullptr, 0);
+    beginCmpPath = fullPath.size();
+    fullPath = fullPath + "/" + path;
+  } else {  // absolute path
+    fullPath = path;
+    beginCmpPath = 1;
+  }
+  if (fullPath[fullPath.size() - 1] != '/') {
+    fullPath += "/";
+  }
+  endCmpPath = fullPath.size();
+
+  // create dirs
+  for (uint32_t i = beginCmpPath; i < endCmpPath; i++) {
+    if ('/' == fullPath[i]) {
+      std::string curPath = fullPath.substr(0, i);
+      if (access(curPath.c_str(), F_OK) != 0) {
+        if (mkdir(curPath.c_str(),
+                  S_IRUSR | S_IWUSR | S_IXUSR | S_IRWXG | S_IRWXO) == -1) {
+          LOG(INFO) << "mkdir: " << curPath << "failed";
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+template <typename T>
+void DumpLog(const T* ptr,
+             size_t len,
+             const std::string& tensor_name,
+             double sum,
+             const std::string& dump_log_path = "") {
+  LOG(INFO) << "******" << tensor_name << ",len=" << len << ",sum=" << sum
+            << ",mean=" << sum / len << "******";
+
+  int print_size = len < 20 ? len : 20;
+  if (dump_log_path.empty()) {
+    return;
+  }
+
+  std::ofstream f;
+  f.open(dump_log_path, std::ofstream::out | std::ofstream::app);
+  f << "******" << tensor_name << ",len=" << len << ",sum=" << sum
+    << ",mean=" << sum / len << "******" << std::endl;
+
+  f << "------";
+  for (int i = 0; i < print_size; i++) {
+    f << static_cast<float>(*(ptr + i)) << ",";
+  }
+  f << "------" << std::endl;
+}
+
+template <typename T>
+void DumpCPUMem(const T* ptr,
+                size_t len,
+                const std::string& tensor_dump_filename,
+                const std::string& tensor_name,
+                const std::string& dump_log_path) {
+  double sum = 0;
+  for (size_t i = 0; i < len; ++i) {
+    sum += static_cast<double>(*(ptr + i));
+  }
+
+  SaveArrayAsNumpy(tensor_dump_filename, false, len, ptr);
+  DumpLog(ptr, len, tensor_name, sum, dump_log_path);
+}
+
+template <typename T>
+void DumpXPUMem(const T* ptr,
+                size_t len,
+                const std::string& tensor_dump_filename,
+                const std::string& tensor_name,
+                const std::string& dump_log_path) {
+  std::vector<T> cpu_mem(len, 0);
+  TargetWrapperXPU::MemcpySync(
+      cpu_mem.data(), ptr, len * sizeof(T), IoDirection::DtoH);
+
+  double sum = 0;
+  for (size_t i = 0; i < len; ++i) {
+    sum += cpu_mem[i];
+  }
+
+  SaveArrayAsNumpy(tensor_dump_filename, false, len, cpu_mem.data());
+  DumpLog(cpu_mem.data(), len, tensor_name, sum, dump_log_path);
+}
+
+template <typename T>
+void DumpTensor(const Tensor* tensor,
+                const std::string& tensor_dump_filename,
+                const std::string& tensor_name,
+                const TargetType& tensor_target,
+                const std::string& dump_log_path) {
+  if (tensor->template data<T>() == nullptr) {
+    LOG(INFO) << "Current tensor:" << tensor_name
+              << "is nullptr. so it is not need dump . ";
+    return;
+  }
+
+  if (tensor->data_size() <= 0) {
+    LOG(INFO) << "Current tensor:" << tensor_name
+              << " data size <= 0. so it is not need dump . ";
+    return;
+  }
+
+  try {
+    if (tensor_target == TargetType::kXPU) {
+      DumpXPUMem<T>(tensor->data<T>(),
+                    tensor->data_size(),
+                    tensor_dump_filename,
+                    tensor_name,
+                    dump_log_path);
+      return;
+    }
+
+    if (tensor_target == TargetType::kX86) {
+      DumpCPUMem<T>(tensor->template data<T>(),
+                    tensor->data_size(),
+                    tensor_dump_filename,
+                    tensor_name,
+                    dump_log_path);
+      return;
+    }
+
+    if (tensor_target == TargetType::kHost) {
+      DumpCPUMem<T>(tensor->template data<T>(),
+                    tensor->data_size(),
+                    tensor_dump_filename,
+                    tensor_name,
+                    dump_log_path);
+      return;
+    }
+  } catch (...) {
+    LOG(INFO) << "Current tensor dump error:" << tensor_name;
+  }
+}
+
+void DumpOpoutTensor(Instruction* inst,
+                     std::shared_ptr<OpLite> op,
+                     const std::string& dump_tensor_path = "",
+                     const std::string& dump_log_path = "") {
+  auto op_name = inst->kernel()->op_type();
+  LOG(INFO) << "**************"
+            << "op_name:" << op_name << ", op_count" << op_count
+            << "**************";
+  if (invalid_op_nodes.count(op_name)) {
+    return;
+  }
+
+  std::string dump_path = "";
+  if (!dump_tensor_path.empty()) {
+    std::stringstream op_count_ss;
+    op_count_ss << std::setw(4) << std::setfill('0') << op_count;
+    dump_path =
+        dump_tensor_path + "/" + op_count_ss.str() + "_" + op_name + "/";
+    op_count++;
+    bool iscreate = create_dirs(dump_path);
+    if (!iscreate) {
+      return;
+    }
+  }
+
+  auto output_names = inst->op()->op_info()->output_names();
+  for (auto tensor_name : output_names) {
+    std::string tmp;
+    CHECK(inst->op()->op_info()->GetOutputArgname(tensor_name, &tmp));
+    auto decl_arg_type = inst->kernel()->GetOutputDeclType(tmp);
+
+    // FindTensor API can't use when tensor precision type is kAny.
+    if (decl_arg_type->precision() == PrecisionType::kAny) {
+      continue;
+    }
+
+    auto tensor_target = decl_arg_type->target();
+
+    auto* pout = op->scope()->FindTensor(tensor_name);
+    CHECK(pout != nullptr) << "find tensor failed: " << tensor_name;
+
+    std::string name = tensor_name;
+    int start_index = name.find(target_trans_name);
+    if (start_index >= 0) {
+      name.erase(start_index, target_trans_name.size());
+    }
+
+    // transform tensor name: A/B  -> A_B,as the file name of the dump tensor.
+    std::replace(name.begin(), name.end(), '/', '_');
+
+    std::string tensor_dump_filename = "";
+    if (!dump_path.empty()) {
+      tensor_dump_filename = dump_path + name + ".npy";
+    }
+
+    switch (pout->precision()) {
+      case PrecisionType::kFP64: {
+        DumpTensor<double>(pout,
+                           tensor_dump_filename,
+                           tensor_name,
+                           tensor_target,
+                           dump_log_path);
+        break;
+      }
+      case PrecisionType::kFloat: {
+        DumpTensor<float>(pout,
+                          tensor_dump_filename,
+                          tensor_name,
+                          tensor_target,
+                          dump_log_path);
+        break;
+      }
+      case PrecisionType::kFP16: {
+        DumpTensor<float16>(pout,
+                            tensor_dump_filename,
+                            tensor_name,
+                            tensor_target,
+                            dump_log_path);
+        break;
+      }
+      case PrecisionType::kInt8: {
+        DumpTensor<int8_t>(pout,
+                           tensor_dump_filename,
+                           tensor_name,
+                           tensor_target,
+                           dump_log_path);
+        break;
+      }
+
+      case PrecisionType::kUInt8: {
+        DumpTensor<uint8_t>(pout,
+                            tensor_dump_filename,
+                            tensor_name,
+                            tensor_target,
+                            dump_log_path);
+        break;
+      }
+
+      case PrecisionType::kInt16: {
+        DumpTensor<int16_t>(pout,
+                            tensor_dump_filename,
+                            tensor_name,
+                            tensor_target,
+                            dump_log_path);
+        break;
+      }
+
+      case PrecisionType::kInt32: {
+        DumpTensor<int32_t>(pout,
+                            tensor_dump_filename,
+                            tensor_name,
+                            tensor_target,
+                            dump_log_path);
+        break;
+      }
+
+      case PrecisionType::kInt64: {
+        DumpTensor<int64_t>(pout,
+                            tensor_dump_filename,
+                            tensor_name,
+                            tensor_target,
+                            dump_log_path);
+        break;
+      }
+
+      case PrecisionType::kBool: {
+        DumpTensor<int8_t>(pout,
+                           tensor_dump_filename,
+                           tensor_name,
+                           tensor_target,
+                           dump_log_path);
+        break;
+      }
+
+      default: {
+        LOG(INFO) << "unsupport Tensor Type ,tensor name:" << tensor_name;
+        break;
+      }
+    }
+  }
+}
+
+}  // namespace npy
+}  // namespace xpu
+}  // namespace lite
+}  // namespace paddle

--- a/lite/core/kernel.h
+++ b/lite/core/kernel.h
@@ -111,6 +111,10 @@ class KernelBase {
     Run();
 
 #ifdef LITE_WITH_PROFILE
+#ifdef LITE_WITH_XPU
+    void* xpu_stream = TargetWrapperXPU::get_xpu_stream();
+    XPU_CALL(xpu_wait(xpu_stream));
+#endif
     // skip test
     if (!is_kernel_test_) {
       SetProfileRuntimeKernelInfo(profiler_->GetOpCharacter(profile_id_));

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -28,6 +28,10 @@
 #ifdef LITE_WITH_PRECISION_PROFILE
 #include "lite/core/profile/precision_profiler.h"
 #endif
+#ifdef LITE_WITH_XPU
+#include "lite/backends/xpu/target_wrapper.h"
+#include "lite/backends/xpu/tensor_dump.h"
+#endif
 
 namespace paddle {
 namespace lite {
@@ -805,6 +809,17 @@ void Instruction::Run() {
   op_->InferShape();
   kernel_->Launch();
   has_run_ = true;
+#ifdef LITE_WITH_XPU
+#ifdef LITE_WITH_PRECISION_PROFILE
+  if (lite::TargetWrapperXPU::xpu_runtime_ptr->need_dump_xpu_info) {
+    const std::string dump_tensor_path =
+        lite::TargetWrapperXPU::xpu_runtime_ptr->xpu_dump_tensor_path;
+    const std::string dump_log_path =
+        lite::TargetWrapperXPU::xpu_runtime_ptr->xpu_dump_log_path;
+    xpu::npy::DumpOpoutTensor(this, op_, dump_tensor_path, dump_log_path);
+  }
+#endif
+#endif
 }
 
 STL::ostream& operator<<(STL::ostream& os, const Instruction& other) {

--- a/lite/kernels/xpu/CMakeLists.txt
+++ b/lite/kernels/xpu/CMakeLists.txt
@@ -61,6 +61,7 @@ add_kernel(range_compute_xpu XPU extra SRCS range_compute.cc)
 add_kernel(where_compute_xpu XPU extra SRCS where_compute.cc)
 add_kernel(gather_nd_compute_xpu XPU extra SRCS gather_nd_compute.cc)
 add_kernel(meshgrid_compute_xpu XPU basic SRCS meshgrid_compute.cc)
+add_kernel(fetch_compute_xpu XPU basic SRCS fetch_compute.cc)
 
 # extra
 add_kernel(lookup_table_compute_xpu XPU extra SRCS lookup_table_compute.cc)

--- a/lite/kernels/xpu/fetch_compute.cc
+++ b/lite/kernels/xpu/fetch_compute.cc
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lite/core/op_registry.h"
+#include "lite/core/type_system.h"
+
+namespace paddle {
+namespace lite {
+namespace kernels {
+namespace xpu {
+
+class FetchCompute
+    : public KernelLite<TARGET(kXPU), PRECISION(kAny), DATALAYOUT(kAny)> {
+ public:
+  using param_t = operators::FeedParam;
+
+  void Run() override {
+    auto& param = Param<operators::FetchParam>();
+    auto* fetch_list = param.fetch_list;
+    if (fetch_list->size() <= static_cast<size_t>(param.col)) {
+      fetch_list->resize(param.col + 1);
+    }
+
+    auto& dst = fetch_list->at(param.col);
+    dst.ShareDataWith(*param.input);
+  }
+};
+
+}  // namespace xpu
+}  // namespace kernels
+}  // namespace lite
+}  // namespace paddle
+
+REGISTER_LITE_KERNEL(
+    fetch, kXPU, kAny, kAny, paddle::lite::kernels::xpu::FetchCompute, def)
+    .BindInput("X",
+               {LiteType::GetTensorTy(TARGET(kXPU),
+                                      PRECISION(kAny),
+                                      DATALAYOUT(kAny))})
+    .BindOutput("Out",
+                {LiteType::GetTensorTy(TARGET(kXPU),
+                                       PRECISION(kAny),
+                                       DATALAYOUT(kAny))})
+    .Finalize();


### PR DESCRIPTION
1.支持XPU输入输出tensor在XPU上，客户根据需要时做显式拷贝；（目前使用环境变量控制，默认方式不变，不影响之前的使用方式）
2.python接口from_numpy（拷贝CPU数据到XPU）,numpy(拷贝XPU数据到CPU):增加数据从CPU <-> XPU拷贝处理行为；
3.增加Lite XPU tensor数据dump功能，用于diff对比。