### PR TITLE
fix bug of xpu memory repeatedly released

### DIFF
--- a/lite/backends/xpu/target_wrapper.h
+++ b/lite/backends/xpu/target_wrapper.h
@@ -154,11 +154,6 @@ class TargetWrapper<TARGET(kXPU)> {
       if (ret != 0 || local_gm_ptr == nullptr) {
         VLOG(3) << "No Enough GM Workspace For Current Predictor.";
       } else {
-        void* old_ptr = xpu_runtime_ptr->xpu_tls_raw_ctx->GetXDNNContext()
-                            ->_gm_mgr.get_ptr();
-        if (old_ptr != nullptr) {
-          TargetWrapperXPU::Free(old_ptr);
-        }
         ret = xpu_runtime_ptr->xpu_tls_raw_ctx->GetXDNNContext()->_gm_mgr.set(
             local_gm_ptr, xpu_runtime_ptr->xpu_local_gm_size);
         if (ret != 0) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->

### Description
<!-- Describe what this PR does -->
修改xpu显存重复释放的问题，解决使用地址重复释放会偶现crash的问题
在_gm_mgr.set函数内部会对记录的旧地址进行释放，再更新记录新地址，若在外部释放，释放后未对对应的指针内容置空，在api内部会重复释放该地址。

