### PR TITLE
directly access the "vector" 's element without initialization 

### DIFF
--- a/lite/backends/nnadapter/nnadapter/src/operation/split.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/split.cc
@@ -53,7 +53,7 @@ NNADAPTER_EXPORT int PrepareSplit(core::Operation* operation) {
     std::vector<int32_t*> output_data_ptrs;
     std::vector<std::vector<int32_t*>> dynamic_output_data_ptrs;
     std::vector<NNAdapterOperandDimensionType> dimension_types;
-    //Initialize the vector and avoid Out of bounds access
+    // Initialize the vector and avoid Out of bounds access
     dimension_types.resize(output_count);
     output_data_ptrs.resize(output_count);
     for (size_t i = 0; i < output_count; i++) {

--- a/lite/backends/nnadapter/nnadapter/src/operation/split.cc
+++ b/lite/backends/nnadapter/nnadapter/src/operation/split.cc
@@ -53,7 +53,9 @@ NNADAPTER_EXPORT int PrepareSplit(core::Operation* operation) {
     std::vector<int32_t*> output_data_ptrs;
     std::vector<std::vector<int32_t*>> dynamic_output_data_ptrs;
     std::vector<NNAdapterOperandDimensionType> dimension_types;
-
+    //Initialize the vector and avoid Out of bounds access
+    dimension_types.resize(output_count);
+    output_data_ptrs.resize(output_count);
     for (size_t i = 0; i < output_count; i++) {
       output_operands[i]->type.lifetime = NNADAPTER_TEMPORARY_SHAPE;
       dimension_types[i].count = output_operands[i]->type.dimensions.data[0];


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
NNadapter
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
 Backends
### Description
<!-- Describe what this PR does -->
initialize the vector before accessing it's element