### PR TITLE
[ARM] fix abs ambiguous error in gcc-6.4.1

### DIFF
--- a/lite/kernels/arm/scale_compute.cc
+++ b/lite/kernels/arm/scale_compute.cc
@@ -31,7 +31,7 @@ void ScaleCompute<T, PType>::Run() {
   if (!param.bias_after_scale) {
     bias *= scale;
   }
-  if (std::isinf(abs(scale))) {
+  if (std::isinf(std::abs(scale))) {
     scale = 0;
   }
   T alpha = param.alpha;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
ARM

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
 Kernels

### Description
<!-- Describe what this PR does -->
In gcc-6.4.1 on arm, using simple `abs` will cause `error: call of overloaded 'abs (float&)' is ambiguous`. Using `std::abs` is a better choice as gpt4 suggested. This usage is also better in other gcc versions.


Here's gpt4's advice:
```
这个错误信息表明编译器在解析 abs(float&) 函数调用时遇到了歧义。这通常是因为全局命名空间中的 abs 函数与 std 命名空间中的 abs 函数之间存在冲突。

在 C++ 中，std::abs 提供了多种重载版本来处理不同类型的数据，而全局命名空间中的 abs 可能没有这些重载版本，或者与标准库中的版本冲突。

解决方案
使用 std::abs：

这是最直接的解决方案，确保你使用的是标准库中的 abs 函数。
确保包含正确的头文件：

确保你包含了 <cmath> 头文件来使用 std::abs。
示例代码
以下是一个示例代码，展示如何正确使用 std::abs 来避免歧义：

#include <iostream>
#include <cmath> // 包含 cmath 头文件以使用 std::abs

int main() {
    int i = -10;
    float f = -10.5f;
    double d = -10.5;

    // 使用 std::abs
    std::cout << "std::abs(i): " << std::abs(i) << std::endl;
    std::cout << "std::abs(f): " << std::abs(f) << std::endl;
    std::cout << "std::abs(d): " << std::abs(d) << std::endl;

    return 0;
}
编译命令
确保使用正确的编译命令来编译你的程序，例如：

g++ -std=c++11 -o my_program my_program.cpp
总结
使用 std::abs 可以避免命名冲突和歧义问题，特别是在处理不同类型的数据时。确保包含 <cmath> 头文件，并在代码中明确使用 std::abs，这样可以避免编译错误。
```