### PR TITLE
[NNAdapter][Verisilicon-TIMVX] fix Tim-VX compile error,

### DIFF
--- a/lite/backends/nnadapter/nnadapter/src/driver/verisilicon_timvx/dependencies.cmake
+++ b/lite/backends/nnadapter/nnadapter/src/driver/verisilicon_timvx/dependencies.cmake
@@ -78,6 +78,7 @@ ExternalProject_Add(
                       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                       -DEXTERNAL_VIV_SDK=${NNADAPTER_VERISILICON_TIMVX_VIV_SDK_ROOT}
                       -DCMAKE_INSTALL_PREFIX=${VERISILICON_TIMVX_INSTALL_DIR}
+                      -DTIM_VX_ENABLE_TENSOR_CACHE=OFF                      
                       ${CROSS_COMPILE_CMAKE_ARGS}
 )
 


### PR DESCRIPTION
### PR devices
[ others ]

### PR types
[ Others ]

### PR changes
Backends

### Description
TIM-VX 最新的main分支，特性『TIM_VX_ENABLE_TENSOR_CACHE』暂不需要，且依赖openssl，关闭该特性
