### PR TITLE
OS: Add support for zephyr rtos.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "third-party/pybind"]
 	path = third-party/pybind
 	url = https://github.com/pybind/pybind11.git
+[submodule "PaddleLite-on-Zephyr"]
+	path = PaddleLite-on-Zephyr
+	url = https://github.com/hnu-esnl/PaddleLite-on-Zephyr.git


### PR DESCRIPTION
Import the PaddleLite library files as a subsystem of Zephyr rtos and implement some samples model
with Zephyr rtos on the qemu and rk3568 platform.
The entire system code is placed in the directory
of PaddleLite_on_Zephyr, and the tutorial is in
the README.md in PaddleLite_on_Zephyr directory.

湖南大学提供的PaddleLite对Zephyr RTOS的支持，以第子仓库的模式加入到Paddle Lite repo中。
