### PR TITLE
[OpenCL] fix opencl multi-thread CL_INVALID_CONTEXT

### DIFF
--- a/lite/backends/opencl/cl_runtime.cc
+++ b/lite/backends/opencl/cl_runtime.cc
@@ -10,9 +10,11 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "lite/backends/opencl/cl_runtime.h"
+
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "lite/backends/opencl/utils/cache.h"
 #include "lite/core/target_wrapper.h"
 #include "lite/core/version.h"
@@ -23,10 +25,12 @@ limitations under the License. */
 namespace paddle {
 namespace lite {
 
+CLRuntime CLRuntime::instance_;
+
 CLRuntime* CLRuntime::Global() {
-  thread_local CLRuntime cl_runtime_;
-  cl_runtime_.Init();
-  return &cl_runtime_;
+  static std::once_flag init_flag;
+  std::call_once(init_flag, []() { instance_.Init(); });
+  return &instance_;
 }
 
 void CLRuntime::Flush(const int index) {

--- a/lite/backends/opencl/cl_runtime.h
+++ b/lite/backends/opencl/cl_runtime.h
@@ -16,6 +16,7 @@ limitations under the License. */
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "lite/api/paddle_place.h"
 #include "lite/backends/opencl/cl_include.h"
 #include "lite/backends/opencl/cl_utility.h"
@@ -221,6 +222,8 @@ class CLRuntime {
                                 const std::vector<int>& tune_vct);
 
  private:
+  static CLRuntime instance_;
+
   CLRuntime() { Init(); }
   CLRuntime(const CLRuntime&) = delete;
   CLRuntime(const CLRuntime&&) = delete;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
OpenCL

### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Backends

### Description
<!-- Describe what this PR does -->
Fix CL_INVALID_CONTEXT error when the model does predictions in multiple threads.

Previous issues: https://github.com/PaddlePaddle/Paddle-Lite/issues/9931 https://github.com/PaddlePaddle/Paddle-Lite/issues/10267

Caused by https://github.com/PaddlePaddle/Paddle-Lite/blob/bd60e696cc8233b0ebef3b4db932923d668e8c50/lite/backends/opencl/cl_runtime.cc#L27

Use `local_thread` here will lead to different opencl contexts in different threads, as mentioned in https://github.com/PaddlePaddle/Paddle-Lite/issues/9931#issuecomment-1407544996. Also, this is not a good solution, as discussed in https://github.com/PaddlePaddle/Paddle-Lite/issues/7888#issuecomment-990679917, which will cause other bugs.

**New solution: Use single instance, all threads share a global `CLRuntime`.**