### PR TITLE
[OpenCL] fix werror

### DIFF
--- a/lite/kernels/opencl/elementwise_add_buffer_compute.cc
+++ b/lite/kernels/opencl/elementwise_add_buffer_compute.cc
@@ -107,7 +107,6 @@ void ElementwiseAddCompute::UpdateParams() {
   auto axis = ele_param_->axis;
   const auto& x_dims = ele_param_->X->dims();
   const auto& y_dims = ele_param_->Y->dims();
-  const auto& out_dims = ele_param_->Out->dims();
   if (axis < 0) {
     axis = static_cast<int>(x_dims.size() - y_dims.size());
   }

--- a/lite/kernels/opencl/layer_norm_buffer_compute.cc
+++ b/lite/kernels/opencl/layer_norm_buffer_compute.cc
@@ -45,8 +45,6 @@ class LayerNormBufferCompute
     layer_norm_param_ = param_.get_mutable<param_t>();
     auto* scale = layer_norm_param_->Scale;
     auto* bias = layer_norm_param_->Bias;
-    bool fp16_flag =
-        (CLRuntime::Global()->get_precision() == lite_api::CL_PRECISION_FP16);
     if (scale != nullptr) {
       auto* scale_cpu = scale->data<float>();
       scale_gpu_t_ = std::unique_ptr<Tensor>(new Tensor);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
OpenCL
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Kernels
### Description
<!-- Describe what this PR does -->
Fix -Werror=unused-variable
```
/media/wjl/D2/github/fork/Paddle-Lite/lite/kernels/opencl/layer_norm_buffer_compute.cc:48:10: error: unused variable ‘fp16_flag’ [-Werror=unused-variable]
   48 |     bool fp16_flag =
      |          ^~~~~~~~~

```