### PR TITLE
[XPU]: add ew_mul/slice op int32 pricision.

### DIFF
--- a/lite/kernels/xpu/elementwise_compute.cc
+++ b/lite/kernels/xpu/elementwise_compute.cc
@@ -353,6 +353,12 @@ using MulFloat32 =
 using MulFloat16 = xpu::ElementwiseCompute<float16,
                                            xpu::MulFunctor<float16>,
                                            PRECISION(kFP16)>;
+
+using MulInt32 =
+    xpu::ElementwiseCompute<int, xpu::MulFunctor<int>, PRECISION(kFloat)>;
+using MulInt32hf =
+    xpu::ElementwiseCompute<int, xpu::MulFunctor<int>, PRECISION(kFP16)>;
+
 using MulInt64 = xpu::ElementwiseCompute<int64_t,
                                          xpu::MulFunctor<int64_t>,
                                          PRECISION(kFloat)>;
@@ -477,6 +483,18 @@ REGISTER_LITE_KERNEL(
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kFloat, kNCHW, MulInt32, int32)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
+    .Finalize();
+
+REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kFP16, kNCHW, MulInt32hf, int32)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
     .Finalize();
 
 REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kFloat, kNCHW, MulInt64, int64)

--- a/lite/kernels/xpu/slice_compute.cc
+++ b/lite/kernels/xpu/slice_compute.cc
@@ -355,6 +355,38 @@ REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceInt32, array_int32)
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
     .Finalize();
 
+using SliceInt32hf =
+    paddle::lite::kernels::xpu::SliceCompute<int32_t, PRECISION(kFP16)>;
+REGISTER_LITE_KERNEL(slice, kXPU, kFP16, kAny, SliceInt32, int32)
+    .BindInput("Input",
+               {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
+    .BindInput("StartsTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
+    .Finalize();
+
+using SliceInt32hf =
+    paddle::lite::kernels::xpu::SliceCompute<int32_t, PRECISION(kFP16)>;
+REGISTER_LITE_KERNEL(slice, kXPU, kFP16, kAny, SliceInt32, array_int32)
+    .BindInput("Input",
+               {LiteType::GetTensorListTy(TARGET(kXPU), PRECISION(kInt32))})
+    .BindInput("StartsTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensor",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("StartsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindInput("EndsTensorList",
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kAny))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
+    .Finalize();
+
 using SliceInt64 =
     paddle::lite::kernels::xpu::SliceCompute<int64_t, PRECISION(kFloat)>;
 REGISTER_LITE_KERNEL(slice, kXPU, kFloat, kAny, SliceInt64, int64)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Kernels
### Description
<!-- Describe what this PR does -->
Add int32 compute precision on ew_mul and slice op.