### PR TITLE
[PASS] fix conv_conv_fuse new weight compute error

### DIFF
--- a/lite/core/optimizer/mir/fusion/conv_conv_fuser.h
+++ b/lite/core/optimizer/mir/fusion/conv_conv_fuser.h
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <memory>
 #include <string>
+
 #include "lite/core/optimizer/mir/pattern_matcher_high_api.h"
 #include "lite/utils/log/cp_logging.h"
 
@@ -56,8 +57,8 @@ class ConvConvFuser : public FuseBase {
     int in_size = ih * iw;
     int in_channel_size = ic * in_size;
     // out = w1[j, i, ih, iw] * w2[k, j, kw, kh]
-    // out_dim = [oc1, ic, kh, kw], din_dim = [oc0, ic, kh, kw]
-    // weight_dim = [oc1, oc0, kh, kw]
+    // out_dim = [oc1, ic, ih, iw]
+    // din_dim = [oc0, ic, ih, iw], weight_dim = [oc1, oc0, kh, kw]
     for (int k = 0; k < oc1; k++) {
       const float* weights_ptr = weights + k * oc0;
       float* out_ptr = dout + k * in_channel_size;
@@ -67,7 +68,7 @@ class ConvConvFuser : public FuseBase {
         for (int i = 0; i < in_size; i++) {
           float sum = 0.f;
           for (int j = 0; j < oc0; j++) {
-            sum += din_ptr[j * in_channel_size] * weights_ptr[j];
+            sum += din_ptr[j * in_channel_size + i] * weights_ptr[j];
           }
           *out_ptr_channel++ = sum;
         }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Host

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
PASS

### Description
<!-- Describe what this PR does -->
In the convolution-convolution fuse, the original new weight computation forgot to add a shift of conv1 weight, causing every new 3x3 array in new weight to be 9 same number, which only the 1st number is correct and others are all wrong. It further causes wrong inference results on models which contains patterns like 3x3conv-1x1conv that will do the above fuse.

Comparison between the original wrong new weight and the correct new weight after this fix:

<img src="https://s2.loli.net/2023/04/01/D2VFhcUzbxjJrf6.png" alt="image" style="max-width: 100%;">

We can see left has 3x3 arrays with all same numbers which are apparently wrong. On right, the weight is correct.