### PR TITLE
[XPU] add scale compute fp16 type and align set_value attribute

### DIFF
--- a/lite/kernels/xpu/scale_compute.cc
+++ b/lite/kernels/xpu/scale_compute.cc
@@ -21,8 +21,8 @@ namespace lite {
 namespace kernels {
 namespace xpu {
 
-template <typename T>
-void ScaleCompute<T>::Run() {
+template <typename T, PrecisionType PType>
+void ScaleCompute<T, PType>::Run() {
   auto& param = this->template Param<param_t>();
   auto& ctx = this->ctx_->template As<XPUContext>();
 
@@ -52,32 +52,30 @@ void ScaleCompute<T>::Run() {
 }  // namespace lite
 }  // namespace paddle
 
-REGISTER_LITE_KERNEL(scale,
-                     kXPU,
-                     kFloat,
-                     kNCHW,
-                     paddle::lite::kernels::xpu::ScaleCompute<float>,
-                     def)
+using XPUScale_FP32 =
+    paddle::lite::kernels::xpu::ScaleCompute<float, PRECISION(kFloat)>;
+REGISTER_LITE_KERNEL(scale, kXPU, kFloat, kNCHW, XPUScale_FP32, def)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU))})
     .Finalize();
 
-REGISTER_LITE_KERNEL(scale,
-                     kXPU,
-                     kFloat,
-                     kNCHW,
-                     paddle::lite::kernels::xpu::ScaleCompute<int>,
-                     int32)
+using XPUScale_FP16 =
+    paddle::lite::kernels::xpu::ScaleCompute<float16, PRECISION(kFP16)>;
+REGISTER_LITE_KERNEL(scale, kXPU, kFP16, kNCHW, XPUScale_FP16, fp16)
+    .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kFP16))})
+    .Finalize();
+
+using XPUScale_Int32 =
+    paddle::lite::kernels::xpu::ScaleCompute<int, PRECISION(kFloat)>;
+REGISTER_LITE_KERNEL(scale, kXPU, kFloat, kNCHW, XPUScale_Int32, int32)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt32))})
     .Finalize();
 
-REGISTER_LITE_KERNEL(scale,
-                     kXPU,
-                     kFloat,
-                     kNCHW,
-                     paddle::lite::kernels::xpu::ScaleCompute<int64_t>,
-                     int64)
+using XPUScale_Int64 =
+    paddle::lite::kernels::xpu::ScaleCompute<int64_t, PRECISION(kFloat)>;
+REGISTER_LITE_KERNEL(scale, kXPU, kFloat, kNCHW, XPUScale_Int64, int64)
     .BindInput("X", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt64))})
     .BindOutput("Out", {LiteType::GetTensorTy(TARGET(kXPU), PRECISION(kInt64))})
     .Finalize();

--- a/lite/kernels/xpu/scale_compute.h
+++ b/lite/kernels/xpu/scale_compute.h
@@ -21,8 +21,8 @@ namespace lite {
 namespace kernels {
 namespace xpu {
 
-template <typename T>
-class ScaleCompute : public KernelLite<TARGET(kXPU), PRECISION(kFloat)> {
+template <typename T, PrecisionType PType>
+class ScaleCompute : public KernelLite<TARGET(kXPU), PType> {
  public:
   using param_t = operators::ScaleParam;
 

--- a/lite/kernels/xpu/set_value_compute.cc
+++ b/lite/kernels/xpu/set_value_compute.cc
@@ -82,8 +82,8 @@ void SetValueCompute::SetValue(const std::vector<int64_t>& starts,
         __ends__,                                                      \
         __steps__,                                                     \
         param.axes,                                                    \
-        {},                                                            \
-        {});                                                           \
+        param.decrease_axes,                                           \
+        param.none_axes);                                              \
     CHECK_EQ(r, 0);                                                    \
     return;                                                            \
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Kernels
### Description
<!-- Describe what this PR does -->
1. add scale compute fp16 type
2. align set_value attribute (decrease_axes, none_axes)