### PR TITLE
[ARM] fix elementwise_add_int64

### DIFF
--- a/lite/backends/arm/math/elementwise_common_broadcast_config.h
+++ b/lite/backends/arm/math/elementwise_common_broadcast_config.h
@@ -108,7 +108,7 @@ struct BasicConfig<int64_t> {
   constexpr static auto neon_dup = vdupq_n_s64;
   constexpr static auto neon_ld = vld1q_s64;
   constexpr static auto neon_st = vst1q_s64;
-  constexpr static int cnt_num = 2;
+  constexpr static int cnt_num = 4;
 };
 
 template <>

--- a/lite/kernels/host/elementwise_op_func.h
+++ b/lite/kernels/host/elementwise_op_func.h
@@ -46,7 +46,7 @@ T naive_max(T a, T b) {
 
 template <class T>
 T naive_min(T a, T b) {
-  return a > b ? a : b;
+  return a > b ? b : a;
 }
 
 template <class T>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
Arm
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Backends
### Description
<!-- Describe what this PR does -->
修复 elementwise_add_int64 内存越界问题