### PR TITLE
[AutoScan] add 0D-tensor check for auto_scan (39 files)

### DIFF
--- a/lite/tests/unittest_py/op/test_abs_op.py
+++ b/lite/tests/unittest_py/op/test_abs_op.py
@@ -61,10 +61,11 @@ class TestAbsOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         abs_op = OpConfig(
             type="abs",
@@ -82,10 +83,20 @@ class TestAbsOp(AutoScanTest):
         return self.get_predictor_configs(), ["abs"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, min_success_num=25, max_examples=25)
+        self.run_and_statis(
+            quant=False, min_success_num=1000, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_acos_op.py
+++ b/lite/tests/unittest_py/op/test_acos_op.py
@@ -75,10 +75,11 @@ class TestAcosOp(AutoScanTest):
                 return (high - low
                         ) * np.random.random(shape).astype(np.float32) + low
 
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         acos_op = OpConfig(
             type="acos",
@@ -99,10 +100,19 @@ class TestAcosOp(AutoScanTest):
         return self.get_predictor_configs(), ["acos"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_asin_op.py
+++ b/lite/tests/unittest_py/op/test_asin_op.py
@@ -75,10 +75,11 @@ class TestAsinOp(AutoScanTest):
                 return (high - low
                         ) * np.random.random(shape).astype(np.float32) + low
 
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         asin_op = OpConfig(
             type="asin",
@@ -99,10 +100,19 @@ class TestAsinOp(AutoScanTest):
         return self.get_predictor_configs(), ["asin"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_atan_op.py
+++ b/lite/tests/unittest_py/op/test_atan_op.py
@@ -49,10 +49,11 @@ class TestAtanOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         atan_op = OpConfig(
             type="atan",
@@ -70,10 +71,19 @@ class TestAtanOp(AutoScanTest):
         return self.get_predictor_configs(), ["atan"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_cast_op.py
+++ b/lite/tests/unittest_py/op/test_cast_op.py
@@ -56,10 +56,11 @@ class TestCastOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=10), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         # BOOL = 0;INT16 = 1;INT32 = 2;INT64 = 3;FP16 = 4;FP32 = 5;FP64 = 6;
         in_dtype = draw(st.sampled_from([0, 2, 3, 5]))
         out_dtype = draw(st.sampled_from([0, 2, 3, 5]))
@@ -135,6 +136,17 @@ class TestCastOp(AutoScanTest):
         self.add_ignore_check_case(
             _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "nvidia_tensorrt now support int32<->float32.")
+
+        def _teller3(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller3, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()

--- a/lite/tests/unittest_py/op/test_ceil_op.py
+++ b/lite/tests/unittest_py/op/test_ceil_op.py
@@ -41,11 +41,11 @@ class TestCeilOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=1, max_size=4))
-
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         ceil_op = OpConfig(
             type="ceil",
             inputs={"X": ["input_data"]},
@@ -62,10 +62,19 @@ class TestCeilOp(AutoScanTest):
         return self.get_predictor_configs(), ["ceil"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=300)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_clip_op.py
+++ b/lite/tests/unittest_py/op/test_clip_op.py
@@ -70,10 +70,11 @@ class TestClipOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         min_val = float(np.random.randint(0, 100) / 100)
         max_val = min_val + 0.5
         min_max_shape = draw(st.integers(min_value=1, max_value=20))
@@ -151,6 +152,17 @@ class TestClipOp(AutoScanTest):
         self.add_ignore_check_case(
             teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support '3 input tensors' on intel_openvino.")
+
+        def _teller3(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller3, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=100)

--- a/lite/tests/unittest_py/op/test_cos_op.py
+++ b/lite/tests/unittest_py/op/test_cos_op.py
@@ -55,10 +55,11 @@ class TestCosOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         cos_op = OpConfig(
             type="cos",
             inputs={"X": ["input_data"]},
@@ -75,10 +76,19 @@ class TestCosOp(AutoScanTest):
         return self.get_predictor_configs(), ["cos"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=300)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_elu_op.py
+++ b/lite/tests/unittest_py/op/test_elu_op.py
@@ -46,10 +46,11 @@ class TestEluOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=20), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         alpha = draw(st.floats(min_value=-1.0, max_value=1.0))
         elu_op = OpConfig(
             type="elu",
@@ -68,10 +69,19 @@ class TestEluOp(AutoScanTest):
         return self.get_predictor_configs(), ["elu"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=300)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_exp_op.py
+++ b/lite/tests/unittest_py/op/test_exp_op.py
@@ -73,10 +73,11 @@ class TestExpOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=2, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         exp_op = OpConfig(
             type="exp",
             inputs={"X": ["input_data"]},
@@ -119,8 +120,19 @@ class TestExpOp(AutoScanTest):
             teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support 'in_shape_size == 1' on nvidia_tensorrt.")
 
+        def _teller3(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller3, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
+
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=100)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_fill_zeros_like_op.py
+++ b/lite/tests/unittest_py/op/test_fill_zeros_like_op.py
@@ -42,10 +42,11 @@ class TestFillZerosLikeOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         def generate_input(*args, **kwargs):
             if kwargs["type"] == "int32":
@@ -55,8 +56,11 @@ class TestFillZerosLikeOp(AutoScanTest):
                 return np.random.randint(kwargs["low"], kwargs["high"],
                                          kwargs["shape"]).astype(np.int64)
             elif kwargs["type"] == "float32":
-                return (kwargs["high"] - kwargs["low"]) * np.random.random(
-                    kwargs["shape"]).astype(np.float32) + kwargs["low"]
+                if kwargs["shape"] == []:
+                    return np.random.random(kwargs["shape"]).astype(np.float32)
+                else:
+                    return (kwargs["high"] - kwargs["low"]) * np.random.random(
+                        kwargs["shape"]).astype(np.float32) + kwargs["low"]
 
         input_type = draw(st.sampled_from(["float32", "int64", "int32"]))
 
@@ -83,10 +87,19 @@ class TestFillZerosLikeOp(AutoScanTest):
         return self.get_predictor_configs(), ["fill_zeros_like"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_floor_op.py
+++ b/lite/tests/unittest_py/op/test_floor_op.py
@@ -49,10 +49,11 @@ class TestFloorOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=1, max_size=2))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         floor_op = OpConfig(
             type="floor",
             inputs={"X": ["input_data"]},
@@ -69,10 +70,19 @@ class TestFloorOp(AutoScanTest):
         return self.get_predictor_configs(), ["floor"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_gelu_op.py
+++ b/lite/tests/unittest_py/op/test_gelu_op.py
@@ -63,10 +63,11 @@ class TestGeluOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         approximate = draw(st.sampled_from([False]))
 
         gelu_op = OpConfig(
@@ -85,10 +86,19 @@ class TestGeluOp(AutoScanTest):
         return self.get_predictor_configs(), ["gelu"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_hard_activation_op.py
+++ b/lite/tests/unittest_py/op/test_hard_activation_op.py
@@ -84,10 +84,11 @@ class TestHardActivationOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=64), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         alpha_data = draw(st.floats(min_value=0.1, max_value=0.9))
         threshold_data = draw(st.floats(min_value=0.5, max_value=0.9))
         scale_data = draw(st.floats(min_value=0.7, max_value=0.9))
@@ -96,7 +97,10 @@ class TestHardActivationOp(AutoScanTest):
         op_type_str = draw(st.sampled_from(["hard_swish", "hard_sigmoid"]))
 
         def generate_input(*args, **kwargs):
-            return 2 * np.random.random(in_shape).astype(np.float32) - 1
+            if in_shape == []:
+                return np.random.random(in_shape).astype(np.float32)
+            else:
+                return 2 * np.random.random(in_shape).astype(np.float32) - 1
 
         def get_attr_np(op_type):
             attr = {}
@@ -142,8 +146,19 @@ class TestHardActivationOp(AutoScanTest):
             teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "NNAdapter tensorrt will support hard_sigmoid later.")
 
+        def _teller2(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
+
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_increment_op.py
+++ b/lite/tests/unittest_py/op/test_increment_op.py
@@ -43,10 +43,11 @@ class TestIncrementOp(AutoScanTest):
 
     def sample_program_configs(self, draw):
         #The number of elements in Input(X) should be 1
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=1), min_size=1, max_size=1))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         step_data = draw(st.floats(min_value=0.1, max_value=0.5))
         input_type = draw(
             st.sampled_from(["type_int", "type_int64", "type_float"]))
@@ -100,10 +101,19 @@ class TestIncrementOp(AutoScanTest):
         return self.get_predictor_configs(), ["increment"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=50)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_inverse_op.py
+++ b/lite/tests/unittest_py/op/test_inverse_op.py
@@ -75,7 +75,16 @@ class TestInverseOp(AutoScanTest):
         return self.get_predictor_configs(), ["inverse"], (5e-5, 5e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
         self.run_and_statis(quant=False, max_examples=25)

--- a/lite/tests/unittest_py/op/test_leaky_relu_op.py
+++ b/lite/tests/unittest_py/op/test_leaky_relu_op.py
@@ -80,10 +80,12 @@ class TestLeakyReluOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=64), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
+
         alpha_data = draw(st.floats(min_value=0.1, max_value=0.9))
 
         def generate_input(*args, **kwargs):
@@ -121,8 +123,19 @@ class TestLeakyReluOp(AutoScanTest):
             teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support 'in_shape_size == 1' on nvidia_tensorrt.")
 
+        def _teller2(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
+
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_log_op.py
+++ b/lite/tests/unittest_py/op/test_log_op.py
@@ -68,10 +68,11 @@ class TestLogOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=3, max_value=64), min_size=2, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         def generate_input(*args, **kwargs):
             return np.random.random(in_shape).astype(np.float32)
@@ -104,8 +105,19 @@ class TestLogOp(AutoScanTest):
             teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support 'in_shape_size == 1' on nvidia_tensorrt.")
 
+        def _teller2(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
+
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_logical_op.py
+++ b/lite/tests/unittest_py/op/test_logical_op.py
@@ -41,13 +41,14 @@ class TestLogicalOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=3, max_value=64), min_size=2, max_size=4))
         op_type_str = draw(
             st.sampled_from(
                 ["logical_and", "logical_not", "logical_or", "logical_xor"]))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         if self.get_nnadapter_device_name() == "kunlunxin_xtcl":
             in_shape = [1]
@@ -122,10 +123,20 @@ class TestLogicalOp(AutoScanTest):
         return self.get_predictor_configs(), ["logical"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data_x"].shape)
+            in_y_shape = list(program_config.inputs["input_data_y"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0 or len(in_y_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=60)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_pow_op.py
+++ b/lite/tests/unittest_py/op/test_pow_op.py
@@ -51,10 +51,11 @@ class TestPowOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=10), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         factor_data = draw(st.sampled_from([1.0, 2.0, 3.0]))
 
         def generate_input(*args, **kwargs):
@@ -78,10 +79,19 @@ class TestPowOp(AutoScanTest):
         return self.get_predictor_configs(), ["pow"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_prelu_op.py
+++ b/lite/tests/unittest_py/op/test_prelu_op.py
@@ -57,16 +57,23 @@ class TestPreluOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=10), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         mode_data = draw(st.sampled_from(["channel", "element"]))
         alpha_shape = [1]
         if mode_data == "channel":
-            alpha_shape = [1, in_shape[1], 1, 1]
+            if in_shape == []:
+                alpha_shape = []
+            else:
+                alpha_shape = [1, in_shape[1], 1, 1]
         elif mode_data == 'element':
-            alpha_shape = [1] + list(in_shape)[1:]
+            if in_shape == []:
+                alpha_shape = []
+            else:
+                alpha_shape = [1] + list(in_shape)[1:]
 
         def generate_input(*args, **kwargs):
             return np.random.random(kwargs['tensor_shape']).astype(np.float32)
@@ -99,10 +106,19 @@ class TestPreluOp(AutoScanTest):
         return self.get_predictor_configs(), ["prelu"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_reciprocal_op.py
+++ b/lite/tests/unittest_py/op/test_reciprocal_op.py
@@ -46,10 +46,11 @@ class TestReciprocalOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=64), max_size=2))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         def generate_input(*args, **kwargs):
             return np.random.random(in_shape).astype(np.float32)
@@ -70,10 +71,19 @@ class TestReciprocalOp(AutoScanTest):
         return self.get_predictor_configs(), ["reciprocal"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=200)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_relu6_op.py
+++ b/lite/tests/unittest_py/op/test_relu6_op.py
@@ -86,7 +86,8 @@ class TestRelu6Op(AutoScanTest):
             st.lists(
                 st.integers(
                     min_value=1, max_value=4), min_size=1, max_size=1))
-        in_shape = in_shape1 + in_shape3
+        in_shape2 = in_shape1 + in_shape3
+        in_shape = draw(st.sampled_from([in_shape2, []]))
         threshold_data = draw(st.floats(min_value=6.0, max_value=6.0))
         build_op = OpConfig(
             type="relu6",
@@ -119,8 +120,19 @@ class TestRelu6Op(AutoScanTest):
             teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support 'in_shape_size == 1' on nvidia_tensorrt.")
 
+        def _teller2(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
+
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_round_op.py
+++ b/lite/tests/unittest_py/op/test_round_op.py
@@ -39,10 +39,11 @@ class TestSetValueOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=10), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         input_type = draw(st.sampled_from(["float32"]))
         value_tensor_flag = draw(st.booleans())
 
@@ -68,10 +69,19 @@ class TestSetValueOp(AutoScanTest):
         return self.get_predictor_configs(), ["round"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=100)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_rsqrt_op.py
+++ b/lite/tests/unittest_py/op/test_rsqrt_op.py
@@ -66,14 +66,18 @@ class TestRsqrtOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         def generate_input(*args, **kwargs):
             # Make sure input data is greater than 0
-            return np.random.random(in_shape).astype(np.float32) + 0.1
+            if in_shape == []:
+                return np.random.random(in_shape).astype(np.float32)
+            else:
+                return np.random.random(in_shape).astype(np.float32) + 0.1
 
         rsqrt_op = OpConfig(
             type="rsqrt",
@@ -93,17 +97,28 @@ class TestRsqrtOp(AutoScanTest):
         return self.get_predictor_configs(), ["rsqrt"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
         target_str = self.get_target()
-        max_examples = 25
+        max_examples = 1000
         if target_str == "OpenCL":
             # Make sure to generate enough valid cases for OpenCL
             max_examples = 200
 
         self.run_and_statis(
-            quant=False, min_success_num=25, max_examples=max_examples)
+            quant=False,
+            min_success_num=max_examples,
+            max_examples=max_examples)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_scale_op.py
+++ b/lite/tests/unittest_py/op/test_scale_op.py
@@ -89,10 +89,11 @@ class TestScaleOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         bias = draw(st.floats(min_value=-5, max_value=5))
         bias_after_scale = draw(st.booleans())
         scale = draw(st.floats(min_value=-5, max_value=5))
@@ -112,17 +113,27 @@ class TestScaleOp(AutoScanTest):
 
             if dtype == "int32":
                 if low == high:
-                    return low * np.ones(shape).astype(np.int32)
+                    if shape == []:
+                        return np.ones(shape).astype(np.int32)
+                    else:
+                        return low * np.ones(shape).astype(np.int32)
                 else:
                     return np.random.randint(low, high, shape).astype(np.int32)
             elif dtype == "int64":
                 if low == high:
-                    return low * np.ones(shape).astype(np.int64)
+                    if shape == []:
+                        return np.ones(shape).astype(np.int64)
+                    else:
+                        return low * np.ones(shape).astype(np.int64)
                 else:
                     return np.random.randint(low, high, shape).astype(np.int64)
             elif dtype == "float32":
-                return (high - low
-                        ) * np.random.random(shape).astype(np.float32) + low
+                if shape == []:
+                    return np.random.random(shape).astype(np.float32)
+                else:
+                    return (
+                        high - low
+                    ) * np.random.random(shape).astype(np.float32) + low
 
         input_dict = {"X": ["input_data"]}
         input_data_dict = {
@@ -185,6 +196,13 @@ class TestScaleOp(AutoScanTest):
                 if len(in_shape) == 1:
                     return True
 
+        def _teller5(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
         self.add_ignore_check_case(
             teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support this op in a specific case. We need to fix it as soon as possible."
@@ -201,9 +219,13 @@ class TestScaleOp(AutoScanTest):
             teller4, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support 'in_shape_size == 1' on nvidia_tensorrt.")
 
+        self.add_ignore_check_case(
+            _teller5, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
+
     def test(self, *args, **kwargs):
         target_str = self.get_target()
-        max_examples = 100
+        max_examples = 1000
         if target_str in ["OpenCL", "Metal"]:
             # Make sure to generate enough valid cases for specific targets
             max_examples = 2000

--- a/lite/tests/unittest_py/op/test_sigmoid_op.py
+++ b/lite/tests/unittest_py/op/test_sigmoid_op.py
@@ -74,10 +74,11 @@ class TestSigmoidOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=64), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         def generate_input(*args, **kwargs):
             return np.random.normal(1.0, 6.0, in_shape).astype(np.float32)
@@ -127,6 +128,17 @@ class TestSigmoidOp(AutoScanTest):
             teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support 'in_shape_size == 1' on nvidia_tensorrt.")
 
+        def _teller3(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller3, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
+
     def test(self, *args, **kwargs):
         target_str = self.get_target()
         if target_str == "Metal":
@@ -134,7 +146,7 @@ class TestSigmoidOp(AutoScanTest):
         elif self.get_nnadapter_device_name() == "kunlunxin_xtcl":
             self.run_and_statis(quant=False, max_examples=200)
         else:
-            self.run_and_statis(quant=False, max_examples=25)
+            self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_silu_op.py
+++ b/lite/tests/unittest_py/op/test_silu_op.py
@@ -39,10 +39,11 @@ class TestSiluOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=64), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         def generate_input(*args, **kwargs):
             return np.random.normal(-1, 1.0, in_shape).astype(np.float32)
@@ -92,9 +93,20 @@ class TestSiluOp(AutoScanTest):
             teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support 'in_shape_size == 1' on nvidia_tensorrt.")
 
+        def _teller3(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller3, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
+
     def test(self, *args, **kwargs):
         target_str = self.get_target()
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_sin_op.py
+++ b/lite/tests/unittest_py/op/test_sin_op.py
@@ -55,10 +55,11 @@ class TestSinOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         sin_op = OpConfig(
             type="sin",
             inputs={"X": ["input_data"]},
@@ -75,10 +76,19 @@ class TestSinOp(AutoScanTest):
         return self.get_predictor_configs(), ["sin"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=300)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_softplus_op.py
+++ b/lite/tests/unittest_py/op/test_softplus_op.py
@@ -42,10 +42,11 @@ class TestSoftplusOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=64), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
         beta = draw(st.sampled_from([1, 2, 3]))
         threshold = draw(st.integers(min_value=10, max_value=20))
 
@@ -76,10 +77,19 @@ class TestSoftplusOp(AutoScanTest):
         return self.get_predictor_configs(), ["softplus"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=50)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_softsign_op.py
+++ b/lite/tests/unittest_py/op/test_softsign_op.py
@@ -39,10 +39,11 @@ class TestSoftsignOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=64), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         def generate_input(*args, **kwargs):
             return np.random.uniform(-1, 1, in_shape).astype(np.float32)
@@ -67,10 +68,19 @@ class TestSoftsignOp(AutoScanTest):
         return self.get_predictor_configs(), ["softsign"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=50)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_sqrt_op.py
+++ b/lite/tests/unittest_py/op/test_sqrt_op.py
@@ -59,10 +59,11 @@ class TestSqrtOp(AutoScanTest):
         return True
 
     def sample_program_configs(self, draw):
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=64), min_size=1, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         def generate_input(*args, **kwargs):
             return np.random.random(in_shape).astype(np.float32)
@@ -87,10 +88,19 @@ class TestSqrtOp(AutoScanTest):
         return self.get_predictor_configs(), ["sqrt"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=50)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_tan_op.py
+++ b/lite/tests/unittest_py/op/test_tan_op.py
@@ -62,10 +62,11 @@ class TestTanOp(AutoScanTest):
                 return (kwargs["high"] - kwargs["low"]) * np.random.random(
                     kwargs["shape"]).astype(np.float32) + kwargs["low"]
 
-        in_shape = draw(
+        in_shape_tmp = draw(
             st.lists(
                 st.integers(
                     min_value=1, max_value=8), min_size=4, max_size=4))
+        in_shape = draw(st.sampled_from([in_shape_tmp, []]))
 
         tan_op = OpConfig(
             type="tan",
@@ -90,10 +91,19 @@ class TestTanOp(AutoScanTest):
         return self.get_predictor_configs(), ["tan"], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=50)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_tanh_op.py
+++ b/lite/tests/unittest_py/op/test_tanh_op.py
@@ -76,7 +76,7 @@ class TestTanhOp(AutoScanTest):
         C = draw(st.integers(min_value=1, max_value=128))
         H = draw(st.integers(min_value=1, max_value=128))
         W = draw(st.integers(min_value=1, max_value=128))
-        in_shape = draw(st.sampled_from([[N, C, H, W], [N, H, W]]))
+        in_shape = draw(st.sampled_from([[N, C, H, W], [N, H, W], []]))
         tanh_op = OpConfig(
             type="tanh",
             inputs={"X": ["input_data"]},
@@ -106,8 +106,19 @@ class TestTanhOp(AutoScanTest):
             teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
             "Lite does not support 'in_shape_size == 1' on nvidia_tensorrt.")
 
+        def _teller2(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller2, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
+
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":

--- a/lite/tests/unittest_py/op/test_thresholded_relu_op.py
+++ b/lite/tests/unittest_py/op/test_thresholded_relu_op.py
@@ -52,7 +52,7 @@ class TestFcOp(AutoScanTest):
         C = draw(st.integers(min_value=1, max_value=128))
         H = draw(st.integers(min_value=1, max_value=128))
         W = draw(st.integers(min_value=1, max_value=128))
-        in_shape = draw(st.sampled_from([[N, C, H, W], [N, H, W]]))
+        in_shape = draw(st.sampled_from([[N, C, H, W], [N, H, W], []]))
         threshold_data = draw(st.floats(min_value=0.0, max_value=1.0))
         thresholded_relu_op = OpConfig(
             type="thresholded_relu",
@@ -70,10 +70,19 @@ class TestFcOp(AutoScanTest):
         return self.get_predictor_configs(), [""], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):
-        pass
+        def _teller1(program_config, predictor_config):
+            target_type = predictor_config.target()
+            in_x_shape = list(program_config.inputs["input_data"].shape)
+            if target_type != TargetType.ARM and target_type != TargetType.X86 and target_type != TargetType.Host:
+                if len(in_x_shape) == 0:
+                    return True
+
+        self.add_ignore_check_case(
+            _teller1, IgnoreReasons.PADDLELITE_NOT_SUPPORT,
+            "Only test 0D-tensor on CPU(ARM/X86/Host) now.")
 
     def test(self, *args, **kwargs):
-        self.run_and_statis(quant=False, max_examples=25)
+        self.run_and_statis(quant=False, max_examples=1000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
Arm/Host

### PR types
New features

### PR changes
OP

### Description
为AutoScan单测增加0D测试case(39个py文件)，同时增加 add_ignore_pass_case，目前只测Host/Arm/X86 CPU
