### PR TITLE
支持Release/v2.6 运行在Zephyr RTOS上

### DIFF
--- a/lite/api/light_api.cc
+++ b/lite/api/light_api.cc
@@ -15,8 +15,10 @@
 #include "lite/api/light_api.h"
 #include <algorithm>
 #include <unordered_map>
+#ifndef LITE_WITH_ZEPHYR
 #include "paddle_use_kernels.h"  // NOLINT
 #include "paddle_use_ops.h"      // NOLINT
+#endif
 
 namespace paddle {
 namespace lite {
@@ -43,7 +45,7 @@ void LightPredictor::Build(const std::string& model_dir,
                            lite_api::LiteModelType model_type,
                            bool model_from_memory) {
   switch (model_type) {
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
     case lite_api::LiteModelType::kProtobuf:
       LoadModelPb(model_dir, "", "", scope_.get(), program_desc_.get());
       break;

--- a/lite/api/light_api_impl.cc
+++ b/lite/api/light_api_impl.cc
@@ -57,7 +57,7 @@ std::unique_ptr<const lite_api::Tensor> LightPredictorImpl::GetOutput(
 }
 
 void LightPredictorImpl::Run() {
-#ifdef LITE_WITH_ARM
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
   lite::DeviceInfo::Global().SetRunMode(mode_, threads_);
 #endif
   raw_predictor_->Run();

--- a/lite/api/paddle_api.cc
+++ b/lite/api/paddle_api.cc
@@ -223,7 +223,7 @@ std::shared_ptr<PaddlePredictor> CreatePaddlePredictor(const ConfigT &) {
 }
 
 ConfigBase::ConfigBase(PowerMode mode, int threads) {
-#ifdef LITE_WITH_ARM
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
   lite::DeviceInfo::Init();
   lite::DeviceInfo::Global().SetRunMode(mode, threads);
   mode_ = lite::DeviceInfo::Global().mode();
@@ -244,7 +244,7 @@ void ConfigBase::set_opencl_tune(bool enable_tune) {
 }
 
 void ConfigBase::set_power_mode(paddle::lite_api::PowerMode mode) {
-#ifdef LITE_WITH_ARM
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
   lite::DeviceInfo::Global().SetRunMode(mode, threads_);
   mode_ = lite::DeviceInfo::Global().mode();
   threads_ = lite::DeviceInfo::Global().threads();
@@ -252,7 +252,7 @@ void ConfigBase::set_power_mode(paddle::lite_api::PowerMode mode) {
 }
 
 void ConfigBase::set_threads(int threads) {
-#ifdef LITE_WITH_ARM
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
   lite::DeviceInfo::Global().SetRunMode(mode_, threads);
   mode_ = lite::DeviceInfo::Global().mode();
   threads_ = lite::DeviceInfo::Global().threads();
@@ -336,7 +336,7 @@ void MobileConfig::set_model_buffer(const char *model_buffer,
 // This is the method for allocating workspace_size according to L3Cache size
 void MobileConfig::SetArmL3CacheSize(L3CacheSetMethod method,
                                      int absolute_val) {
-#ifdef LITE_WITH_ARM
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
   lite::DeviceInfo::Global().SetArmL3CacheSize(method, absolute_val);
 #endif
 }

--- a/lite/backends/arm/math/saturate.h
+++ b/lite/backends/arm/math/saturate.h
@@ -17,6 +17,9 @@
 #include <limits.h>
 #include <algorithm>
 #include <cmath>
+#ifdef LITE_WITH_ZEPHYR
+#include <climits>
+#endif
 
 namespace paddle {
 namespace lite {

--- a/lite/core/context.h
+++ b/lite/core/context.h
@@ -202,7 +202,7 @@ class Context<TargetType::kXPU> {
 };
 #endif
 
-#ifdef LITE_WITH_ARM
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
 template <>
 class Context<TargetType::kARM> {
  public:
@@ -433,7 +433,7 @@ class ContextScheduler {
             &context);
       } break;
 #endif
-#ifdef LITE_WITH_ARM
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
       case TARGET(kARM):
         kernel_contexts_[TargetType::kARM].As<ARMContext>().CopySharedTo(
             &ctx->As<ARMContext>());
@@ -514,7 +514,7 @@ class ContextScheduler {
 #ifdef LITE_WITH_CUDA
     InitContext<TargetType::kCUDA, CUDAContext>();
 #endif
-#ifdef LITE_WITH_ARM
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
     InitContext<TargetType::kARM, ARMContext>();
 #endif
 #ifdef LITE_WITH_OPENCL

--- a/lite/core/device_info.cc
+++ b/lite/core/device_info.cc
@@ -58,7 +58,8 @@
 namespace paddle {
 namespace lite {
 
-#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_MLU))
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_MLU) || \
+     (defined LITE_WITH_ZEPHYR))
 LITE_THREAD_LOCAL lite_api::PowerMode DeviceInfo::mode_;
 LITE_THREAD_LOCAL ARMArch DeviceInfo::arch_;
 LITE_THREAD_LOCAL int DeviceInfo::mem_size_;

--- a/lite/core/device_info.h
+++ b/lite/core/device_info.h
@@ -29,7 +29,8 @@ namespace paddle {
 namespace lite {
 
 using L3CacheSetMethod = lite_api::L3CacheSetMethod;
-#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_MLU))
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_MLU) || \
+     (defined LITE_WITH_ZEPHYR))
 
 typedef enum {
   kAPPLE = 0,

--- a/lite/core/op_registry.h
+++ b/lite/core/op_registry.h
@@ -405,7 +405,7 @@ class KernelRegistry final {
 
  private:
   mutable std::vector<any_kernel_registor_t> registries_;
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
   mutable std::map<
       std::string,
       std::vector<std::tuple<TargetType, PrecisionType, DataLayoutType>>>

--- a/lite/core/program.cc
+++ b/lite/core/program.cc
@@ -221,7 +221,7 @@ RuntimeProgram::RuntimeProgram(
       VLOG(3) << "The attr '" << kKernelTypeAttr
               << "' not found, pick the first kernel for " << op_type;
       std::vector<std::unique_ptr<KernelBase>> kernels;
-#if defined(LITE_WITH_ARM)
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
       kernels = op->CreateKernels({Place{TARGET(kARM)}, Place{TARGET(kHost)}});
 #elif defined(LITE_WITH_X86)
       kernels = op->CreateKernels({Place{TARGET(kX86)}, Place{TARGET(kHost)}});

--- a/lite/core/workspace.h
+++ b/lite/core/workspace.h
@@ -59,7 +59,7 @@ class WorkSpace {
   static WorkSpace& Global_X86() { return Global_Host(); }
 #endif
 
-#if defined(LITE_WITH_ARM)
+#if ((defined LITE_WITH_ARM) || (defined LITE_WITH_ZEPHYR))
   static WorkSpace& Global_ARM() { return Global_Host(); }
 #endif
 

--- a/lite/model_parser/compatibility.cc
+++ b/lite/model_parser/compatibility.cc
@@ -19,7 +19,7 @@
 #include "lite/model_parser/naive_buffer/op_desc.h"
 #include "lite/model_parser/naive_buffer/program_desc.h"
 #include "lite/model_parser/naive_buffer/var_desc.h"
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
 #include "lite/model_parser/cpp/block_desc.h"
 #include "lite/model_parser/cpp/op_desc.h"
 #include "lite/model_parser/cpp/program_desc.h"

--- a/lite/model_parser/compatible_pb.cc
+++ b/lite/model_parser/compatible_pb.cc
@@ -19,7 +19,7 @@
 #include "lite/model_parser/naive_buffer/op_desc.h"
 #include "lite/model_parser/naive_buffer/program_desc.h"
 #include "lite/model_parser/naive_buffer/var_desc.h"
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
 #include "lite/model_parser/pb/block_desc.h"
 #include "lite/model_parser/pb/op_desc.h"
 #include "lite/model_parser/pb/program_desc.h"
@@ -43,7 +43,7 @@ namespace lite {
     }                                                              \
   }
 
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
 template <>
 void TransformVarDescAnyToCpp<pb::VarDesc>(const pb::VarDesc &any_desc,
                                            cpp::VarDesc *cpp_desc) {
@@ -296,7 +296,7 @@ TRANS_OP_ANY_WITH_CPP_IMPL(naive_buffer::OpDesc);
 TRANS_BLOCK_ANY_WITH_CPP_IMPL(BlockDesc, naive_buffer, naive_buffer);
 TRANS_PROGRAM_ANY_WITH_CPP_IMPL(ProgramDesc, naive_buffer, naive_buffer);
 
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
 TRANS_VAR_ANY_WITH_CPP_IMPL(pb::VarDesc);
 TRANS_OP_ANY_WITH_CPP_IMPL(pb::OpDesc);
 TRANS_BLOCK_ANY_WITH_CPP_IMPL(BlockDesc, pb, framework);

--- a/lite/model_parser/model_parser.cc
+++ b/lite/model_parser/model_parser.cc
@@ -27,16 +27,19 @@
 #include "lite/model_parser/naive_buffer/param_desc.h"
 #include "lite/model_parser/naive_buffer/program_desc.h"
 #include "lite/model_parser/naive_buffer/var_desc.h"
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
 #include "lite/model_parser/pb/program_desc.h"
 #include "lite/model_parser/pb/var_desc.h"
 #endif
 #include "lite/utils/io.h"
+#ifdef LITE_WITH_ZEPHYR
+#include "lite/utils/config.h"
+#endif
 
 namespace paddle {
 namespace lite {
 
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
 int SizeOfType(framework::proto::VarType::Type type) {
   using Type = framework::proto::VarType::Type;
   switch (static_cast<int>(type)) {
@@ -604,6 +607,7 @@ void SetTensorDataNaive(T *out, size_t size, const std::vector<T> &src) {
   }
 }
 
+#ifndef LITE_WITH_ZEPHYR
 void GetParamInfoNaive(const naive_buffer::ParamDesc &desc,
                        lite::Scope *scope,
                        const std::string &name) {
@@ -747,6 +751,7 @@ void LoadModelNaive(const std::string &model_dir,
 
   VLOG(4) << "Load naive buffer model in '" << model_dir << "' successfully";
 }
+#endif
 
 /*
  * Binary structure of naive_buffer model: model.nb
@@ -778,6 +783,7 @@ void ReadModelDataFromFile(T *data,
   *offset = *offset + size;
 }
 
+#ifndef LITE_WITH_ZEPHYR
 void LoadModelNaiveFromFile(const std::string &filename,
                             Scope *scope,
                             cpp::ProgramDesc *cpp_prog) {
@@ -835,9 +841,11 @@ void LoadModelNaiveFromFile(const std::string &filename,
 
   VLOG(4) << "Load naive buffer model in '" << filename << "' successfully";
 }
+#endif
 
 // warning: this is an old inference and is not suggested.
 // todo: this inference will be abandened in release/v3.0.0
+#ifndef LITE_WITH_ZEPHYR
 void LoadModelNaiveFromMemory(const std::string &model_buffer,
                               const std::string &param_buffer,
                               Scope *scope,
@@ -865,6 +873,7 @@ void LoadModelNaiveFromMemory(const std::string &model_buffer,
 
   VLOG(4) << "Load model from naive buffer memory successfully";
 }
+#endif
 
 // usage: LoadModelNaiveFromMemory is used for loading naive model from memory
 template <typename T>
@@ -877,6 +886,7 @@ void ReadModelDataFromBuffer(T *data,
   memcpy(data, data_table.cursor(), size);
   *offset = *offset + size;
 }
+#ifndef LITE_WITH_ZEPHYR
 void LoadModelNaiveFromMemory(const std::string &model_buffer,
                               Scope *scope,
                               cpp::ProgramDesc *cpp_prog) {
@@ -922,6 +932,7 @@ void LoadModelNaiveFromMemory(const std::string &model_buffer,
 
   VLOG(4) << "Load model from naive buffer memory successfully";
 }
+#endif
 
 }  // namespace lite
 }  // namespace paddle

--- a/lite/model_parser/model_parser.h
+++ b/lite/model_parser/model_parser.h
@@ -19,7 +19,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
 #include "lite/core/framework.pb.h"
 #endif
 #include "lite/core/scope.h"
@@ -30,7 +30,7 @@
 namespace paddle {
 namespace lite {
 
-#ifndef LITE_ON_TINY_PUBLISH
+#if !defined(LITE_ON_TINY_PUBLISH) && !defined(LITE_WITH_ZEPHYR)
 // Read a __model__ file.
 std::unique_ptr<framework::proto::ProgramDesc> LoadProgram(
     const std::string& path, bool program_from_memory = false);

--- a/lite/model_parser/naive_buffer/naive_buffer.cc
+++ b/lite/model_parser/naive_buffer/naive_buffer.cc
@@ -14,6 +14,9 @@
 
 #include "lite/model_parser/naive_buffer/naive_buffer.h"
 #include <stdio.h>
+#ifdef LITE_WITH_ZEPHYR
+#include "lite/utils/mem.h"
+#endif
 
 namespace paddle {
 namespace lite {

--- a/lite/model_parser/naive_buffer/naive_buffer.h
+++ b/lite/model_parser/naive_buffer/naive_buffer.h
@@ -67,6 +67,9 @@ struct BinaryTable {
   void LoadFromFile(const std::string& filename,
                     const size_t& offset = 0,
                     const size_t& size = 0);
+#ifdef LITE_WITH_ZEPHYR
+  void LoadFromFile(const uint64_t& topo_size, uint8_t* start);
+#endif
   void LoadFromMemory(const char* buffer, size_t buffer_size);
 };
 

--- a/lite/utils/io.h
+++ b/lite/utils/io.h
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #pragma once
-
+#ifdef LITE_WITH_ZEPHYR
+#include "lite/utils/dirent.h"
+#endif
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
我们将paddle lite作为zephyr RTOS的一个第三方外部模块，加入了zephyr RTOS的代码仓库中。并在Firefly ROC-RK3568-PC开发板上进行了测试，预测结果和arm linux一致，同时在部分场景下paddle lite on zephyr RTOS的推理速度优于linux.
