### PR TITLE
Fix asm error (issue #10102)

### DIFF
--- a/lite/tools/build.sh
+++ b/lite/tools/build.sh
@@ -132,9 +132,9 @@ function build_opt {
     rm -rf build.opt
     mkdir -p build.opt
     cd build.opt
-    opt_arch=$(echo `uname -p`)
+    opt_arch=$(echo `uname -m`)
     with_x86=OFF
-    if [ $opt_arch == "aarch64" ]; then
+    if [ $opt_arch == "aarch64" ] || [ $opt_arch == "armv6l" ] || [ $opt_arch == "armv7" ] || [ $opt_arch == "armv7l" ]; then
         with_x86=OFF
     else
        with_x86=ON

--- a/lite/tools/build_linux.sh
+++ b/lite/tools/build_linux.sh
@@ -378,8 +378,16 @@ function build_opt {
     rm -rf $build_dir
     mkdir -p $build_dir
     cd $build_dir
+    opt_arch=$(echo `uname -m`)
+    with_x86=OFF
+    if [ $opt_arch == "aarch64" ] || [ $opt_arch == "armv6l" ] || [ $opt_arch == "armv7" ] || [ $opt_arch == "armv7l" ]; then
+        with_x86=OFF
+    else
+       with_x86=ON
+    fi
     cmake $workspace \
       -DLITE_ON_MODEL_OPTIMIZE_TOOL=ON \
+      -DLITE_WITH_X86=${with_x86} \
       -DWITH_TESTING=OFF \
       -DLITE_BUILD_EXTRA=ON \
       -DWITH_MKL=OFF


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
ARM  

### PR types
Bug fixes

### PR changes
build.sh and build_linux.sh

### Description
When running on a **aarch64** or **armv7l** device like a Raspberry PI or Jetson Nano, the compilation of the Optimize tool will error with `impossible constraint in asm`. It is caused by the branch ` #ifdef LITE_WITH_X86` in device_info.cc, being still active while running an ARM device. Forcing the -DLITE_WITH_X86 CMake parameter to follow the found OS, it is solved.
