### PR TITLE
[tool] benchmark updating

### DIFF
--- a/lite/api/tools/benchmark/benchmark.h
+++ b/lite/api/tools/benchmark/benchmark.h
@@ -38,7 +38,7 @@ class PerfData {
  public:
   void init(const int repeats) { repeats_ = repeats; }
   const float init_time() const { return init_time_; }
-  const float first_time() const { return run_time_.at(0); }
+  const float first_time() const { return run_time_.at(run_time_.size() - repeats_); }
   const float avg_pre_process_time() const {
     return std::accumulate(pre_process_time_.end() - repeats_,
                            pre_process_time_.end(),


### PR DESCRIPTION
when then benchmark tool calculates the first_time result, it fetches the 1st prediction duration, which may be the warm-up value. We actually need the value AFTER the warm-ups, so calculate the first_value backwards from the end, at an offset of repeats_ length.

<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
 Framework

### PR types
Bug fixes

### PR changes
API tool

### Description
just adjust the first_value. calculation offset, from 0 to run_time_.size() - repeats
