### PR TITLE
[BUGFIX] Ensure feed op has valid input and output variables, test=de…

### DIFF
--- a/lite/operators/feed_op.cc
+++ b/lite/operators/feed_op.cc
@@ -50,15 +50,23 @@ class FeedOp : public OpLite {
 
  protected:
   bool AttachImpl(const cpp::OpDesc& opdesc, lite::Scope* scope) override {
-    auto feed_var_name = opdesc.Input("X").front();
+    auto inputs = opdesc.Input("X");
+    CHECK(!inputs.empty()) << "Feed op requires at least one input";
+
+    auto feed_var_name = inputs.front();
     auto* feed_var = scope->FindVar(feed_var_name);
-    CHECK(feed_var);
+    CHECK(feed_var) << "Cannot find feed variable: " << feed_var_name;
+
     auto* feed_tensor_list = feed_var->GetMutable<std::vector<lite::Tensor>>();
     param_.feed_list = feed_tensor_list;
 
-    auto out_name = opdesc.Output("Out").front();
+    auto outputs = opdesc.Output("Out");
+    CHECK(!outputs.empty()) << "Feed op requires at least one output";
+
+    auto out_name = outputs.front();
     auto* out_var = scope->FindVar(out_name);
-    CHECK(out_var);
+    CHECK(out_var) << "Cannot find output variable: " << out_name;
+
     param_.out = out_var->GetMutable<lite::Tensor>();
 
     // NOTE need boost here


### PR DESCRIPTION
### PR devices 
Framework

### PR types
Bug fixes
### PR changes
OP
### Description
Ensure feed op has valid input and output variables

ABI: arm64

signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0

x0  0000007a055e6740  x1  0000000000000000  x2  0000000000000058  x3  0000000000000000
x4  00000078ebdeb778  x5  8080808080808080  x6  0000000000000004  x7  7f7f7f7f7f7f7f7f
x8  d5a3d4374d70d641  x9  d5a3d4374d70d641  x10 fffffffc5b666c74  x11 0000000000000008
x12 0000000000000000  x13 0000000000000000  x14 0000000000000001  x15 ffffffffffffffff
x16 00000078ec1b6398  x17 0000007a04d3e334  x18 ac0a0c59ca395a09  x19 0000007b4dd3b9d0
x20 0000007b23dc77b0  x21 0000007af9e021b0  x22 0000007a055e8000  x23 0000007aebee1da0
x24 00000078ebc3223f  x25 0000000000000041  x26 0000000000000000  x27 0000007b23d8afb0
x28 0000007af9e01790  x29 0000007a055e66e0

0x2c2570: paddle::lite::operators::FeedOp::AttachImpl(paddle::lite::fbs::OpDescView const&, paddle::lite::Scope*) at paddlelite/src/Paddle-Lite/lite/operators/feed_op.cc:53


