### PR TITLE
Fix kernel pick bug in multi-thread for XPU.

### DIFF
--- a/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
+++ b/lite/core/optimizer/mir/__xpu__static_kernel_pick_pass.h
@@ -97,6 +97,7 @@ class XPUStaticKernelPickPass : public mir::StmtPass {
     xpu_int8_compute_autotune_ = GetBoolFromEnv("XPU_INT8_AUTOTUNE", false);
     xpu_full_quantization_ = GetBoolFromEnv("XPU_FULL_QUANTIZATION", true);
     fetch_tensor_in_xpu_ = GetBoolFromEnv("FETCH_TENSOR_IN_XPU", false);
+    kernel_use_host_ = false;
 #endif
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
PASS
### Description
<!-- Describe what this PR does -->
Fix a bug where many OPs in other threads except the main thread run on the CPU in the multithreaded mode.
