### PR TITLE
[XPU] Fix the issue of model accuracy caused by weight max initialization of  __xpu__mmdnn_search_attention2

### DIFF
--- a/lite/kernels/xpu/__xpu__search_attention_2_compute.cc
+++ b/lite/kernels/xpu/__xpu__search_attention_2_compute.cc
@@ -35,7 +35,7 @@ void XPUMmdnnSearchAttention2Compute::PrepareForRun() {
   auto& param = this->template Param<param_t>();
   float weight_max_cpu[maxptr_size];
   for (int i = 0; i < maxptr_size; i++) {
-    weight_max_cpu[maxptr_size] = param.W_max;
+    weight_max_cpu[i] = param.W_max;
   }
   XPU_CALL(xpu_memcpy(weight_max_xpu_guard_->addr_,
                       weight_max_cpu,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
x86

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Backends
### Description
<!-- Describe what this PR does -->
Fix Bug For XPU Precision