### PR TITLE
[XPU] don't use first l3 tune plan when new input shape; test=develop

### DIFF
--- a/lite/backends/xpu/xpu_l3_strategy.h
+++ b/lite/backends/xpu/xpu_l3_strategy.h
@@ -44,15 +44,15 @@ class XPUL3Planner {
     } else {
       auto it = plans_.lower_bound(query_shape_);
       if (it == plans_.end()) {
-        LOG(INFO) << "new query_shape, use the first L3 cache plan";
-        return &(plans_.begin()->second);
+        return nullptr;
       } else {
         return &(it->second);
       }
     }
   }
   bool if_find_plan_query_shape() {
-    return (!query_shape_.empty() && plans_.find(query_shape_) != plans_.end());
+    return (query_shape_.size() == 0 ||
+            plans_.find(query_shape_) != plans_.end());
   }
   // greedy strategy
   void run_autotune_greedy(const std::vector<XPUL3CacheBlock*>& l3_block_dict,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle-Lite/pull/8688 -->
### PR devices
<!-- One of [ Framework | Host | Arm | x86 | OpenCL | Metal | XPU | NNadapter | others ] -->
XPU
### PR types
<!-- One of [ New features | Bug fixes | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OP | API | PASS | Kernels | Backends | Docs ] -->
Backends
### Description
<!-- Describe what this PR does -->
don't use first L3 plan when new input shape