### PR TITLE
[Core] fix var desc update error when doing conv-conv fuse

### DIFF
--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -41,9 +41,9 @@ void CheckProgramDescValidity(std::shared_ptr<cpp::ProgramDesc> program_desc,
   CHECK_GT(block_size, 0) << "No block exists in current program_desc";
   // TODD(hong19860320) Only support updating the block desc which already
   // exists in the origin program desc
-  CHECK_LE(block_size, inst_block_size)
-      << "Invalid block size, expected (0," << inst_block_size << "] but got "
-      << block_size;
+  CHECK_LE(block_size, inst_block_size) << "Invalid block size, expected (0,"
+                                        << inst_block_size << "] but got "
+                                        << block_size;
 }
 
 std::map<std::string, cpp::VarDesc> ClearBlockDescInfo(

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -41,9 +41,9 @@ void CheckProgramDescValidity(std::shared_ptr<cpp::ProgramDesc> program_desc,
   CHECK_GT(block_size, 0) << "No block exists in current program_desc";
   // TODD(hong19860320) Only support updating the block desc which already
   // exists in the origin program desc
-  CHECK_LE(block_size, inst_block_size) << "Invalid block size, expected (0,"
-                                        << inst_block_size << "] but got "
-                                        << block_size;
+  CHECK_LE(block_size, inst_block_size)
+      << "Invalid block size, expected (0," << inst_block_size << "] but got "
+      << block_size;
 }
 
 std::map<std::string, cpp::VarDesc> ClearBlockDescInfo(
@@ -75,7 +75,8 @@ void UpdatePersistableVarDesc(cpp::VarDesc* var,
     }
   }
   if (var_name != "feed" && var_name != "fetch") {
-    var->SetShape(previous_var_desc.GetShape());
+    auto tensor = scope->FindVar(var_name)->GetMutable<Tensor>();
+    var->SetShape(tensor->dims().data());
     var->SetDataType(previous_var_desc.GetDataType());
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Host

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Core

### Description
<!-- Describe what this PR does -->
After optimizing the model graph, the original code only copies the shape of `Vardesc` from old to new. This is not totally correct because some fuse operations may change the shape of old tensors.
I discover this mistake in conv-conv fuse. For example, a pattern like an 8x8x3x3 tensor then a 32x8x1x1 tensor will fuse into a 32x8x3x3 tensor. But the above code will copy the shape of the first old tensor so the `Vardesc` of the new tensor will be 8x8x3x3 which is wrong.
The key is that the current fuse code only computes the new tensor and copies it to the old tensor, which only changes the tensor itself, but does not change the `Vardesc` outside in `ProgramDesc`. Notice that the fuse code can't fetch the original compute program so correcting the shape in fuse operations is not easy.

An alternative method as shown in this pr is to modify the updating shape code in `program.cc`. Instead of getting the old `Vardesc`, we get the new tensor and directly update its shape to the new `Vardesc`.

A comparison between the original code and after the fix:

<img src="https://s2.loli.net/2023/04/04/8mRjboQVBNPWDuU.png" alt="image" style="max-width: 100%;">

Left is the wrong shape 8x8x3x3 and right is the right shape 32x8x3x3.
