### PR TITLE
[BUGFIX] Protect against null pointer exceptions when accessing attri…

### DIFF
--- a/lite/model_parser/flatbuffers/op_desc.cc
+++ b/lite/model_parser/flatbuffers/op_desc.cc
@@ -21,6 +21,11 @@ namespace fbs {
 template <>
 std::string OpDescView::GetAttr<std::string>(const char* name) const {
   const auto& it = desc_->attrs()->LookupByKey(name);
+  // protect npe
+  if (!it) {
+    LOG(WARNING) << "Attribute " << name << " does not exist.";
+    return {};
+  }
   if (!it->s()) {
     return std::string();
   }
@@ -36,7 +41,11 @@ template <>
 lite::VectorView<std::string, Flatbuffers>
 OpDescView::GetAttr<std::vector<std::string>>(const char* name) const {
   const auto& it = desc_->attrs()->LookupByKey(name);
-  CHECK(it) << "Attr " << name << "does not exist.";
+  // protect npe
+  if (!it) {
+    LOG(WARNING) << "Attribute " << name << " does not exist.";
+    return VectorView<std::string>(nullptr);
+  }
   return VectorView<std::string>(it->strings());
 }
 
@@ -51,6 +60,10 @@ OpDescView::GetAttr<std::vector<std::string>>(const std::string& name) const {
   typename lite::OpDataTypeTrait<T, Flatbuffers>::RT OpDescView::GetAttr<T>( \
       const char* name) const {                                              \
     const auto& it = desc_->attrs()->LookupByKey(name);                      \
+    if (!it) {                                                               \
+      LOG(WARNING) << "Attribute " << name << " does not exist.";            \
+      return typename lite::OpDataTypeTrait<T, Flatbuffers>::RT();           \
+    }                                                                        \
     return it->fb_f__();                                                     \
   }                                                                          \
   template <>                                                                \


### PR DESCRIPTION
fix npe in op desc

### PR devices
Framework
### PR types
Bug fixes

### PR changes
Model Parser

### Description
fix npe in op desc

ABI: arm64
Timestamp: 2025-05-20 19:29:15.371 
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
x0  0000000000000000  x1  0000006d81e6f310  x2  0000000000000070  x3  c08f4a6b00000000
x4  0000000000000000  x5  0725e0b000000000  x6  00000000b0e02507  x7  6b6e6e6ffefefefe
x8  0000000000000000  x9  0000006dbad927c0  x10 0101010101010101  x11 0000000000000020
x12 0000006fe455c020  x13 2e6574694c2d656c  x14 0000000000000060  x15 aaaaaaaaaaaaaaab
x16 0000006d823f4568  x17 0000007106c750c0  x18 ac0a0c59ca395a09  x19 0000006fe4559c90
x20 0000006fe455c020  x21 0000006dbb5991e0  x22 0000006fe455c020  x23 0000006fd6ee6600
x24 0000006ff557e8c0  x25 00000000000000e1  x26 000000000000002b  x27 0000006dbad28ea0
x28 0000006dbb599140  x29 0000006fe4559c70

#00 pc 000000000062eb3c ~/Paddle-Lite/lite/model_parser/flatbuffers/op_desc.cc:24
