### PR TITLE
rename XpuConfig

### DIFF
--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -646,8 +646,8 @@ void ConfigBase::set_xpu_dump_log_path(const std::string &dump_log_path) {
 #endif
 }
 
-// user's LiteXpuConfig -> configbase's XPURunTimeOption
-void ConfigBase::set_xpu_config(const LiteXpuConfig &xpu_config) {
+// user's XpuConfig -> configbase's XPURunTimeOption
+void ConfigBase::set_xpu_config(const XpuConfig &xpu_config) {
 #ifdef LITE_WITH_XPU
   lite::XPURunTimeOption *xpu_runtime_opt =
       reinterpret_cast<lite::XPURunTimeOption *>(

--- a/lite/api/paddle_api.h
+++ b/lite/api/paddle_api.h
@@ -149,7 +149,7 @@ class LITE_API PaddlePredictor {
 
 // reference XpuConfig in PaddlePaddle
 // paddle/fluid/inference/api/paddle_analysis_config.h
-struct LITE_API LiteXpuConfig {
+struct LITE_API XpuConfig {
   // Select which xpu device to run model.
   int device_id{0};
 
@@ -171,43 +171,35 @@ struct LITE_API LiteXpuConfig {
   void* stream{nullptr};
 
   // Conv autotune level. Default 0 means no autotune.
-  // Note: Paddle-Lite only.
   int conv_autotune_level{0};
   // Base conv autotune info is read from conv_autotune_file.
-  // Note: Paddle-Lite only.
   std::string conv_autotune_file;
   // Whether write new conv autotune info to conv_autotune_file.
-  // Note: Paddle-Lite only.
   bool conv_autotune_file_writeback{false};
 
   // Fc autotune level. The Optional values are 0-9. Default 0 means no
-  // autotune. Note: Paddle-Lite only.
+  // autotune.
   int fc_autotune_level{0};
   // Base fc autotune info is read from fc_autotune_file.
-  // Note: Paddle-Lite only.
   std::string fc_autotune_file;
   // Whether write new fc autotune info to fc_autotune_file.
-  // Note: Paddle-Lite only.
   bool fc_autotune_file_writeback{false};
 
   // Gemm compute precision. Optional values are 0(int8),1(int16),2(int31).
   // Note: "gemm_compute_precision" has no effect on quanted ops of quant model
   int gemm_compute_precision{1};
   // Which method to optimize softmax in transformer structure. Optional values
-  // are 0,1,2. Note: Paddle-Lite only.
+  // are 0,1,2.
   int transformer_softmax_optimize_level{0};
   // Whether enable adaptive_seqlen optimize on transformer encoder.
-  // Note: Paddle-Lite only.
   bool transformer_encoder_adaptive_seqlen{true};
 
   // Gelu out max threshold is limited to quant_post_static_gelu_out_threshold
   // if use static post-quantization.
-  // Note: Paddle-Lite only.
   float quant_post_static_gelu_out_threshold{10.f};
   // Activation method if use dynamic post-quantization.
   // For kunlun1, optional values are 0(per_tensor),1(per_batch),2(per_head).
   // For kunlun2, optional values are 0(per_tensor) or non-zero(every_16).
-  // Note: Paddle-Lite only.
   int quant_post_dynamic_activation_method{0};
 };
 /// Base class for all the configs.
@@ -389,7 +381,7 @@ class LITE_API ConfigBase {
     return nnadapter_model_cache_buffers_;
   }
   // use this api to replace all set_xpu_xxx
-  void set_xpu_config(const LiteXpuConfig& xpu_config);
+  void set_xpu_config(const XpuConfig& xpu_config);
   // XPU only, set the size of the workspace memory from L3 cache for the
   // current thread.
   // **DEPRECATED**, use set_xpu_l3_cache_method() in the future


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
API

### Description
<!-- Describe what this PR does -->
- rename LiteXpuConfig to XpuConfig