### PR TITLE
[NNAdapter] The shape attribute of fill_constant op supports int32_t

### DIFF
--- a/lite/core/optimizer/mir/elimination/fill_constant_calc_offline_pass.cc
+++ b/lite/core/optimizer/mir/elimination/fill_constant_calc_offline_pass.cc
@@ -107,7 +107,16 @@ void FillConstantCalcOfflinePass::RemoveFillConstantPattern(
         convert_stream >> value;
       }
     }
-    auto shape = op_desc->GetAttr<std::vector<int64_t>>("shape");
+    std::vector<int64_t> shape;
+    if (op_desc->GetAttrType("shape") ==
+        OpAttrType::INTS) {  // paddle1.0 shape type is ints
+      auto tmp_shape = op_desc->GetAttr<std::vector<int32_t>>("shape");
+      shape.resize(tmp_shape.size());
+      shape.assign(tmp_shape.begin(), tmp_shape.end());
+    } else {
+      shape = op_desc->GetAttr<std::vector<int64_t>>("shape");
+    }
+
     // Get fill_constant's output tensor
     auto out_var = scope->FindVar(op_desc->Output("Out").front());
     auto out_t = out_var->GetMutable<lite::Tensor>();

--- a/lite/kernels/nnadapter/converter/fill_constant.cc
+++ b/lite/kernels/nnadapter/converter/fill_constant.cc
@@ -48,8 +48,14 @@ int ConvertFillConstant(Converter* converter, OpInfo* op, Scope* scope) {
     // Concat operation
     converter->AddOperation(NNADAPTER_CONCAT, shapes_operands, {shape_operand});
   } else if (op->HasAttr("shape")) {
-    std::vector<int64_t> shape = op->GetAttr<std::vector<int64_t>>("shape");
-    shape_operand = converter->AddConstantOperand(shape);
+    if (op->GetAttrType("shape") ==
+        OpAttrType::INTS) {  // paddle1.0 shape type is ints
+      auto shape = op->GetAttr<std::vector<int32_t>>("shape");
+      shape_operand = converter->AddConstantOperand(shape);
+    } else {
+      std::vector<int64_t> shape = op->GetAttr<std::vector<int64_t>>("shape");
+      shape_operand = converter->AddConstantOperand(shape);
+    }
   } else {
     LOG(WARNING)
         << "One of ShapeTensor, ShapeTensorList or shape(attr) must be set.";


### PR DESCRIPTION
PR types:
Fix Bug for int32

PR changes:
support int32

Describe:

[Qualcomm-QNN] Fix bug for fill constant to support int32 format.