### PR TITLE
[Arm] support check_fp16_valid api for Cortex-X3 & A715

### DIFF
--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -279,6 +279,12 @@ void get_cpu_arch(std::vector<ARMArch>* archs, const int cpu_num) {
         case 0xd48:
           arch_type = kX2;
           break;
+        case 0xd4d:
+          arch_type = kA715;
+          break;  
+        case 0xd4e:
+          arch_type = kX3;  
+          break;
         default:
           LOG(ERROR) << "Unknow cpu arch: " << arch_id;
       }

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -40,6 +40,7 @@ typedef enum {
   kAPPLE = 0,
   kX1 = 1,
   kX2 = 2,
+  kX3 = 3,
   kA35 = 35,
   kA53 = 53,
   kA55 = 55,
@@ -55,6 +56,7 @@ typedef enum {
   kGold_Prime = 80,
   kSilver = 81,
   kA710 = 82,
+  kA715 = 83,
   kARMArch_UNKOWN = -1
 } ARMArch;
 
@@ -136,7 +138,9 @@ class DeviceInfo {
                                       kGold_Prime,
                                       kSilver,
                                       kA710,
-                                      kA510};
+                                      kA510,
+                                      kA715,
+                                      kX3};
     for (int i = 0; i < core_num_; ++i) {
       auto iter = std::find(int8_arch.begin(), int8_arch.end(), archs_[i]);
       if (iter == std::end(int8_arch)) {
@@ -159,7 +163,9 @@ class DeviceInfo {
                                       kGold,
                                       kGold_Prime,
                                       kSilver,
-                                      kA710};
+                                      kA710,
+                                      kA715,
+                                      kX3};
     for (int i = 0; i < core_num_; ++i) {
       auto iter = std::find(fp16_arch.begin(), fp16_arch.end(), archs_[i]);
       if (iter != std::end(fp16_arch)) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Arm

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes 

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
API

### Description
<!-- Describe what this PR does -->  
- support check_fp16_valid api for Cortex-X3 & A715
- reference: https://developer.arm.com/documentation/101593/0102/?lang=en, page 409, Cortex-X3 Core ROM table. Bits [7:0] of part number 0xD4E.
- reference: https://developer.arm.com/documentation/101590/0103/?lang=en, page 265, Cortex‑A715 PartNum 0xD4D.
- 测试机器：vivo x90, 天玑9200

