### PR TITLE
add bool tensor support and disable shape cache of split op

### DIFF
--- a/lite/api/paddle_place.h
+++ b/lite/api/paddle_place.h
@@ -166,6 +166,8 @@ static size_t PrecisionTypeLength(PrecisionType type) {
       return 2;
     case PrecisionType::kInt16:
       return 2;
+    case PrecisionType::kBool:
+      return 1;
     default:
       return 0;
   }

--- a/lite/kernels/xpu/elementwise_compute.cc
+++ b/lite/kernels/xpu/elementwise_compute.cc
@@ -646,8 +646,8 @@ REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kInt8, kNCHW, MulInt8, Int8)
     .Finalize();
 
 using MulBool =
-    xpu::ElementwiseCompute<bool, xpu::MulFunctor<bool>, PRECISION(kBool)>;
-REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kBool, kNCHW, MulBool, bool)
+    xpu::ElementwiseCompute<bool, xpu::MulFunctor<bool>, PRECISION(kFloat)>;
+REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kFloat, kNCHW, MulBool, bool)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kBool))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kBool))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kBool))})

--- a/lite/kernels/xpu/elementwise_compute.cc
+++ b/lite/kernels/xpu/elementwise_compute.cc
@@ -647,7 +647,7 @@ REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kInt8, kNCHW, MulInt8, Int8)
 
 using MulBool =
     xpu::ElementwiseCompute<bool, xpu::MulFunctor<bool>, PRECISION(kBool)>;
-REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kBool, kNCHW, MulBool, kBool)
+REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kBool, kNCHW, MulBool, bool)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kBool))})
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kBool))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kBool))})

--- a/lite/kernels/xpu/elementwise_compute.cc
+++ b/lite/kernels/xpu/elementwise_compute.cc
@@ -644,3 +644,11 @@ REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kInt8, kNCHW, MulInt8, Int8)
     .BindInput("Y", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt8))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt8))})
     .Finalize();
+
+using MulBool =
+    xpu::ElementwiseCompute<bool, xpu::MulFunctor<bool>, PRECISION(kBool)>;
+REGISTER_LITE_KERNEL(elementwise_mul, kXPU, kBool, kNCHW, MulBool, kBool)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kBool))})
+    .BindInput("Y", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kBool))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kBool))})
+    .Finalize();

--- a/lite/kernels/xpu/split_compute.cc
+++ b/lite/kernels/xpu/split_compute.cc
@@ -63,9 +63,7 @@ REGISTER_LITE_KERNEL(split, kXPU, kFloat, kNCHW, split_float, def)
     .BindInput("AxisTensor",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindInput("SectionsTensorList",
-                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
-    .BindOutput("SectionsTensorList",
-                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU))})
     .Finalize();
 
@@ -76,9 +74,7 @@ REGISTER_LITE_KERNEL(split, kXPU, kFP16, kNCHW, split_fp16, fp16)
     .BindInput("AxisTensor",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindInput("SectionsTensorList",
-                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
-    .BindOutput("SectionsTensorList",
-                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
     .Finalize();
 
@@ -89,8 +85,6 @@ REGISTER_LITE_KERNEL(split, kXPU, kInt8, kNCHW, split_int8, int8)
     .BindInput("AxisTensor",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindInput("SectionsTensorList",
-                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
-    .BindOutput("SectionsTensorList",
-                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+               {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt8))})
     .Finalize();

--- a/lite/kernels/xpu/split_compute.cc
+++ b/lite/kernels/xpu/split_compute.cc
@@ -62,6 +62,8 @@ REGISTER_LITE_KERNEL(split, kXPU, kFloat, kNCHW, split_float, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU))})
     .BindInput("AxisTensor",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindInput("SectionsTensorList",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("SectionsTensorList",
                 {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU))})
@@ -73,6 +75,8 @@ REGISTER_LITE_KERNEL(split, kXPU, kFP16, kNCHW, split_fp16, fp16)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
     .BindInput("AxisTensor",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindInput("SectionsTensorList",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("SectionsTensorList",
                 {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
@@ -84,6 +88,8 @@ REGISTER_LITE_KERNEL(split, kXPU, kInt8, kNCHW, split_int8, int8)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt8))})
     .BindInput("AxisTensor",
                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
+    .BindInput("SectionsTensorList",
+                {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("SectionsTensorList",
                 {LiteType::GetTensorTy(TARGET(kHost), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt8))})

--- a/lite/model_parser/pb/utils.cc
+++ b/lite/model_parser/pb/utils.cc
@@ -27,6 +27,7 @@ lite::VarDataType ConvertVarType(
   case VarType_Type::VarType_Type_##vtype: \
     type = lite::VarDataType::vtype;       \
     break
+    CASE(BOOL);
     CASE(FP64);
     CASE(FP32);
     CASE(INT8);

--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -48,8 +48,8 @@ bool SplitOp::InferShapeImpl() const {
   if (infer_num < 2) {
     for (int i = 0; i < sections.size(); i++) {
       if (sections[i] == -1) {
-        sections[i] =
-            in_dims[axis] - std::accumulate(sections.begin(), sections.end(), 1);
+        sections[i] = in_dims[axis] -
+                      std::accumulate(sections.begin(), sections.end(), 1);
       }
     }
   }

--- a/lite/operators/split_op.cc
+++ b/lite/operators/split_op.cc
@@ -45,11 +45,12 @@ bool SplitOp::InferShapeImpl() const {
   }
   // update sections
   int infer_num = std::count(sections.begin(), sections.end(), -1);
-  CHECK_LT(infer_num, 2);
-  for (int i = 0; i < sections.size(); i++) {
-    if (sections[i] == -1) {
-      sections[i] =
-          in_dims[axis] - std::accumulate(sections.begin(), sections.end(), 1);
+  if (infer_num < 2) {
+    for (int i = 0; i < sections.size(); i++) {
+      if (sections[i] == -1) {
+        sections[i] =
+            in_dims[axis] - std::accumulate(sections.begin(), sections.end(), 1);
+      }
     }
   }
   // update sections end

--- a/lite/operators/split_op.h
+++ b/lite/operators/split_op.h
@@ -32,7 +32,7 @@ class SplitOp : public OpLite {
 
   bool InferShapeImpl() const override;
 
-  bool InferShapeWithCache() const override { return true; }
+  bool InferShapeWithCache() const override { return false; }
 
   bool AttachImpl(const cpp::OpDesc &opdesc, lite::Scope *scope) override;
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Kernels
### Description
<!-- Describe what this PR does -->
add bool tensor support and disable shape cache of split op